### PR TITLE
Add ES7 support to ecmaVersion array

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -400,7 +400,7 @@
           "$ref": "#/properties/ecmaFeatures"
         },
         "ecmaVersion": {
-          "enum": [ 3, 5, 6 ],
+          "enum": [ 3, 5, 6, 7 ],
           "default": 5
         },
         "sourceType": {


### PR DESCRIPTION
Per the ESLint docs [here](http://eslint.org/docs/user-guide/configuring#specifying-parser-options), `7` is a valid value in the `ecmaVersion` array. This PR adds support for ECMAScript 7 / 2016 by adding 7 to the array.