### PR TITLE
Add id, module, essential and threadId to annotatedCodeLocation. Rena…

### DIFF
--- a/src/schemas/json/sarif-1.0.0-beta.5.json
+++ b/src/schemas/json/sarif-1.0.0-beta.5.json
@@ -7,6 +7,7 @@
   "properties": {
 
     "$schema": {
+      "description": "The URI of the JSON schema corresponding to the version.",
       "type": "string",
       "format": "uri"
     },
@@ -34,9 +35,24 @@
       "type": "object",
       "properties": {
 
+        "id": {
+          "description": "An identifier for the location, unique within the scope of the code flow within which it occurs.",
+          "type": "string"
+        },
+
         "physicalLocation": {
           "description": "A code location to which this annotation refers.",
           "$ref": "#/definitions/physicalLocation"
+        },
+
+        "module": {
+          "description": "The name of the module that contains the code that is executing.",
+          "type": "string"
+        },
+
+        "threadId": {
+          "description": "The thread identifier of the code that is executing.",
+          "type": "integer"
         },
 
         "message": {
@@ -47,6 +63,11 @@
         "kind": {
           "description": "A descriptive identifier that categorizes the annotation.",
           "enum": [ "branch", "call", "callReturn", "declaration", "functionEnter", "functionExit", "sanitizer", "sink", "source", "usage" ]
+        },
+
+        "essential": {
+          "description": "True if this location is essential to understanding the code flow in which it occurs.",
+          "type": "boolean"
         },
 
         "properties": {
@@ -147,7 +168,7 @@
           "format": "uri"
         },
 
-        "relativeTo": {
+        "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
         },
@@ -175,7 +196,7 @@
           "format": "uri"
         },
 
-        "relativeTo": {
+        "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
         },
@@ -377,12 +398,17 @@
         },
 
         "fullyQualifiedLogicalName": {
-          "description": "The fully qualified name of the logical location where the analysis tool produced the result. If 'logicalLocationKey' is not specified, this member is can used to retrieve the location logicalLocation from the logicalLocations dictionary, if one exists.",
+          "description": "The human-readable fully qualified name of the logical location where the analysis tool produced the result. If 'logicalLocationKey' is not specified, this member is can used to retrieve the location logicalLocation from the logicalLocations dictionary, if one exists.",
           "type": "string"
         },
 
         "logicalLocationKey": {
           "description": "A key used to retrieve the location logicalLocation from the logicalLocations dictionary, when the string specified by 'fullyQualifiedLogicalName' is not unique.",
+          "type": "string"
+        },
+
+        "decoratedName": {
+          "description": "The machine-readable fully qualified name for the logical location where the analysis tool produced the result, such as the mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.",
           "type": "string"
         },
 
@@ -458,6 +484,11 @@
           "enum": [ "note", "warning", "error" ]
         },
 
+        "threadId": {
+          "description": "The thread identifier of the code that generated the notification.",
+          "type": "integer"
+        },
+
         "time": {
           "description": "The date and time at which the analysis tool generated the notification.",
           "type": "string",
@@ -501,7 +532,7 @@
           "format": "uri"
         },
         
-        "relativeTo": {
+        "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
         },
@@ -925,7 +956,7 @@
           "format": "uri"
         },
 
-        "relativeTo": {
+        "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
         },
@@ -941,17 +972,17 @@
         },
 
         "module": {
-          "description": "The name of the module that contains the code that is executing.",
+          "description": "The name of the module that contains the code of this stack frame.",
           "type": "string"
+        },
+
+        "threadId": {
+          "description": "The thread identifier of the stack frame.",
+          "type": "integer"
         },
 
         "fullyQualifiedLogicalName": {
           "description": "The fully qualified name of the method or function that is executing.",
-          "type": "string"
-        },
-
-        "logicalLocationKey": {
-          "description": "A string used as a key into the logicalLocations dictionary, in case the string specified by 'fullyQualifiedLogicalName' is not unique.",
           "type": "string"
         },
 
@@ -991,7 +1022,9 @@
             }
           }
         }
-      }
+      },
+
+      "required": ["module", "fullyQualifiedLogicalName"]
     },
     "tool": {
       "description": "The analysis tool that was run.",

--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -7,6 +7,7 @@
   "properties": {
 
     "$schema": {
+      "description": "The URI of the JSON schema corresponding to the version.",
       "type": "string",
       "format": "uri"
     },
@@ -34,9 +35,24 @@
       "type": "object",
       "properties": {
 
+        "id": {
+          "description": "An identifier for the location, unique within the scope of the code flow within which it occurs.",
+          "type": "string"
+        },
+
         "physicalLocation": {
           "description": "A code location to which this annotation refers.",
           "$ref": "#/definitions/physicalLocation"
+        },
+
+        "module": {
+          "description": "The name of the module that contains the code that is executing.",
+          "type": "string"
+        },
+
+        "threadId": {
+          "description": "The thread identifier of the code that is executing.",
+          "type": "integer"
         },
 
         "message": {
@@ -47,6 +63,11 @@
         "kind": {
           "description": "A descriptive identifier that categorizes the annotation.",
           "enum": [ "branch", "call", "callReturn", "declaration", "functionEnter", "functionExit", "sanitizer", "sink", "source", "usage" ]
+        },
+
+        "essential": {
+          "description": "True if this location is essential to understanding the code flow in which it occurs.",
+          "type": "boolean"
         },
 
         "properties": {
@@ -147,7 +168,7 @@
           "format": "uri"
         },
 
-        "relativeTo": {
+        "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
         },
@@ -175,7 +196,7 @@
           "format": "uri"
         },
 
-        "relativeTo": {
+        "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
         },
@@ -377,12 +398,17 @@
         },
 
         "fullyQualifiedLogicalName": {
-          "description": "The fully qualified name of the logical location where the analysis tool produced the result. If 'logicalLocationKey' is not specified, this member is can used to retrieve the location logicalLocation from the logicalLocations dictionary, if one exists.",
+          "description": "The human-readable fully qualified name of the logical location where the analysis tool produced the result. If 'logicalLocationKey' is not specified, this member is can used to retrieve the location logicalLocation from the logicalLocations dictionary, if one exists.",
           "type": "string"
         },
 
         "logicalLocationKey": {
           "description": "A key used to retrieve the location logicalLocation from the logicalLocations dictionary, when the string specified by 'fullyQualifiedLogicalName' is not unique.",
+          "type": "string"
+        },
+
+        "decoratedName": {
+          "description": "The machine-readable fully qualified name for the logical location where the analysis tool produced the result, such as the mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.",
           "type": "string"
         },
 
@@ -458,6 +484,11 @@
           "enum": [ "note", "warning", "error" ]
         },
 
+        "threadId": {
+          "description": "The thread identifier of the code that generated the notification.",
+          "type": "integer"
+        },
+
         "time": {
           "description": "The date and time at which the analysis tool generated the notification.",
           "type": "string",
@@ -501,7 +532,7 @@
           "format": "uri"
         },
         
-        "relativeTo": {
+        "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
         },
@@ -925,7 +956,7 @@
           "format": "uri"
         },
 
-        "relativeTo": {
+        "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
         },
@@ -941,17 +972,17 @@
         },
 
         "module": {
-          "description": "The name of the module that contains the code that is executing.",
+          "description": "The name of the module that contains the code of this stack frame.",
           "type": "string"
+        },
+
+        "threadId": {
+          "description": "The thread identifier of the stack frame.",
+          "type": "integer"
         },
 
         "fullyQualifiedLogicalName": {
           "description": "The fully qualified name of the method or function that is executing.",
-          "type": "string"
-        },
-
-        "logicalLocationKey": {
-          "description": "A string used as a key into the logicalLocations dictionary, in case the string specified by 'fullyQualifiedLogicalName' is not unique.",
           "type": "string"
         },
 
@@ -991,7 +1022,9 @@
             }
           }
         }
-      }
+      },
+
+      "required": ["module", "fullyQualifiedLogicalName"]
     },
     "tool": {
       "description": "The analysis tool that was run.",

--- a/src/test/sarif/BinSkim.AllRules.sarif
+++ b/src/test/sarif/BinSkim.AllRules.sarif
@@ -3,19 +3,18 @@
   "version": "1.0.0-beta.5",
   "runs": [
     {
+      "id": "e750dd72-dd8e-4bea-abb0-b15348b65591",
       "tool": {
         "name": "BinSkim",
-        "fullName": "BinSkim 1.3.0.0-beta",
-        "version": "1.3.0.0",
-        "semanticVersion": "1.3.0",
-        "fileVersion": "1.3.2.0",
+        "fullName": "BinSkim 1.3.3.0-beta",
+        "version": "1.3.3.0",
+        "semanticVersion": "1.3.3",
+        "sarifLoggerVersion": "1.5.22.0",
         "language": "en-US",
         "properties": {
-          "Language": "Language Neutral",
           "Comments": "A security and correctness analyzer for portable executable and MSIL formats.",
           "CompanyName": "Microsoft",
-          "ProductName": "BinSkim Portable Executable Analyzer",
-          "ProductVersion": "1.3.2.0"
+          "ProductName": "BinSkim Portable Executable Analyzer"
         }
       },
       "results": [
@@ -3422,45 +3421,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msidcrl.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3468,45 +3430,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msidcrl.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3514,45 +3439,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msidcrl.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3560,45 +3448,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msidcrl.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3606,45 +3457,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msidcrl.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3652,45 +3466,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msidcrl.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msidcrl.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3698,45 +3475,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3744,45 +3484,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3790,45 +3493,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3836,45 +3502,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3882,45 +3511,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3928,45 +3520,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\msxml6.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -3974,45 +3529,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4020,45 +3538,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4066,45 +3547,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4112,45 +3556,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4158,45 +3565,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4204,45 +3574,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Fail\\xmllite.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4250,45 +3583,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4296,45 +3592,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4342,45 +3601,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4388,45 +3610,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4434,45 +3619,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4480,45 +3628,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/msxml6.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\msxml6.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4526,45 +3637,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4572,45 +3646,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4618,45 +3655,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4664,45 +3664,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4710,45 +3673,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4756,45 +3682,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/xmllite.dll"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotShipVulnerableBinaries\\Pass\\xmllite.dll' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4802,45 +3691,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Fail/badexecimports.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0014",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4848,45 +3700,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Fail/badexecimports.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0014",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4894,45 +3709,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Fail/badexecimports.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0014",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4940,45 +3718,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Fail/badexecimports.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0014",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -4986,45 +3727,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Fail/badexecimports.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0014",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5032,45 +3736,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Fail/badexecimports.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0014",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\DoNotMarkImportsSectionAsExecutable\\Fail\\badexecimports.exe' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NO_DEBUG_INFO (Pdb is stripped of cv info)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5078,45 +3745,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/MixedMode_x64_VS2013_NoPdb.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5124,45 +3754,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/MixedMode_x64_VS2013_NoPdb.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5170,45 +3763,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/MixedMode_x64_VS2013_NoPdb.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5216,45 +3772,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/MixedMode_x64_VS2013_NoPdb.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5262,45 +3781,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/MixedMode_x64_VS2013_NoPdb.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5308,45 +3790,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/MixedMode_x64_VS2013_NoPdb.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableControlFlowGuard\\NotApplicable\\MixedMode_x64_VS2013_NoPdb.exe' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5354,45 +3799,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5400,45 +3808,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5446,45 +3817,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5492,45 +3826,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5538,45 +3835,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5584,45 +3844,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\EnableStackProtection\\Fail\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5630,45 +3853,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'BuildWithSecureTools' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5676,45 +3862,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'DoNotDisableStackProtectionForFunctions' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5722,45 +3871,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'DoNotIncorporateVulnerableDependencies' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5768,45 +3880,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'EnableCriticalCompilerWarnings' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5814,45 +3889,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'EnableStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         },
         {
           "id": "ExceptionLoadingPdb",
@@ -5860,45 +3898,8 @@
           "analysisTarget": {
             "uri": "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/Native_x86_VS2013_PdbMissing.exe"
           },
-          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded.\nE_PDB_NOT_FOUND (File not found)",
-          "level": "error",
-          "exception": {
-            "kind": "PdbParseException",
-            "message": "E_PDB_NOT_FOUND (File not found)",
-            "stack": {
-              "frames": [
-                {
-                  "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                  "line": 111,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                },
-                {
-                  "uri": "file:///d:/src/binskim/src/BinSkim.Sdk/BinaryAnalyzerContext.cs",
-                  "line": 82,
-                  "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.IL.Sdk.BinaryAnalyzerContext.get_Pdb()"
-                }
-              ]
-            },
-            "innerExceptions": [
-              {
-                "kind": "COMException",
-                "message": "Exception from HRESULT: 0x806D0005",
-                "stack": {
-                  "frames": [
-                    {
-                      "fullyQualifiedLogicalName": "Dia2Lib.IDiaDataSource.loadDataForExe(String executable, String searchPath, Object pCallback)"
-                    },
-                    {
-                      "uri": "file:///d:/src/binskim/src/BinaryParsers/ProgramDatabase/Pdb.cs",
-                      "line": 107,
-                      "fullyQualifiedLogicalName": "Microsoft.CodeAnalysis.BinaryParsers.ProgramDatabase.Pdb.Init(String peOrPdbPath, String symbolPath)"
-                    }
-                  ]
-                },
-                "innerExceptions": []
-              }
-            ]
-          }
+          "message": "'d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\MarkImageAsNXCompatible\\Pass\\Native_x86_VS2013_PdbMissing.exe' was not evaluated for check 'InitializeStackProtection' because its PDB could not be loaded. ('E_PDB_NOT_FOUND (File not found)')",
+          "level": "error"
         }
       ],
       "rules": {
@@ -6140,6 +4141,7 @@
       "files": {
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6158,6 +4160,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Pass/Native_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "A6220653CCEA28E2E6556FC297F209AB",
@@ -6176,6 +4179,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Pass/NoVulnATL32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "BE7CFFCC650237F9FBB557D070DD4732",
@@ -6194,6 +4198,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Pass/ATLVersion/atl100/VulnATL32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "E2913E54E088A74E204BC752DA6228CD",
@@ -6212,6 +4217,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Pass/ATLVersion/atl90/VulnATL32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "38C5DAAA7043566781A5356790EDF99B",
@@ -6230,6 +4236,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6248,6 +4255,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsExecutable/Pass/AllFail32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "97C45893560E9FC5EDE3BF45DD8250F4",
@@ -6266,6 +4274,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsExecutable/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6284,6 +4293,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsShared/Fail/AllFail32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "97C45893560E9FC5EDE3BF45DD8250F4",
@@ -6302,6 +4312,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsShared/Fail/AllFail64.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "8A80E170066069470EDA5940E5EE7672",
@@ -6320,6 +4331,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsShared/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6338,6 +4350,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsShared/Pass/PassSharedSection32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "66074E6C1CA1A468F13F08A5631047C2",
@@ -6356,6 +4369,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsShared/Pass/PassSharedSection64.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "3D9985003A8E61CC392D5A223B62F97C",
@@ -6374,6 +4388,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotModifyStackProtectionCookie/Pass/internal.io.filesystem.primitives.ni.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B235718B21B6C24F4E1CEB3E825FD611",
@@ -6392,6 +4407,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotModifyStackProtectionCookie/Pass/Native_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "A6220653CCEA28E2E6556FC297F209AB",
@@ -6410,6 +4426,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msidcrl.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B404DC411247DFCCA393C2532FC658E9",
@@ -6428,6 +4445,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/msxml6.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "93E3D65953C59685ED1D823949C08722",
@@ -6446,6 +4464,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Fail/xmllite.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "BEA4AEE74FEF171EB61DE1BAD8FAF427",
@@ -6464,6 +4483,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6482,6 +4502,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/msxml6.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "4E2A0C91A8246AB25B140695123EAECA",
@@ -6500,6 +4521,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/xmllite.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "24360C89F7487992B7BC1D8B9AAF52B6",
@@ -6518,6 +4540,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableAddressSpaceLayoutRandomization/Fail/AllFail32/AllFail32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "97C45893560E9FC5EDE3BF45DD8250F4",
@@ -6536,6 +4559,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableAddressSpaceLayoutRandomization/Fail/AllFail64/AllFail64.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "8A80E170066069470EDA5940E5EE7672",
@@ -6554,6 +4578,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableAddressSpaceLayoutRandomization/Fail/ManagedFail/ManagedFail.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "45F47A0D81A06BB3FD1DAB1782122F21",
@@ -6572,6 +4597,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableAddressSpaceLayoutRandomization/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6590,6 +4616,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableAddressSpaceLayoutRandomization/Pass/PassDB32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "E39722B2B8D5D4B8744B204B7092BC6C",
@@ -6608,6 +4635,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableAddressSpaceLayoutRandomization/Pass/PassDB64.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B98DB8B56C70BB6BD92F2EEB6F5F12FD",
@@ -6626,6 +4654,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/Fail/Native_x64_VS2015_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "F6ECB83310D6CD823ADF648DE69F88B5",
@@ -6644,6 +4673,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6662,6 +4692,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/Native_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "A6220653CCEA28E2E6556FC297F209AB",
@@ -6680,6 +4711,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/Pass/Native_x64_VS2015_ControlFlowGuardEnabled.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "4200E92436B8436A85715EC3AFBEE4DC",
@@ -6698,6 +4730,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableHighEntropyVirtualAddresses/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6716,6 +4749,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableSafeSEH/Pass/PassSafeSEHNative.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "4A26884650B4582D094E5F5203634228",
@@ -6734,6 +4768,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/ManagedFail/ManagedFail.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "45F47A0D81A06BB3FD1DAB1782122F21",
@@ -6752,6 +4787,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6770,6 +4806,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Pass/Native_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "A6220653CCEA28E2E6556FC297F209AB",
@@ -6788,6 +4825,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/InitializeStackProtection/Fail/AllFail64.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "23A800DA9B5B1B5B3198B55AA80B2848",
@@ -6806,6 +4844,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/InitializeStackProtection/Pass/PassGSFriendly32/PassGSFriendlyInit32.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "F7C23C3DE37BA7AF99E193526122C0F8",
@@ -6824,6 +4863,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/InitializeStackProtection/Pass/PassGSriendly64/PassGSFriendlyInit64.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "8FEA7086D6ABF2096926623C128EF690",
@@ -6842,6 +4882,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/LoadImageAboveFourGigabyteAddress/Pass/MixedMode_x64_VS2013_Default.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7450B749DB3518CA4193D0016C931796",
@@ -6860,6 +4901,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Fail/ManagedFail.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "45F47A0D81A06BB3FD1DAB1782122F21",
@@ -6878,6 +4920,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/SignSecurely/Fail/vccorlib110.dll": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "C5C2295981EEDEFF9924889A7F084CC2",
@@ -6896,6 +4939,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Fail/Compiled2003.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B448BC9C53383CA529EB494263BD9726",
@@ -6914,6 +4958,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Fail/managed2003.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "E02B0FF109B4FF1F063145BF8DE54E22",
@@ -6932,6 +4977,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Fail/native2005.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "83AFC2435413F189D782E65B00EED818",
@@ -6950,6 +4996,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Fail/native2005x64.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "67EA5DE7948A32B63A51BD6853D7E982",
@@ -6968,6 +5015,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Fail/vs2008/XRay.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "E832CC4D0DA7F0C6D430D3424BED721C",
@@ -6986,6 +5034,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Fail/vs2010/comclient.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "5171FFE658B3AED0395D72E2B228BC06",
@@ -7004,6 +5053,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Fail/vs2010/vulnprocess.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "95698D9A942DB3769A54311C3D944F72",
@@ -7022,6 +5072,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -7040,6 +5091,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/BuildWithSecureTools/Pass/Native_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "C549C31FE11FFACC7C7A7A121F83301D",
@@ -7058,6 +5110,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotDisableStackProtectionForFunctions/Fail/MinimalSafeBuffers.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "4C2A9E4C42DA3558B14CFFF42FFE7CF0",
@@ -7076,6 +5129,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotDisableStackProtectionForFunctions/Pass/HelloWorld.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "08ECD5C29CBE8ABAD3C67F4B2B127E76",
@@ -7094,6 +5148,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotDisableStackProtectionForFunctions/Pass/WhitelistedFunctions.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "E5F706B07CC5DFB2556FE74D09F48234",
@@ -7112,6 +5167,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Fail/MinimalAtlUse_VS2008RTM.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "A5EB12A6FF476E790CFBAE947FC1CFB6",
@@ -7130,6 +5186,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Pass/sha256.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "0B0375C989FB0CBCBC58BFDDF9B05D30",
@@ -7148,6 +5205,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Pass/UnknownHash_VS2013_Update4.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "F0A70DBA03E46F3CE0C49ECB8A4010BB",
@@ -7166,6 +5224,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Pass/UnknownHash_VS2015_Preview.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "CE57DD9079E15748618D70656226C5E7",
@@ -7184,6 +5243,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Pass/VS2013_With_Update3.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "F7D7CB2AAF40E910FEFC4088E6A02E1D",
@@ -7202,6 +5262,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotIncorporateVulnerableDependencies/Pass/VS2015_Preview.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "160F34A952888623BD8209D34C67459E",
@@ -7220,6 +5281,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Fail/badexecimports.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "3046731C4ABBF9CB687D860DE60E8930",
@@ -7238,6 +5300,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkImportsSectionAsExecutable/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -7256,6 +5319,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsExecutable/Fail/TestFixed.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "F23554AB15E97B59876F98DA69E38416",
@@ -7274,6 +5338,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsExecutable/Fail/VS2003-DotNetProgram-WithWritableCode.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "E73A252F55F19F2DFB88C9AA6F77D041",
@@ -7292,6 +5357,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsExecutable/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -7310,6 +5376,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotMarkWritableSectionsAsShared/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -7328,6 +5395,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotModifyStackProtectionCookie/Fail/__security_cookie.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B3FD986783406F8F6C13B71D32A8A849",
@@ -7346,6 +5414,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotModifyStackProtectionCookie/Pass/vs2012.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B9B913541EA2C6003C12F8B868B5C6AA",
@@ -7364,6 +5433,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/DoNotShipVulnerableBinaries/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -7382,6 +5452,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableAddressSpaceLayoutRandomization/Fail/VS2003-DotNetProgram.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "3C4F1A80D7A0036EE2B593D61F9A781F",
@@ -7400,6 +5471,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableAddressSpaceLayoutRandomization/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -7418,6 +5490,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/Fail/Native_x86_VS2015_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "875384EBB5D23EAAC9230EE89A508FE6",
@@ -7436,6 +5509,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/NotApplicable/MixedMode_x64_VS2013_NoPdb.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "39114314A9A66BEA7BFC2E354501D58E",
@@ -7454,6 +5528,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableControlFlowGuard/Pass/Native_x86_VS2015_ControlFlowGuardEnabled.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "3774C8F663490D03FBC180BF7954C717",
@@ -7472,6 +5547,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_noWswitch_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "24C5E53E803F12AC48991342F76D4CFB",
@@ -7490,6 +5566,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_noWswitch_LTCG_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "BB66E104CCA2F12E8916C3927BDA1981",
@@ -7508,6 +5585,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_W3_W2_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "EB6ACBB1D5AD0276ADCAE3F5AF6AF1D9",
@@ -7526,6 +5604,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_W3_W2_LTCG_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "3102BC2201AF082D4D6D46268001BE84",
@@ -7544,6 +5623,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_W4_wd4018_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "FE4C9CAD611AFE681EB14C8C8F76F9ED",
@@ -7562,6 +5642,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_W4_wd4018_LTCG_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "45F505E54CD24E130E314B2B66D0E128",
@@ -7580,6 +5661,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_Wall_W2_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7974536EA1E8537E488B2BA1BF3C2DBD",
@@ -7598,6 +5680,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_Wall_W2_LTCG_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "56A6B6625DE12924D20FA7A24D6FFBC3",
@@ -7616,6 +5699,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_wd4018_W4_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "D13D328E476383D69CEB5D45EAF2FBB5",
@@ -7634,6 +5718,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Fail/testwarn_wd4018_W4_LTCG_FAIL.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B34C081516B2D78D96FBAD55C1865494",
@@ -7652,6 +5737,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W1_W4_LTCG_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "6A75C61BE3B2D2B04CF3BEFA67275ED7",
@@ -7670,6 +5756,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W1_W4_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "6436868D6677E8A4633A872CAFE7BCAB",
@@ -7688,6 +5775,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W3_LTCG_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "E4384DF66E0D5DA3D23F94B4BA2EAD7D",
@@ -7706,6 +5794,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W3_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "6AAABB090FEDB9DA6E203F6B430922D7",
@@ -7724,6 +5813,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W3_W4_LTCG_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "4E3F810D031A828F3230ECD9A1F75E3D",
@@ -7742,6 +5832,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W3_W4_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "8A91A4C63C9D40F427F14EAB2A99B6A2",
@@ -7760,6 +5851,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W4_wd4999_LTCG_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B849C74C76F92CB7485D072379DFB851",
@@ -7778,6 +5870,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W4_wd4999_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "705BE6A8AACD5B41208C7BC476EE871C",
@@ -7796,6 +5889,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W4_wd703_LTCG_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "BD9F572FCAAC0B9F9C428FC152C06288",
@@ -7814,6 +5908,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_W4_wd703_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B29A42B3E8F9CE2B69667A5642071C1A",
@@ -7832,6 +5927,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_Wall_LTCG_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7F85688699CF742A5E0869B610CDF326",
@@ -7850,6 +5946,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_Wall_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "6693B2031FD7B455025548B50492E6E1",
@@ -7868,6 +5965,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_Wall_wd4018_we4018_LTCG_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B3F63633B32824F7B9FBAEBDCF3933D6",
@@ -7886,6 +5984,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_Wall_wd4018_we4018_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "581DD19DDE1FFE2AE468140A93B1CAC9",
@@ -7904,6 +6003,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_wd4999_W4_LTCG_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "730A37DE08BEF9840F3B3CFCDAD2C532",
@@ -7922,6 +6022,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableCriticalCompilerWarnings/Pass/testwarn_wd4999_W4_PASS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B379CD5A3DD5A39EFF328BC5B7B5B4BF",
@@ -7940,6 +6041,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableHighEntropyVirtualAddresses/Fail/HIGHENTROPYVA/vs2012.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "F1CC772A9BA62EA7C3F89F172FB2942D",
@@ -7958,6 +6060,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableHighEntropyVirtualAddresses/Fail/LARGEADDRESSAWARE/vs2012.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "F57008873BFFA7D46E559D3BF1BBEAF2",
@@ -7976,6 +6079,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableHighEntropyVirtualAddresses/Fail/Nothing/vs2012.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "7EEBD522C21F73C4E2E1C112AC585A44",
@@ -7994,6 +6098,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableHighEntropyVirtualAddresses/Pass/vs2012.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "00174440EDF2D5AE637BAD631468BBF6",
@@ -8012,6 +6117,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableSafeSEH/Fail/vs2012.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "4C5AAFA09F1AF6255F7D811A194949F2",
@@ -8030,6 +6136,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableSafeSEH/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -8048,6 +6155,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableSafeSEH/Pass/TestFixed.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "DB59DC8784CF07CD45911FC56E2CAEF6",
@@ -8066,6 +6174,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/Native_x86_VS2013_PdbMissing.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "3C4D605E7CDB07284045F128A481C1DE",
@@ -8084,6 +6193,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/broken/TestFixed.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "9952210CEDEDB8099F4F62198B2E6D23",
@@ -8102,6 +6212,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/ConsoleNoGS/ConsoleNoGS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "9B02BBF5D3A897C3C27B72DC0BC26490",
@@ -8120,6 +6231,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Fail/Mixed/Mixed.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "DBDED6E4518E7A6F3EA6DD797C608A9B",
@@ -8138,6 +6250,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -8156,6 +6269,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Pass/Native_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "C549C31FE11FFACC7C7A7A121F83301D",
@@ -8174,6 +6288,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/EnableStackProtection/Pass/ConsoleGS/ConsoleGS.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B954E75792377135F79C3BC5DC2F3E09",
@@ -8192,6 +6307,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/LoadImageAboveFourGigabyteAddress/Fail/vs2012.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "4B587153CEA9EFCA887D0170CF6F7352",
@@ -8210,6 +6326,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/LoadImageAboveFourGigabyteAddress/Pass/vs2012.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "C6542048DDB2068F73B8208307C95C70",
@@ -8228,6 +6345,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Fail/VS2003-DotNetProgram.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "3C4F1A80D7A0036EE2B593D61F9A781F",
@@ -8246,6 +6364,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/MixedMode_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "393E603074650F12EEB68622557BE977",
@@ -8264,6 +6383,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/Native_x86_VS2013_Default.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "C549C31FE11FFACC7C7A7A121F83301D",
@@ -8282,6 +6402,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/MarkImageAsNXCompatible/Pass/Native_x86_VS2013_PdbMissing.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "3C4D605E7CDB07284045F128A481C1DE",
@@ -8300,6 +6421,7 @@
         ],
         "file:///d:/src/binskim/src/BinSkim.Rules.FunctionalTests/FunctionalTestsData/SignSecurely/Fail/Sha1SignedUntrustedRoot.exe": [
           {
+            "mimeType": "application/octet-stream",
             "hashes": [
               {
                 "value": "B4EF593DA0CF640A6B452C8B754BB7B6",
@@ -8319,9 +6441,9 @@
       },
       "invocation": {
         "commandLine": "d:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x64_Release\\BinSkim.exe  analyze d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\*.dll d:\\src\\binskim\\src\\BinSkim.Rules.FunctionalTests\\FunctionalTestsData\\*.exe --hashes --recurse --config default -o .\\\\BinSkim.AllRules.sarif",
-        "startTime": "2016-05-04T00:15:51.17Z",
-        "endTime": "2016-05-04T00:15:57.25Z",
-        "processId": 54820,
+        "startTime": "2016-05-16T21:22:15.896Z",
+        "endTime": "2016-05-16T21:22:21.230Z",
+        "processId": 18188,
         "fileName": "d:\\src\\binskim\\bld\\bin\\BinSkim.Driver\\x64_Release\\BinSkim.exe",
         "workingDirectory": "d:\\src\\sarif-sdk\\src\\Sarif.FunctionalTests\\DirectProducerTestData\\BinSkim"
       }


### PR DESCRIPTION
…me 'relativeTo' to 'uriBaseId' wherever that name occurs. Add threadId to notification and stackFrame instances. Remove logicalLocationKey from stackFrame. Mark 'module' and 'fullyQualifiedLogicalName' properties on stackFrame as required.

@lgolding @madskristensen 