### PR TITLE
Remove deprecation of definition of the doc prop

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -141,9 +141,6 @@
 		"directories": {
 			"type": "object",
 			"properties": {
-				"doc": {
-					"type": "string"
-				},
 				"bin": {
 					"description": "If you specify a 'bin' directory, then all the files in that folder will be used as the 'bin' hash.",
 					"type": "string"


### PR DESCRIPTION
In [package.json](http://json.schemastore.org/package), I found that the `doc` property is defined twice.