### PR TITLE
Correct the public / OSS sign name

### DIFF
--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -42,7 +42,7 @@
 					"type": "boolean",
 					"default": false
 				},
-				"useOssSigning": {
+				"publicSign": {
 					"type": "boolean",
 					"default": false
 				},


### PR DESCRIPTION
This should be publicSign not useOssSigning.  Context in CLI repo

https://github.com/dotnet/cli/commit/869b92735033435ecd6eb91dc28d02a3f67bb1b7