### PR TITLE
Add scripts property to .bowerrc schema

### DIFF
--- a/src/schemas/json/bowerrc.json
+++ b/src/schemas/json/bowerrc.json
@@ -103,13 +103,31 @@
       "description": "Identifies pluggable resolvers to be used for locating and fetching packages",
       "items": {
         "type": "string"
-      } 
+      }
     },
     "shallowCloneHosts": {
       "type": "array",
       "description": "Whitelists hosts which are known to support shallow cloning",
       "items": {
         "type": "string"
+      }
+    },
+    "scripts": {
+      "description": "Contains custom hooks used to trigger other automated tools",
+      "type": "object",
+      "properties": {
+        "preinstall": {
+          "type": "string",
+          "description": "A script to run before install"
+        },
+        "postinstall": {
+          "type": "string",
+          "description": "A script to run after install"
+        },
+        "preuninstall": {
+          "type": "string",
+          "description": "A script to run before uninstall"
+        }
       }
     }
 	}

--- a/src/test/bowerrc/bowerrc-test2.json
+++ b/src/test/bowerrc/bowerrc-test2.json
@@ -1,0 +1,8 @@
+﻿{
+  "$schema": "http://json.schemastore.org/bowerrc",
+
+  "directory": "wwwroot/lib",
+  "scripts": {
+    "postinstall": "./.bower-postinstall.sh"
+  }
+}


### PR DESCRIPTION
Per the [.bowerrc file specification](http://bower.io/docs/config/#hooks), there's a `scripts` property available which offers 3 hooks. This PR adds support for this in the `.bowerrc` file's JSON schema.