### PR TITLE
Fixes #19, updated all JSCS schema validations according to the latest ruleset.

### DIFF
--- a/src/schemas/json/jscsrc.json
+++ b/src/schemas/json/jscsrc.json
@@ -1,369 +1,3399 @@
 {
-  "title": "JSON schema for JSCS configuration files",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-
-  "type": "object",
-  "additionalProperties": true,
-
-  "definitions": {
-    "validateJSDoc": {
-      "description": "Enables JSDoc validation.",
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "checkParamNames": {
-          "description": "Ensures param names in jsdoc and in function declaration are equal",
-          "type": "boolean"
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON schema for JSCS configuration files",
+    "type": "object",
+    "additionalProperties": true,
+    "definitions": {
+        "blockKeywords": {
+            "type": [ "array", "null" ],
+            "items": {
+                "enum": [ "catch", "do", "else", "finally", "for", "function", "if", "try", "while" ]
+            },
+            "uniqueItems": true
         },
-        "checkRedundantParams": {
-          "description": "Ensures params in jsdoc contains type",
-          "type": "boolean"
+        "braceRules": {
+            "type": [ "null", "object" ],
+            "properties": {
+                "beforeOpeningRoundBrace": {
+                    "type": [ "boolean", "null" ]
+                },
+                "beforeOpeningCurlyBrace": {
+                    "type": [ "boolean", "null" ]
+                }
+            }
         },
-        "requireParamTypes": {
-          "description": "Reports redundant params in jsdoc",
-          "type": "boolean"
+        "esprimaNodeTypes": {
+            "type": [ "array", "null" ],
+            "items": {
+                "enum": [ "ArrayExpression", "ArrayPattern", "ArrowFunctionExpression", "AssignmentExpression", "AssignmentPattern", "BinaryExpression", "BlockStatement", "BreakStatement", "CallExpression", "CatchClause", "ClassBody", "ClassDeclaration", "ClassExpression", "ConditionalExpression", "ContinueStatement", "DebuggerStatement", "DoWhileStatement", "EmptyStatement", "ExportAllDeclaration", "ExportDefaultDeclaration", "ExportNamedDeclaration", "ExportSpecifier", "ExpressionStatement", "ForInStatement", "ForStatement", "FunctionDeclaration", "FunctionExpression", "Identifier", "IfStatement", "ImportDeclaration", "ImportDefaultSpecifier", "ImportNamespaceSpecifier", "ImportSpecifier", "LabeledStatement", "Literal", "LogicalExpression", "MemberExpression", "MethodDefinition", "NewExpression", "ObjectExpression", "ObjectPattern", "Program", "Property", "RestElement", "ReturnStatement", "SequenceExpression", "SpreadElement", "Super", "SwitchCase", "SwitchStatement", "TaggedTemplateExpression", "TemplateElement", "TemplateLiteral", "ThisExpression", "ThrowStatement", "TryStatement", "UnaryExpression", "UpdateExpression", "VariableDeclaration", "VariableDeclarator", "WhileStatement", "WithStatement" ]
+            },
+            "uniqueItems": true
+        },
+        "jsDoc": {
+            "description": "Validate jsdoc comments.",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "checkAnnotations": {
+                    "description": "Checks whether tag names are valid.",
+                    "type": [ "boolean", "null", "object", "string" ],
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/nullRule"
+                        },
+                        {
+                            "description": "By default, any tag from any preset is allowed.  You can pass Object to select preset with preset field and add custom tags with extra field.",
+                            "type": "object",
+                            "properties": {
+                                "preset": {
+                                    "type": "string",
+                                    "oneOf": [
+                                        {
+                                            "description": "https://github.com/google/closure-compiler",
+                                            "enum": [ "closurecompiler" ]
+                                        },
+                                        {
+                                            "description": "https://github.com/jsdoc3/jsdoc",
+                                            "enum": [ "jsdoc3" ]
+                                        },
+                                        {
+                                            "description": "https://github.com/senchalabs/jsduck",
+                                            "enum": [ "jsduck5" ]
+                                        }
+                                    ]
+                                },
+                                "extra": {
+                                    "description": "Add custom tags with the extra field.  The extra field should contain tags in keys with true, false, or \"some\" for the values.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "oneOf": [
+                                            {
+                                                "type": [ "boolean", "string" ],
+                                                "enum": [ true, false, "some" ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "description": "There are 3 presets:  Closure Compiler, JSDoc3 and JSDuck5.",
+                            "type": "string",
+                            "oneOf": [
+                                {
+                                    "description": "https://github.com/google/closure-compiler",
+                                    "enum": [ "closurecompiler" ]
+                                },
+                                {
+                                    "description": "https://github.com/jsdoc3/jsdoc",
+                                    "enum": [ "jsdoc3" ]
+                                },
+                                {
+                                    "description": "https://github.com/senchalabs/jsduck",
+                                    "enum": [ "jsduck5" ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "checkParamExistence": {
+                    "description": "Checks whether all parameters are documented.",
+                    "type": [ "boolean", "null" ]
+                },
+                "checkParamNames": {
+                    "description": "Checks whether param names in jsdoc and in function declaration are equal.",
+                    "type": [ "boolean", "null" ]
+                },
+                "requireParamTypes": {
+                    "description": "Checks whether params in jsdoc contains type.",
+                    "type": [ "boolean", "null" ]
+                },
+                "checkRedundantParams": {
+                    "description": "Reports redundant params in jsdoc.",
+                    "type": [ "boolean", "null" ]
+                },
+                "checkReturnTypes": {
+                    "description": "Checks for differences between the jsdoc and actual return types if both exist.",
+                    "type": [ "boolean", "null" ]
+                },
+                "checkRedundantReturns": {
+                    "description": "Report statements for functions without a return, which are described with an @return tag.",
+                    "type": [ "boolean", "null" ]
+                },
+                "requireReturnTypes": {
+                    "description": "Checks whether @returns in jsdoc contains type.",
+                    "type": [ "boolean", "null" ]
+                },
+                "checkTypes": {
+                    "description": "Reports invalid types for bunch of tags.",
+                    "type": [ "boolean", "null", "string" ],
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/nullRule"
+                        },
+                        {
+                            "description": "Can equal \"strictNativeCase\" or \"capitalizedNativeCase\".",
+                            "type": "string",
+                            "oneOf": [
+                                {
+                                    "description": "The strictNativeCase mode checks that case of natives is the same as in this list: boolean, number, string, Object, Array, Date, RegExp.",
+                                    "enum": [ "strictNativeCase" ]
+                                },
+                                {
+                                    "description": "The capitalizedNativeCase mode checks that the first letter in all native types and primitives is uppercased except the case with function in google closure format:  {function(...)}.",
+                                    "enum": [ "capitalizedNativeCase" ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "checkRedundantAccess": {
+                    "description": "Reports redundant access declarations.",
+                    "type": [ "boolean", "null", "string" ],
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/nullRule"
+                        },
+                        {
+                            "type": "string",
+                            "oneOf": [
+                                {
+                                    "description": "If an @access tag is specified, the function name must contain a leading _underscore.",
+                                    "enum": [ "enforceLeadingUnderscore" ]
+                                },
+                                {
+                                    "description": "If an @access tag is specified, the function name must contain a trailing underscore_.",
+                                    "enum": [ "enforceTrailingUnderscore" ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "leadingUnderscoreAccess": {
+                    "description": "Checks whether access declaration is set for _underscored function names.  Ignores a bunch of popular identifiers: __filename, __dirname, __proto__, __defineGetter__, super_, __constructor, etc.",
+                    "type": [ "boolean", "null", "string" ],
+                    "oneOf": [
+                        {
+                            "description": "true (means not public).  Report if @private or @protected is absent from _underscored function names.",
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/nullRule"
+                        },
+                        {
+                            "type": "string",
+                            "oneOf": [
+                                {
+                                    "description": "Enforce only @private for all _underscored function names.",
+                                    "enum": [ "private" ]
+                                },
+                                {
+                                    "description": "Enforce only @protected for all _underscored function names.",
+                                    "enum": [ "protected" ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "enforceExistence": {
+                    "description": "Checks whether jsdoc block exists.",
+                    "type": [ "boolean", "null", "object", "string" ],
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/nullRule"
+                        },
+                        {
+                            "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                            "type": "object",
+                            "properties": {
+                                "allExcept": {
+                                    "description": "Array of quoted keywords to exempt.",
+                                    "type": "array",
+                                    "minItems": 0,
+                                    "items": {
+                                        "type": "string",
+                                        "oneOf": [
+                                            {
+                                                "description": "Skip expression functions.",
+                                                "enum": [ "expressions" ]
+                                            },
+                                            {
+                                                "description": "Skip module.exports = function () {};",
+                                                "enum": [ "exports" ]
+                                            },
+                                            {
+                                                "description": "Functions without parameters and with empty return statements will be skipped.",
+                                                "enum": [ "paramless-procedures" ]
+                                            }
+                                        ]
+                                    },
+                                    "uniqueItems": true
+                                }
+                            }
+                        },
+                        {
+                            "description": "Deprecated in favor of the object \"allExcept\": [\"exports\"] rule format.",
+                            "type": "string",
+                            "oneOf": [
+                                {
+                                    "description": "Skip expression functions.",
+                                    "enum": [ "exceptExports" ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "requireHyphenBeforeDescription": {
+                    "description": "Checks whether a jsdoc param description has a hyphen before it (checks for -).",
+                    "type": [ "boolean", "null" ]
+                },
+                "requireNewlineAfterDescription": {
+                    "description": "Checks whether a jsdoc comment description has a padding (trailing) newline separator between it and additional @tags.",
+                    "type": [ "boolean", "null" ]
+                },
+                "disallowNewlineAfterDescription": {
+                    "description": "Checks whether a jsdoc comment description has no padding (trailing) newline separator between it and additional @tags.",
+                    "type": [ "boolean", "null" ]
+                },
+                "requireDescriptionCompleteSentence": {
+                    "description": "Checks whether a jsdoc comment description is a complete sentence.  A complete sentence is defined as starting with an upper case letter and ending with a period.",
+                    "type": [ "boolean", "null" ]
+                },
+                "requireParamDescription": {
+                    "description": "Checks whether a jsdoc param description exists.",
+                    "type": [ "boolean", "null" ]
+                },
+                "requireReturnDescription": {
+                    "description": "Checks whether a jsdoc return description exists.",
+                    "type": [ "boolean", "null" ]
+                }
+            }
+        },
+        "keywords": {
+            "type": [ "array", "null" ],
+            "items": {
+                "enum": [ "break", "case", "catch", "continue", "debugger", "default", "delete", "do", "else", "finally", "for", "function", "if", "in", "instanceof", "new", "return", "switch", "this", "throw", "try", "typeof", "var", "void", "while", "with" ]
+            },
+            "uniqueItems": true
+        },
+        "keywords2": {
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/keywords"
+                },
+                {
+                    "type": "boolean"
+                }
+            ]
+        },
+        "nullRule": {
+            "description": "Removes the rule.",
+            "type": "null"
+        },
+        "operators": {
+            "type": [ "array", "boolean", "null" ],
+            "items": {
+                "enum": [ ",", ":", "?", "^", "^=", "|", "||", "|=", "&", "&&", "&=", "+", "+=", "-", "-=", "%", "%=", "/", "/=", "*", "*=", "=", "==", "===", "!=", "!==", ">", ">>", ">>>", ">=", ">>=", ">>>=", "<", "<<", "<=", "<<=", null ]
+            },
+            "uniqueItems": true
+        },
+        "equalityOperators": {
+            "type": [ "array", "boolean", "null" ],
+            "items": {
+                "enum": [ "==", "===", "!=", "!==", null ]
+            },
+            "uniqueItems": true
+        },
+        "unaryOperators": {
+            "type": [ "array", "boolean", "null" ],
+            "items": {
+                "enum": [ "++", "--", "+", "-", "~", "!" ]
+            },
+            "uniqueItems": true
         }
-      }
     },
-    "braceRules": {
-      "type": [ "null", "object" ],
-      "properties": {
-        "beforeOpeningRoundBrace": {
-          "type": "boolean"
+    "properties": {
+        "additionalRules": {
+            "description": "Path to load additional rules",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
         },
-        "beforeOpeningCurlyBrace": {
-          "type": "boolean"
+        "disallowAnonymousFunctions": {
+            "description": "Requires that a function expression be named. Named functions provide more information in the error stack trace than anonymous functions.  This option does not help if you use Arrow functions (ES6) which are always anonymous.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowArrowFunctions": {
+            "description": "Disallows arrow functions.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowCapitalizedComments": {
+            "description": "Requires the first alphabetical character of a comment to be lowercase.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowCommaBeforeLineBreak": {
+            "description": "Disallows commas as last token on a line in lists.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "For default behavior (strict mode, comma on the same line).",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "enum": [ "function" ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowCurlyBraces": {
+            "description": "Disallows curly braces after statements.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords2" } ]
+        },
+        "disallowDanglingUnderscores": {
+            "description": "Disallows identifiers that start or end in _.  Some popular identifiers are automatically listed as exceptions:  __proto__ (javascript), _ (underscore.js), __filename (node.js global), __dirname (node.js global), super_ (node.js, used by util.inherits).",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowEmptyBlocks": {
+            "description": "Disallows empty blocks (except for catch blocks).",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "For default behavior (strict mode, no empty blocks allowed).",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.  Blocks containing only comments would not be considered empty.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "enum": [ "comments" ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowFunctionDeclarations": {
+            "description": "Disallows function declarations.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowIdenticalDestructuringNames": {
+            "description": "Disallows identical destructuring names for the key and value in favor of using shorthand destructuring.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowIdentifierNames": {
+            "description": "Disallows a specified set of identifier names.",
+            "type": [ "array", "null" ],
+            "oneOf": [
+                {
+                    "description": "An array of strings, which should be disallowed as identifier names.",
+                    "type": "array",
+                    "minItems": 0,
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "disallowImplicitTypeConversion": {
+            "description": "Disallows implicit type conversion.",
+            "type": [ "array", "null" ],
+            "items": {
+                "enum": [ "numeric", "boolean", "binary", "string" ]
+            },
+            "uniqueItems": true
+        },
+        "disallowKeywordsInComments": {
+            "description": "Disallows one or more keywords in comments.",
+            "type": [ "array", "boolean", "null", "string" ],
+            "oneOf": [
+                {
+                    "description": "An array of strings, which should be disallowed keywords in comments.",
+                    "type": "array",
+                    "minItems": 0,
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                {
+                    "description": "If true, \"TODO\" and \"FIXME\" will be disallowed in comments.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "A valid Regular Expression.",
+                    "type": "string"
+                }
+            ]
+        },
+        "disallowKeywordsOnNewLine": {
+            "description": "Disallows placing the specified keywords on a new line.",
+            "type": [ "array", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords" } ]
+        },
+        "disallowKeywords": {
+            "description": "Disallows usage of the specified keywords.",
+            "type": [ "array", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords" } ]
+        },
+        "disallowMixedSpacesAndTabs": {
+            "description": "Requires lines to not contain both spaces and tabs consecutively, or spaces after tabs only for alignment if \"smart",
+            "type": [ "boolean", "null", "string" ],
+            "enum": [ true, false, null, "smart" ]
+        },
+        "disallowMultiLineTernary": {
+            "description": "Disallows the test, consequent and alternate to be on separate lines when using the ternary operator.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowMultipleLineBreaks": {
+            "description": "Disallows multiple blank lines in a row.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowMultipleLineStrings": {
+            "description": "Disallows strings that span multiple lines without using concatenation.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowMultipleSpaces": {
+            "description": "Disallows multiple indentation characters (tabs or spaces) between identifiers, keywords, and any other token.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains a \"allowEOLComments\" key equal to a boolean.",
+                    "type": "object",
+                    "properties": {
+                        "allowEOLComments": {
+                            "type": [ "boolean", "null" ]
+                        }
+                    }
+
+                }
+            ]
+        },
+        "disallowMultipleVarDecl": {
+            "description": "Disallows multiple `var` declaration (except for-loop).",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains a \"allowEOLComments\" key equal to a boolean.",
+                    "type": "object",
+                    "properties": {
+                        "strict": {
+                            "type": [ "boolean", "null" ]
+                        },
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Allows declarations where all variables are importing external modules with require.",
+                                        "enum": [ "require" ]
+                                    },
+                                    {
+                                        "description": "Allows declarations where all variables are not defined.",
+                                        "enum": [ "undefined" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+
+                }
+            ]
+        },
+        "disallowNamedUnassignedFunctions": {
+            "description": "Disallows unassigned functions to be named inline.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowNestedTernaries": {
+            "description": "Disallows nested ternaries.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains a \"maxLevel\" property equal to an integer indicating the maximum levels of nesting to be allowed.",
+                    "type": "object",
+                    "properties": {
+                        "maxLevel": {
+                            "description": "The maximum levels of ternary nesting to be allowed.",
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowNewlineBeforeBlockStatements": {
+            "description": "Disallows newline before opening curly brace of all block statements.",
+            "type": [ "array", "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/blockKeywords"
+                },
+                {
+                    "description": "A value of true will always disallow newline before curly brace of block statements.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains a \"value\" key equal to a boolean or an array, and / or an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": [ "array", "boolean" ]
+                        },
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.  If `multiline` is specified, when the conditions span on multiple lines, require a new line before the curly brace.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    { "type": "string" },
+                                    { "enum": [ "multiline" ] }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowNodeTypes": {
+            "description": "Disallow use of certain node types (from Esprima/ESTree).  Value equals an array of parser node types to be disallowed.",
+            "type": [ "array", "null" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/esprimaNodeTypes"
+                }
+            ]
+        },
+        "disallowNotOperatorsInConditionals": {
+            "description": "Disallows the not, not equals, and strict not equals operators in conditionals.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowObjectKeysOnNewLine": {
+            "description": "Disallows placing object keys on new line.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowOperatorBeforeLineBreak": {
+            "description": "Requires putting certain operators on the next line rather than on the current line before a line break.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/operators"
+                }
+            ]
+        },
+        "disallowPaddingNewLinesAfterBlocks": {
+            "description": "Disallow a newline after blocks.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowPaddingNewLinesAfterUseStrict": {
+            "description": "Disallow a blank line after 'use strict'; statements.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowPaddingNewLinesBeforeExport": {
+            "description": "Disallows newline before module.exports.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowPaddingNewlinesBeforeKeywords": {
+            "description": "Disallow an empty line above the specified keywords.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords2" } ]
+        },
+        "disallowPaddingNewLinesBeforeLineComments": {
+            "description": "Disallows newline before line comments.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "disallowPaddingNewlinesInBlocks": {
+            "description": "Disallows blocks from beginning or ending with 2 newlines.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "A value of true validates all non-empty blocks.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains a \"open\" key equal to a boolean, an \"close\" key equal to a boolean, and / or an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "close": {
+                            "description": "A value of true validates that there is a newline before the closing brace in a block.  A value of false ignores the newline validation before the closing brace in a block.",
+                            "type": "boolean"
+                        },
+                        "open": {
+                            "description": "A value of true validates that there is a newline after the opening brace in a block.  A value of false ignores the newline validation after the opening brace in a block.",
+                            "type": "boolean"
+                        },
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.  If `conditionals` is specified, conditionals (if, else if, else) blocks are ignored.  If `functions` is specified, function blocks are ignored.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "enum": [ "conditionals", "functions" ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowPaddingNewLinesInObjects": {
+            "description": "Disallows newlines adjacent to curly braces in all object literals.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowParenthesesAroundArrowParam": {
+            "description": "Disallows parentheses around arrow function expressions that contain a single parameter.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowQuotedKeysInObjects": {
+            "description": "Disallows quoted keys in object if possible.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "description": "Set to true for strict mode.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "Allows ES3+ reserved words to remain quoted which is helpful when using this option with JSHint's es3 flag.",
+                                        "enum": [ "reserved" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "description": "Deprecated in favor of the object \"allExcept\": [\"reserved\"] rule format.",
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "enum": [ "allButReserved" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "disallowSemicolons": {
+            "description": "Disallows lines from ending in a semicolon.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowShorthandArrowFunctions": {
+            "description": "Require arrow functions to use a block statement (explicit return).",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowSpaceAfterBinaryOperators": {
+            "description": "Requires sticking binary operators to the right.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/operators"
+                }
+            ]
+        },
+        "disallowSpaceAfterComma": {
+            "description": "Disallows spaces after commas.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "A value of true will disallow any spaces after any comma.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Allow spaces in place of absent values in sparse arrays.",
+                                        "enum": [ "sparseArrays" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowSpaceAfterKeywords": {
+            "description": "Disallows space after the specified keywords.  A value of true will require spaces after all possible keywords.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords2" } ]
+        },
+        "disallowSpaceAfterLineComment": {
+            "description": "Requires that a line comment (//) not be followed by a space.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowSpaceAfterObjectKeys": {
+            "description": "Disallows space after object keys.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Ignores objects if the object only takes up a single line.",
+                                        "enum": [ "singleline" ]
+                                    },
+                                    {
+                                        "description": "Ignores objects if the object takes up multiple lines.",
+                                        "enum": [ "multiline" ]
+                                    },
+                                    {
+                                        "description": "Ignores aligned object properties.",
+                                        "enum": [ "aligned" ]
+                                    },
+                                    {
+                                        "description": "Ignores method declarations.",
+                                        "enum": [ "method" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "description": "Deprecated in favor of the object \"allExcept\": [] rule format.",
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Ignores objects if the object only takes up a single line.",
+                            "enum": [ "ignoreSingleLine" ]
+                        },
+                        {
+                            "description": "Ignores objects if the object takes up multiple lines.",
+                            "enum": [ "ignoreMultiLine" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "disallowSpaceAfterPrefixUnaryOperators": {
+            "description": "Requires sticking unary operators to the right.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/unaryOperators" } ]
+        },
+        "disallowSpaceBeforeBinaryOperators": {
+            "description": "Requires sticking binary operators to the left.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/operators" } ]
+        },
+        "disallowSpaceBeforeBlockStatements": {
+            "description": "Disallows space before block statements (for loops, control structures).",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowSpaceBeforeComma": {
+            "description": "Disallows spaces before commas.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "A value of true will disallow any spaces before any comma.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Allow spaces in place of absent values in sparse arrays.",
+                                        "enum": [ "sparseArrays" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "description": "Deprecated in favor of the object \"allExcept\": [\"exports\"] rule format.",
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Skip expression functions.",
+                            "enum": [ "exceptExports" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "disallowSpaceBeforeKeywords": {
+            "description": "Disallows space before keyword.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords2" } ]
+        },
+        "disallowSpaceBeforeObjectValues": {
+            "description": "Disallows space before object values.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowSpaceBeforePostfixUnaryOperators": {
+            "description": "Requires sticking unary operators to the left.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/unaryOperators" } ]
+        },
+        "disallowSpaceBeforeSemicolon": {
+            "description": "Disallows spaces before semicolons.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "A value of true will disallow any spaces before any semicolon.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception tokens.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted tokens to exempt (allows whitespace before semicolon if preceded by the specified token).",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "anyOf": [
+                                    {
+                                        "enum": [ "(" ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "maxLength": 1
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowSpaceBetweenArguments": {
+            "description": "Ensure there are no spaces after argument separators in call expressions.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowSpacesInAnonymousFunctionExpression": {
+            "description": "Disallows space before () or {} in anonymous function expressions.",
+            "type": [ "null", "object" ],
+            "oneOf": [ { "$ref": "#/definitions/braceRules" } ]
+        },
+        "disallowSpacesInCallExpression": {
+            "description": "Disallows space before () in call expressions.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowSpacesInConditionalExpression": {
+            "description": "Disallows space before and/or after ? or : in conditional expressions.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "A value of true will set all properties [afterTest, beforeConsequent, afterConsequent, beforeAlternate] to true.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains keys of type boolean.",
+                    "properties": {
+                        "afterConsequent": {
+                            "type": "boolean"
+                        },
+                        "afterTest": {
+                            "type": "boolean"
+                        },
+                        "beforeAlternate": {
+                            "type": "boolean"
+                        },
+                        "beforeConsequent": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowSpacesInForStatement": {
+            "description": "Disallow spaces in between for statement.",
+            "type": [ "boolean", "null" ]
+        },
+        "disallowSpacesInFunction": {
+            "description": "Disallows space before `()` or `{}` in function expressions (both named and anonymous) and function declarations.",
+            "type": [ "null", "object" ],
+            "oneOf": [ { "$ref": "#/definitions/braceRules" } ]
+        },
+        "disallowSpacesInFunctionDeclaration": {
+            "description": "Disallows space before () or {} in function declarations.",
+            "type": [ "null", "object" ],
+            "oneOf": [ { "$ref": "#/definitions/braceRules" } ]
+        },
+        "disallowSpacesInFunctionExpression": {
+            "description": "Disallows space before `()` or `{}` in function expressions (both named and anonymous).",
+            "type": [ "null", "object" ],
+            "oneOf": [ { "$ref": "#/definitions/braceRules" } ]
+        },
+        "disallowSpacesInGenerator": {
+            "description": "Disallow space before or after * in generator functions.",
+            "type": [ "null", "object" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "At least one of the object properties must be present and it must be set to true.",
+                    "type": "object",
+                    "properties": {
+                        "beforeStar": {
+                            "description": "A value of true disallows space before *.",
+                            "type": "boolean"
+                        },
+                        "afterStar": {
+                            "description": "A value of true disallows space after *.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowSpacesInNamedFunctionExpression": {
+            "description": "Disallows space before () or {} in named function expressions",
+            "type": [ "null", "object" ],
+            "oneOf": [ { "$ref": "#/definitions/braceRules" } ]
+        },
+        "disallowSpacesInsideArrayBrackets": {
+            "description": "Disallows space after opening array square bracket and before closing.  Reports only on arrays, not on property accessors.  Use disallowSpacesInsideBrackets to report on all brackets.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "description": "Use \"all\" or true for strict mode.",
+                    "type": [ "boolean", "string" ],
+                    "enum": [ true, false, "all" ]
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception tokens.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted tokens to exempt.  Tokens should consist of an opener with a matching closer () {} [] etc.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Tokens should consist of an opener with a matching closer () {} [] etc.",
+                                        "enum": [ "(", ")", "{", "}", "[", "]" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "description": "Deprecated in favor of the object \"allExcept\": [] rule format.",
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "enum": [ "nested" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "disallowSpacesInsideBrackets": {
+            "description": "Disallows space after opening square bracket and before closing.  Reports on all on brackets, even on property accessors.  Use disallowSpacesInsideArrayBrackets to exclude property accessors.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "Use true for strict mode.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception tokens.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted tokens to exempt.  Tokens should consist of an opener with a matching closer () {} [] etc.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Tokens should consist of an opener with a matching closer () {} [] etc.",
+                                        "enum": [ "(", ")", "{", "}", "[", "]" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowSpacesInsideObjectBrackets": {
+            "description": "Disallows space after opening object curly brace and before closing.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "description": "Use \"all\" or true for strict mode.",
+                    "type": [ "boolean", "string" ],
+                    "enum": [ true, false, "all" ]
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception tokens.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted tokens to exempt.  Applies only to closer tokens:  e.g. ) } ].  If a (closer) token is specified, the rule ignores contiguous (closer) tokens.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Tokens should consist of an closer:  ) } ] etc.",
+                                        "enum": [ ")", "}", "]" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "description": "Deprecated in favor of the object \"allExcept\": [] rule format.",
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "enum": [ "nested" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "disallowSpacesInsideParentheses": {
+            "description": "Disallows space after opening round bracket and before closing.",
+            "type": [ "boolean", "null", "string", "object" ],
+            "oneOf": [
+                {
+                    "type": [ "boolean", "string" ],
+                    "enum": [ true, false, "all" ]
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"only\" key equal to an array of values which indicate where to apply this rule.",
+                    "type": "object",
+                    "properties": {
+                        "only": {
+                            "description": "Array of quoted values to target.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "anyOf": [
+                                    {
+                                        "enum": [ "(", ")", "{", "}", "[", "]", "function" ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowSpacesInsideParenthesizedExpression": {
+            "description": "Disallows space after opening and before closing grouping parentheses.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, always disallow spaces inside grouping parentheses.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted tokens or items to exempt.  Tokens should consist of an opener with a matching closer () {} [] or `function`.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Tokens should consist of an opener with a matching closer () {} [] etc. or `function`.",
+                                        "enum": [ "(", ")", "{", "}", "[", "]", "function" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "disallowSpacesInsideTemplateStringPlaceholders": {
+            "description": "Disallows spaces before and after curly brace inside template string placeholders.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "disallowTabs": {
+            "description": "Disallows tabs everywhere.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "disallowTrailingComma": {
+            "description": "Disallows an extra comma following the final element of an array or object literal.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "disallowTrailingWhitespace": {
+            "description": "Requires all lines to end on a non-whitespace character.",
+            "type": [ "boolean", "null", "string" ],
+            "oneOf": [
+                {
+                    "description": "Use \"ignoreEmptyLines\" to allow whitespace on empty lines (default is false).",
+                    "type": [ "boolean", "string" ],
+                    "enum": [ true, false, "ignoreEmptyLines" ]
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "disallowUnusedParams": {
+            "description": "Disallows unused params in function expression and function declaration.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "disallowVar": {
+            "description": "Disallows declaring variables with var.",
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "disallowYodaConditions": {
+            "description": "Requires the variable to be the left hand operator when doing a boolean comparison.  Array of quoted operators or true to disallow yoda conditions for most possible comparison operators.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/equalityOperators" } ]
+        },
+        "excludeFiles": {
+            "description": "Disables style checking for specified paths.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "jsDoc": {
+            "$ref": "#/definitions/jsDoc"
+        },
+        "maximumLineLength": {
+            "description": "Requires all lines to be at most the number of characters specified.",
+            "type": [ "integer", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "Lines should be at most the number of characters specified.",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array an array of conditions that will exempt a line, in addition to other attributes.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of conditions that will exempt a line.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "description": "Allows comments to break the rule.",
+                                        "enum": [ "comments" ]
+                                    },
+                                    {
+                                        "description": "Allows function definitions to break the rule.",
+                                        "enum": [ "functionSignature" ]
+                                    },
+                                    {
+                                        "description": "Allows regular expression literals to break the rule.",
+                                        "enum": [ "regex" ]
+                                    },
+                                    {
+                                        "description": "Allows require expressions to break the rule.",
+                                        "enum": [ "require" ]
+                                    },
+                                    {
+                                        "description": "Allows comments with long urls to break the rule.",
+                                        "enum": [ "urlComments" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        },
+                        "tabSize": {
+                            "description": "Considered the tab character as number of specified spaces.",
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "value": {
+                            "description": "Lines should be at most the number of characters specified.",
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    "required": [ "value" ]
+                }
+            ]
+        },
+        "maximumNumberOfLines": {
+            "description": "Requires the file to be at most the number of lines specified.",
+            "type": [ "integer", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "File should be at most the number of lines specified.",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array an array of conditions that will exempt a line, in addition to other attributes.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of conditions that will exempt a line.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "description": "Allows comments to break the rule.",
+                                        "enum": [ "comments" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        },
+                        "value": {
+                            "description": "Lines should be at most the number of characters specified.",
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    "required": [ "value" ]
+                }
+            ]
+        },
+        "preset": {
+            "description": "Extends defined rules with preset rules.",
+            "type": "string",
+            "enum": [ "airbnb", "crockford", "google", "grunt", "idiomatic", "jquery", "mdcs", "node-style-guide", "wikimedia", "wordpress", "yandex" ]
+        },
+        "requireAlignedMultilineParams": {
+            "description": "Enforces indentation of parameters in multiline functions.",
+            "type": [ "boolean", "integer", "null", "string" ],
+            "oneOf": [
+                {
+                    "description": "If true, require parameters to align with the body of the function.",
+                    "type": "boolean"
+                },
+                {
+                    "description": "The number of columns the parameters should be indented past the function body.",
+                    "type": "integer"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "Use `firstParam` to require parameters on a new line to be aligned with the first parameter(s) on the previous line.",
+                    "type": "string",
+                    "enum": [ "firstParam" ]
+                }
+            ]
+        },
+        "requireAlignedObjectValues": {
+            "description": "Requires proper alignment in object literals.",
+            "type": [ "null", "string" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Use for strict mode.",
+                            "enum": [ "all" ]
+                        },
+                        {
+                            "description": "Ignores objects if one of the property values is a function expression.",
+                            "enum": [ "ignoreFunction" ]
+                        },
+                        {
+                            "description": "Ignores objects if there are line breaks between properties.",
+                            "enum": [ "ignoreLineBreak" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "requireAnonymousFunctions": {
+            "description": "Requires that a function expression be anonymous.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "description": "Ignores function declarations.",
+                                        "enum": [ "declarations" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireArrayDestructuring": {
+            "description": "Requires that variable assignment from array values are * destructured.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireArrowFunctions": {
+            "description": "Requires that arrow functions are used instead of anonymous function expressions in callbacks.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireBlocksOnNewline": {
+            "description": "Requires blocks to begin and end with a newline.",
+            "type": [ "boolean", "integer", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, validates all non-empty blocks.",
+                    "type": "boolean"
+                },
+                {
+                    "description": "Specifies a minimum number of lines containing elements in the block before validating.",
+                    "type": "integer"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "includeComments": {
+                            "description": "If true, includes comments as part of the validation.",
+                            "type": "boolean"
+                        },
+                        "minLines": {
+                            "description": "Specifies a minimum number of lines containing elements in the block before validating.",
+                            "type": "integer"
+                        }
+                    }
+                }
+            ]
+        },
+        "requireCamelCaseOrUpperCaseIdentifiers": {
+            "description": "Requires identifiers to be camelCased or UPPERCASE_WITH_UNDERSCORES.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values, in addition to other attributes.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of String, RegExp, or ESTree RegExpLiteral values permitted as exceptions.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        },
+                        "allowedPrefixes": {
+                            "description": "Array of String, RegExp, or ESTree RegExpLiteral values permitted as prefixes.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        },
+                        "allowedSuffixes": {
+                            "description": "Array of String, RegExp, or ESTree RegExpLiteral values permitted as suffixes.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        },
+                        "ignoreProperties": {
+                            "description": "If true, allows an exception for object property names.",
+                            "type": "boolean"
+                        },
+                        "strict": {
+                            "description": "If true, forces the first character to not be capitalized.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "description": "Deprecated in favor of the object \"ignoreProperties\" rule format.",
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "enum": [ "ignoreProperties" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "requireCapitalizedComments": {
+            "description": "Requires the first alphabetical character of a comment to be uppercase, unless it is part of a multi-line textblock.  This rule automatically ignores jscs, jshint, eslint, and istanbul specific comments.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions, in addition to other attributes.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        },
+                        "inlined": {
+                            "description": "If true, ignore comments in the middle of the code line.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "requireCapitalizedConstructorsNew": {
+            "description": "Requires capitalized constructors to to use the new keyword.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireCapitalizedConstructors": {
+            "description": "Requires constructors to be capitalized (except for \"this\")",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireCommaBeforeLineBreak": {
+            "description": "Requires commas as last token on a line in lists.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireCurlyBraces": {
+            "description": "Requires curly braces after statements.  A value of true will require curly braces for all the necessary keywords:  if, else, for, while do, try, catch, case, and default.",
+            "type": [ "array", "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/keywords2"
+                },
+                {
+                    "description": "An object that contains a \"keywords\" or \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "keywords": {
+                            "description": "Array of quoted keywords that would require curly braces.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        },
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.  Allows not using braces in some instances; ex.  /*allowed:*/ if (x) return; /* not allowed*/ if (x) i++; given \"allExcept\": [\"return\", \"continue\", \"break\", ...],",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireDollarBeforejQueryAssignment": {
+            "description": "Require a $ before variable names that are jquery assignments.",
+            "type": [ "boolean", "null", "string" ],
+            "oneOf": [
+                {
+                    "type": [ "boolean", "string" ],
+                    "enum": [ true, false, "ignoreProperties" ]
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireDotNotation": {
+            "description": "Requires member expressions to use dot notation when possible.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Allow quoted identifiers made of reserved words.",
+                                        "enum": [ "keywords" ]
+                                    },
+                                    {
+                                        "description": "Allow quoted snake cased identifiers.",
+                                        "enum": [ "snake_case" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "description": "Deprecated in favor of the object \"allExcept\": [\"snake_case\"] rule format.",
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Allow quoted snake cased identifiers.",
+                            "enum": [ "except_snake_case" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "requireEarlyReturn": {
+            "description": "Requires early return in a function.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "description": "If true, disallow the use of `else` if the corresponding parent `if` block contains a return.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireEnhancedObjectLiterals": {
+            "description": "Requires declaring objects via ES6 enhanced object literals.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireFunctionDeclarations": {
+            "description": "Requires function declarations by disallowing assignment of functions expressions to variables. Function expressions are allowed in all other contexts, including when passed as function arguments or immediately invoked.  Assignment of function expressions to object members is also permitted, since these can't be declared.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireImportAlphabetized": {
+            "description": "Requires imports to be alphabetized (A-Z).",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireKeywordsOnNewLine": {
+            "description": "Requires placing the specified keywords on a new line.",
+            "type": [ "array", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords" } ]
+        },
+        "requireLineBreakAfterVariableAssignment": {
+            "description": "Requires placing line feed after assigning a variable.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireLineFeedAtFileEnd": {
+            "description": "Requires placing line feed at file end.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireMatchingFunctionName": {
+            "description": "Requires function names to match member and property names.  It doesn't affect anonymous functions nor functions assigned to members or properties named with a reserved word.  Assigning to module.exports is also ignored, unless includeModuleExports: true is configured.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"includeModuleExports\" key of boolean type.",
+                    "type": "object",
+                    "properties": {
+                        "includeModuleExports": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "requireMultiLineTernary": {
+            "description": "Requires the test, consequent and alternate to be on separate lines when using the ternary operator.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireMultipleVarDecl": {
+            "description": "Requires multiple `var` declaration.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "description": "If true, it will report only consecutive vars.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "`require` statements are allowed to have a var declaration per variable.",
+                                        "enum": [ "require" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "If equal to 'onevar', requireMultipleVarDecl will allow only one var per function scope.",
+                            "enum": [ "onevar" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "requireNamedUnassignedFunctions": {
+            "description": "Require unassigned functions to be named inline.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireNewlineBeforeBlockStatements": {
+            "description": "Requires newline before opening curly brace of all block statements.  If true, always requires newline before curly brace of block statements.  Array specifies block-type keywords after which newlines are required before curly brace.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords2" } ]
+        },
+        "requireNumericLiterals": {
+            "description": "Requires use of binary, hexadecimal, and octal literals instead of parseInt.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireObjectDestructuring": {
+            "description": "Requires variable declarations from objects via destructuring.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireObjectKeysOnNewLine": {
+            "description": "Requires placing object keys on new line.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Ignores the rule if all the keys and values are on the same line.",
+                                        "enum": [ "sameLine" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireOperatorBeforeLineBreak": {
+            "description": "Requires operators to appear before line breaks and not after.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/operators"
+                }
+            ]
+        },
+        "requirePaddingNewLineAfterVariableDeclaration": {
+            "description": "Requires an extra blank newline after var declarations, as long as it is not the last expression in the current block.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requirePaddingNewLinesAfterBlocks": {
+            "description": "Requires newline after blocks.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, always require a newline after blocks.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Blocks don't need a line of padding in function argument lists.",
+                                        "enum": [ "inCallExpressions" ]
+                                    },
+                                    {
+                                        "description": "Blocks don't need a line of padding in constructor argument lists.",
+                                        "enum": [ "inNewExpressions" ]
+                                    },
+                                    {
+                                        "description": "Blocks don't need a line of padding in arrays.",
+                                        "enum": [ "inArrayExpressions" ]
+                                    },
+                                    {
+                                        "description": "Blocks don't need a line of padding as object properties.",
+                                        "enum": [ "inProperties" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requirePaddingNewLinesAfterUseStrict": {
+            "description": "Requires a blank line after 'use strict'; statements.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, require blank line after 'use strict' statements.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Allows 'require' statements to occur immediately after 'use strict'.",
+                                        "enum": [ "require" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requirePaddingNewLinesBeforeExport": {
+            "description": "Requires newline before module.exports.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requirePaddingNewlinesBeforeKeywords": {
+            "description": "Requires an empty line above the specified keywords unless the keyword is the first expression in a block.  If true, specifies that the spacedKeywords found in the utils module require an empty line above it.  Array values indicate keywords that require an empty line above it.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords2" } ]
+        },
+        "requirePaddingNewLinesBeforeLineComments": {
+            "description": "Requires newline before line comments.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, always require a newline before line comments.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Comments may be first line of block without extra padding.",
+                                        "enum": [ "firstAfterCurly" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requirePaddingNewlinesInBlocks": {
+            "description": "Requires blocks to begin and end with 2 newlines.",
+            "type": [ "boolean", "integer", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, validates all non-empty blocks.",
+                    "type": "boolean"
+                },
+                {
+                    "description": "Specifies a minimum number of lines containing elements in the block before validating.",
+                    "type": "integer"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "At least one of the object properties must be true.",
+                    "type": "object",
+                    "properties": {
+                        "open": {
+                            "description": "If true, validates that there is a newline after the opening brace in a block.",
+                            "type": "boolean"
+                        },
+                        "close": {
+                            "description": "If true, validates that there is a newline before the closing brace in a block.",
+                            "type": "boolean"
+                        },
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Ignores conditional (if, else if, else) blocks.",
+                                        "enum": [ "conditionals" ]
+                                    },
+                                    {
+                                        "description": "Ignores function blocks.",
+                                        "enum": [ "functions" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requirePaddingNewLinesInObjects": {
+            "description": "Requires newline inside curly braces of all objects.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireParenthesesAroundArrowParam": {
+            "description": "Requires parentheses around arrow function expressions with a single parameter.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireParenthesesAroundIIFE": {
+            "description": "Requires parentheses around immediately invoked function expressions.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireQuotedKeysInObjects": {
+            "description": "Requires quoted keys in objects.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireSemicolons": {
+            "description": "Requires semicolon after:  var declaration, expression statement, return, throw, break, continue, do-while.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireShorthandArrowFunctions": {
+            "description": "Require arrow functions to use an expression body when returning a single statement (no block statement, implicit return).",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireSpaceAfterBinaryOperators": {
+            "description": "Disallows sticking binary operators to the right.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/operators"
+                }
+            ]
+        },
+        "requireSpaceAfterComma": {
+            "description": "Requires space after comma.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, require a space after any comma.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of quoted exceptions.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Ignore trailing commas.",
+                                        "enum": [ "trailing" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireSpaceAfterKeywords": {
+            "description": "Requires space after the specified keywords.  A value of true will disallow spaces after all possible keywords.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/keywords2" } ]
+        },
+        "requireSpaceAfterLineComment": {
+            "description": "Requires that a line comment (`//`) be followed by a space.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of allowed strings before space.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "description": "Deprecated in favor of the object \"allExcept\": [\"/\"] rule format.",
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "enum": [ "allowSlash" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "requireSpaceAfterObjectKeys": {
+            "description": "Requires space after object keys.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireSpaceAfterPrefixUnaryOperators": {
+            "description": "Disallows sticking unary operators to the right.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/unaryOperators" } ]
+        },
+        "requireSpaceBeforeBinaryOperators": {
+            "description": "Disallows sticking binary operators to the left.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/operators" } ]
+        },
+        "requireSpaceBeforeBlockStatements": {
+            "description": "Requires space before block statements (for loops, control structures).",
+            "type": [ "boolean", "null", "integer" ],
+            "oneOf": [
+                {
+                    "description": "If true, require at least a single space.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "Require at least the specified number of spaces.  Value must be greater than or equal to 1.",
+                    "type": "integer",
+                    "minimum": 1
+                }
+            ]
+        },
+        "requireSpaceBeforeComma": {
+            "description": "Requires a space before a comma.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "description": "If true, require a space before any comma.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireSpaceBeforeKeywords": {
+            "description": "Requires a space before a keyword.",
+            "type": [ "array", "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/blockKeywords"
+                },
+                {
+                    "description": "If true, report on all possible ES3 keywords except `function`.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of allowed strings before space.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireSpaceBeforeObjectValues": {
+            "description": "Requires space after object keys.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireSpaceBeforePostfixUnaryOperators": {
+            "description": "Disallows sticking unary operators to the left.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [ { "$ref": "#/definitions/unaryOperators" } ]
+        },
+        "requireSpaceBetweenArguments": {
+            "description": "Ensure there are spaces after argument separators in call expressions.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireSpacesInAnonymousFunctionExpression": {
+            "description": "Requires space before `()` or `{}` in function expressions (both named and anonymous).",
+            "type": [ "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "An object with the following properties (one of \"beforeOpeningRoundBrace\" and \"beforeOpeningCurlyBrace\" must be provided):",
+                    "type": "object",
+                    "properties": {
+                        "beforeOpeningRoundBrace": {
+                            "type": [ "boolean", "null" ]
+                        },
+                        "beforeOpeningCurlyBrace": {
+                            "type": [ "boolean", "null" ]
+                        },
+                        "allExcept": {
+                            "description": "A boolean or an array of quoted exceptions.",
+                            "type": [ "boolean", "null", "array" ],
+                            "oneOf": [
+                                {
+                                    "description": "If true, enable all configuration exceptions.",
+                                    "type": "boolean"
+                                },
+                                {
+                                    "$ref": "#/definitions/nullRule"
+                                },
+                                {
+                                    "description": "Array of quoted keywords to exempt.",
+                                    "type": "array",
+                                    "minItems": 0,
+                                    "items": {
+                                        "type": "string",
+                                        "oneOf": [
+                                            {
+                                                "description": "If \"shorthand\" is provided, spaces will not be required for ES6 method definitions.",
+                                                "enum": [ "shorthand" ]
+                                            }
+                                        ]
+                                    },
+                                    "uniqueItems": true
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "requireSpacesInCallExpression": {
+            "description": "Requires space before `()` in call expressions.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireSpacesInConditionalExpression": {
+            "description": "Requires space before and/or after `?` or `:` in conditional expressions.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, set all properties to true.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "afterTest": {
+                            "type": "boolean"
+                        },
+                        "beforeConsequent": {
+                            "type": "boolean"
+                        },
+                        "afterConsequent": {
+                            "type": "boolean"
+                        },
+                        "beforeAlternate": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "requireSpacesInForStatement": {
+            "description": "Requires spaces in between `for` statement.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireSpacesInFunction": {
+            "description": "Requires space before `()` or `{}` in function expressions (both named and anonymous) and function declarations.",
+            "type": [ "null", "object" ],
+            "oneOf": [ { "$ref": "#/definitions/braceRules" } ]
+        },
+        "requireSpacesInFunctionDeclaration": {
+            "description": "Requires space before `()` or `{}` in function declarations.",
+            "type": [ "null", "object" ],
+            "oneOf": [ { "$ref": "#/definitions/braceRules" } ]
+        },
+        "requireSpacesInFunctionExpression": {
+            "description": "Requires space before `()` or `{}` in function expressions (both named and anonymous).",
+            "type": [ "null", "object" ],
+            "oneOf": [
+                { "$ref": "#/definitions/braceRules" }
+            ]
+        },
+        "requireSpacesInGenerator": {
+            "description": "Requires space before and after `*` in generator functions.",
+            "type": [ "null", "object" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object where at least one of its properties must be present and it must be set to true.",
+                    "type": "object",
+                    "properties": {
+                        "beforeStar": {
+                            "description": "If true, validates that there is a space before `*`.",
+                            "type": "boolean"
+                        },
+                        "afterStar": {
+                            "description": "If true, validates that there is a space after `*`.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "requireSpacesInNamedFunctionExpression": {
+            "description": "Requires space before `()` or `{}` in named function expressions.",
+            "type": [ "null", "object" ],
+            "oneOf": [
+                { "$ref": "#/definitions/braceRules" }
+            ]
+        },
+        "requireSpacesInsideArrayBrackets": {
+            "description": "Requires space after opening array square bracket and before closing.  Reports only on arrays, not on property accessors.  Use requireSpacesInsideBrackets to report on all brackets.",
+            "type": [ "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception tokens.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted tokens that can occur after an opening square bracket or before a closing square bracket without a space.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "enum": [ "{", "}", "[", "]" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Strict mode.",
+                            "enum": [ "all" ]
+                        },
+                        {
+                            "description": "Deprecated in favor of the object \"allExcept\": [\"[\", \"]\"] format.",
+                            "enum": [ "allButNested" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "requireSpacesInsideBrackets": {
+            "description": "Requires space after opening square bracket and before closing.  Reports on all on brackets, even on property accessors.  Use requireSpacesInsideArrayBrackets to exclude property accessors.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "For default behavior (strict mode).",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception tokens.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted tokens that can occur after an opening square bracket or before a closing square bracket without a space.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "enum": [ "{", "}", "[", "]" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireSpacesInsideObjectBrackets": {
+            "description": "Requires space after opening object curly brace and before closing.",
+            "type": [ "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception tokens.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted tokens that can occur after an opening object brace or before a closing object brace without a space.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "enum": [ "(", ")", "{", "}", "[", "]" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Strict mode.",
+                            "enum": [ "all" ]
+                        },
+                        {
+                            "description": "Deprecated in favor of the object \"allExcept\": [\"}\"] format.",
+                            "enum": [ "allButNested" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "requireSpacesInsideParentheses": {
+            "description": "Requires space after opening round bracket and before closing.",
+            "type": [ "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"except\" key equal to an array of exception tokens, in addition to other attributes.",
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean"
+                        },
+                        "ignoreParenthesizedExpression": {
+                            "type": "boolean"
+                        },
+                        "except": {
+                            "description": "Array of quoted tokens that can occur after an opening bracket or before a closing bracket without a space.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "anyOf": [
+                                    {
+                                        "enum": [ "(", ")", "{", "}", "[", "]" ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "maxLength": 1
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Strict mode.",
+                            "enum": [ "all" ]
+                        },
+                        {
+                            "description": "Deprecated in favor of the object \"except\": [\"(\", \")\"] format.  Ignores nested brackets in a row.",
+                            "enum": [ "allButNested" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "requireSpacesInsideParenthesizedExpression": {
+            "description": "Requires space after opening and before closing grouping parentheses.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, always require spaces inside grouping parentheses.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Ignore parenthesized objects and functions.",
+                                        "enum": [ "{", "}", "function" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireSpread": {
+            "description": "Disallows using `.apply` in favor of the spread operator.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "description": "If true, specifies that apply `.apply` is disallowed.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireTemplateStrings": {
+            "description": "Requires the use of template strings instead of string concatenation.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "An object that contains an \"allExcept\" key equal to an array of exception values.",
+                    "type": "object",
+                    "properties": {
+                        "allExcept": {
+                            "description": "Array of quoted keywords to exempt.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Ignores strings concatenated with other strings.",
+                                        "enum": [ "stringConcatenation" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "requireTrailingComma": {
+            "description": "Requires an extra comma following the final element of an array or object literal.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, validates all arrays and objects.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "ignoreSingleValue": {
+                            "description": "If true, allows single property objects and single element arrays to not require a trailing comma.",
+                            "type": "boolean"
+                        },
+                        "ignoreSingleLine": {
+                            "description": "If true, allows objects and arrays on a single line to not require a trailing comma.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "requireVarDeclFirst": {
+            "description": "Requires `var` declaration to be on the top of an enclosing scope.",
+            "type": [ "boolean", "null" ],
+            "oneOf": [
+                {
+                    "description": "If true, specifies that `var` declarations must occur the top of a function scope.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "requireYodaConditions": {
+            "description": "Requires the variable to be the right hand operator when doing a boolean comparison.  An array of quoted operators can be supplied to indicate which operators requires yoda conditions.",
+            "type": [ "array", "boolean", "null" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/equalityOperators"
+                },
+                {
+                    "description": "If true, specifies that yoda conditions are required for most possible comparison operators.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                }
+            ]
+        },
+        "safeContextKeyword": {
+            "description": "Option to check `var that = this` expressions.",
+            "type": [ "array", "null", "string" ],
+            "oneOf": [
+                {
+                    "description": "Array of quoted keywords that can be assigned to `this` context.",
+                    "type": "array",
+                    "minItems": 0,
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "description": "Represents the keyword that can be assigned to `this` context.",
+                    "type": "string",
+                    "minLength": 1
+                }
+            ]
+        },
+        "validateAlignedFunctionParameters": {
+            "description": "Validates proper alignment of function parameters.",
+            "type": [ "boolean", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, this is the same as validating the rule using `{lineBreakAfterOpeningBrace: true, lineBreakBeforeClosingBrace: true}`.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "lineBreakAfterOpeningBrace": {
+                            "description": "If true, specifies that the first function parameter must not be on the same line as the opening parenthesis `(` of the function parameters list.",
+                            "type": "boolean"
+                        },
+                        "lineBreakBeforeClosingBrace": {
+                            "description": "If true, specifies that the last function parameter must not be on the same line as the closing parenthesis `)` of the function parameters list.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "validateCommentPosition": {
+            "description": "This rule is for validating the positioning of line comments.  Block comments are ignored.  Comments that start with the following keywords are also ignored:  `eslint`, `jshint`, `jslint`, `istanbul`, `global`, `exported`, `jscs`, `falls through` eg. // jshint strict: true",
+            "type": [ "null", "object" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "position": {
+                            "type": "string",
+                            "enum": [ "above", "beside" ]
+                        },
+                        "allExcept": {
+                            "description": "Array of quoted exceptions (comments that start with these values will be excepted).",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            ]
+        },
+        "validateIndentation": {
+            "description": "Validates indentation for switch statements and block statements.",
+            "type": [ "integer", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "description": "A positive number of spaces.",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": [ "integer", "string" ],
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "includeEmptyLines": {
+                            "description": "Deprecated.  Require empty lines to be indented.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "allExcept": {
+                            "description": "Array of quoted exceptions.",
+                            "type": "array",
+                            "minItems": 0,
+                            "items": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "description": "Ignores comments.",
+                                        "enum": [ "comments" ]
+                                    },
+                                    {
+                                        "description": "Ignores empty lines, included by default.",
+                                        "enum": [ "emptyLines" ]
+                                    }
+                                ]
+                            },
+                            "uniqueItems": true
+                        }
+                    },
+                    "required": [ "value" ]
+                }
+            ]
+        },
+        "validateLineBreaks": {
+            "description": "Option to check line break characters.",
+            "type": [ "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "character": {
+                            "type": "string",
+                            "enum": [ "CR", "LF", "CRLF" ]
+                        },
+                        "reportOncePerFile": {
+                            "description": "If true, specifies that validation for the file should stop running upon encountering the first rule violation and return the details of that violation in the report.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "description": "Setting this is the same as validating the rule using `{character: String, reportOncePerFile: false}`.",
+                    "type": "string",
+                    "enum": [ "CR", "LF", "CRLF" ]
+                }
+            ]
+        },
+        "validateNewlineAfterArrayElements": {
+            "description": "Requires each element in array on a single line when array length is more than passed maximum number or array fills more than one line.",
+            "type": [ "boolean", "integer", "null", "object" ],
+            "oneOf": [
+                {
+                    "description": "If true, this is the same as validating the rule using `{maximum: Infinity, ignoreBrackets: false}`.",
+                    "type": "boolean"
+                },
+                {
+                    "description": "Setting this is the same as validating the rule using `{maximum: Integer, ignoreBrackets: false}`.",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "maximum": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "ignoreBrackets": {
+                            "description": "If true, specifies that the `[` and `]` brackets can be placed on the same line as the array elements.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        },
+        "validateOrderInObjectKeys": {
+            "description": "Validates the order in object keys.",
+            "type": [ "boolean", "null", "string" ],
+            "oneOf": [
+                {
+                    "description": "If true, alias to `asc`.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Requires sorting in ascending order.",
+                            "enum": [ "asc" ]
+                        },
+                        {
+                            "description": "Requires sorting in ascending order (case-insensitive).",
+                            "enum": [ "asc-insensitive" ]
+                        },
+                        {
+                            "description": "Requires sorting in ascending natural order.",
+                            "enum": [ "asc-natural" ]
+                        },
+                        {
+                            "description": "Requires sorting in descending order.",
+                            "enum": [ "desc" ]
+                        },
+                        {
+                            "description": "Requires sorting in descending order (case-insensitive).",
+                            "enum": [ "desc-insensitive" ]
+                        },
+                        {
+                            "description": "Requires sorting in descending natural order.",
+                            "enum": [ "desc-natural" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "validateParameterSeparator": {
+            "description": "Enable validation of separators between function parameters.  Will ignore newlines.",
+            "type": [ "null", "string" ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "Function parameters are immediately followed by a comma.",
+                            "enum": [ "," ]
+                        },
+                        {
+                            "description": "Function parameters are immediately followed by a comma and then a space.",
+                            "enum": [ ", " ]
+                        },
+                        {
+                            "description": "Function parameters are immediately followed by a space and then a comma.",
+                            "enum": [ " ," ]
+                        },
+                        {
+                            "description": "Function parameters are immediately followed by a space, a comma, and then a space.",
+                            "enum": [ " , " ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "validateQuoteMarks": {
+            "description": "Requires all quote marks to be either the supplied value, or consistent if `true`.",
+            "type": [ "boolean", "null", "object", "string" ],
+            "oneOf": [
+                {
+                    "description": "If true, all strings require the quote mark first encountered in the source code.",
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/definitions/nullRule"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "escape": {
+                            "description": "Allow the \"other\" quote mark to be used, but only to avoid having to escape.",
+                            "type": "boolean"
+                        },
+                        "mark": {
+                            "description": "The same effect as the non-object values.",
+                            "type": "string",
+                            "oneOf": [
+                                {
+                                    "description": "All strings require double quotes.",
+                                    "enum": [ "" ]
+                                },
+                                {
+                                    "description": "All strings require single quotes.",
+                                    "enum": [ "" ]
+                                }
+                            ]
+                        },
+                        "ignoreJSX": {
+                            "description": "Ignore JSX nodes.",
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [ "value" ]
+                },
+                {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "description": "All strings require double quotes.",
+                            "enum": [ "\"" ]
+                        },
+                        {
+                            "description": "All strings require single quotes.",
+                            "enum": [ "'" ]
+                        }
+                    ]
+                }
+            ]
         }
-      }
-    },
-    "keywords": {
-      "type": [ "array", "null" ],
-      "items": {
-        "enum": [ "break", "case", "catch", "continue", "debugger", "default", "delete", "do", "else", "finally", "for", "function", "if", "in", "instanceof", "new", "return", "switch", "this", "throw", "try", "typeof", "var", "void", "while", "with" ]
-      }
-    },
-    "operators": {
-      "type": [ "array", "boolean", "null" ],
-      "items": {
-        "enum": [ "?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<=", null ]
-      }
-    },
-    "unaryOperators": {
-      "type": [ "array", "boolean", "null" ],
-      "items": {
-        "enum": [ "++", "--", "+", "-", "~", "!" ]
-      }
     }
-  },
-
-  "properties": {
-    "requireCurlyBraces": {
-      "$ref": "#/definitions/keywords"
-    },
-    "requireSpaceAfterKeywords": {
-      "$ref": "#/definitions/keywords"
-    },
-    "disallowSpaceAfterKeywords": {
-      "$ref": "#/definitions/keywords"
-    },
-    "requireSpaceBeforeBlockStatements": {
-      "description": "Requires space before block statements (for loops, control structures).",
-      "type": "boolean"
-    },
-    "disallowSpaceBeforeBlockStatements": {
-      "description": "Disallows space before block statements (for loops, control structures).",
-      "type": [ "null", "boolean" ]
-    },
-    "requireParenthesesAroundIIFE": {
-      "description": "Requires parentheses around immediately invoked function expressions.",
-      "type": "boolean"
-    },
-    "requireSpacesInFunctionExpression": {
-      "$ref": "#/definitions/braceRules"
-    },
-    "requireSpacesInAnonymousFunctionExpression": {
-      "$ref": "#/definitions/braceRules"
-    },
-    "disallowSpacesInAnonymousFunctionExpression": {
-      "$ref": "#/definitions/braceRules"
-    },
-    "requireSpacesInNamedFunctionExpression": {
-      "$ref": "#/definitions/braceRules"
-    },
-    "disallowSpacesInNamedFunctionExpression": {
-      "$ref": "#/definitions/braceRules"
-    },
-    "requireSpacesInFunctionDeclaration": {
-      "$ref": "#/definitions/braceRules"
-    },
-    "disallowSpacesInFunctionDeclaration": {
-      "$ref": "#/definitions/braceRules"
-    },
-    "disallowSpacesInFunctionExpression": {
-      "properties": {
-        "beforeOpeningRoundBrace": {
-          "type": "boolean"
-        }
-      }
-    },
-    "disallowMultipleVarDecl": {
-      "description": "Disallows multiple 'var' declaration (except for-loop).",
-      "type": [ "null", "boolean" ]
-    },
-    "requireMultipleVarDecl": {
-      "description": "Requires multiple 'var' declaration.",
-      "type": [ "boolean", "string" ],
-      "enum": [ true, "onevar" ]
-    },
-    "requireBlocksOnNewline": {
-      "description": "Requires blocks to begin and end with a newline.",
-      "type": [ "boolean", "integer" ]
-    },
-    "requirePaddingNewlinesInBlocks": {
-      "description": "Requires blocks to begin and end with 2 newlines.",
-      "type": [ "boolean", "integer" ]
-    },
-    "disallowSpaceAfterLineComment": {
-      "type": [ "boolean", "null" ]
-    },
-    "requireSpaceAfterLineComment": {
-      "type": [ "boolean", "null" ]
-    },
-    "disallowSpacesInConditionalExpression": {
-      "type": [ "boolean", "null" ]
-    },
-    "requireSpacesInConditionalExpression": {
-      "type": [ "boolean", "null" ]
-    },
-    "disallowPaddingNewlinesInBlocks": {
-      "description": "Disallows blocks from beginning and ending with 2 newlines.",
-      "type": [ "boolean", "null" ]
-    },
-    "disallowEmptyBlocks": {
-      "description": "Disallows empty blocks (except for catch blocks).",
-      "type": "boolean"
-    },
-    "disallowSpacesInsideObjectBrackets": {
-      "description": "Disallows space after opening object curly brace and before closing.",
-      "type": [ "null", "boolean" ]
-    },
-    "disallowSpacesInsideArrayBrackets": {
-      "description": "Disallows space after opening array square bracket and before closing.",
-      "anyOf": [
-        {
-          "enum": [ true, "all", "nested" ]
-        },
-        {
-          "type": "object"
-        }
-      ]
-    },
-    "disallowSpacesInsideParentheses": {
-      "description": "Disallows space after opening round bracket and before closing.",
-      "type": [ "null", "boolean" ]
-    },
-    "requireSpacesInsideObjectBrackets": {
-      "description": "Requires space after opening object curly brace and before closing.",
-      "type": "string",
-      "enum": [ "all", "allButNested" ]
-    },
-    "requireSpacesInsideArrayBrackets": {
-      "description": "Requires space after opening array square bracket and before closing.",
-      "type": "string",
-      "enum": [ "all", "allButNested" ]
-    },
-    "requireSpacesInsideParentheses": {
-      "type": "string",
-      "enum": [ "all", "allButNested" ]
-    },
-    "disallowQuotedKeysInObjects": {
-      "description": "Disallows quoted keys in object if possible.",
-      "type": [ "string", "boolean" ],
-      "enum": [ true, false, "allButReserved" ]
-    },
-    "disallowDanglingUnderscores": {
-      "description": "Disallows identifiers that start or end in '_', except for some popular exceptions:",
-      "type": "boolean"
-    },
-    "disallowSpaceAfterObjectKeys": {
-      "description": "Disallows space after object keys.",
-      "type": [ "null", "boolean" ]
-    },
-    "requireSpaceAfterObjectKeys": {
-      "description": "Requires space after object keys.",
-      "type": "boolean"
-    },
-    "disallowCommaBeforeLineBreak": {
-      "description": "Disallows commas as last token on a line in lists.",
-      "type": [ "null", "boolean" ]
-    },
-    "requireCommaBeforeLineBreak": {
-      "description": "Requires commas as last token on a line in lists.",
-      "type": "boolean"
-    },
-    "requireAlignedObjectValues": {
-      "description": "Requires proper alignment in object literals.",
-      "type": "string",
-      "enum": [ "all", "skipWithFunction", "skipWithLineBreak" ]
-    },
-    "requireOperatorBeforeLineBreak": {
-      "$ref": "#/definitions/operators"
-    },
-    "disallowLeftStickedOperators": {
-      "$ref": "#/definitions/operators"
-    },
-    "requireRightStickedOperators": {
-      "$ref": "#/definitions/operators"
-    },
-    "disallowRightStickedOperators": {
-      "$ref": "#/definitions/operators"
-    },
-    "requireLeftStickedOperators": {
-      "description": "Requires sticking operators to the left.",
-      "type": "array",
-      "items": {
-        "enum": [ "," ]
-      }
-    },
-    "disallowSpaceAfterPrefixUnaryOperators": {
-      "$ref": "#/definitions/unaryOperators"
-    },
-    "requireSpaceAfterPrefixUnaryOperators": {
-      "$ref": "#/definitions/unaryOperators"
-    },
-    "disallowSpaceBeforePostfixUnaryOperators": {
-      "$ref": "#/definitions/unaryOperators"
-    },
-    "requireSpaceBeforePostfixUnaryOperators": {
-      "$ref": "#/definitions/unaryOperators"
-    },
-    "disallowSpaceBeforeBinaryOperators": {
-      "$ref": "#/definitions/operators"
-    },
-    "requireSpaceBeforeBinaryOperators": {
-      "$ref": "#/definitions/operators"
-    },
-    "disallowSpaceAfterBinaryOperators": {
-      "$ref": "#/definitions/operators"
-    },
-    "requireSpaceAfterBinaryOperators": {
-      "$ref": "#/definitions/operators"
-    },
-    "disallowImplicitTypeConversion": {
-      "description": "Disallows implicit type conversion.",
-      "type": "array",
-      "items": {
-        "enum": [ "numeric", "boolean", "binary", "string" ]
-      }
-    },
-    "requireCamelCaseOrUpperCaseIdentifiers": {
-      "description": "Requires identifiers to be camelCased or UPPERCASE_WITH_UNDERSCORES",
-      "type": [ "boolean", "string" ],
-      "enum": [ true, "ignoreProperties" ]
-    },
-    "disallowKeywords": {
-      "$ref": "#/definitions/keywords"
-    },
-    "disallowMultipleLineStrings": {
-      "description": "Disallows strings that span multiple lines without using concatenation.",
-      "type": "boolean"
-    },
-    "disallowMultipleLineBreaks": {
-      "description": "Disallows multiple blank lines in a row.",
-      "type": "boolean"
-    },
-    "validateLineBreaks": {
-      "description": "Option to check line break characters.",
-      "type": "string",
-      "enum": [ "CR", "LF", "CRLF" ]
-    },
-    "validateQuoteMarks": {
-      "description": "Requires all quote marks to be either the supplied value, or consistent if true",
-      "type": [ "object", "string", "boolean" ],
-      "enum": [ true, "\"", "'" ],
-      "properties": {
-        "escape": {
-          "type": "boolean"
-        },
-        "mark": {
-          "type": "string",
-          "enum": [ "\"", "'" ]
-        }
-      }
-    },
-    "validateIndentation": {
-      "description": "Validates indentation for arrays, objects, switch statements, and block statements.",
-      "type": [ "string", "integer" ],
-      "minimum": 0
-    },
-    "disallowMixedSpacesAndTabs": {
-      "description": "Requires lines to not contain both spaces and tabs consecutively, or spaces after tabs only for alignment if \"smart\"",
-      "type": [ "boolean", "string" ],
-      "enum": [ true, false, "smart" ]
-    },
-    "disallowTrailingWhitespace": {
-      "description": "Requires all lines to end on a non-whitespace character.",
-      "type": "boolean"
-    },
-    "disallowTrailingComma": {
-      "description": "Disallows an extra comma following the final element of an array or object literal.",
-      "type": [ "null", "boolean" ]
-    },
-    "requireTrailingComma": {
-      "description": "Requires an extra comma following the final element of an array or object literal.",
-      "type": "boolean"
-    },
-    "disallowKeywordsOnNewLine": {
-      "$ref": "#/definitions/keywords"
-    },
-    "requireKeywordsOnNewLine": {
-      "$ref": "#/definitions/keywords"
-    },
-    "requireLineFeedAtFileEnd": {
-      "description": "Requires placing line feed at file end.",
-      "type": "boolean"
-    },
-    "maximumLineLength": {
-      "description": "Requires all lines to be at most the number of characters specified.",
-      "type": [ "integer", "object" ]
-    },
-    "requireCapitalizedConstructors": {
-      "description": "Requires constructors to be capitalized (except for \"this\")",
-      "type": "boolean"
-    },
-    "safeContextKeyword": {
-      "description": "Option to check \"var that = this\" expressions.",
-      "type": [ "array", "string", "boolean" ]
-    },
-    "requireDotNotation": {
-      "description": "Requires member expressions to use dot notation when possible.",
-      "type": "boolean"
-    },
-    "disallowYodaConditions": {
-      "description": "Requires the variable to be the left hand operator when doing a boolean comparison.",
-      "type": "boolean"
-    },
-    "validateJSDoc": {
-      "$ref": "#/definitions/validateJSDoc"
-    },
-    "excludeFiles": {
-      "description": "Disables style checking for specified paths.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "additionalRules": {
-      "description": "Path to load additional rules",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "preset": {
-      "description": "Extends defined rules with preset rules.",
-      "type": "string",
-      "enum": ["airbnb", "crockford", "google", "grunt", "idiomatic", "jquery", "mdcs", "node-style-guide", "wikimedia", "wordpress", "yandex"]
-    }
-  }
 }

--- a/src/schemas/json/jscsrc.json
+++ b/src/schemas/json/jscsrc.json
@@ -1037,7 +1037,7 @@
         "disallowSpacesInConditionalExpression": {
             "description": "Disallows space before and/or after ? or : in conditional expressions.",
             "type": [ "boolean", "null", "object" ],
-            "oneOf": [
+            "anyOf": [
                 {
                     "description": "A value of true will set all properties [afterTest, beforeConsequent, afterConsequent, beforeAlternate] to true.",
                     "type": "boolean"

--- a/src/test/jscsrc/jscsrc-test.json
+++ b/src/test/jscsrc/jscsrc-test.json
@@ -36,7 +36,7 @@
 	"disallowTrailingWhitespace": true,
 	"disallowYodaConditions": true,
 	"maximumLineLength": 120,
-	"requireAlignedObjectValues": "skipWithFunction",
+	"requireAlignedObjectValues": "all",
 	"requireBlocksOnNewline": true,
 	"requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
 	"requireCapitalizedConstructors": true,
@@ -76,7 +76,7 @@
 	"requireSpacesInsideObjectBrackets": "allButNested",
 	"requireSpacesInsideParentheses": "all",
 	"requireTrailingComma": true,
-	"safeContextKeyword": true,
+	"safeContextKeyword": "self",
 	"validateIndentation": 4,
 	"validateJSDoc": {
 		"checkParamNames": true,


### PR DESCRIPTION
Additional details:
-  Replaced validateJSDoc definition with new jsDoc definiton.

-  Updated the following rule definitions:
   requireLeftStickedOperators replaced by disallowSpaceBeforeBinaryOperators.
   disallowLeftStickedOperators replaced by requireSpaceBeforeBinaryOperators.
   requireRightStickedOperators replaced by disallowSpaceAfterBinaryOperators.
   disallowRightStickedOperators replaced by requireSpaceAfterBinaryOperators.

-  Updating the operators definition
   Adding "," and ":" entries to the enum array in addition to other operators used in https://github.com/jscs-dev/node-jscs/blob/master/lib/utils.js

-  Updating all properties entries to include descriptions among other changes to reflect the latest JSCS ruleset.

-  Adding missing rules.