### PR TITLE
Actually remove 'id' member. Clean up enum definition.

### DIFF
--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -1,5 +1,4 @@
 ﻿{
-  "id": "http://json.schemastore.org/sarif",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4)",
   "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4). SARIF defines a standard format for the output of static analysis tools.",
@@ -8,8 +7,7 @@
     "version": 
     {
       "description": "The SARIF tool format version of this log file. This value should be set to 0.4, currently. This is the third proposed revision of a file format that is not yet completely finalized.",
-      "type": "string",
-      "enum" : ["0.4"]
+      "enum": [ "0.4"]
     },
 
     "runLogs": 


### PR DESCRIPTION
@madskristensen @nguerrera @lgolding Neglected to actually remove 'id' member previously. 