### PR TITLE
Add JSON schema for .typingsrc file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -341,10 +341,16 @@
       "url": "http://json.schemastore.org/tslint"
     },
     {
-      "name": "typings.json",
-      "description": "Typings TypeScript definitions manager definition file",
-      "fileMatch": [ "typings.json" ],
-      "url": "http://json.schemastore.org/typings"
+        "name": "typings.json",
+        "description": "Typings TypeScript definitions manager definition file",
+        "fileMatch": [ "typings.json" ],
+        "url": "http://json.schemastore.org/typings"
+    },
+    {
+        "name": "typingsrc.json",
+        "description": "Typings TypeScript definitions manager configuration file",
+        "fileMatch": [ ".typingsrc" ],
+        "url": "http://json.schemastore.org/typingsrc"
     },
     {
       "name": "Web Manifest",

--- a/src/schemas/json/typingsrc.json
+++ b/src/schemas/json/typingsrc.json
@@ -1,0 +1,50 @@
+﻿{
+	"$schema": "http://json-schema.org/draft-04/schema",
+	"title": "JSON schema for .typingsrc files",
+
+  "type": "object",
+  "additionalProperties": true,
+
+  "properties": {
+    "ca": {
+      "type": [ "array", "string" ],
+      "description": "A string or array of strings of trusted certificates in PEM format",
+      "items": {
+        "type": "string"
+      }
+    },
+    "cert": {
+      "type": "string",
+      "description": "Public x509 certificate to use"
+    },
+    "httpProxy": {
+      "type": "string",
+      "description": "The proxy to use for HTTP requests"
+    },
+    "httpsProxy": {
+      "type": "string",
+      "description": "The proxy to use for HTTPS requests"
+    },
+    "key": {
+      "type": "string",
+      "description": "Private key to use for SSL"
+    },
+    "noProxy": {
+      "type": "string",
+      "description": "A string of space-separated hosts to not proxy"
+    },
+    "proxy": {
+      "type": "string",
+      "description": "A HTTP(s) proxy URI for outgoing requests"
+    },
+    "rejectUnauthorized": {
+      "type": "boolean",
+      "description": "Reject invalid SSL certificates",
+      "default": true
+    },
+    "userAgent": {
+      "type": "string",
+      "description": "Set the User-Agent for HTTP requests"
+    }
+  }
+}

--- a/src/test/typingsrc/typingsrc-test.json
+++ b/src/test/typingsrc/typingsrc-test.json
@@ -1,0 +1,4 @@
+﻿{
+  "proxy": "http://XX.XX.XX.XX:8080",
+  "rejectUnauthorized": false
+}


### PR DESCRIPTION
This PR adds JSON schema support for the Typings project's [`.typingsrc` configuration file](https://github.com/typings/typings#configuration). 