### PR TITLE
Add descriptions and missing properties to .eslintrc env

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -271,27 +271,102 @@
       "type": "object",
 
       "properties": {
-        "amd": { "type": "boolean" },
-        "applescript": { "type": "boolean" },
-        "browser": { "type": "boolean" },
-        "commonjs": { "type": "boolean" },
-        "embertest": { "type": "boolean" },
-        "es6": { "type": "boolean" },
-        "jasmine": { "type": "boolean" },
-        "jest": { "type": "boolean" },
-        "jquery": { "type": "boolean" },
-        "meteor": { "type": "boolean" },
-        "mocha": { "type": "boolean" },
-        "mongo": { "type": "boolean" },
-        "nashorn": { "type": "boolean" },
-        "node": { "type": "boolean" },
-        "phantomjs": { "type": "boolean" },
-        "prototypejs": { "type": "boolean" },
-        "protractor": { "type": "boolean" },
-        "qunit": { "type": "boolean" },
-        "serviceworker": { "type": "boolean" },
-        "shelljs": { "type": "boolean" },
-        "worker": { "type": "boolean" }
+        "amd": {
+          "type": "boolean",
+          "description": "defines require() and define() as global variables as per the amd spec"
+        },
+        "applescript": {
+          "type": "boolean",
+          "description": "AppleScript global variables"
+        },
+        "atomtest": {
+          "type": "boolean",
+          "description": "Atom test helper globals"
+        },
+        "browser": {
+          "type": "boolean",
+          "description": "browser global variables"
+        },
+        "commonjs": {
+          "type": "boolean",
+          "description": "CommonJS global variables and CommonJS scoping (use this for browser-only code that uses Browserify/WebPack)"
+        },
+        "embertest": {
+          "type": "boolean",
+          "description": "Ember test helper globals"
+        },
+        "es6": {
+          "type": "boolean",
+          "description": "enable all ECMAScript 6 features except for modules"
+        },
+        "greasemonkey": {
+          "type": "boolean",
+          "description": "GreaseMonkey globals"
+        },
+        "jasmine": {
+          "type": "boolean",
+          "description": "adds all of the Jasmine testing global variables for version 1.3 and 2.0"
+        },
+        "jest": {
+          "type": "boolean",
+          "description": "Jest global variables"
+        },
+        "jquery": {
+          "type": "boolean",
+          "description": "jQuery global variables"
+        },
+        "meteor": {
+          "type": "boolean",
+          "description": "Meteor global variables"
+        },
+        "mocha": {
+          "type": "boolean",
+          "description": "adds all of the Mocha test global variables"
+        },
+        "mongo": {
+          "type": "boolean",
+          "description": "MongoDB global variables"
+        },
+        "nashorn": {
+          "type": "boolean",
+          "description": "Java 8 Nashorn global variables"
+        },
+        "node": {
+          "type": "boolean",
+          "description": "Node.js global variables and Node.js scoping"
+        },
+        "phantomjs": {
+          "type": "boolean",
+          "description": "PhantomJS global variables"
+        },
+        "prototypejs": {
+          "type": "boolean",
+          "description": "Prototype.js global variables"
+        },
+        "protractor": {
+          "type": "boolean",
+          "description": "Protractor global variables"
+        },
+        "qunit": {
+          "type": "boolean",
+          "description": "QUnit global variables"
+        },
+        "serviceworker": {
+          "type": "boolean",
+          "description": "Service Worker global variables"
+        },
+        "shelljs": {
+          "type": "boolean",
+          "description": "ShellJS global variables"
+        },
+        "webextensions": {
+          "type": "boolean",
+          "description": "WebExtensions globals"
+        },
+        "worker": {
+          "type": "boolean",
+          "description": "web workers global variables"
+        }
       }
     },
     "extends": {


### PR DESCRIPTION
This PR adds descriptions for each property within the `env` property, per the documentation [here](http://eslint.org/docs/2.0.0/user-guide/configuring.html#specifying-environments). It also adds the following 3 properties which were missing:

1. `atomtest`
1. `greasemonkey`
1. `webextensions`