### PR TITLE
add haxelib.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -146,6 +146,12 @@
       "url": "http://json.schemastore.org/grunt-task"
     },
     {
+      "name": "haxelib.json",
+      "description": "Haxelib manifest",
+      "fileMatch": [ "haxelib.json" ],
+      "url": "http://json.schemastore.org/haxelib"
+    },
+    {
       "name": "host-meta.json",
       "description": "Schema for host-meta JDR files",
       "fileMatch": [ "host-meta.json" ],

--- a/src/schemas/json/haxelib.json
+++ b/src/schemas/json/haxelib.json
@@ -1,0 +1,93 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"description": "A haxelib project",
+	"type": "object",
+	"properties": {
+		"name": { "$ref": "#/definitions/projectName" },
+		"url": {
+			"description": "Project's website",
+			"type": "string",
+			"format": "uri"
+		},
+		"description": {
+			"description": "Short description of the project",
+			"type": "string"
+		},
+		"license": {
+			"description": "Open source license under which the project is licensed",
+			"enum": ["GPL", "LGPL", "BSD", "Public", "MIT", "Apache"]
+		},
+		"version": { "$ref": "#/definitions/semver" },
+		"classPath": {
+			"description": "Folder in the package which contains the source files for this project",
+			"type": "string"
+		},
+		"contributors": {
+			"description": "List of project contributors that are allowed to upload to haxelib",
+			"type": "array",
+			"items": { "$ref": "#/definitions/userName" },
+			"minItems": 1,
+			"uniqueItems": true
+		},
+		"tags": {
+			"description": "List of tags for easier finding the project on haxelib",
+			"type": "array",
+			"items": { "$ref": "#/definitions/haxelibTag" },
+			"uniqueItems": true
+		},
+		"dependencies": {
+			"type": "object",
+			"description": "Project's dependencies",
+			"patternProperties": {
+				"^[A-Za-z0-9_.-]{3,}$": { "$ref": "#/definitions/dependencyVersion" }
+			},
+			"additionalProperties": false
+		},
+		"releasenote": {
+			"description": "Short description of changes made in this version",
+			"type": "string"
+		}
+	},
+	"additionalProperties": false,
+	"required": ["name", "license", "releasenote", "contributors", "version"],
+	"definitions": {
+		"userName": {
+			"description": "The name of a user",
+			"type": "string",
+			"minLength": 3,
+			"pattern": "^[A-Za-z0-9_.-]{3,}$"
+		},
+		"projectName": {
+			"description": "The name of a haxelib project",
+			"type": "string",
+			"minLength": 3,
+			"pattern": "^[A-Za-z0-9_.-]{3,}$",
+			"not": {
+				"anyOf": [
+					{"enum": ["haxe", "all"]},
+					{"pattern": "\\.(zip|hxml)$"}
+				]
+			}
+		},
+		"haxelibTag": {
+			"description": "A keyword or term associated with a haxelib project",
+			"type": "string",
+			"minLength": 2,
+			"pattern": "^[A-Za-z0-9_.-]{2,}$"
+		},
+		"semver": {
+			"type": "string",
+			"description": "Project's version",
+			"pattern": "^(\\d|[1-9]\\d*)\\.(\\d|[1-9]\\d*)\\.(\\d|[1-9]\\d*)(-(alpha|beta|rc)(\\.(\\d|[1-9]\\d*))?)?$"
+		},
+		"dependencyVersion": {
+			"oneOf": [
+				{ "$ref": "#/definitions/semver" },
+				{
+					"type": "string",
+					"maxLength": 0
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
This adds a schema for haxelib.json files which are manifest files used for creating [Haxe](http://haxe.org/) libraries (it's somewhat similar to npm's package.json).