### PR TITLE
Disallow capital letters in package.json name property value

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -50,7 +50,8 @@
           "description": "The name of the package.",
           "type": "string",
           "maxLength": 214,
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "^[^A-Z]+$"
         },
         "version": {
           "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency.",


### PR DESCRIPTION
This is the regex portion of the fix mentioned in issue https://github.com/aspnet/Templates/issues/369. This PR will prevent the inclusion of capital letters in the `package.json` file's `name` property value, as per the specification.