### PR TITLE
Define missing property formats in package.json schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -62,7 +62,8 @@
         },
         "homepage": {
           "description": "The url to the project homepage.",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         },
         "bugs": {
           "description": "The url to your project's issue tracker and / or the email address to which issues should be reported. These are helpful for people who encounter issues with your package.",
@@ -75,7 +76,8 @@
             },
             "email": {
               "type": "string",
-              "description": "The email address to which issues should be reported."
+              "description": "The email address to which issues should be reported.",
+              "format": "email"
             }
           }
         },
@@ -176,7 +178,8 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           }
         },


### PR DESCRIPTION
This PR explicitly defines the expected formats for 3 properties in `package.json`.