### PR TITLE
Define array types for resolvers and shallowCloneHosts

### DIFF
--- a/src/schemas/json/bowerrc.json
+++ b/src/schemas/json/bowerrc.json
@@ -100,11 +100,17 @@
 		},
     "resolvers": {
       "type": "array",
-      "description": "Identifies pluggable resolvers to be used for locating and fetching packages" 
+      "description": "Identifies pluggable resolvers to be used for locating and fetching packages",
+      "items": {
+        "type": "string"
+      } 
     },
     "shallowCloneHosts": {
       "type": "array",
-      "description": "Whitelists hosts which are known to support shallow cloning"
+      "description": "Whitelists hosts which are known to support shallow cloning",
+      "items": {
+        "type": "string"
+      }
     }
 	}
 }


### PR DESCRIPTION
This PR expands upon the changes made to the `.bowerrc` schema in PR https://github.com/SchemaStore/schemastore/pull/75. Specifically, it's made clear that the arrays expected by `resolvers` and `shallowCloneHosts` are of type string. 