### PR TITLE
Adding more descriptions to project.json schema

### DIFF
--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -6,6 +6,7 @@
 
 	"definitions": {
 		"compilationOptions": {
+            "description": "Compilation options that are passed through to Roslyn.",
 			"type": "object",
 			"properties": {
 				"define": {
@@ -75,7 +76,8 @@
 					  "enum": [ "project", "package" ]
 					}
 				}
-			}
+			},
+   			"description": "The dependencies of the application. Each is defined by name and version. The runtime loaders will determine what should be loaded: NuGet package, source code, etc."
 		},
 		"script": {
 			"type": [ "string", "array" ],
@@ -88,6 +90,7 @@
 
 	"properties": {
 		"authors": {
+            "description": "The author of the application.",
 			"type": "array",
 			"items": {
 				"type": "string",
@@ -241,6 +244,7 @@
 		},
 
 		"commands": {
+            "description": "Commands that are available for this application.",
 			"type": "object",
 			"additionalProperties": {
 				"type": "string"
@@ -315,6 +319,7 @@
 			"type": "string"
 		},
 		"frameworks": {
+            "description": "Target frameworks that will be built, and dependencies that are specific to the configuration.",
 			"type": "object",
 			"additionalProperties": { "$ref": "#/definitions/configType" }
 		},

--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -6,7 +6,7 @@
 
 	"definitions": {
 		"compilationOptions": {
-      "description": "Options that are passed to the compiler.",
+			"description": "Options that are passed to the compiler.",
 			"type": "object",
 			"properties": {
 				"define": {
@@ -90,7 +90,7 @@
 
 	"properties": {
 		"authors": {
-		  "description": "The author of the application.",
+			"description": "The author of the application.",
 			"type": "array",
 			"items": {
 				"type": "string",
@@ -290,9 +290,9 @@
 			"type": "string"
 		},
 		"summary": {
-				"description": "A short description of the package.",
-				"type": "string"
-			},
+			"description": "A short description of the package.",
+			"type": "string"
+		},
 		"tags": {
 			"description": "A space-delimited list of tags and keywords that describe the package.",
 			"type": "array",

--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -6,7 +6,7 @@
 
 	"definitions": {
 		"compilationOptions": {
-            "description": "Compilation options that are passed through to Roslyn.",
+      "description": "Options that are passed to the compiler.",
 			"type": "object",
 			"properties": {
 				"define": {
@@ -77,7 +77,7 @@
 					}
 				}
 			},
-   			"description": "The dependencies of the application. Each is defined by name and version. The runtime loaders will determine what should be loaded: NuGet package, source code, etc."
+			"description": "Each dependency is defined by a name and a version. Dependencies are resolved from NuGet feeds defined by your package sources and projects located in the directories specified by the 'global.json' file."
 		},
 		"script": {
 			"type": [ "string", "array" ],
@@ -90,7 +90,7 @@
 
 	"properties": {
 		"authors": {
-            "description": "The author of the application.",
+		  "description": "The author of the application.",
 			"type": "array",
 			"items": {
 				"type": "string",
@@ -244,7 +244,6 @@
 		},
 
 		"commands": {
-            "description": "Commands that are available for this application.",
 			"type": "object",
 			"additionalProperties": {
 				"type": "string"
@@ -319,7 +318,7 @@
 			"type": "string"
 		},
 		"frameworks": {
-            "description": "Target frameworks that will be built, and dependencies that are specific to the configuration.",
+		  "description": "Target frameworks that will be built, and dependencies that are specific to the build of this project for that framework.",
 			"type": "object",
 			"additionalProperties": { "$ref": "#/definitions/configType" }
 		},


### PR DESCRIPTION
Some of the properties in the project.json schema lack a description. In VS code we use the description for hovers and in intellisense, so we're interested in having them as complete as possible.

I copied the descriptions from https://github.com/aspnet/Home/wiki/Project.json-file. If you have connections to the aspnet team, it would be great to let them have a look too if all is still accurate.
