### PR TITLE
Remove 'id' and 'additionalProperties' members. Switch root version to enum

### DIFF
--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -1,5 +1,4 @@
 ﻿{
-  "id": "http://json.schemastore.org/sarif",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4)",
   "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4). SARIF defines a standard format for the output of static analysis tools.",
@@ -8,8 +7,7 @@
     "version": 
     {
       "description": "The SARIF tool format version of this log file. This value should be set to 0.4, currently. This is the third proposed revision of a file format that is not yet completely finalized.",
-      "type": "string",
-      "pattern": "0.4"
+      "enum": ["0.4"]
     },
 
     "runLogs": 
@@ -24,7 +22,6 @@
     }
   },
   "required": ["version", "runLogs"],
-  "additionalProperties": false,
   "definitions":
   {
     "annotatedCodeLocation": 
@@ -49,7 +46,6 @@
         }
       },
       "required": ["physicalLocation"],
-      "additionalProperties": false
     },
     "fileChange": 
     {
@@ -75,7 +71,6 @@
         }
       },
       "required": ["uri", "replacements"],
-      "additionalProperties": false
     },
     "fileReference": 
     {
@@ -101,7 +96,6 @@
         }
       },
       "required": ["uri"],
-      "additionalProperties": false
     },
     "fix": 
     {
@@ -125,7 +119,6 @@
         }
       },
       "required": ["description", "fileChanges"],
-      "additionalProperties": false
     },
     "hash": 
     {
@@ -145,7 +138,6 @@
         }
       },
       "required": ["value", "algorithm"],
-      "additionalProperties": false
     },
     "location": 
     {
@@ -195,7 +187,6 @@
         }
       },
       "required": ["analysisTarget"],
-      "additionalProperties": false
     },
     "logicalLocationComponent": 
     {
@@ -215,7 +206,6 @@
         }
       },
       "required": ["name"],
-      "additionalProperties": false
     },
     "physicalLocationComponent": 
     {
@@ -243,7 +233,6 @@
         }
       },
       "required": ["uri"],
-      "additionalProperties": false
     },
     "region": 
     {
@@ -292,7 +281,6 @@
           "minimum": 0
         }
       },
-      "additionalProperties": false
     },
     "replacement": 
     {
@@ -320,7 +308,6 @@
         }
       },
       "required": ["offset", "deletedLength", "insertedBytes"],
-      "additionalProperties": false
     },
     "result": 
     {
@@ -432,7 +419,6 @@
         }
       },
       "required": ["ruleId", "fullMessage", "locations"],
-      "additionalProperties": false
     },
     "runInfo": 
     {
@@ -456,7 +442,6 @@
           }
         }
       },
-      "additionalProperties": false
     },
     "runLog": 
     {
@@ -486,7 +471,6 @@
         }
       },
       "required": ["toolInfo", "results"],
-      "additionalProperties": false
     },
     "toolInfo": 
     {
@@ -520,7 +504,6 @@
         }
       },
       "required": ["name"],
-      "additionalProperties": false
     }
   }
 }

--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -1,4 +1,5 @@
 ﻿{
+  "id": "http://json.schemastore.org/sarif",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4)",
   "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4). SARIF defines a standard format for the output of static analysis tools.",
@@ -7,7 +8,8 @@
     "version": 
     {
       "description": "The SARIF tool format version of this log file. This value should be set to 0.4, currently. This is the third proposed revision of a file format that is not yet completely finalized.",
-      "enum": ["0.4"]
+      "type": "string",
+      "enum" : ["0.4"]
     },
 
     "runLogs": 
@@ -45,7 +47,7 @@
           "type": "string"
         }
       },
-      "required": ["physicalLocation"],
+      "required": ["physicalLocation"]
     },
     "fileChange": 
     {
@@ -70,7 +72,7 @@
           }
         }
       },
-      "required": ["uri", "replacements"],
+      "required": ["uri", "replacements"]
     },
     "fileReference": 
     {
@@ -95,7 +97,7 @@
           }
         }
       },
-      "required": ["uri"],
+      "required": ["uri"]
     },
     "fix": 
     {
@@ -118,7 +120,7 @@
           }
         }
       },
-      "required": ["description", "fileChanges"],
+      "required": ["description", "fileChanges"]
     },
     "hash": 
     {
@@ -137,7 +139,7 @@
           "enum": [ "BLAKE-256","BLAKE-512","ECOH","FSB","GOST","Groestl","HAS-160","HAVAL","JH","MD2","MD4","MD5","MD6","RadioGatun","RIPEMD","RIPEMD-128","RIPEMD-160","RIPEMD-320","SHA-1","SHA-224","SHA-256","SHA-384","SHA-512","SHA-3","Skein","Snefru","Spectral Hash","SWIFFT","Tiger","Whirlpool"]
         }
       },
-      "required": ["value", "algorithm"],
+      "required": ["value", "algorithm"]
     },
     "location": 
     {
@@ -186,7 +188,7 @@
           "type": "object"
         }
       },
-      "required": ["analysisTarget"],
+      "required": ["analysisTarget"]
     },
     "logicalLocationComponent": 
     {
@@ -205,7 +207,7 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": ["name"]
     },
     "physicalLocationComponent": 
     {
@@ -232,7 +234,7 @@
           "$ref": "#/definitions/region"
         }
       },
-      "required": ["uri"],
+      "required": ["uri"]
     },
     "region": 
     {
@@ -280,7 +282,7 @@
           "type": "integer",
           "minimum": 0
         }
-      },
+      }
     },
     "replacement": 
     {
@@ -307,7 +309,7 @@
           "type": "integer"
         }
       },
-      "required": ["offset", "deletedLength", "insertedBytes"],
+      "required": ["offset", "deletedLength", "insertedBytes"]
     },
     "result": 
     {
@@ -418,7 +420,7 @@
           "default": {}
         }
       },
-      "required": ["ruleId", "fullMessage", "locations"],
+      "required": ["ruleId", "fullMessage", "locations"]
     },
     "runInfo": 
     {
@@ -441,7 +443,7 @@
             "$ref": "#/definitions/fileReference"
           }
         }
-      },
+      }
     },
     "runLog": 
     {
@@ -470,7 +472,7 @@
           }
         }
       },
-      "required": ["toolInfo", "results"],
+      "required": ["toolInfo", "results"]
     },
     "toolInfo": 
     {
@@ -503,7 +505,7 @@
           "pattern": "[0-9]+(\\.[0-9]+){3}"
         }
       },
-      "required": ["name"],
+      "required": ["name"]
     }
   }
 }


### PR DESCRIPTION
Responding to Mads PR feedback. @madskristensen  @nguerrera @lgolding