### PR TITLE
Update jshint, add jsbeautifyrc. Insert jsbeautify in json catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -141,6 +141,12 @@
       "url": "http://json.schemastore.org/host-meta"
     },
     {
+      "name": ".jsbeautifyrc",
+      "description": "js-beautify configuration file",
+      "fileMatch": [ ".jsbeautifyrc" ],
+      "url": "http://json.schemastore.org/jsbeautifyrc"
+    },
+    {
       "name": ".jscsrc",
       "description": "JSCS configuration file",
       "fileMatch": [ ".jscsrc", "jscsrc.json" ],

--- a/src/schemas/json/jsbeautifyrc.json
+++ b/src/schemas/json/jsbeautifyrc.json
@@ -1,0 +1,164 @@
+{
+	"title": "JSON schema for jsbeautifyrc: js-beautify's configuration file",
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	
+	"type": "object",
+	
+	"properties": {
+		"indent_size": {
+			"description": "Indent size. [JS,CSS,HTML]",
+			"type": "integer",
+			"default": 4
+		},
+		"indent_char": {
+			"description": "Indentation character. [JS,CSS,HTML]",
+			"type": "string",
+			"default": " ",
+			"maxLength": 1
+		},
+		"indent_with_tabs": {
+			"description": "Indent with tabs, overrides 'indent_size' and 'indent_char' [JS,CSS,HTML]",
+			"type": "boolean",
+			"default": false
+		},
+		"eol": {
+			"description": "Character(s) to use as line terminators. [JS,CSS,HTML]",
+			"type": "string",
+			"default": "\\n"
+		},
+		"preserve_newlines": {
+			"description": "Preserve line-breaks. [JS,HTML]",
+			"type": "boolean",
+			"default": true
+		},
+		"max_preserve_newlines": {
+			"description": "Number of line-breaks to be preserved in one chunk. [JS,HTML]",
+			"type": "integer",
+			"default": 10
+		},
+		"indent_level": {
+			"description": "Initial indentation level. [JS]",
+			"type": "integer",
+			"default": 0
+		},
+		"space_in_paren": {
+			"description": "Add padding spaces within parentheses, ie. f( a, b ). [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"jslint_happy": {
+			"description": "Enable jslint-stricter mode. (Forces 'space_after_anon_function') [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"space_after_anon_function": {
+			"description": "Add a space before an anonymous function's parens, ie. function (). [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"brace_style": {
+			"description": "[collapse|expand|end-expand|none] [JS,HTML]",
+			"type": "string",
+			"default": "collapse",
+			"enum": [
+				"collapse", "expand", "end-expand", "none"
+			]
+		},
+		"break_chained_methods": {
+			"description": "Break chained method calls across subsequent lines. [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"keep_array_indentation": {
+			"description": "Preserve array indentation. [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"keep_function_indentation": {
+			"description": "Preserve function indentation. [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"space_before_conditional": {
+			"description": "Ensure a space before conditional statement. [JS]",
+			"type": "boolean",
+			"default": true
+		},
+		"unescape_strings": {
+			"description": "Decode printable characters encoded in xNN notation. [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"wrap_line_length": {
+			"description": "Wrap lines at next opportunity after N characters. [JS,HTML]",
+			"type": "integer",
+			"default": 0
+		},
+		"wrap_attributes": {
+			"description": "Wrap attributes to new lines. [HTML]",
+			"type": "string",
+			"default": "auto",
+			"enum": [
+			"auto", "force"
+		]
+		},
+		"wrap_attributes_indent_size": {
+			"description": "Indent wrapped attributes to after N characters. Defaults to 'indent_size'. [HTML]",
+			"type": "number"
+		},
+		"end_with_newline": {
+			"description": "Ensure newline at end of file. [JS,HTML]",
+			"type": "boolean",
+			"default": false
+		},
+		"indent_inner_html": {
+			"description": "Indent <head> and <body> sections. [HTML]",
+			"type": "boolean",
+			"default": false
+		},
+		"indent_scripts": {
+			"description": "[keep|separate|normal] [HTML]",
+			"type": "string",
+			"default": "normal",
+			"enum": [
+			"keep", "separate", "normal"
+		]
+		},
+		"unformatted": {
+			"description": "List of tags that should not be reformatted. [HTML]",
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"default": ["inline"]
+		},
+		"extra_liners": {
+			"description": "List of tags that should have an extra newline before them. [HTML]",
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"default": ["head", "body", "/html"]
+		},
+		"comma_first": {
+			"description": "Put commas at the beginning of new line instead of end. [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"e4x": {
+			"description": "Pass E4X xml literals through untouched. [JS]",
+			"type": "boolean",
+			"default": false
+		},
+		"newline_between_rules": {
+			"description": "Add a newline between CSS rules. [CSS]",
+			"type": "boolean",
+			"default": false
+		},
+		"selector_separator_newline": {
+			"description": "Add a newline between multiple selectors. [CSS]",
+			"type": "boolean",
+			"default": true
+		}
+	}
+}

--- a/src/schemas/json/jshintrc.json
+++ b/src/schemas/json/jshintrc.json
@@ -5,256 +5,325 @@
 	"type": "object",
 
 	"properties": {
-		"maxerr": {
-			"description": "Maximum error before stopping",
-			"type": "integer"
-		},
 		"bitwise": {
-			"description": "Prohibit bitwise operators (&, |, ^, etc.)",
-			"type": "boolean"
-		},
-		"camelcase": {
-			"description": "Identifiers must be in camelCase",
-			"type": "boolean"
+			"description": "Prohibit the use of bitwise operators (&, |, ^, etc.)",
+			"type": "boolean",
+			"default": false
 		},
 		"curly": {
-			"description": "Require {} for every new block or scope",
-			"type": "boolean"
+			"description": "Requires you to always put curly braces around blocks in loops and conditionals",
+			"type": "boolean",
+			"default": false
 		},
 		"eqeqeq": {
-			"description": "Require triple equals (===) for comparison",
-			"type": "boolean"
+			"description": "Prohibits the use of `==` and `!=` in favor of `===` and `!==`",
+			"type": "boolean",
+			"default": false
+		},
+		"esversion": {
+			"description": "The ECMAScript version to which the code must adhere",
+			"type": "integer",
+			"default": 5,
+			"enum": [3, 5, 6]
 		},
 		"forin": {
-			"description": "Require filtering for..in loops with obj.hasOwnProperty()",
-			"type": "boolean"
+			"description": "Requires all `for in` loops to filter object's items with obj.hasOwnProperty()",
+			"type": "boolean",
+			"default": false
 		},
-		"immed": {
-			"description": "Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`",
-			"type": "boolean"
+		"freeze": {
+			"description": "Prohibits overwriting prototypes of native objects such as Array, Date and so on",
+			"type": "boolean",
+			"default": false
 		},
-		"indent": {
-			"description": "Number of spaces to use for indentation",
-			"type": [ "boolean", "integer" ]
+		"funcscope": {
+			"description": "Suppresses warnings about declaring variables inside of control structures while accessing them later from the outside",
+			"type": "boolean",
+			"default": false
+		},
+		"futurehostile": {
+			"description": "Enables warnings about the use of identifiers which are defined in future versions of JavaScript",
+			"type": "boolean",
+			"default": false
+		},
+		"iterator": {
+			"description": "Suppresses warnings about the __iterator__ property.",
+			"type": "boolean",
+			"default": false
 		},
 		"latedef": {
-			"description": "Require variables/functions to be defined before being used",
-			"type": "boolean"
-		},
-		"newcap": {
-			"description": "Require capitalization of all constructor functions e.g. `new F()`",
-			"type": "boolean"
-		},
-		"noarg": {
-			"description": "Prohibit use of `arguments.caller` and `arguments.callee`",
-			"type": "boolean"
-		},
-		"noempty": {
-			"description": "Prohibit use of empty blocks",
-			"type": "boolean"
-		},
-		"nonew": {
-			"description": "Prohibit use of constructors for side-effects (without assignment)",
-			"type": "boolean"
-		},
-		"plusplus": {
-			"description": "Prohibit use of `++` & `--`",
-			"type": "boolean"
-		},
-		"quotmark": {
-			"description": "Quotation mark consistency",
-			"type": [ "boolean", "string" ],
-			"enum": [ true, false, "single", "double" ]
-		},
-		"undef": {
-			"description": "Require all non-global variables to be declared (prevents global leaks)",
-			"type": "boolean"
-		},
-		"unused": {
-			"description": "This option warns when you define and never use your variables. It is very useful for general code cleanup, especially when used in addition to 'undef'.",
-			"enum": [ true, false, "vars", "strict" ]
-		},
-		"strict": {
-			"description": "Requires all functions run in ES5 Strict Mode",
-			"type": "boolean"
-		},
-		"trailing": {
-			"description": "Prohibit trailing whitespaces",
-			"type": "boolean"
-		},
-		"maxparams": {
-			"description": "Max number of formal params allowed per function",
-			"type": [ "boolean", "integer" ]
-		},
-		"maxdepth": {
-			"description": "Max depth of nested blocks (within functions)",
-			"type": [ "boolean", "integer" ]
-		},
-		"maxstatements": {
-			"description": "Max number statements per function",
-			"type": [ "boolean", "integer" ]
+			"description": "Prohibits the use of a variable before it was defined",
+			"type": "boolean",
+			"default": false
 		},
 		"maxcomplexity": {
 			"description": "Max cyclomatic complexity per function",
-			"type": [ "boolean", "integer" ]
+			"type": ["boolean", "integer"],
+			"default": false
 		},
-		"maxlen": {
-			"description": "Max number of characters per line",
-			"type": [ "boolean", "integer" ]
+		"maxdepth": {
+			"description": "Max depth of nested blocks",
+			"type": ["boolean", "integer"],
+			"default": false
+		},
+		"maxerr": {
+			"description": "Maximum amount of warnings JSHint will produce before giving up",
+			"type": "integer",
+			"default": 50
+		},
+		"maxparams": {
+			"description": "Max number of formal parameters allowed per function",
+			"type": ["boolean", "integer"]
+		},
+		"maxstatements": {
+			"description": "Max number statements per function",
+			"type": ["boolean", "integer"],
+			"default": false
+		},
+		"noarg": {
+			"description": "Prohibits the use of `arguments.caller` and `arguments.callee`",
+			"type": "boolean",
+			"default": false
+		},
+		"nocomma": {
+			"description": "Prohibits the use of the comma operator",
+			"type": "boolean",
+			"default": false
+		},
+		"nonbsp": {
+			"description": "Warns about `non-breaking whitespace` characters",
+			"type": "boolean",
+			"default": false
+		},
+		"nonew": {
+			"description": "Prohibits the use of constructors for side-effects (without assignment)",
+			"type": "boolean",
+			"default": false
+		},
+		"notypeof": {
+			"description": "Suppresses warnings about invalid `typeof`operator values",
+			"type": "boolean",
+			"default": false
+		},
+		"shadow": {
+			"description": "Suppresses warnings about variable shadowing. i.e. declaring a variable that had been already declared somewhere in the outer scope",
+			"type": ["boolean", "string"],
+			"default": false,
+			"enum": [true, false, "inner", "outer"]
+		},
+		"singleGroups": {
+			"description": "Prohibits the use of the grouping operator when it is not strictly required.",
+			"type": "boolean",
+			"default": false
+		},
+		"strict": {
+			"description": "Requires all code to run in ES5 strict mode",
+			"type": ["boolean", "string"],
+			"default": false,
+			"enum": [true, false, "implied", "global", "func"]
+		},
+		"undef": {
+			"description": "Prohibits the use of explicitly undeclared variables",
+			"type": "boolean",
+			"default": false
+		},
+		"unused": {
+			"description": "Warns when you define and never use your variables",
+			"type": ["boolean", "string"],
+			"default": false,
+			"enum": [true, false, "vars", "strict"]
+		},
+		"varstmt": {
+			"description": "Forbids the use of VariableStatements (`var`) in favor of `let` and `const`",
+			"type": "boolean",
+			"default": false
 		},
 
 		"asi": {
-			"description": "Tolerate Automatic Semicolon Insertion (no semicolons)",
-			"type": "boolean"
+			"description": "Suppresses warnings about missing semicolons",
+			"type": "boolean",
+			"default": false
 		},
 		"boss": {
-			"description": "Tolerate assignments where comparisons would be expected",
-			"type": "boolean"
+			"description": "Suppresses warnings about the use of assignments in cases where comparisons are expected",
+			"type": "boolean",
+			"default": false
 		},
 		"debug": {
-			"description": "Allow debugger statements e.g. browser breakpoints",
-			"type": "boolean"
+			"description": "Suppresses warnings about the `debugger` statements in your code",
+			"type": "boolean",
+			"default": false
+		},
+		"elision": {
+			"description": "Tells JSHint that your code uses ES3 array elision elements, or empty elements",
+			"type": "boolean",
+			"default": false
 		},
 		"eqnull": {
-			"description": "Tolerate use of `== null`",
-			"type": "boolean"
-		},
-		"es5": {
-			"description": "Allow ES5 syntax (ex: getters and setters)",
-			"type": "boolean"
-		},
-		"esnext": {
-			"description": "Allow ES.next (ES6) syntax (ex: `const`)",
-			"type": "boolean"
-		},
-		"moz": {
-			"description": "Allow Mozilla specific syntax (extends and overrides esnext features)",
-			"type": "boolean"
+			"description": "Suppresses warnings about `== null` comparisons",
+			"type": "boolean",
+			"default": false
 		},
 		"evil": {
-			"description": "Tolerate use of `eval` and `new Function()`",
-			"type": "boolean"
+			"description": "Suppresses warnings about the use of `eval`",
+			"type": "boolean",
+			"default": false
 		},
 		"expr": {
-			"description": "Tolerate `ExpressionStatement` as Programs",
-			"type": "boolean"
-		},
-		"funcscope": {
-			"description": "Tolerate defining variables inside control statements",
-			"type": "boolean"
-		},
-		"globalstrict": {
-			"description": "Allow global 'use strict' (also enables 'strict')",
-			"type": "boolean"
-		},
-		"iterator": {
-			"description": "Tolerate using the `__iterator__` property",
-			"type": "boolean"
+			"description": "Suppresses warnings about the use of expressions where normally you would expect to see assignments or function calls",
+			"type": "boolean",
+			"default": false
 		},
 		"lastsemic": {
-			"description": "Tolerate omitting a semicolon for the last statement of a 1-line block",
-			"type": "boolean"
-		},
-		"laxbreak": {
-			"description": "Tolerate possibly unsafe line breakings",
-			"type": "boolean"
-		},
-		"laxcomma": {
-			"description": "Tolerate comma-first style coding",
-			"type": "boolean"
+			"description": "Suppresses warnings about missing semicolons, but only when the semicolon is omitted for the last statement in a one-line block",
+			"type": "boolean",
+			"default": false
 		},
 		"loopfunc": {
-			"description": "Tolerate functions being defined in loops",
-			"type": "boolean"
+			"description": "Suppresses warnings about functions inside of loops",
+			"type": "boolean",
+			"default": false
 		},
-		"multistr": {
-			"description": "Tolerate multi-line strings",
-			"type": "boolean"
+		"moz": {
+			"description": "Tells JSHint that your code uses Mozilla JavaScript extensions",
+			"type": "boolean",
+			"default": false
+		},
+		"noyield": {
+			"description": "Suppresses warnings about generator functions with no `yield` statement in them",
+			"type": "boolean",
+			"default": false
+		},
+		"plusplus": {
+			"description": "Prohibits the use of `++` and `--`",
+			"type": "boolean",
+			"default": false
 		},
 		"proto": {
-			"description": "Tolerate using the `__proto__` property",
-			"type": "boolean"
+			"description": "Suppresses warnings about the `__proto__` property",
+			"type": "boolean",
+			"default": false
 		},
 		"scripturl": {
-			"description": "Tolerate script-targeted URLs",
-			"type": "boolean"
-		},
-		"smarttabs": {
-			"description": "Tolerate mixed tabs/spaces when used for alignment",
-			"type": "boolean"
-		},
-		"shadow": {
-			"description": "Allows re-define variables later in code e.g. `var x=1; x=2;`",
-			"type": "boolean"
-		},
-		"sub": {
-			"description": "Tolerate using `[]` notation when it can still be expressed in dot notation",
-			"type": "boolean"
+			"description": "Suppresses warnings about the use of script-targeted URLs",
+			"type": "boolean",
+			"default": false
 		},
 		"supernew": {
-			"description": "Tolerate `new function () { ... };` and `new Object;`",
-			"type": "boolean"
+			"description": "Suppresses warnings about constructions like `new function () { ... };` and `new Object;`",
+			"type": "boolean",
+			"default": false
 		},
 		"validthis": {
-			"description": "Tolerate using this in a non-constructor function",
-			"type": "boolean"
+			"description": "Suppresses warnings about possible strict violations when the code is running in strict mode and you use `this` in a non-constructor function",
+			"type": "boolean",
+			"default": false
+		},
+		"withstmt": {
+			"description": "Suppresses warnings about the use of the `with` statement",
+			"type": "boolean",
+			"default": false
 		},
 		"browser": {
-			"description": "Web Browser (window, document, etc)",
-			"type": "boolean"
+			"description": "[Environment] Web Browser (window, document, etc)",
+			"type": "boolean",
+			"default": false
 		},
 		"couch": {
-			"description": "CouchDB",
-			"type": "boolean"
+			"description": "[Environment] CouchDB",
+			"type": "boolean",
+			"default": false
 		},
 		"devel": {
-			"description": "Development/debugging (alert, confirm, etc)",
-			"type": "boolean"
+			"description": "[Environment] Development/debugging (alert, confirm, etc)",
+			"type": "boolean",
+			"default": false
 		},
 		"dojo": {
-			"description": "Dojo Toolkit",
-			"type": "boolean"
+			"description": "[Environment] Dojo Toolkit",
+			"type": "boolean",
+			"default": false
+		},
+		"jasmine": {
+			"description": "[Environment] Jasmine unit testing framework",
+			"type": "boolean",
+			"default": false
 		},
 		"jquery": {
-			"description": "jQuery",
-			"type": "boolean"
+			"description": "[Environment] jQuery",
+			"type": "boolean",
+			"default": false
+		},
+		"mocha": {
+			"description": "[Environment] Mocha unit testing framework",
+			"type": "boolean",
+			"default": false
+		},
+		"module": {
+			"description": "[Environment] ES6 module",
+			"type": "boolean",
+			"default": false
 		},
 		"mootools": {
-			"description": "MooTools",
-			"type": "boolean"
+			"description": "[Environment] MooTools",
+			"type": "boolean",
+			"default": false
 		},
 		"node": {
-			"description": "Node.js",
-			"type": "boolean"
+			"description": "[Environment] Node.js",
+			"type": "boolean",
+			"default": false
 		},
 		"nonstandard": {
-			"description": "Widely adopted globals (escape, unescape, etc)",
-			"type": "boolean"
+			"description": "[Environment] Widely adopted globals (escape, unescape, etc)",
+			"type": "boolean",
+			"default": false
+		},
+		"phantom": {
+			"description": "[Environment] PhantomJS runtime environment",
+			"type": "boolean",
+			"default": false
 		},
 		"prototypejs": {
-			"description": "Prototype and Scriptaculous",
-			"type": "boolean"
+			"description": "[Environment] Prototype JavaScript framework",
+			"type": "boolean",
+			"default": false
 		},
 		"rhino": {
-			"description": "Rhino",
-			"type": "boolean"
+			"description": "[Environment] Rhino",
+			"type": "boolean",
+			"default": false
+		},
+		"shelljs": {
+			"description": "[Environment] Defines globals exposed by the ShellJS library",
+			"type": "boolean",
+			"default": false
+		},
+		"typed": {
+			"description": "[Environment] Defines globals for typed array constructors",
+			"type": "boolean",
+			"default": false
 		},
 		"worker": {
-			"description": "Web Workers",
-			"type": "boolean"
+			"description": "[Environment] Web Workers",
+			"type": "boolean",
+			"default": false
 		},
 		"wsh": {
-			"description": "Windows Scripting Host",
-			"type": "boolean"
+			"description": "[Environment] Windows Scripting Host",
+			"type": "boolean",
+			"default": false
 		},
 		"yui": {
-			"description": "Yahoo User Interface",
-			"type": "boolean"
+			"description": "[Environment] Yahoo User Interface",
+			"type": "boolean",
+			"default": false
 		},
 		"globals": {
-			"description": "additional predefined global variables",
+			"description": "Specify a white list of global variables that are not formally defined in the source code",
 			"type": "object",
 			"additionalProperties": {
+				"description": "Name of the global. Set to `true` for read/write, `false` for read-only.",
 				"type": "boolean"
 			}
 		}


### PR DESCRIPTION
`jshintrc.json` updated to match current options listed at [JSHint Options](http://jshint.com/docs/options/) reference page.

`jsbeautifyrc.json` added. See [JS-Beauitify](https://github.com/beautify-web/js-beautify) on GitHub for options reference.

Updated `catalog.json` with js-beautify schema.