### PR TITLE
Add useCustomIconFontPath property to .bootstraprc JSON schema

### DIFF
--- a/src/schemas/json/bootstraprc.json
+++ b/src/schemas/json/bootstraprc.json
@@ -60,6 +60,11 @@
           "description": "Excludes/includes Bootstrap's CSS modules",
           "type": [ "boolean", "object" ]
         },
+        "useCustomIconFontPath": {
+          "default": false,
+          "description": "Set to true if using a custom icon font and you need to specify its path in your Sass files",
+          "type": "boolean"
+        },
         "useFlexbox": {
           "default": true,
           "description": "Enables/disables the flexbox model available in Bootstrap 4",


### PR DESCRIPTION
With the latest release of bootstrap-loader, a new [useCustomIconFontPath](https://github.com/shakacode/bootstrap-loader#usecustomiconfontpath) property is now supported. This PR simply adds support for it in the schema.