### PR TITLE
.babelrc schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4,6 +4,12 @@
   "version": 1.0,
   "schemas": [
     {
+      "name": "babelrc.json",
+      "description": "Babel configuration file",
+      "fileMatch": [ ".babelrc" ],
+      "url": "http://json.schemastore.org/babelrc"
+    },
+    {
       "name": "bower.json",
       "description": "Bower package description file",
       "fileMatch": [ "bower.json", ".bower.json" ],

--- a/src/schemas/json/babelrc.json
+++ b/src/schemas/json/babelrc.json
@@ -1,0 +1,128 @@
+{
+	"title": "JSON schema for Babel 6+ configuration files",
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"type": "object",
+	"properties": {
+		"ast": {
+			"default": true,
+			"description": "Include the AST in the returned object",
+			"type": "boolean"
+		},	
+		"auxiliaryCommentAfter":{
+			"description": "Attach a comment after all non-user injected code.",
+			"type": "string"
+		},
+		"auxiliaryCommentBefore": {
+			"description": "Attach a comment before all non-user injected code.",
+			"type": "string"
+		},
+		"code": {
+			"default": true,
+			"description": "Enable code generation",
+			"type": "boolean"
+		},
+		"comments": {
+			"default": true,
+			"description": "Output comments in generated output.",
+			"type": "boolean"
+		},
+		"compact": {
+			"default": "auto",
+			"description": "Do not include superfluous whitespace characters and line terminators. When set to \"auto\" compact is set to true on input sizes of >100KB.",
+			"type": "string"
+		},
+		"env": {
+			"default": {},
+			"description": "This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the enviroment variable BABEL_ENV is set to \"production\". If BABEL_ENV isn't set then NODE_ENV will be used, if it's not set then it defaults to \"development\"",
+			"type": "object"
+		},
+		"filename": {
+			"default": "unknown",
+			"description": "Filename for use in errors etc.",
+			"type": "string"
+		},
+		"filenameRelative": {
+			"description": "Filename relative to sourceRoot (defaults to \"filename\")",
+			"type": "string"
+		},
+		"highlightCode": {
+			"description": "ANSI highlight syntax error code frames",
+			"type": "boolean"	
+		},
+		"ignore": {
+			"description": "Opposite of the \"only\" option",
+			"type": ["array", "string"],
+			"items": {
+				"type": "string"
+			}
+		},
+		"inputSourceMap": {
+			"description": "A source map object that the output source map will be based on.",
+			"type": "object"
+		},
+		"keepModuleIdExtensions":{
+			"default": false,
+			"description": "Keep extensions in module ids",
+			"type": "boolean"
+		},
+		"moduleId": {
+			"description": "Specify a custom name for module ids.",
+			"type": "string"	
+		},
+		"moduleIds": {
+			"default": false,
+			"description": "If truthy, insert an explicit id for modules. By default, all modules are anonymous. (Not available for common modules)",
+			"type": "string"
+		},
+		"moduleRoot": {
+			"description": "Optional prefix for the AMD module formatter that will be prepend to the filename on module definitions. (defaults to \"sourceRoot\")",
+			"type": "string"
+		},
+		"only": {
+			"description": "A glob, regex, or mixed array of both, matching paths to only compile. Can also be an array of arrays containing paths to explicitly match. When attempting to compile a non-matching file it's returned verbatim.",
+			"type": ["array", "string"],
+			"items": {
+				"type": "string"
+			}
+		},
+		"plugins": {
+			"description": "List of plugins to load and use",
+			"minItems": 1,
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"presets": {
+			"description": "List of presets (a set of plugins) to load and use",
+			"minItems": 1,
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"retainLines": {
+			"default": false,
+			"description": "Retain line numbers. This will lead to wacky code but is handy for scenarios where you can't use source maps. NOTE: This will obviously not retain the columns.",
+			"type": "boolean"
+		},
+		"sourceFileName": {
+			"description": "Set sources[0] on returned source map. (defaults to \"filenameRelative\")",
+			"type": "string"
+		},
+		"sourceMaps": {
+			"default": false,
+			"description": "If truthy, adds a map property to returned output. If set to \"inline\", a comment with a sourceMappingURL directive is added to the bottom of the returned code. If set to \"both\" then a map property is returned as well as a source map comment appended.",
+			"type": ["string"],
+			"enum": ["both", "inline"]	
+		},
+		"sourceMapTarget": {
+			"description": "Set file on returned source map. (defaults to \"filenameRelative\")",
+			"type": "string"
+		},
+		"sourceRoot": {
+			"description": "The root from which all sources are relative. (defaults to \"moduleRoot\")",
+			"type": "string"		
+		}
+	}
+}


### PR DESCRIPTION
Created JSON schema based on [options, defaults, and descriptions on Babel site](http://babeljs.io/docs/usage/options/).

Though the site claims that the `.babelrc` file can support the full range of Babel options, there are a few options which are callbacks (`getModuleId`, `resolveModuleSource`, `shouldPrintComment `), so I'm not sure how these could be supported except via programmatic usage.