### PR TITLE
Enforce max length of description in bower.json

### DIFF
--- a/src/schemas/json/bower.json
+++ b/src/schemas/json/bower.json
@@ -22,7 +22,8 @@
 		},
 		"description": {
 			"description": "Help users identify and search for your package with a brief description.",
-			"type": "string"
+			"type": "string",
+      "maxLength": 140
 		},
 		"version": {
 			"description": "A semantic version number.",


### PR DESCRIPTION
Per the `bower.json` file's [`description` property spec](https://github.com/bower/spec/blob/master/json.md#description), the maximum number of characters is 140. This PR updates the schema to enforce that rule. 