### PR TITLE
feat: add patternplate pattern manifest schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -226,6 +226,12 @@
       "url": "http://json.schemastore.org/package.manifest"
     },
     {
+      "name": "pattern.json",
+      "description": "Patternplate pattern manifest file",
+      "fileMatch": [ "pattern.json" ],
+      "url": "http://json.schemastore.org/pattern"
+    },
+    {
       "name": "project.json",
       "description": "ASP.NET vNext project configuration file",
       "fileMatch": [ "project.json" ],

--- a/src/schemas/json/pattern.json
+++ b/src/schemas/json/pattern.json
@@ -1,0 +1,121 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "pattern manifest",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"name",
+		"version"
+	],
+	"properties": {
+		"id": {
+			"description": "Unique id of this pattern",
+			"type": "string",
+			"minLength": 1
+		},
+		"name": {
+			"description": "Machine readable name of the pattern",
+			"type": "string",
+			"minLength": 1,
+			"pattern": "^[[a-z]*[-]?[a-z]*]*$"
+		},
+		"displayName": {
+			"description": "Human readable name of the pattern",
+			"type": "string",
+			"minLength": 1
+		},
+		"version": {
+			"description": "Semantic version of the pattern",
+			"type": "string",
+			"pattern": "^\\d\\.\\d\\.\\d(-[a-z]*){0,1}$"
+		},
+		"versions": {
+			"description": "Available semantic versions of the pattern",
+			"type": "array",
+			"minItems": 1,
+			"items": {
+				"description": "Semantic version of the pattern",
+				"type": "string",
+				"pattern": "^\\d\\.\\d\\.\\d(-[a-z]*){0,1}$"
+			}
+		},
+		"flag": {
+			"description": "Stability flag of the pattern",
+			"type": "string",
+			"pattern": "^alpha|beta|rc|stable$"
+		},
+		"tags": {
+			"description": "Array of tags describing the pattern",
+			"type": "array",
+			"minItems": 1,
+			"items": {
+				"description": "Tag describing the pattern",
+				"type": "string",
+				"minLength": 1
+			},
+			"uniqueItems": true
+		},
+		"data": {
+			"description": "Custom data object supplied by user",
+			"type": "object",
+			"minProperties": 1
+		},
+		"meta": {
+			"description": "Custom meta data object supplied by user",
+			"type": "object",
+			"minProperties": 1
+		},
+		"options": {
+			"description": "Custom options object supplied by user",
+			"type": "object",
+			"minProperties": 1
+		},
+		"patterns": {
+			"description": "Dependencies of the pattern",
+			"type": "object",
+			"minProperties": 1,
+			"patternProperties": {
+				"^.+$": {
+					"type": "string",
+					"pattern": "^(/)?([^/\u0000]+(/)?)+$"
+				}
+			}
+		},
+		"demoPatterns": {
+			"description": "Dependencies of the pattern used for demo purposes",
+			"minProperties": 1,
+			"patternProperties": {
+				"^.+$": {
+					"type": "string",
+					"pattern": "^(/)?([^/\u0000]+(/)?)+$"
+				}
+			}
+		},
+		"overrides": {
+			"description": "Options for overriding of core pattern behaviour",
+			"type": "object",
+			"minProperties": 1,
+			"properties": {
+				"files": {
+					"description": "Custom mapping between patternplate files and paths to use in exchange for this pattern",
+					"type": "object",
+					"minProperties": 1,
+					"patternProperties": {
+						"^.+$": {
+							"type": "string",
+							"pattern": "^(/)?([^/\u0000]+(/)?)+$"
+						}
+					}
+				},
+				"demo": {
+					"description": "Custom url to use as demo for this pattern",
+					"type": "string"
+				}
+			}
+		},
+		"_patternplate": {
+			"description": "Technical values saved by patternplate core",
+			"type": "object"
+		}
+	}
+}


### PR DESCRIPTION
This adds the schema used for `pattern.json` file, a manifest format used by [patternplate](https://github.com/sinnerschrader/patternplate)