### PR TITLE
Correct spelling mistake in .bowerrc timeout description

### DIFF
--- a/src/schemas/json/bowerrc.json
+++ b/src/schemas/json/bowerrc.json
@@ -56,7 +56,7 @@
 		},
 		"timeout": {
 			"type": "number",
-			"description": "he timeout to be used when making requests in milliseconds.",
+			"description": "The timeout to be used when making requests in milliseconds.",
 			"default": 60000
 		},
 		"strict-ssl": {


### PR DESCRIPTION
The schema for the `.bowerrc` file has a minor spelling mistake in the description for the `timeout` property.