### PR TITLE
Define uri format for multiple .bowerrc properties

### DIFF
--- a/src/schemas/json/bowerrc.json
+++ b/src/schemas/json/bowerrc.json
@@ -26,29 +26,35 @@
 		},
 		"registry": {
 			"type": [ "string", "object" ],
-			"description": "The registry config",
+      "description": "The registry config",
+      "format": "uri",
 			"properties": {
 				"search": {
 					"type": [ "array", "string" ],
-					"description": "An array of URLs pointing to read-only Bower registries. A string means only one. When looking into the registry for an endpoint, Bower will query these registries by the specified order."
+          "description": "An array of URLs pointing to read-only Bower registries. A string means only one. When looking into the registry for an endpoint, Bower will query these registries by the specified order.",
+          "format": "uri"
 				},
 				"register": {
 					"type": "string",
-					"description": "The URL to use when registering packages."
+          "description": "The URL to use when registering packages.",
+          "format": "uri"
 				},
 				"publish": {
 					"type": "string",
-					"description": "The URL to use when publishing packages."
+          "description": "The URL to use when publishing packages.",
+          "format": "uri"
 				}
 			}
 		},
 		"proxy": {
 			"type": "string",
-			"description": "The proxy to use for http requests."
+      "description": "The proxy to use for http requests.",
+      "format": "uri"
 		},
 		"https-proxy": {
 			"type": "string",
-			"description": "The proxy to use for https requests."
+      "description": "The proxy to use for https requests.",
+      "format": "uri"
 		},
 		"user-agent": {
 			"type": "string",


### PR DESCRIPTION
This PR explicitly declares the `uri` format for 6 existing properties in the `.bowerrc` file's schema, as documented [here](https://github.com/bower/spec/blob/master/config.md).