### PR TITLE
Prevent usage of mutually exclusive props in .bootstraprc

### DIFF
--- a/src/schemas/json/bootstraprc.json
+++ b/src/schemas/json/bootstraprc.json
@@ -13,72 +13,107 @@
           "type": "boolean"
         }
       }
-    }
-  },
+    },
 
-  "properties": {
-    "appStyles": {
-      "description": "Import your custom styles here. Usually this endpoint file contains a list of @imports of your application styles.",
-      "type": "string"
-    },
-    "bootstrapCustomizations": {
-      "description": "The .scss file path to be loaded after Bootstrap's _variables.scss file",
-      "type": "string"
-    },
-    "bootstrapVersion": {
-      "default": 3,
-      "description": "The major version of Bootstrap being used",
-      "enum": [ 3, 4 ],
-      "type": "integer"
-    },
-    "env": {
-      "description": "Sets the extractStyles property based on the value of NODE_ENV",
+    "coreProperties": {
       "type": "object",
+
       "properties": {
-        "development": {
-          "$ref": "#/definitions/extractStyling"
+        "appStyles": {
+          "description": "Import your custom styles here. Usually this endpoint file contains a list of @imports of your application styles.",
+          "type": "string"
         },
-        "production": {
-          "$ref": "#/definitions/extractStyling"
+        "bootstrapCustomizations": {
+          "description": "The .scss file path to be loaded after Bootstrap's _variables.scss file",
+          "type": "string"
+        },
+        "bootstrapVersion": {
+          "default": 3,
+          "description": "The major version of Bootstrap being used",
+          "enum": [ 3, 4 ],
+          "type": "integer"
+        },
+        "loglevel": {
+          "description": "The verbosity of logging. Exclude this property to disable.",
+          "enum": [ "debug" ],
+          "type": "string"
+        },
+        "preBootstrapCustomizations": {
+          "description": "The .scss file path to be loaded before Bootstrap's _variables.scss file",
+          "type": "string"
+        },
+        "scripts": {
+          "description": "Excludes/includes Bootstrap's JavaScript modules",
+          "type": [ "boolean", "object" ]
+        },
+        "styleLoaders": {
+          "default": [ "style", "css", "sass" ],
+          "description": "An array of Webpack loader names. Order matters, and sass-loader is required.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "styles": {
+          "description": "Excludes/includes Bootstrap's CSS modules",
+          "type": [ "boolean", "object" ]
+        },
+        "useFlexbox": {
+          "default": true,
+          "description": "Enables/disables the flexbox model available in Bootstrap 4",
+          "type": "boolean"
         }
       }
-    },
-    "extractStyles": {
-      "$ref": "#/definitions/extractStyling/properties/extractStyles"
-    },
-    "loglevel": {
-      "description": "The verbosity of logging. Exclude this property to disable.",
-      "enum": [ "debug" ],
-      "type": "string"
-    },
-    "preBootstrapCustomizations": {
-      "description": "The .scss file path to be loaded before Bootstrap's _variables.scss file",
-      "type": "string"
-    },
-    "scripts": {
-      "description": "Excludes/includes Bootstrap's JavaScript modules",
-      "type": [ "boolean", "object" ]
-    },
-    "styleLoaders": {
-      "default": [ "style", "css", "sass" ],
-      "description": "An array of Webpack loader names. Order matters, and sass-loader is required.",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 1,
-      "type": "array",
-      "uniqueItems": true
-    },
-    "styles": {
-      "description": "Excludes/includes Bootstrap's CSS modules",
-      "type": [ "boolean", "object" ]
-    },
-    "useFlexbox": {
-      "default": true,
-      "description": "Enables/disables the flexbox model available in Bootstrap 4",
-      "type": "boolean"
     }
   },
 
-  "required": [ "bootstrapVersion", "styleLoaders" ]
+  "allOf": [
+    {
+      "$ref": "#/definitions/coreProperties"
+    },
+    {
+      "anyOf": [
+        {
+          "properties": {
+            "env": {
+              "description": "Sets the extractStyles property based on the value of NODE_ENV",
+              "type": "object",
+              "properties": {
+                "development": {
+                  "$ref": "#/definitions/extractStyling"
+                },
+                "production": {
+                  "$ref": "#/definitions/extractStyling"
+                }
+              }
+            }
+          },
+          "not": {
+            "properties": {
+              "extractStyles": { }
+            },
+            "required": [ "extractStyles" ]
+          }
+        },
+        {
+          "properties": {
+            "extractStyles": {
+              "$ref": "#/definitions/extractStyling/properties/extractStyles"
+            }
+          },
+          "not": {
+            "properties": {
+              "env": { }
+            },
+            "required": [ "env" ]
+          }
+        }
+      ]
+    },
+    {
+      "required": [ "bootstrapVersion", "styleLoaders" ]
+    }
+  ]
 }


### PR DESCRIPTION
The `env` and `extractStyles` properties of the `.bootstraprc` JSON file are mutually exclusive. This PR enforces that validation rule. 