### PR TITLE
fullMessage no longer required

### DIFF
--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -467,7 +467,7 @@
           "default": {}
         }
       },
-      "required": ["ruleId", "fullMessage", "locations"]
+      "required": ["ruleId", "locations"]
     },
     "ruleDescriptor": 
     {


### PR DESCRIPTION
@lgolding @madskristensen 

Also provides correct byteOffset and charOffset member. Adds missing helpUri member.