### PR TITLE
Fix .bootstraprc extractStyles attribute schema definition

### DIFF
--- a/src/schemas/json/bootstraprc.json
+++ b/src/schemas/json/bootstraprc.json
@@ -5,6 +5,7 @@
 
   "definitions": {
     "extractStyling": {
+      "type": "object",
       "properties": {
         "extractStyles": {
           "default": false,
@@ -43,7 +44,7 @@
       }
     },
     "extractStyles": {
-      "$ref": "#/definitions/extractStyling"
+      "$ref": "#/definitions/extractStyling/properties/extractStyles"
     },
     "loglevel": {
       "description": "The verbosity of logging. Exclude this property to disable.",


### PR DESCRIPTION
This PR adjusts the schema definition for the `extractStyles` attribute to address a bug in which the following nesting of properties is being allowed:

```json
"extractStyles": { "extractStyles": {} }
```