### PR TITLE
Add target values as specified in TypeScript documentation

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -140,7 +140,7 @@
             },
             "target": {
               "description": "Specify ECMAScript target version.",
-              "enum": [ "es3", "es5", "es6", "es2015" ],
+              "enum": [ "es3", "es5", "es6", "es2015", "ES3", "ES5", "ES6" ],
               "default": "es5"
             },
             "watch": {


### PR DESCRIPTION
see issue #79.
This is a pragmatic fix so that at least the values named in the [TypeScript documentation](https://github.com/Microsoft/TypeScript/wiki/Compiler-Options) are in the value set of `target`
