### PR TITLE
Add .bowerrc schema support for resolvers and shallowCloneHosts

### DIFF
--- a/src/schemas/json/bowerrc.json
+++ b/src/schemas/json/bowerrc.json
@@ -97,6 +97,14 @@
 		"interactive": {
 			"type": "boolean",
 			"description": "Makes bower interactive, prompting whenever necessary"
-		}
+		},
+    "resolvers": {
+      "type": "array",
+      "description": "Identifies pluggable resolvers to be used for locating and fetching packages" 
+    },
+    "shallowCloneHosts": {
+      "type": "array",
+      "description": "Whitelists hosts which are known to support shallow cloning"
+    }
 	}
 }


### PR DESCRIPTION
As documented [here](https://github.com/bower/spec/blob/master/config.md#resolvers), the `.bowerrc` file supports the following 2 properties which aren't yet supported in this project's schema:

1. resolvers
2. shallowCloneHosts

This PR adds support for both properties as array types.