### PR TITLE
Fix spelling mistake and incorrect description in tsd.json title

### DIFF
--- a/src/schemas/json/tsd.json
+++ b/src/schemas/json/tsd.json
@@ -1,5 +1,5 @@
 {
-  "title": "JSON schema for DefinatelyTyped description manager (TSD)",
+  "title": "JSON schema for DefinitelyTyped TypeScript definitions manager (TSD)",
   "$schema": "http://json-schema.org/draft-04/schema#",
 
   "type": "object",


### PR DESCRIPTION
This PR fixes a spelling mistake in "Defin**a**telyTyped" and corrects the description in the `title` property.