### PR TITLE
results property no longer required on runLog.

### DIFF
--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -565,7 +565,7 @@
           }
         }
       },
-      "required": ["toolInfo", "results"]
+      "required": ["toolInfo"]
     },
     "toolInfo": 
     {


### PR DESCRIPTION
@madskristensen @lgolding @nguerrera