### PR TITLE
Add support for `string` to the `repository` field in `package.json`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -212,7 +212,7 @@
         },
         "repository": {
           "description": "Specify the place where your code lives. This is helpful for people who want to contribute.",
-          "type": "object",
+          "type": ["object", "string"],
           "properties": {
             "type": {
               "type": "string"


### PR DESCRIPTION
The schema from `package.json` isn't entirely correct. The `repository` field supports a `string` as well and not only an `object`.

From the [documentation](https://docs.npmjs.com/files/package.json#repository)

> For GitHub, GitHub gist, Bitbucket, or GitLab repositories you can use the same shortcut syntax you use for npm install:
> 
> ```
> "repository": "npm/npm"
> 
> "repository": "gist:11081aaa281"
> 
> "repository": "bitbucket:example/repo"
> 
> "repository": "gitlab:another/repo"
> ```