### PR TITLE
Update TSLint schema to release 2.5.1

### DIFF
--- a/src/schemas/json/tslint-2.5.1.json
+++ b/src/schemas/json/tslint-2.5.1.json
@@ -8,6 +8,13 @@
 	"definitions": {
 		"ruledefinitions": {
 			"properties": {
+			  "align": {
+			    "description": "Enforces vertical alignment for parameters, arguments and/or statements",
+					"type": [ "array" ],
+					"items": {
+						"enum": [ true, false, "parameters", "arguments", "statements" ]
+					}
+			  },
 				"ban": {
 					"description": "Bans the use of specific functions",
 					"type": "array",
@@ -35,7 +42,7 @@
 					"type": "boolean"
 				},
 				"forin": {
-					"description": "Enforces a for...in  statement to be filtered with an if statement",
+					"description": "Enforces a for...in statement to be filtered with an if statement",
 					"type": "boolean"
 				},
 				"indent": {
@@ -63,10 +70,24 @@
 				},
 				"max-line-length": {
 					"description": "Sets the maximum length of a line",
-					"type": "array"
+					"type": "array",
+					"items": {
+						"type": [ "boolean", "integer" ]
+					}
+				},
+				"member-access": {
+					"description": "Enforces using explicit visibility on class members",
+					"type": "boolean"
+				},
+				"member-ordering": {
+					"description": "Enforces chosen member ordering",
+					"type": "array",
+					"items": {
+						"enum": [ true, "public-before-private", "static-before-instance", "variables-before-functions" ]
+					}
 				},
 				"no-any": {
-					"description": "diallows usages of any as a type decoration",
+					"description": "Disallows usages of any as a type decoration",
 					"type": "boolean"
 				},
 				"no-arg": {
@@ -76,6 +97,10 @@
 				"no-bitwise": {
 					"description": "Disallows bitwise operators",
 					"type": "boolean"
+				},
+				"no-conditional-assignment": {
+				  "description": "Disallows any type of assignment in any conditionals; this applies to do-while, for, if, and while statements",
+				  "type": "boolean"
 				},
 				"no-console": {
 					"description": "Disallows access to the specified functions on console",
@@ -93,7 +118,7 @@
 					"type": "boolean"
 				},
 				"no-constructor-vars": {
-					"description": "Disallows the `public` and `private` modifiers for constructor parameters",
+					"description": "Disallows the public and private modifiers for constructor parameters",
 					"type": "boolean"
 				},
 				"no-debugger": {
@@ -105,7 +130,11 @@
 					"type": "boolean"
 				},
 				"no-duplicate-variable": {
-					"description": "Disallows duplicate variable declarations",
+					"description": "Disallows duplicate variable declarations in the same block scope",
+					"type": "boolean"
+				},
+				"no-shadowed-variable": {
+					"description": "Disallows shadowed variable declarations",
 					"type": "boolean"
 				},
 				"no-empty": {
@@ -114,6 +143,18 @@
 				},
 				"no-eval": {
 					"description": "Disallows eval function invocations",
+					"type": "boolean"
+				},
+				"no-inferrable-types": {
+					"description": "Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean",
+					"type": "boolean"
+				},
+				"no-internal-module": {
+				  "description": "Disallows internal module, use namespace instead",
+					"type": "boolean"
+				},
+				"no-require-imports": {
+				  "description": "Disallows require() style imports",
 					"type": "boolean"
 				},
 				"no-string-literal": {
@@ -132,6 +173,10 @@
 					"description": "Disallows trailing whitespace at the end of a line",
 					"type": "boolean"
 				},
+				"no-unreachable": {
+				  "description": "Disallows unreachable code after break, catch, throw, and return statements",
+					"type": "boolean"
+				},
 				"no-unused-expression": {
 					"description": "Disallows unused expression statements",
 					"type": "boolean"
@@ -144,12 +189,12 @@
 						"enum": [ true, false, "check-parameters" ]
 					}
 				},
-				"no-unreachable": {
-					"description": "Disallows unreachable code after break, catch, throw and return statements",
-					"type": "boolean"
-				},
 				"no-use-before-declare": {
 					"description": "Disallows usage of variables before their declaration",
+					"type": "boolean"
+				},
+				"no-var-keyword": {
+				  "description": "Disallows usage of the var keyword, use let or const instead",
 					"type": "boolean"
 				},
 				"no-var-requires": {
@@ -160,14 +205,14 @@
 					"description": "Enforces the specified tokens to be on the same line as the expression preceding it",
 					"type": "array",
 					"items": {
-						"enum": [ true, false, "check-open-brace", "check-catch", "check-else", "check-whitespace" ]
+						"enum": [ true, "check-open-brace", "check-catch", "check-else", "check-whitespace" ]
 					}
 				},
 				"quotemark": {
 					"description": "Enforces consistent single or double quoted string literals",
 					"type": "array",
 					"items": {
-						"enum": [ true, false, "double", "single" ]
+						"enum": [ true, "double", "single", "avoid-escape" ]
 					}
 				},
 				"radix": {
@@ -176,6 +221,14 @@
 				},
 				"semicolon": {
 					"description": "Enforces semicolons at the end of every statement",
+					"type": "boolean"
+				},
+				"sort-object-literal-keys": {
+				  "description": "Checks that keys in object literals are declared in alphabetical order",
+					"type": "boolean"
+				},
+				"switch-default": {
+				  "description": "Enforces a default case in switch statements",
 					"type": "boolean"
 				},
 				"triple-equals": {
@@ -189,7 +242,7 @@
 					"description": "Enforces type definitions to exist",
 					"type": "array",
 					"items": {
-						"enum": [ true, "callSignature", "indexSignature", "parameter", "propertySignature", "variableDeclarator" ]
+						"enum": [ true, "call-signature", "parameter", "property-declaration", "variable-declaration", "member-variable-declaration" ]
 					}
 				},
 				"typedef-whitespace": {
@@ -203,21 +256,21 @@
 					"description": "Enforces ECMAScript 5's strict mode",
 					"type": "array",
 					"items": {
-						"enum": [ true, false, "check-module", "check-function" ]
+						"enum": [ true, "check-module", "check-function" ]
 					}
 				},
 				"variable-name": {
 					"description": "Allows only camelCased or UPPER_CASED variable names",
 					"type": [ "array", "boolean" ],
 					"items": {
-						"enum": [ true, false, "allow-leading-underscore" ]
+						"enum": [ true, "allow-leading-underscore", "allow-trailing-underscore" ]
 					}
 				},
 				"whitespace": {
 					"description": "Enforces spacing whitespace",
 					"type": "array",
 					"items": {
-						"enum": [ true, false, "check-branch", "check-decl", "check-operator", "check-separator", "check-type" ]
+						"enum": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
 					}
 				}
 			},

--- a/src/schemas/json/tslint-2.5.1.json
+++ b/src/schemas/json/tslint-2.5.1.json
@@ -30,7 +30,7 @@
 					"description": "Enforces rules for single-line comments",
 					"type": "array",
 					"items": {
-						"enum": [ true, "check-space", "check-lowercase" ]
+						"enum": [ true, false, "check-space", "check-lowercase" ]
 					}
 				},
 				"curly": {
@@ -83,7 +83,7 @@
 					"description": "Enforces chosen member ordering",
 					"type": "array",
 					"items": {
-						"enum": [ true, "public-before-private", "static-before-instance", "variables-before-functions" ]
+						"enum": [ true, false, "public-before-private", "static-before-instance", "variables-before-functions" ]
 					}
 				},
 				"no-any": {
@@ -205,14 +205,14 @@
 					"description": "Enforces the specified tokens to be on the same line as the expression preceding it",
 					"type": "array",
 					"items": {
-						"enum": [ true, "check-open-brace", "check-catch", "check-else", "check-whitespace" ]
+						"enum": [ true, false, "check-open-brace", "check-catch", "check-else", "check-whitespace" ]
 					}
 				},
 				"quotemark": {
 					"description": "Enforces consistent single or double quoted string literals",
 					"type": "array",
 					"items": {
-						"enum": [ true, "double", "single", "avoid-escape" ]
+						"enum": [ true, false, "double", "single", "avoid-escape" ]
 					}
 				},
 				"radix": {
@@ -242,7 +242,7 @@
 					"description": "Enforces type definitions to exist",
 					"type": "array",
 					"items": {
-						"enum": [ true, "call-signature", "parameter", "property-declaration", "variable-declaration", "member-variable-declaration" ]
+						"enum": [ true, false, "call-signature", "parameter", "property-declaration", "variable-declaration", "member-variable-declaration" ]
 					}
 				},
 				"typedef-whitespace": {
@@ -256,21 +256,21 @@
 					"description": "Enforces ECMAScript 5's strict mode",
 					"type": "array",
 					"items": {
-						"enum": [ true, "check-module", "check-function" ]
+						"enum": [ true, false, "check-module", "check-function" ]
 					}
 				},
 				"variable-name": {
 					"description": "Allows only camelCased or UPPER_CASED variable names",
 					"type": [ "array", "boolean" ],
 					"items": {
-						"enum": [ true, "allow-leading-underscore", "allow-trailing-underscore" ]
+						"enum": [ true, false, "allow-leading-underscore", "allow-trailing-underscore" ]
 					}
 				},
 				"whitespace": {
 					"description": "Enforces spacing whitespace",
 					"type": "array",
 					"items": {
-						"enum": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+						"enum": [ true, false, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
 					}
 				}
 			},


### PR DESCRIPTION
I went through the latest TSLint release's [README](https://github.com/palantir/tslint/blob/2.5.1/README.md) and added any missing options, as well as ensured that existing options had good descriptions and all of the possible values for enums.

I hope this can be merged, especially as some of the suggested enums have led to us not realising that TSLint wasn't checking everything (with the latest release)!