### PR TITLE
Add schema for Webpack bootstrap-loader config file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10,6 +10,12 @@
       "url": "http://json.schemastore.org/babelrc"
     },
     {
+      "name": ".bootstraprc",
+      "description": "Webpack bootstrap-loader configuration file",
+      "fileMatch": [ ".bootstraprc" ],
+      "url": "http://json.schemastore.org/bootstraprc"
+    },
+    {
       "name": "bower.json",
       "description": "Bower package description file",
       "fileMatch": [ "bower.json", ".bower.json" ],

--- a/src/schemas/json/bootstraprc.json
+++ b/src/schemas/json/bootstraprc.json
@@ -1,0 +1,83 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON schema for Webpack's bootstrap-loader configuration file",
+  "type": "object",
+
+  "definitions": {
+    "extractStyling": {
+      "properties": {
+        "extractStyles": {
+          "default": false,
+          "description": "Enables/disables extraction of styles to a standalone CSS file using extract-text-webpack-plugin",
+          "type": "boolean"
+        }
+      }
+    }
+  },
+
+  "properties": {
+    "appStyles": {
+      "description": "Import your custom styles here. Usually this endpoint file contains a list of @imports of your application styles.",
+      "type": "string"
+    },
+    "bootstrapCustomizations": {
+      "description": "The .scss file path to be loaded after Bootstrap's _variables.scss file",
+      "type": "string"
+    },
+    "bootstrapVersion": {
+      "default": 3,
+      "description": "The major version of Bootstrap being used",
+      "enum": [ 3, 4 ],
+      "type": "integer"
+    },
+    "env": {
+      "description": "Sets the extractStyles property based on the value of NODE_ENV",
+      "type": "object",
+      "properties": {
+        "development": {
+          "$ref": "#/definitions/extractStyling"
+        },
+        "production": {
+          "$ref": "#/definitions/extractStyling"
+        }
+      }
+    },
+    "extractStyles": {
+      "$ref": "#/definitions/extractStyling"
+    },
+    "loglevel": {
+      "description": "The verbosity of logging. Exclude this property to disable.",
+      "enum": [ "debug" ],
+      "type": "string"
+    },
+    "preBootstrapCustomizations": {
+      "description": "The .scss file path to be loaded before Bootstrap's _variables.scss file",
+      "type": "string"
+    },
+    "scripts": {
+      "description": "Excludes/includes Bootstrap's JavaScript modules",
+      "type": [ "boolean", "object" ]
+    },
+    "styleLoaders": {
+      "default": [ "style", "css", "sass" ],
+      "description": "An array of Webpack loader names. Order matters, and sass-loader is required.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "styles": {
+      "description": "Excludes/includes Bootstrap's CSS modules",
+      "type": [ "boolean", "object" ]
+    },
+    "useFlexbox": {
+      "default": true,
+      "description": "Enables/disables the flexbox model available in Bootstrap 4",
+      "type": "boolean"
+    }
+  },
+
+  "required": [ "bootstrapVersion", "styleLoaders" ]
+}

--- a/src/test/bootstraprc/bootstraprc-test.json
+++ b/src/test/bootstraprc/bootstraprc-test.json
@@ -1,0 +1,54 @@
+﻿{
+  "$schema": "http://json.schemastore.org/bootstraprc",
+  "bootstrapVersion": 3,
+  "styleLoaders": [ "style", "css", "sass" ],
+  "env": {
+    "development": {
+      "extractStyles": false
+    },
+    "production": {
+      "extractStyles": true
+    }
+  },
+  "styles": {
+    "mixins": true,
+    "normalize": true,
+    "print": true,
+    "glyphicons": true,
+    "scaffolding": true,
+    "type": true,
+    "code": true,
+    "grid": true,
+    "tables": true,
+    "forms": true,
+    "buttons": true,
+    "component-animations": false,
+    "dropdowns": true,
+    "button-groups": false,
+    "input-groups": false,
+    "navs": true,
+    "navbar": true,
+    "breadcrumbs": false,
+    "pagination": false,
+    "pager": true,
+    "labels": true,
+    "badges": false,
+    "jumbotron": false,
+    "thumbnails": false,
+    "alerts": false,
+    "progress-bars": true,
+    "media": false,
+    "list-group": true,
+    "panels": true,
+    "wells": true,
+    "responsive-embed": false,
+    "close": true,
+    "modals": false,
+    "tooltip": false,
+    "popovers": false,
+    "carousel": false,
+    "utilities": true,
+    "responsive-utilities": false
+  },
+  "scripts": false
+}

--- a/src/test/bootstraprc/bootstraprc-test2.json
+++ b/src/test/bootstraprc/bootstraprc-test2.json
@@ -1,0 +1,9 @@
+﻿{
+  "$schema": "http://json.schemastore.org/bootstraprc",
+  "loglevel": "debug",
+  "bootstrapVersion": 3,
+  "styleLoaders": [ "style", "css", "sass" ],
+  "extractStyles": false,
+  "styles": true,
+  "scripts": true
+}

--- a/src/test/bootstraprc/bootstraprc-test3.json
+++ b/src/test/bootstraprc/bootstraprc-test3.json
@@ -1,0 +1,9 @@
+﻿{
+  "$schema": "http://json.schemastore.org/bootstraprc",
+  "bootstrapVersion": 4,
+  "styleLoaders": [ "style", "css", "sass" ],
+  "extractStyles": false,
+  "useFlexbox": true,
+  "styles": true,
+  "scripts": true
+}


### PR DESCRIPTION
This PR adds a JSON schema and some tests for the Webpack [bootstrap-loader](https://www.npmjs.com/package/bootstrap-loader) configuration file (`.bootstraprc`). This loader is needed when using the Sass Bootstrap npm module with Webpack.