### PR TITLE
GeoJSON

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -99,6 +99,11 @@
       "url": "http://json.schemastore.org/eslintrc"
     },
     {
+      "name": "geojson.json",
+      "description": "GeoJSON format for representing geographic data.",
+      "url": "http://json.schemastore.org/geojson"
+    },
+    {
       "name": "global.json",
       "description": "ASP.NET global configuration file",
       "fileMatch": [ "global.json" ],

--- a/src/schemas/json/geojson.json
+++ b/src/schemas/json/geojson.json
@@ -1,0 +1,354 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://raw.githubusercontent.com/dwhieb/geojson-schema/master/geojson-schema.json",
+  "title": "GeoJSON Object",
+  "type": "object",
+  "description": "This object represents a geometry, feature, or collection of features.",
+  "additionalProperties": true,
+  "required": ["type"],
+
+  "properties": {
+
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "description": "The type of GeoJSON object.",
+      "enum": [
+        "Point",
+        "MultiPoint",
+        "LineString",
+        "MultiLineString",
+        "Polygon",
+        "MultiPolygon",
+        "GeometryCollection",
+        "Feature",
+        "FeatureCollection"
+      ]
+    },
+
+    "crs": {
+      "title": "Coordinate Reference System (CRS)",
+      "description": "The coordinate reference system (CRS) of a GeoJSON object is determined by its `crs` member (referred to as the CRS object below). If an object has no crs member, then its parent or grandparent object's crs member may be acquired. If no crs member can be so acquired, the default CRS shall apply to the GeoJSON object.\n\n* The default CRS is a geographic coordinate reference system, using the WGS84 datum, and with longitude and latitude units of decimal degrees.\n\n* The value of a member named `crs` must be a JSON object (referred to as the CRS object below) or JSON null. If the value of CRS is null, no CRS can be assumed.\n\n* The crs member should be on the top-level GeoJSON object in a hierarchy (in feature collection, feature, geometry order) and should not be repeated or overridden on children or grandchildren of the object.\n\n* A non-null CRS object has two mandatory members: `type` and `properties`.\n\n* The value of the type member must be a string, indicating the type of CRS object.\n\n* The value of the properties member must be an object.\n\n* CRS shall not change coordinate ordering.",
+
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["type", "properties"],
+          "properties": {
+            "type": {
+              "title": "CRS Type",
+              "type": "string",
+              "description": "The value of the type member must be a string, indicating the type of CRS object.",
+              "minLength": 1
+            },
+            "properties": {
+              "title": "CRS Properties",
+              "type": "object"
+            }
+          }
+        }
+      ],
+
+      "not": {
+        "anyOf": [
+
+          {
+            "properties": {
+              "type": { "enum": ["name"] },
+              "properties": {
+                "not": {
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            "properties": {
+              "type": { "enum": ["link"] },
+              "properties": {
+                "not": {
+                  "title": "Link Object",
+                  "type": "object",
+                  "required": ["href"],
+                  "properties": {
+
+                    "href": {
+                      "title": "href",
+                      "type": "string",
+                      "description": "The value of the required `href` member must be a dereferenceable URI.",
+                      "format": "uri"
+                    },
+
+                    "type": {
+                      "title": "Link Object Type",
+                      "type": "string",
+                      "description": "The value of the optional `type` member must be a string that hints at the format used to represent CRS parameters at the provided URI. Suggested values are: `proj4`, `ogcwkt`, `esriwkt`, but others can be used."
+                    }
+
+                  }
+                }
+              }
+            }
+          }
+
+        ]
+      }
+
+    },
+
+    "bbox": {
+      "title": "Bounding Box",
+      "type": "array",
+      "description": "To include information on the coordinate range for geometries, features, or feature collections, a GeoJSON object may have a member named `bbox`. The value of the bbox member must be a 2*n array where n is the number of dimensions represented in the contained geometries, with the lowest values for all axes followed by the highest values. The axes order of a bbox follows the axes order of geometries. In addition, the coordinate reference system for the bbox is assumed to match the coordinate reference system of the GeoJSON object of which it is a member.",
+      "minItems": 4,
+      "items": {
+        "type": "number"
+      }
+    }
+
+  },
+
+  "oneOf": [
+
+    {
+      "title": "Point",
+      "description": "For type `Point`, the `coordinates` member must be a single position.",
+      "required": ["coordinates"],
+      "properties": {
+        "type": { "enum": ["Point"] },
+        "coordinates": {
+          "allOf": [
+            { "$ref": "#/definitions/coordinates" },
+            { "$ref": "#/definitions/position" }
+          ]
+        }
+      },
+      "allOf": [{ "$ref": "#/definitions/geometry" }]
+    },
+
+    {
+      "title": "Multi Point Geometry",
+      "description": "For type `MultiPoint`, the `coordinates` member must be an array of positions.",
+      "required": ["coordinates"],
+      "properties": {
+        "type": { "enum": ["MultiPoint"] },
+        "coordinates": {
+          "allOf": [
+            { "$ref": "#/definitions/coordinates" },
+            {
+              "items": { "$ref": "#/definitions/position" }
+            }
+          ]
+        }
+      },
+      "allOf": [{ "$ref": "#/definitions/geometry" }]
+    },
+
+    {
+      "title": "Line String",
+      "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.\n\nA LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
+      "required": ["coordinates"],
+      "properties": {
+        "type": { "enum": ["LineString"] },
+        "coordinates": { "$ref": "#/definitions/lineStringCoordinates" }
+      },
+      "allOf": [{ "$ref": "#/definitions/geometry" }]
+    },
+
+    {
+      "title": "MultiLineString",
+      "description": "For type `MultiLineString`, the `coordinates` member must be an array of LineString coordinate arrays.",
+      "required": ["coordinates"],
+      "properties": {
+        "type": { "enum": ["MultiLineString"] },
+        "coordinates": {
+          "allOf": [
+            { "$ref": "#/definitions/coordinates" },
+            {
+              "items": { "$ref": "#/definitions/lineStringCoordinates" }
+            }
+          ]
+        }
+      },
+      "allOf": [{ "$ref": "#/definitions/geometry" }]
+    },
+
+    {
+      "title": "Polygon",
+      "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
+      "required": ["coordinates"],
+      "properties": {
+        "type": { "enum": ["Polygon"] },
+        "coordinates": { "$ref": "#/definitions/polygonCoordinates" }
+      },
+      "allOf": [{ "$ref": "#/definitions/geometry" }]
+    },
+
+    {
+      "title": "Multi-Polygon Geometry",
+      "description": "For type `MultiPolygon`, the `coordinates` member must be an array of Polygon coordinate arrays.",
+      "required": ["coordinates"],
+      "properties": {
+        "type": { "enum": ["MultiPolygon"] },
+        "coordinates": {
+          "allOf": [
+            { "$ref": "#/definitions/coordinates" },
+            {
+              "items": { "$ref": "#/definitions/polygonCoordinates" }
+            }
+          ]
+        }
+      },
+      "allOf": [{ "$ref": "#/definitions/geometry" }]
+    },
+
+    {
+      "title": "Geometry Collection",
+      "description": "A GeoJSON object with type `GeometryCollection` is a geometry object which represents a collection of geometry objects.\n\nA geometry collection must have a member with the name `geometries`. The value corresponding to `geometries` is an array. Each element in this array is a GeoJSON geometry object.",
+      "required": ["geometries"],
+      "properties": {
+        "type": { "enum": ["GeometryCollection"] },
+        "geometries": {
+          "title": "Geometries",
+          "type": "array",
+          "items": { "$ref": "#/definitions/geometry" }
+        }
+      },
+      "allOf": [{ "$ref": "#/definitions/geometry" }]
+    },
+
+    { "$ref": "#/definitions/feature" },
+
+    {
+      "title": "Feature Collection",
+      "description": "A GeoJSON object with the type `FeatureCollection` is a feature collection object.\n\nAn object of type `FeatureCollection` must have a member with the name `features`. The value corresponding to `features` is an array. Each element in the array is a feature object as defined above.",
+      "required": ["features"],
+      "properties": {
+        "type": { "enum": ["FeatureCollection"] },
+        "features": {
+          "title": "Features",
+          "type": "array",
+          "items": { "$ref": "#/definitions/feature" }
+        }
+      }
+    }
+
+  ],
+
+  "definitions": {
+
+    "coordinates": {
+      "title": "Coordinates",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "array" },
+          { "type": "number" }
+        ]
+      }
+    },
+
+    "geometry": {
+      "title": "Geometry",
+      "description": "A geometry is a GeoJSON object where the type member's value is one of the following strings: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, or `GeometryCollection`.",
+      "properties": {
+        "type": {
+          "enum": [
+            "Point",
+            "MultiPoint",
+            "LineString",
+            "MultiLineString",
+            "Polygon",
+            "MultiPolygon",
+            "GeometryCollection"
+          ]
+        }
+      }
+    },
+
+    "feature": {
+      "title": "Feature",
+      "description": "A GeoJSON object with the type `Feature` is a feature object.\n\n* A feature object must have a member with the name `geometry`. The value of the geometry member is a geometry object as defined above or a JSON null value.\n\n* A feature object must have a member with the name `properties`. The value of the properties member is an object (any JSON object or a JSON null value).\n\n* If a feature has a commonly used identifier, that identifier should be included as a member of the feature object with the name `id`.",
+      "required": ["geometry", "properties"],
+
+      "properties": {
+
+        "type": { "enum": ["Feature"] },
+
+        "geometry": {
+          "title": "Geometry",
+          "oneOf": [
+            { "$ref": "#/definitions/geometry" },
+            { "type": "null" }
+          ]
+        },
+
+        "properties": {
+          "title": "Properties",
+          "oneOf": [
+            { "type": "object" },
+            { "type": "null" }
+          ]
+        },
+
+        "id": {}
+
+      }
+    },
+
+    "linearRingCoordinates": {
+      "title": "Linear Ring Coordinates",
+      "description": "A LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
+      "allOf": [
+        { "$ref": "#/definitions/lineStringCoordinates" },
+        {
+          "minItems": 4
+        }
+      ]
+    },
+
+    "lineStringCoordinates": {
+      "title": "Line String Coordinates",
+      "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.",
+      "allOf": [
+        { "$ref": "#/definitions/coordinates" },
+        {
+          "minLength": 2,
+          "items": { "$ref": "#/definitions/position" }
+        }
+      ]
+    },
+
+    "polygonCoordinates": {
+      "title": "Polygon Coordinates",
+      "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
+      "allOf": [
+        { "$ref": "#/definitions/coordinates" },
+        {
+          "items": { "$ref": "#/definitions/linearRingCoordinates" }
+        }
+      ]
+    },
+
+    "position": {
+      "title": "Position",
+      "type": "array",
+      "description": "A position is the fundamental geometry construct. The `coordinates` member of a geometry object is composed of one position (in the case of a Point geometry), an array of positions (LineString or MultiPoint geometries), an array of arrays of positions (Polygons, MultiLineStrings), or a multidimensional array of positions (MultiPolygon).\n\nA position is represented by an array of numbers. There must be at least two elements, and may be more. The order of elements must follow x, y, z order (easting, northing, altitude for coordinates in a projected coordinate reference system, or longitude, latitude, altitude for coordinates in a geographic coordinate reference system). Any number of additional elements are allowed -- interpretation and meaning of additional elements is beyond the scope of this specification.",
+      "minItems": 2,
+      "additionalItems": true,
+      "items": {
+        "type": "number"
+      }
+    }
+
+  }
+
+}

--- a/src/schemas/json/geojson.json
+++ b/src/schemas/json/geojson.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://raw.githubusercontent.com/dwhieb/geojson-schema/master/geojson-schema.json",
   "title": "GeoJSON Object",
   "type": "object",
   "description": "This object represents a geometry, feature, or collection of features.",


### PR DESCRIPTION
* adds GeoJSON to schema catalog
* adds GeoJSON schema (`geojson.json`)

GeoJSON website: http://geojson.org/
GeoJSON specification: http://geojson.org/geojson-spec.html

Examples of GeoJSON in use:
* Catalog of the world's languages: http://glottolog.org/
* Google Maps: https://developers.google.com/maps/tutorials/data/importing_data
* Leaflet: http://leafletjs.com/examples/geojson.html
* GitHub: https://help.github.com/articles/mapping-geojson-files-on-github/