### PR TITLE
Add new --lib compiler option

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -235,10 +235,10 @@
             },
             "lib": {
               "description": "Specify library file to be included in the compilation.",
-              "enum": [ "es3", "es5", "es6", "es7", "dom", "dom.iterable", "webworker", "scripthost", "node",
-                        "es6.array", "es6.collection", "es6.function", "es6.generator", "es6.iterable",
-                        "es6.math", "es6.number", "es6.object", "es6.promise", "es6.proxy", "es6.reflect",
-                        "es6.regexp", "es6.string", "es6.symbol", "es6.symbol.wellknown", "es7.array.include"]
+              "enum": [ "es3", "es5", "es6", "es2015", "es7", "es2016", "dom", "dom.iterable", "webworker", "scripthost",
+                        "es6.core", "es6.collection", "es6.generator", "es6.iterable",
+                        "es6.promise", "es6.proxy", "es6.reflect",
+                        "es6.symbol", "es6.symbol.wellknown", "es7.array.include"]
             }
           }
         }

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -232,6 +232,13 @@
             "noImplicitUseStrict": {
               "type": "boolean",
               "description": "Do not emit \"use strict\" directives in module output."
+            },
+            "lib": {
+              "description": "Specify library file to be included in the compilation.",
+              "enum": [ "es3", "es5", "es6", "es7", "dom", "dom.iterable", "webworker", "scripthost", "node",
+                        "es6.array", "es6.collection", "es6.function", "es6.generator", "es6.iterable",
+                        "es6.math", "es6.number", "es6.object", "es6.promise", "es6.proxy", "es6.reflect",
+                        "es6.regexp", "es6.string", "es6.symbol", "es6.symbol.wellknown", "es7.array.include"]
             }
           }
         }


### PR DESCRIPTION
We are adding a new compiler flag call `--lib` (the PR is [here](https://github.com/Microsoft/TypeScript/pull/7452) The list of all possible value can be found [here](https://github.com/Microsoft/TypeScript/issues/6974)