### PR TITLE
Provide array type for package.json keywords property

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -55,7 +55,10 @@
         },
         "keywords": {
           "description": "This helps people discover your package as it's listed in 'npm search'.",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "homepage": {
           "description": "The url to the project homepage.",


### PR DESCRIPTION
The `keywords` property in `package.json` expects an array of strings. This PR defines the array type, per the spec [here](https://docs.npmjs.com/files/package.json#keywords).