### PR TITLE
Update SARIF schema to 1.0.0-beta.1

### DIFF
--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -1,14 +1,14 @@
 ﻿{
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4)",
-  "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4). SARIF defines a standard format for the output of static analysis tools.",
+  "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.1)",
+  "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.1). SARIF defines a standard format for the output of static analysis tools.",
   "additionalProperties": false,
   "type": "object",
   "properties": {
     "version": 
     {
-      "description": "The SARIF tool format version of this log file. This value should be set to 0.4, currently. This is the third proposed revision of a file format that is not yet completely finalized.",
-      "enum": [ "0.4"]
+      "description": "The SARIF tool format version of this log file. This value should be set to 1.0.0-beta.1, currently. This is the third proposed revision of a file format that is not yet completely finalized.",
+      "enum": [ "1.0.0-beta.1"]
     },
 
     "runLogs": 
@@ -441,7 +441,12 @@
           "minItems": 1,
           "items":
           {
-            "$ref": "#/definitions/annotatedCodeLocation"
+            "type": "array",
+            "minItems": 1,
+            "items":
+            {
+              "$ref": "#/definitions/annotatedCodeLocation"
+            }
           }
         },
 
@@ -507,7 +512,7 @@
           }
         }
       },
-      "required": ["ruleId", "locations"]
+      "required": ["locations"]
     },
     "ruleDescriptor": 
     {
@@ -664,8 +669,7 @@
         "version": 
         {
           "description": "A version that refers to the tool as a whole (as opposed to, for example, the build version of an individual binary in the tool).",
-          "type": "string",
-          "pattern": "[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z-]+)?(\\+[0-9A-Za-z-]+)?"
+          "type": "string"
         },
 
         "fileVersion": 
@@ -673,6 +677,20 @@
           "description": "For operating systems (such as Windows) that provide the data, the binary version of the primary tool exe.",
           "type": "string",
           "pattern": "[0-9]+(\\.[0-9]+){3}"
+        },
+
+        "runStartTime": 
+        {
+          "description": "An optional string specifying the date and time at which the run started.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "runEndTime": 
+        {
+          "description": "An optional string specifying the date and time at which the run ended.",
+          "type": "string",
+          "format": "date-time"
         }
       },
       "required": ["name"]

--- a/src/test/sarif/binskim.sarif.json
+++ b/src/test/sarif/binskim.sarif.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4",
+  "version": "1.0.0-beta.1",
   "runLogs": [
     {
       "toolInfo": {


### PR DESCRIPTION
Fix bug in stacks representation. ruleId is now optional. Remove Semver 2.0 pattern matching for version property. add runStartTime and runEndTime to runLog. Update version from 0.4 to 1.0.0-beta.1.

@madskristensen @lgolding