### PR TITLE
Define length constraints for package.json name property

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -41,7 +41,9 @@
       "properties": {
         "name": {
           "description": "The name of the package.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 214,
+          "minLength": 1
         },
         "version": {
           "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency.",


### PR DESCRIPTION
Per the npm `package.json` file's `name` property validation rules [here](https://github.com/npm/validate-npm-package-name#naming), the property value must be > 0 and <= 214 characters. This PR introduces `minLength` and `maxLength` constraints to enforce that.   