### PR TITLE
Add JSON schema for .jsinspectrc

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -159,6 +159,12 @@
       "url": "http://json.schemastore.org/jshintrc"
     },
     {
+      "name": ".jsinspectrc",
+      "description": "JSInspect configuration file",
+      "fileMatch": [ ".jsinspectrc" ],
+      "url": "http://json.schemastore.org/jsinspectrc"
+    },
+    {
       "name": "*.jsonld",
       "description": "JSON Linked Data files",
       "fileMatch": [ "*.jsonld" ],

--- a/src/schemas/json/jsinspectrc.json
+++ b/src/schemas/json/jsinspectrc.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON schema for JSInspect configuration files",
+  "type": "object",
+  "properties": {
+    "identifiers": {
+      "default": false,
+      "description": "A flag indicating whether to limit the search to nodes with matching identifiers",
+      "type": "boolean"
+    },
+    "ignore": {
+      "description": "A regular expression used for matching paths to ignore",
+      "type": "string"
+    },
+    "jsx": {
+      "default": false,
+      "description": "A flag indicating whether to process JSX files",
+      "type": "boolean"
+    },
+    "reporter": {
+      "default": "default",
+      "description": "The name of the reporter to be used",
+      "enum": [ "default", "json", "pmd" ],
+      "type": "string"
+    },
+    "suppress": {
+      "default": 100,
+      "description": "The number of lines at which diffs should be suppressed. A value of 0 is off.",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "threshold": {
+      "default": 15,
+      "description": "A threshold determining the smallest subset of nodes to analyze",
+      "type": "integer"
+    }
+  } 
+}


### PR DESCRIPTION
This PR adds a JSON schema for the [JSInspect](https://github.com/danielstjules/jsinspect) tool's configuration file (`.jsinspectrc`). This is a popular JavaScript analysis tool for detecting code smells such as duplicated code.