### PR TITLE
Add debugType compile option to the schema

### DIFF
--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -45,6 +45,10 @@
 				"useOssSigning": {
 					"type": "boolean",
 					"default": false
+				},
+				"debugType": {
+					"type": "string",
+					"enum": [ "portable", "full", "none" ]
 				}
 			}
 		},


### PR DESCRIPTION
This makes the schema consistent with the usage in dotnet/cli.

https://github.com/dotnet/cli/pull/1392