### PR TITLE
Add 'ignoredDependencies' support to .bowerrc schema

### DIFF
--- a/src/schemas/json/bowerrc.json
+++ b/src/schemas/json/bowerrc.json
@@ -129,6 +129,13 @@
           "description": "A script to run before uninstall"
         }
       }
+    },
+    "ignoredDependencies": {
+      "type": "array",
+      "description": "Bower will ignore these dependencies when resolving packages",
+      "items": {
+        "type": "string"
+      }
     }
 	}
 }


### PR DESCRIPTION
This PR adds schema support for the `.bowerrc` file's [`ignoredDependencies`](https://github.com/bower/spec/blob/master/config.md#ignoreddependencies) property.