### PR TITLE
Define uri format in bower.json properties

### DIFF
--- a/src/schemas/json/bower.json
+++ b/src/schemas/json/bower.json
@@ -59,7 +59,8 @@
 		},
 		"homepage": {
 			"description": "URL to learn more about the package. Falls back to GitHub project if not specified and it's a GitHub endpoint.",
-			"type": "string"
+      "type": "string",
+      "format": "uri"
 		},
 		"repository": {
 			"description": "The repository in which the source code can be found.",
@@ -70,7 +71,8 @@
 					"enum": [ "git" ]
 				},
 				"url": {
-					"type": "string"
+          "type": "string",
+          "format": "uri"
 				}
 			}
 		},


### PR DESCRIPTION
The `homepage` and `repository.url` properties of `bower.json` expect a format of `uri`. This PR updates the schema to include the expected format.