### PR TITLE
Support 4 new properties in .typingsrc schema

### DIFF
--- a/src/schemas/json/typingsrc.json
+++ b/src/schemas/json/typingsrc.json
@@ -1,6 +1,6 @@
 ﻿{
-	"$schema": "http://json-schema.org/draft-04/schema",
-	"title": "JSON schema for .typingsrc files",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "JSON schema for .typingsrc files",
 
   "type": "object",
   "additionalProperties": true,
@@ -16,6 +16,20 @@
     "cert": {
       "type": "string",
       "description": "Public x509 certificate to use"
+    },
+    "defaultAmbientSource": {
+      "type": "string",
+      "description": "Override the default ambient installation source (e.g., when doing 'typings install node -A')",
+      "default": "dt"
+    },
+    "defaultSource": {
+      "type": "string",
+      "description": "Override the default installation source (e.g., when doing 'typings install debug')",
+      "default": "npm"
+    },
+    "githubToken": {
+      "type": "string",
+      "description": "Set your GitHub for resolving 'github:' locations"
     },
     "httpProxy": {
       "type": "string",
@@ -36,6 +50,10 @@
     "proxy": {
       "type": "string",
       "description": "A HTTP(s) proxy URI for outgoing requests"
+    },
+    "registryURL": {
+      "type": "string",
+      "description": "Override the registry URL"
     },
     "rejectUnauthorized": {
       "type": "boolean",


### PR DESCRIPTION
The Typings project has added support for the following 4 properties in the `.typingsrc` file:
1. `githubToken`
2. `registryURL`
3. `defaultSource`
4. `defaultAmbientSource`

The supporting documentation can be found [here](https://github.com/typings/typings#configuration).