### PR TITLE
Add bundledDependency definition to package.json schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -20,6 +20,13 @@
         }
       }
     },
+    "bundledDependency": {
+      "description": "Array of package names that will be bundled when publishing the package.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "dependency": {
       "description": "Dependencies are specified with a simple hash of package name to version range. The version range is a string which has one or more space-separated descriptors. Dependencies can also be identified with a tarball or git URL.",
       "type": "object",
@@ -202,18 +209,10 @@
           "$ref": "#/definitions/dependency"
         },
         "bundleDependencies": {
-          "type": "array",
-          "description": "Array of package names that will be bundled when publishing the package.",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/bundledDependency"
         },
         "bundledDependencies": {
-          "type": "array",
-          "description": "Array of package names that will be bundled when publishing the package.",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/bundledDependency"
         },
         "optionalDependencies": {
           "$ref": "#/definitions/dependency"
@@ -282,4 +281,3 @@
     { "required": [ "name", "version" ] }
   ]
 }
-


### PR DESCRIPTION
This PR eliminates the duplication contained within the `bundleDependencies` and `bundledDependencies` properties through the creation of a `bundledDependency` schema definition in `package.json`'s schema.