### PR TITLE
Add missing libraryIncludeFlag: none

### DIFF
--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -62,7 +62,7 @@
 		},
 		"libraryIncludeFlag": {
 			"type": "string",
-			"enum": [ "all", "runtime", "compile", "build", "contentFiles", "native", "analyzers" ]
+			"enum": [ "all", "runtime", "compile", "build", "contentFiles", "native", "analyzers", "none" ]
 		},
 		"libraryIncludeFlags": {
 			"oneOf": [


### PR DESCRIPTION
Consistent with [docs](https://github.com/NuGet/Home/wiki/%5BSpec%5D-Managing-dependency-package-assets#include-flags), "none" is a valid value for the `suppressParent` field.

CC: @davidfowl @emgarten