### PR TITLE
Add url property to project.json' repository object

### DIFF
--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -329,11 +329,15 @@
 			"type": "object",
 			"description": "Contains information about the repository where the project is stored.",
 			"properties": {
-				"type": {
-					"type": "string",
-					"enum": [ "git" ],
-					"default": "git"
-				}
+        "type": {
+          "type": "string",
+          "enum": [ "git" ],
+          "default": "git"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
 			},
 			"additionalProperties": {
 				"type": "string"


### PR DESCRIPTION
Per the `project.json` file [here](https://github.com/aspnet/Hosting/blob/dev/src/Microsoft.AspNet.TestHost/project.json), a `url` property is allowed in the `repository` object of `project.json`. This PR adds the JSON schema definition for that `url` property.