### PR TITLE
Add reserved npm script names to properties

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -34,6 +34,38 @@
         "type": "string"
       }
     },
+    "scriptsInstallAfter": {
+      "description": "Run AFTER the package is installed",
+      "type": "string"
+    },
+    "scriptsPublishAfter": {
+      "description": "Run AFTER the package is published",
+      "type": "string"
+    },
+    "scriptsRestart": {
+      "description": "Run by the 'npm restart' command. Note: 'npm restart' will run the stop and start scripts if no restart script is provided.",
+      "type": "string"
+    },
+    "scriptsStart": {
+      "description": "Run by the 'npm start' command",
+      "type": "string"
+    },
+    "scriptsStop": {
+      "description": "Run by the 'npm stop' command",
+      "type": "string"
+    },
+    "scriptsTest": {
+      "description": "Run by the 'npm test' command",
+      "type": "string"
+    },
+    "scriptsUninstallBefore": {
+      "description": "Run BEFORE the package is uninstalled",
+      "type": "string"
+    },
+    "scriptsVersionBefore": {
+      "description": "Run BEFORE bump the package version",
+      "type": "string"
+    },
     "coreProperties": {
       "type": "object",
 
@@ -194,6 +226,84 @@
         "scripts": {
           "description": "The 'scripts' member is an object hash of script commands that are run at various times in the lifecycle of your package. The key is the lifecycle event, and the value is the command to run at that point.",
           "type": "object",
+          "properties": {
+            "prepublish": {
+              "type": "string",
+              "description": "Run BEFORE the package is published (Also run on local npm install without any arguments)"
+            },
+            "publish": {
+              "$ref": "#/definitions/scriptsPublishAfter"
+            },
+            "postpublish": {
+              "$ref": "#/definitions/scriptsPublishAfter"
+            },
+            "preinstall": {
+              "type": "string",
+              "description": "Run BEFORE the package is installed"
+            },
+            "install": {
+              "$ref": "#/definitions/scriptsInstallAfter"
+            },
+            "postinstall": {
+              "$ref": "#/definitions/scriptsInstallAfter"
+            },
+            "preuninstall": {
+              "$ref": "#/definitions/scriptsUninstallBefore"
+            },
+            "uninstall": {
+              "$ref": "#/definitions/scriptsUninstallBefore"
+            },
+            "postuninstall": {
+              "type": "string",
+              "description": "Run AFTER the package is uninstalled"
+            },
+            "preversion": {
+              "$ref": "#/definitions/scriptsVersionBefore"
+            },
+            "version": {
+              "$ref": "#/definitions/scriptsVersionBefore"
+            },
+            "postversion": {
+              "type": "string",
+              "description": "Run AFTER bump the package version"
+            },
+            "pretest": {
+              "$ref": "#/definitions/scriptsTest"
+            },
+            "test": {
+              "$ref": "#/definitions/scriptsTest"
+            },
+            "posttest": {
+              "$ref": "#/definitions/scriptsTest"
+            },
+            "prestop": {
+              "$ref": "#/definitions/scriptsStop"
+            },
+            "stop": {
+              "$ref": "#/definitions/scriptsStop"
+            },
+            "poststop": {
+              "$ref": "#/definitions/scriptsStop"
+            },
+            "prestart": {
+              "$ref": "#/definitions/scriptsStart"
+            },
+            "start": {
+              "$ref": "#/definitions/scriptsStart"
+            },
+            "poststart": {
+              "$ref": "#/definitions/scriptsStart"
+            },
+            "prerestart": {
+              "$ref": "#/definitions/scriptsRestart"
+            },
+            "restart": {
+              "$ref": "#/definitions/scriptsRestart"
+            },
+            "postrestart": {
+              "$ref": "#/definitions/scriptsRestart"
+            }
+          },
           "additionalProperties": {
             "type": "string"
           }
@@ -285,7 +395,7 @@
             "properties": {
               "bundledDependencies": { }
             },
-            "required": ["bundledDependencies"]
+            "required": [ "bundledDependencies" ]
           }
         },
         {
@@ -298,7 +408,7 @@
             "properties": {
               "bundleDependencies": { }
             },
-            "required": ["bundleDependencies"]
+            "required": [ "bundleDependencies" ]
           }
         }
       ]

--- a/src/test/package/package-test8.json
+++ b/src/test/package/package-test8.json
@@ -1,0 +1,16 @@
+﻿{
+  "name": "asp.net",
+  "version": "0.0.0",
+  "devDependencies": {
+    "gulp": "3.9.1",
+    "gulp-concat": "2.5.2",
+    "gulp-cssmin": "0.1.7",
+    "gulp-uglify": "1.2.0",
+    "rimraf": "2.2.8"
+  },
+  "scripts": {
+    "install": "bower install && typings install",
+    "build-js": "gulp clean:js && gulp min:js",
+    "build-css": "gulp clean:css && gulp min:css"
+  }
+}


### PR DESCRIPTION
Per the [npm scripts documentation](https://docs.npmjs.com/misc/scripts), there are several reserved script names (e.g., `install`, `test`, `publish`). This PR adds those script names as optional properties within the `scripts` property. This should save developers the trouble of trying to find the documentation. IntelliSense within the editor will now display the names and descriptions of these reserved scripts.