### PR TITLE
Add xUnit.net runner schema to JSON schema catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -257,6 +257,12 @@
 			"description": "Azure Webjobs publish settings file",
 			"fileMatch": [ "webjobpublishsettings.json" ],
 			"url": "http://json.schemastore.org/webjob-publish-settings"
+		},
+		{
+			"name": "xunit.runner.json",
+			"description": "xUnit.net Runner Configuration File",
+			"fileMatch": [ "xunit.runner.json" ],
+			"url": "http://xunit.github.io/schema/v1/xunit.runner.schema.json"
 		}
 	]
 }


### PR DESCRIPTION
The only open question I have is: I noticed that you have copies of all the schema here on your site. Is that a requirement, or is it okay to use the external link that I've used in the PR?