### PR TITLE
Add "tools" node to project.json

### DIFF
--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -70,9 +70,9 @@
 						"enum": [ "default", "build" ]
 					},
 					"target": {
-					  "type": "string",
-					  "description": "Restrict this dependency to matching only a Project or a Package",
-					  "enum": [ "project", "package" ]
+						"type": "string",
+						"description": "Restrict this dependency to matching only a Project or a Package",
+						"enum": [ "project", "package" ]
 					}
 				}
 			}
@@ -96,8 +96,8 @@
 		},
 
 		"packInclude": {
-		  "description": "Pairs of destination folders and glob patterns specifying additional files to include in the output NuGet package. (data type: JSON map). Example: { \"tools/\": \"tools/**/*.*\" }",
-		  "type": "object"
+			"description": "Pairs of destination folders and glob patterns specifying additional files to include in the output NuGet package. (data type: JSON map). Example: { \"tools/\": \"tools/**/*.*\" }",
+			"type": "object"
 		},
 
 		"publishExclude": {
@@ -329,15 +329,15 @@
 			"type": "object",
 			"description": "Contains information about the repository where the project is stored.",
 			"properties": {
-        "type": {
-          "type": "string",
-          "enum": [ "git" ],
-          "default": "git"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
+				"type": {
+					"type": "string",
+					"enum": [ "git" ],
+					"default": "git"
+				},
+				"url": {
+					"type": "string",
+					"format": "uri"
+				}
 			},
 			"additionalProperties": {
 				"type": "string"
@@ -361,6 +361,18 @@
 		"version": {
 			"description": "The version of the project/package. Examples: 1.2.3, 1.2.3-beta, 1.2.3-*",
 			"type": "string"
+		},
+		"tools": {
+			"description": "Project-specific command line tools accessible when in the project.json directory.",
+			"type": "object",
+			"additionalProperties": {
+				"type": [ "string", "object" ],
+				"properties": {
+					"version": {
+						"type": "string"
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
1. Add the "tools" node to project.json schema.
2. Clean up some inconsistent indentation. 

I tested this by pointing VS 2015 directly to my local project.json. Intellisense for the "tools" property and children seemed to work. This is my first time editing a project.json, so could I get some eyes on this? Someone trying it would also be very appreciated!

@madskristensen @brthor @emgarten @yishaigalatzer @davidfowl 