### PR TITLE
Use RegExp to validate 'target' compiler option.

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -93,7 +93,7 @@
               "format": "uri"
             },
             "module": {
-              "description": "Specify module code generation: 'CommonJS', 'Amd', 'System', 'UMD', 'es6', or 'es2015'.",
+              "description": "Specify module code generation: 'CommonJS', 'Amd', 'System', 'UMD', or 'es2015'.",
               "enum": [ "commonjs", "amd", "umd", "system", "es6", "es2015" ]
             },
             "newLine": {
@@ -121,7 +121,7 @@
               "type": "boolean"
             },
             "noResolve": {
-              "description": "  Do not add triple-slash references or module import targets to the list of compiled files.",
+              "description": "Do not add triple-slash references or module import targets to the list of compiled files.",
               "type": "boolean"
             },
             "skipDefaultLibCheck": {
@@ -180,8 +180,9 @@
               "type": "boolean"
             },
             "target": {
-              "description": "Specify ECMAScript target version.",
-              "enum": [ "es3", "es5", "es6", "es2015" ],
+              "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', or 'es2015'.",
+              "type": "string",
+              "pattern": "^([eE][sS]([356]|(2015)))$",
               "default": "es3"
             },
             "watch": {
@@ -198,7 +199,8 @@
             },
             "moduleResolution": {
               "description": "Specifies module resolution strategy: 'node' (Node) or 'classic' (TypeScript pre 1.6) .",
-              "enum": [ "classic", "node" ],
+              "type": "string",
+              "pattern": "^(([Nn]ode)|([Cc]lassic))$",
               "default": "classic"
             },
             "allowUnusedLabels": {


### PR DESCRIPTION
By using a RegExp case is no longer important.

@mhegazy can you take a look here?