### PR TITLE
Add test for .jsinspectrc schema

### DIFF
--- a/src/test/jsinspectrc/jsinspectrc-test.json
+++ b/src/test/jsinspectrc/jsinspectrc-test.json
@@ -1,0 +1,8 @@
+﻿{
+  "$schema": "http://json.schemastore.org/jsinspectrc",
+  "identifiers": true,
+  "ignore": "tests",
+  "reporter": "default",
+  "suppress": 100,
+  "threshold": 30
+}


### PR DESCRIPTION
This PR adds a test to go along with the `.jsinspectrc` JSON schema which was added in PR https://github.com/SchemaStore/schemastore/pull/83.