### PR TITLE
Add vega and vega-lite

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -403,6 +403,18 @@
       "url": "http://json.schemastore.org/typingsrc"
     },
     {
+      "name": "vega.json",
+      "description": "Vega visualization specification file",
+      "fileMatch": [ "*.vg", "*.vg.json" ],
+      "url": "http://json.schemastore.org/vega"
+    },
+    {
+      "name": "vega-lite.json",
+      "description": "Vega-Lite visualization specification file",
+      "fileMatch": [ "*.vl", "*.vl.json" ],
+      "url": "http://json.schemastore.org/vega-lite"
+    },
+    {
       "name": "Web Manifest",
       "description": "Web Appliation manifest file",
       "fileMatch": [ "manifest.json" ],

--- a/src/schemas/json/vega-lite.json
+++ b/src/schemas/json/vega-lite.json
@@ -1,0 +1,1847 @@
+{
+    "oneOf": [
+        {
+            "$ref": "#/definitions/ExtendedUnitSpec",
+            "description": "Schema for a unit Vega-Lite specification, with the syntactic sugar extensions:\n\n- `row` and `column` are included in the encoding.\n\n- (Future) label, box plot\n\n\n\nNote: the spec could contain facet."
+        },
+        {
+            "$ref": "#/definitions/FacetSpec"
+        },
+        {
+            "$ref": "#/definitions/LayerSpec"
+        }
+    ],
+    "definitions": {
+        "ExtendedUnitSpec": {
+            "type": "object",
+            "properties": {
+                "mark": {
+                    "$ref": "#/definitions/Mark",
+                    "description": "A name for the specification. The name is used to annotate marks, scale names, and more."
+                },
+                "encoding": {
+                    "$ref": "#/definitions/Encoding"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "data": {
+                    "$ref": "#/definitions/Data"
+                },
+                "transform": {
+                    "$ref": "#/definitions/Transform"
+                },
+                "config": {
+                    "$ref": "#/definitions/Config"
+                }
+            },
+            "required": [
+                "mark"
+            ]
+        },
+        "Mark": {
+            "type": "string",
+            "enum": [
+                "area",
+                "bar",
+                "line",
+                "point",
+                "text",
+                "tick",
+                "rule",
+                "circle",
+                "square"
+            ]
+        },
+        "Encoding": {
+            "type": "object",
+            "properties": {
+                "row": {
+                    "$ref": "#/definitions/PositionChannelDef"
+                },
+                "column": {
+                    "$ref": "#/definitions/PositionChannelDef"
+                },
+                "x": {
+                    "$ref": "#/definitions/PositionChannelDef"
+                },
+                "y": {
+                    "$ref": "#/definitions/PositionChannelDef"
+                },
+                "color": {
+                    "$ref": "#/definitions/ChannelDefWithLegend"
+                },
+                "opacity": {
+                    "$ref": "#/definitions/ChannelDefWithLegend"
+                },
+                "size": {
+                    "$ref": "#/definitions/ChannelDefWithLegend"
+                },
+                "shape": {
+                    "$ref": "#/definitions/ChannelDefWithLegend"
+                },
+                "detail": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/FieldDef",
+                            "description": "Interface for any kind of FieldDef;\n\nFor simplicity, we do not declare multiple interfaces of FieldDef like\n\nwe do for JSON schema."
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FieldDef",
+                                "description": "Interface for any kind of FieldDef;\n\nFor simplicity, we do not declare multiple interfaces of FieldDef like\n\nwe do for JSON schema."
+                            }
+                        }
+                    ]
+                },
+                "text": {
+                    "$ref": "#/definitions/FieldDef"
+                },
+                "label": {
+                    "$ref": "#/definitions/FieldDef"
+                },
+                "path": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/OrderChannelDef"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OrderChannelDef"
+                            }
+                        }
+                    ]
+                },
+                "order": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/OrderChannelDef"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OrderChannelDef"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "PositionChannelDef": {
+            "type": "object",
+            "properties": {
+                "axis": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/AxisProperties"
+                        }
+                    ]
+                },
+                "scale": {
+                    "$ref": "#/definitions/Scale"
+                },
+                "sort": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/SortField"
+                        },
+                        {
+                            "$ref": "#/definitions/SortOrder"
+                        }
+                    ]
+                },
+                "field": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type"
+                },
+                "value": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                "timeUnit": {
+                    "$ref": "#/definitions/TimeUnit"
+                },
+                "bin": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/BinProperties",
+                            "description": "Binning properties or boolean flag for determining whether to bin data or not."
+                        }
+                    ]
+                },
+                "aggregate": {
+                    "$ref": "#/definitions/AggregateOp"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "AxisProperties": {
+            "type": "object",
+            "properties": {
+                "labelAngle": {
+                    "description": "The rotation angle of the axis labels.",
+                    "type": "number"
+                },
+                "format": {
+                    "description": "The formatting pattern for axis labels.",
+                    "type": "string"
+                },
+                "orient": {
+                    "$ref": "#/definitions/AxisOrient",
+                    "description": "The orientation of the axis. One of top, bottom, left or right. The orientation can be used to further specialize the axis type (e.g., a y axis oriented for the right edge of the chart)."
+                },
+                "title": {
+                    "description": "A title for the axis. Shows field name and its function by default.",
+                    "type": "string"
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "axisWidth": {
+                    "description": "Width of the axis line",
+                    "type": "number"
+                },
+                "layer": {
+                    "description": "A string indicating if the axis (and any gridlines) should be placed above or below the data marks.",
+                    "type": "string"
+                },
+                "offset": {
+                    "description": "The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.",
+                    "type": "number"
+                },
+                "axisColor": {
+                    "description": "Color of axis line.",
+                    "type": "string"
+                },
+                "grid": {
+                    "description": "A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.",
+                    "type": "boolean"
+                },
+                "gridColor": {
+                    "description": "Color of gridlines.",
+                    "type": "string"
+                },
+                "gridDash": {
+                    "description": "The offset (in pixels) into which to begin drawing with the grid dash array.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "gridOpacity": {
+                    "description": "The stroke opacity of grid (value between [0,1])",
+                    "type": "number"
+                },
+                "gridWidth": {
+                    "description": "The grid width, in pixels.",
+                    "type": "number"
+                },
+                "labels": {
+                    "description": "Enable or disable labels.",
+                    "type": "boolean"
+                },
+                "labelAlign": {
+                    "description": "Text alignment for the Label.",
+                    "type": "string"
+                },
+                "labelBaseline": {
+                    "description": "Text baseline for the label.",
+                    "type": "string"
+                },
+                "labelMaxLength": {
+                    "description": "Truncate labels that are too long.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "shortTimeLabels": {
+                    "description": "Whether month and day names should be abbreviated.",
+                    "type": "boolean"
+                },
+                "subdivide": {
+                    "description": "If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.",
+                    "type": "number"
+                },
+                "ticks": {
+                    "description": "A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are \"nice\" (multiples of 2, 5, 10) and lie within the underlying scale's range.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickColor": {
+                    "description": "The color of the axis's tick.",
+                    "type": "string"
+                },
+                "tickLabelColor": {
+                    "description": "The color of the tick label, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "tickLabelFont": {
+                    "description": "The font of the tick label.",
+                    "type": "string"
+                },
+                "tickLabelFontSize": {
+                    "description": "The font size of label, in pixels.",
+                    "type": "number"
+                },
+                "tickPadding": {
+                    "description": "The padding, in pixels, between ticks and text labels.",
+                    "type": "number"
+                },
+                "tickSize": {
+                    "description": "The size, in pixels, of major, minor and end ticks.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickSizeMajor": {
+                    "description": "The size, in pixels, of major ticks.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickSizeMinor": {
+                    "description": "The size, in pixels, of minor ticks.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickSizeEnd": {
+                    "description": "The size, in pixels, of end ticks.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickWidth": {
+                    "description": "The width, in pixels, of ticks.",
+                    "type": "number"
+                },
+                "titleColor": {
+                    "description": "Color of the title, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "titleFont": {
+                    "description": "Font of the title.",
+                    "type": "string"
+                },
+                "titleFontSize": {
+                    "description": "Size of the title.",
+                    "type": "number"
+                },
+                "titleFontWeight": {
+                    "description": "Weight of the title.",
+                    "type": "string"
+                },
+                "titleOffset": {
+                    "description": "A title offset value for the axis.",
+                    "type": "number"
+                },
+                "titleMaxLength": {
+                    "description": "Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "characterWidth": {
+                    "description": "Character width for automatically determining title max length.",
+                    "type": "number"
+                },
+                "properties": {
+                    "description": "Optional mark property definitions for custom axis styling."
+                }
+            }
+        },
+        "AxisOrient": {
+            "type": "string",
+            "enum": [
+                "top",
+                "right",
+                "left",
+                "bottom"
+            ]
+        },
+        "Scale": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "$ref": "#/definitions/ScaleType"
+                },
+                "domain": {
+                    "description": "The domain of the scale, representing the set of data values. For quantitative data, this can take the form of a two-element array with minimum and maximum values. For ordinal/categorical data, this may be an array of valid input values. The domain may also be specified by a reference to a data source.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                "range": {
+                    "description": "The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain. For ordinal scales only, the range can be defined using a DataRef: the range values are then drawn dynamically from a backing data set.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            }
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                "round": {
+                    "description": "If true, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.",
+                    "type": "boolean"
+                },
+                "bandSize": {
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "padding": {
+                    "description": "Applies spacing among ordinal elements in the scale range. The actual effect depends on how the scale is configured. If the __points__ parameter is `true`, the padding value is interpreted as a multiple of the spacing between points. A reasonable value is 1.0, such that the first and last point will be offset from the minimum and maximum value by half the distance between points. Otherwise, padding is typically in the range [0, 1] and corresponds to the fraction of space in the range interval to allocate to padding. A value of 0.5 means that the range band width will be equal to the padding width. For more, see the [D3 ordinal scale documentation](https://github.com/mbostock/d3/wiki/Ordinal-Scales).",
+                    "type": "number"
+                },
+                "clamp": {
+                    "description": "If true, values that exceed the data domain are clamped to either the minimum or maximum range value",
+                    "type": "boolean"
+                },
+                "nice": {
+                    "description": "If specified, modifies the scale domain to use a more human-friendly value range. If specified as a true boolean, modifies the scale domain to use a more human-friendly number range (e.g., 7 instead of 6.96). If specified as a string, modifies the scale domain to use a more human-friendly value range. For time and utc scale types only, the nice value should be a string indicating the desired time interval.",
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/NiceTime"
+                        }
+                    ]
+                },
+                "exponent": {
+                    "description": "Sets the exponent of the scale transformation. For pow scale types only, otherwise ignored.",
+                    "type": "number"
+                },
+                "zero": {
+                    "description": "If true, ensures that a zero baseline value is included in the scale domain. This option is ignored for non-quantitative scales.",
+                    "type": "boolean"
+                },
+                "useRawDomain": {
+                    "description": "Uses the source data range as scale domain instead of aggregated data for aggregate axis.\n\nThis property only works with aggregate functions that produce values within the raw data domain (`\"mean\"`, `\"average\"`, `\"stdev\"`, `\"stdevp\"`, `\"median\"`, `\"q1\"`, `\"q3\"`, `\"min\"`, `\"max\"`). For other aggregations that produce values outside of the raw data domain (e.g. `\"count\"`, `\"sum\"`), this property is ignored.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "ScaleType": {
+            "type": "string",
+            "enum": [
+                "linear",
+                "log",
+                "pow",
+                "sqrt",
+                "quantile",
+                "quantize",
+                "ordinal",
+                "time",
+                "utc"
+            ]
+        },
+        "NiceTime": {
+            "type": "string",
+            "enum": [
+                "second",
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year"
+            ]
+        },
+        "SortField": {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "description": "The field name to aggregate over.",
+                    "type": "string"
+                },
+                "op": {
+                    "$ref": "#/definitions/AggregateOp",
+                    "description": "The sort aggregation operator"
+                },
+                "order": {
+                    "$ref": "#/definitions/SortOrder"
+                }
+            },
+            "required": [
+                "field",
+                "op"
+            ]
+        },
+        "AggregateOp": {
+            "type": "string",
+            "enum": [
+                "values",
+                "count",
+                "valid",
+                "missing",
+                "distinct",
+                "sum",
+                "mean",
+                "average",
+                "variance",
+                "variancep",
+                "stdev",
+                "stdevp",
+                "median",
+                "q1",
+                "q3",
+                "modeskew",
+                "min",
+                "max",
+                "argmin",
+                "argmax"
+            ]
+        },
+        "SortOrder": {
+            "type": "string",
+            "enum": [
+                "ascending",
+                "descending",
+                "none"
+            ]
+        },
+        "Type": {
+            "type": "string",
+            "enum": [
+                "quantitative",
+                "ordinal",
+                "temporal",
+                "nominal"
+            ]
+        },
+        "TimeUnit": {
+            "type": "string",
+            "enum": [
+                "year",
+                "month",
+                "day",
+                "date",
+                "hours",
+                "minutes",
+                "seconds",
+                "milliseconds",
+                "yearmonth",
+                "yearmonthday",
+                "yearmonthdate",
+                "yearday",
+                "yeardate",
+                "yearmonthdayhours",
+                "yearmonthdayhoursminutes",
+                "yearmonthdayhoursminutesseconds",
+                "hoursminutes",
+                "hoursminutesseconds",
+                "minutesseconds",
+                "secondsmilliseconds"
+            ]
+        },
+        "BinProperties": {
+            "type": "object",
+            "properties": {
+                "min": {
+                    "description": "The minimum bin value to consider. If unspecified, the minimum value of the specified field is used.",
+                    "type": "number"
+                },
+                "max": {
+                    "description": "The maximum bin value to consider. If unspecified, the maximum value of the specified field is used.",
+                    "type": "number"
+                },
+                "base": {
+                    "description": "The number base to use for automatic bin determination (default is base 10).",
+                    "type": "number"
+                },
+                "step": {
+                    "description": "An exact step size to use between bins. If provided, options such as maxbins will be ignored.",
+                    "type": "number"
+                },
+                "steps": {
+                    "description": "An array of allowable step sizes to choose from.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "minstep": {
+                    "description": "A minimum allowable step size (particularly useful for integer values).",
+                    "type": "number"
+                },
+                "div": {
+                    "description": "Scale factors indicating allowable subdivisions. The default value is [5, 2], which indicates that for base 10 numbers (the default base), the method may consider dividing bin sizes by 5 and/or 2. For example, for an initial step size of 10, the method can check if bin sizes of 2 (= 10/5), 5 (= 10/2), or 1 (= 10/(5*2)) might also satisfy the given constraints.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "maxbins": {
+                    "description": "Maximum number of bins.",
+                    "minimum": 2,
+                    "type": "number"
+                }
+            }
+        },
+        "ChannelDefWithLegend": {
+            "type": "object",
+            "properties": {
+                "legend": {
+                    "$ref": "#/definitions/LegendProperties"
+                },
+                "scale": {
+                    "$ref": "#/definitions/Scale"
+                },
+                "sort": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/SortField"
+                        },
+                        {
+                            "$ref": "#/definitions/SortOrder"
+                        }
+                    ]
+                },
+                "field": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type"
+                },
+                "value": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                "timeUnit": {
+                    "$ref": "#/definitions/TimeUnit"
+                },
+                "bin": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/BinProperties",
+                            "description": "Binning properties or boolean flag for determining whether to bin data or not."
+                        }
+                    ]
+                },
+                "aggregate": {
+                    "$ref": "#/definitions/AggregateOp"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "LegendProperties": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "description": "An optional formatting pattern for legend labels. Vega uses D3\\'s format pattern.",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "A title for the legend. (Shows field name and its function by default.)",
+                    "type": "string"
+                },
+                "values": {
+                    "description": "Explicitly set the visible legend values.",
+                    "type": "array",
+                    "items": {}
+                },
+                "orient": {
+                    "description": "The orientation of the legend. One of \"left\" or \"right\". This determines how the legend is positioned within the scene. The default is \"right\".",
+                    "type": "string"
+                },
+                "offset": {
+                    "description": "The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.",
+                    "type": "number"
+                },
+                "padding": {
+                    "description": "The padding, in pixels, between the lengend and axis.",
+                    "type": "number"
+                },
+                "margin": {
+                    "description": "The margin around the legend, in pixels",
+                    "type": "number"
+                },
+                "gradientStrokeColor": {
+                    "description": "The color of the gradient stroke, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "gradientStrokeWidth": {
+                    "description": "The width of the gradient stroke, in pixels.",
+                    "type": "number"
+                },
+                "gradientHeight": {
+                    "description": "The height of the gradient, in pixels.",
+                    "type": "number"
+                },
+                "gradientWidth": {
+                    "description": "The width of the gradient, in pixels.",
+                    "type": "number"
+                },
+                "labelAlign": {
+                    "description": "The alignment of the legend label, can be left, middle or right.",
+                    "type": "string"
+                },
+                "labelBaseline": {
+                    "description": "The position of the baseline of legend label, can be top, middle or bottom.",
+                    "type": "string"
+                },
+                "labelColor": {
+                    "description": "The color of the legend label, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "labelFont": {
+                    "description": "The font of the lengend label.",
+                    "type": "string"
+                },
+                "labelFontSize": {
+                    "description": "The font size of lengend lable.",
+                    "type": "number"
+                },
+                "labelOffset": {
+                    "description": "The offset of the legend label.",
+                    "type": "number"
+                },
+                "shortTimeLabels": {
+                    "description": "Whether month names and weekday names should be abbreviated.",
+                    "type": "boolean"
+                },
+                "symbolColor": {
+                    "description": "The color of the legend symbol,",
+                    "type": "string"
+                },
+                "symbolShape": {
+                    "description": "The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',\n\n'triangle-up', 'triangle-down'.",
+                    "type": "string"
+                },
+                "symbolSize": {
+                    "description": "The size of the lengend symbol, in pixels.",
+                    "type": "number"
+                },
+                "symbolStrokeWidth": {
+                    "description": "The width of the symbol's stroke.",
+                    "type": "number"
+                },
+                "titleColor": {
+                    "description": "Optional mark property definitions for custom legend styling.\n\nThe color of the legend title, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "titleFont": {
+                    "description": "The font of the legend title.",
+                    "type": "string"
+                },
+                "titleFontSize": {
+                    "description": "The font size of the legend title.",
+                    "type": "number"
+                },
+                "titleFontWeight": {
+                    "description": "The font weight of the legend title.",
+                    "type": "string"
+                },
+                "properties": {
+                    "description": "Optional mark property definitions for custom legend styling."
+                }
+            }
+        },
+        "FieldDef": {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type"
+                },
+                "value": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                "timeUnit": {
+                    "$ref": "#/definitions/TimeUnit"
+                },
+                "bin": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/BinProperties",
+                            "description": "Binning properties or boolean flag for determining whether to bin data or not."
+                        }
+                    ]
+                },
+                "aggregate": {
+                    "$ref": "#/definitions/AggregateOp"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "OrderChannelDef": {
+            "type": "object",
+            "properties": {
+                "sort": {
+                    "$ref": "#/definitions/SortOrder"
+                },
+                "field": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type"
+                },
+                "value": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                "timeUnit": {
+                    "$ref": "#/definitions/TimeUnit"
+                },
+                "bin": {
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/BinProperties",
+                            "description": "Binning properties or boolean flag for determining whether to bin data or not."
+                        }
+                    ]
+                },
+                "aggregate": {
+                    "$ref": "#/definitions/AggregateOp"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "Data": {
+            "type": "object",
+            "properties": {
+                "formatType": {
+                    "$ref": "#/definitions/DataFormat"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "values": {
+                    "description": "Pass array of objects instead of a url to a file.",
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "DataFormat": {
+            "type": "string",
+            "enum": [
+                "json",
+                "csv",
+                "tsv"
+            ]
+        },
+        "Transform": {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "description": "A string containing the filter Vega expression. Use `datum` to refer to the current data object.",
+                    "type": "string"
+                },
+                "filterNull": {
+                    "description": "Filter null values from the data. If set to true, all rows with null values are filtered. If false, no rows are filtered. Set the property to undefined to filter only quantitative and temporal fields.",
+                    "type": "boolean"
+                },
+                "calculate": {
+                    "description": "Calculate new field(s) using the provided expresssion(s). Calculation are applied before filter.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Formula"
+                    }
+                }
+            }
+        },
+        "Formula": {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "description": "The field in which to store the computed formula value.",
+                    "type": "string"
+                },
+                "expr": {
+                    "description": "A string containing an expression for the formula. Use the variable `datum` to to refer to the current data object.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "field",
+                "expr"
+            ]
+        },
+        "Config": {
+            "type": "object",
+            "properties": {
+                "viewport": {
+                    "description": "The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.",
+                    "type": "number"
+                },
+                "background": {
+                    "description": "CSS color property to use as background of visualization. Default is `\"transparent\"`.",
+                    "type": "string"
+                },
+                "numberFormat": {
+                    "description": "D3 Number format for axis labels and text tables. For example \"s\" for SI units.",
+                    "type": "string"
+                },
+                "timeFormat": {
+                    "description": "Default datetime format for axis and legend labels. The format can be set directly on each axis and legend.",
+                    "type": "string"
+                },
+                "cell": {
+                    "$ref": "#/definitions/CellConfig"
+                },
+                "mark": {
+                    "$ref": "#/definitions/MarkConfig"
+                },
+                "scale": {
+                    "$ref": "#/definitions/ScaleConfig"
+                },
+                "axis": {
+                    "$ref": "#/definitions/AxisConfig"
+                },
+                "legend": {
+                    "$ref": "#/definitions/LegendConfig"
+                },
+                "facet": {
+                    "$ref": "#/definitions/FacetConfig"
+                }
+            }
+        },
+        "CellConfig": {
+            "type": "object",
+            "properties": {
+                "width": {
+                    "type": "number"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "clip": {
+                    "type": "boolean"
+                },
+                "fill": {
+                    "format": "color",
+                    "type": "string"
+                },
+                "fillOpacity": {
+                    "type": "number"
+                },
+                "stroke": {
+                    "type": "string"
+                },
+                "strokeWidth": {
+                    "type": "number"
+                },
+                "strokeOpacity": {
+                    "type": "number"
+                },
+                "strokeDash": {
+                    "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "strokeDashOffset": {
+                    "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+                    "type": "number"
+                }
+            }
+        },
+        "MarkConfig": {
+            "type": "object",
+            "properties": {
+                "filled": {
+                    "description": "Whether the shape\\'s color should be used as fill color instead of stroke color.\n\nThis is only applicable for \"bar\", \"point\", and \"area\".\n\nAll marks except \"point\" marks are filled by default.\n\nSee Mark Documentation (http://vega.github.io/vega-lite/docs/marks.html)\n\nfor usage example.",
+                    "type": "boolean"
+                },
+                "color": {
+                    "description": "Default color.",
+                    "format": "color",
+                    "type": "string"
+                },
+                "fill": {
+                    "description": "Default Fill Color.  This has higher precedence than config.color",
+                    "format": "color",
+                    "type": "string"
+                },
+                "stroke": {
+                    "description": "Default Stroke Color.  This has higher precedence than config.color",
+                    "format": "color",
+                    "type": "string"
+                },
+                "opacity": {
+                    "minimum": 0,
+                    "maximum": 1,
+                    "type": "number"
+                },
+                "fillOpacity": {
+                    "minimum": 0,
+                    "maximum": 1,
+                    "type": "number"
+                },
+                "strokeOpacity": {
+                    "minimum": 0,
+                    "maximum": 1,
+                    "type": "number"
+                },
+                "strokeWidth": {
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "strokeDash": {
+                    "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "strokeDashOffset": {
+                    "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+                    "type": "number"
+                },
+                "stacked": {
+                    "$ref": "#/definitions/StackOffset"
+                },
+                "orient": {
+                    "description": "The orientation of a non-stacked bar, tick, area, and line charts.\n\nThe value is either horizontal (default) or vertical.\n\n- For bar, rule and tick, this determines whether the size of the bar and tick\n\nshould be applied to x or y dimension.\n\n- For area, this property determines the orient property of the Vega output.\n\n- For line, this property determines the sort order of the points in the line\n\nif `config.sortLineBy` is not specified.\n\nFor stacked charts, this is always determined by the orientation of the stack;\n\ntherefore explicitly specified value will be ignored.",
+                    "type": "string"
+                },
+                "interpolate": {
+                    "$ref": "#/definitions/Interpolate",
+                    "description": "The line interpolation method to use. One of linear, step-before, step-after, basis, basis-open, cardinal, cardinal-open, monotone."
+                },
+                "tension": {
+                    "description": "Depending on the interpolation type, sets the tension parameter.",
+                    "type": "number"
+                },
+                "lineSize": {
+                    "description": "Size of line mark.",
+                    "type": "number"
+                },
+                "ruleSize": {
+                    "description": "Size of rule mark.",
+                    "type": "number"
+                },
+                "barSize": {
+                    "description": "The size of the bars.  If unspecified, the default size is  `bandSize-1`,\n\nwhich provides 1 pixel offset between bars.",
+                    "type": "number"
+                },
+                "barThinSize": {
+                    "description": "The size of the bars on continuous scales.",
+                    "type": "number"
+                },
+                "shape": {
+                    "$ref": "#/definitions/Shape",
+                    "description": "The symbol shape to use. One of circle (default), square, cross, diamond, triangle-up, or triangle-down."
+                },
+                "size": {
+                    "description": "The pixel area each the point. For example: in the case of circles, the radius is determined in part by the square root of the size value.",
+                    "type": "number"
+                },
+                "tickSize": {
+                    "description": "The width of the ticks.",
+                    "type": "number"
+                },
+                "tickThickness": {
+                    "description": "Thickness of the tick mark.",
+                    "type": "number"
+                },
+                "align": {
+                    "$ref": "#/definitions/HorizontalAlign",
+                    "description": "The horizontal alignment of the text. One of left, right, center."
+                },
+                "angle": {
+                    "description": "The rotation angle of the text, in degrees.",
+                    "type": "number"
+                },
+                "baseline": {
+                    "$ref": "#/definitions/VerticalAlign",
+                    "description": "The vertical alignment of the text. One of top, middle, bottom."
+                },
+                "dx": {
+                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "type": "number"
+                },
+                "dy": {
+                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "type": "number"
+                },
+                "radius": {
+                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the x and y properties.",
+                    "type": "number"
+                },
+                "theta": {
+                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the x and y properties. Values for theta follow the same convention of arc mark startAngle and endAngle properties: angles are measured in radians, with 0 indicating \"north\".",
+                    "type": "number"
+                },
+                "font": {
+                    "description": "The typeface to set the text in (e.g., Helvetica Neue).",
+                    "type": "string"
+                },
+                "fontSize": {
+                    "description": "The font size, in pixels.",
+                    "type": "number"
+                },
+                "fontStyle": {
+                    "$ref": "#/definitions/FontStyle",
+                    "description": "The font style (e.g., italic)."
+                },
+                "fontWeight": {
+                    "$ref": "#/definitions/FontWeight",
+                    "description": "The font weight (e.g., bold)."
+                },
+                "format": {
+                    "description": "The formatting pattern for text value. If not defined, this will be determined automatically.",
+                    "type": "string"
+                },
+                "shortTimeLabels": {
+                    "description": "Whether month names and weekday names should be abbreviated.",
+                    "type": "boolean"
+                },
+                "text": {
+                    "description": "Placeholder Text",
+                    "type": "string"
+                },
+                "applyColorToBackground": {
+                    "description": "Apply color field to background color instead of the text.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "StackOffset": {
+            "type": "string",
+            "enum": [
+                "zero",
+                "center",
+                "normalize",
+                "none"
+            ]
+        },
+        "Interpolate": {
+            "type": "string",
+            "enum": [
+                "linear",
+                "linear-closed",
+                "step",
+                "step-before",
+                "step-after",
+                "basis",
+                "basis-open",
+                "basis-closed",
+                "cardinal",
+                "cardinal-open",
+                "cardinal-closed",
+                "bundle",
+                "monotone"
+            ]
+        },
+        "Shape": {
+            "type": "string",
+            "enum": [
+                "circle",
+                "square",
+                "cross",
+                "diamond",
+                "triangle-up",
+                "triangle-down"
+            ]
+        },
+        "HorizontalAlign": {
+            "type": "string",
+            "enum": [
+                "left",
+                "right",
+                "center"
+            ]
+        },
+        "VerticalAlign": {
+            "type": "string",
+            "enum": [
+                "top",
+                "middle",
+                "bottom"
+            ]
+        },
+        "FontStyle": {
+            "type": "string",
+            "enum": [
+                "normal",
+                "italic"
+            ]
+        },
+        "FontWeight": {
+            "type": "string",
+            "enum": [
+                "normal",
+                "bold"
+            ]
+        },
+        "ScaleConfig": {
+            "type": "object",
+            "properties": {
+                "round": {
+                    "description": "If true, rounds numeric output values to integers.\n\nThis can be helpful for snapping to the pixel grid.\n\n(Only available for `x`, `y`, `size`, `row`, and `column` scales.)",
+                    "type": "boolean"
+                },
+                "textBandWidth": {
+                    "description": "Default band width for `x` ordinal scale when is mark is `text`.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "bandSize": {
+                    "description": "Default band size for (1) `y` ordinal scale,\n\nand (2) `x` ordinal scale when the mark is not `text`.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "opacity": {
+                    "description": "Default range for opacity.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "padding": {
+                    "description": "Default padding for `x` and `y` ordinal scales.",
+                    "type": "number"
+                },
+                "useRawDomain": {
+                    "description": "Uses the source data range as scale domain instead of aggregated data for aggregate axis.\n\nThis property only works with aggregate functions that produce values within the raw data domain (`\"mean\"`, `\"average\"`, `\"stdev\"`, `\"stdevp\"`, `\"median\"`, `\"q1\"`, `\"q3\"`, `\"min\"`, `\"max\"`). For other aggregations that produce values outside of the raw data domain (e.g. `\"count\"`, `\"sum\"`), this property is ignored.",
+                    "type": "boolean"
+                },
+                "nominalColorRange": {
+                    "description": "Default range for nominal color scale",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                "sequentialColorRange": {
+                    "description": "Default range for ordinal / continuous color scale",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                "shapeRange": {
+                    "description": "Default range for shape",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                "barSizeRange": {
+                    "description": "Default range for bar size scale",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "fontSizeRange": {
+                    "description": "Default range for font size scale",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "ruleSizeRange": {
+                    "description": "Default range for rule stroke widths",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "tickSizeRange": {
+                    "description": "Default range for tick spans",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "pointSizeRange": {
+                    "description": "Default range for bar size scale",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        },
+        "AxisConfig": {
+            "type": "object",
+            "properties": {
+                "axisWidth": {
+                    "description": "Width of the axis line",
+                    "type": "number"
+                },
+                "layer": {
+                    "description": "A string indicating if the axis (and any gridlines) should be placed above or below the data marks.",
+                    "type": "string"
+                },
+                "offset": {
+                    "description": "The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.",
+                    "type": "number"
+                },
+                "axisColor": {
+                    "description": "Color of axis line.",
+                    "type": "string"
+                },
+                "grid": {
+                    "description": "A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.",
+                    "type": "boolean"
+                },
+                "gridColor": {
+                    "description": "Color of gridlines.",
+                    "type": "string"
+                },
+                "gridDash": {
+                    "description": "The offset (in pixels) into which to begin drawing with the grid dash array.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "gridOpacity": {
+                    "description": "The stroke opacity of grid (value between [0,1])",
+                    "type": "number"
+                },
+                "gridWidth": {
+                    "description": "The grid width, in pixels.",
+                    "type": "number"
+                },
+                "labels": {
+                    "description": "Enable or disable labels.",
+                    "type": "boolean"
+                },
+                "labelAngle": {
+                    "description": "The rotation angle of the axis labels.",
+                    "type": "number"
+                },
+                "labelAlign": {
+                    "description": "Text alignment for the Label.",
+                    "type": "string"
+                },
+                "labelBaseline": {
+                    "description": "Text baseline for the label.",
+                    "type": "string"
+                },
+                "labelMaxLength": {
+                    "description": "Truncate labels that are too long.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "shortTimeLabels": {
+                    "description": "Whether month and day names should be abbreviated.",
+                    "type": "boolean"
+                },
+                "subdivide": {
+                    "description": "If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.",
+                    "type": "number"
+                },
+                "ticks": {
+                    "description": "A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are \"nice\" (multiples of 2, 5, 10) and lie within the underlying scale's range.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickColor": {
+                    "description": "The color of the axis's tick.",
+                    "type": "string"
+                },
+                "tickLabelColor": {
+                    "description": "The color of the tick label, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "tickLabelFont": {
+                    "description": "The font of the tick label.",
+                    "type": "string"
+                },
+                "tickLabelFontSize": {
+                    "description": "The font size of label, in pixels.",
+                    "type": "number"
+                },
+                "tickPadding": {
+                    "description": "The padding, in pixels, between ticks and text labels.",
+                    "type": "number"
+                },
+                "tickSize": {
+                    "description": "The size, in pixels, of major, minor and end ticks.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickSizeMajor": {
+                    "description": "The size, in pixels, of major ticks.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickSizeMinor": {
+                    "description": "The size, in pixels, of minor ticks.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickSizeEnd": {
+                    "description": "The size, in pixels, of end ticks.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tickWidth": {
+                    "description": "The width, in pixels, of ticks.",
+                    "type": "number"
+                },
+                "titleColor": {
+                    "description": "Color of the title, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "titleFont": {
+                    "description": "Font of the title.",
+                    "type": "string"
+                },
+                "titleFontSize": {
+                    "description": "Size of the title.",
+                    "type": "number"
+                },
+                "titleFontWeight": {
+                    "description": "Weight of the title.",
+                    "type": "string"
+                },
+                "titleOffset": {
+                    "description": "A title offset value for the axis.",
+                    "type": "number"
+                },
+                "titleMaxLength": {
+                    "description": "Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "characterWidth": {
+                    "description": "Character width for automatically determining title max length.",
+                    "type": "number"
+                },
+                "properties": {
+                    "description": "Optional mark property definitions for custom axis styling."
+                }
+            }
+        },
+        "LegendConfig": {
+            "type": "object",
+            "properties": {
+                "orient": {
+                    "description": "The orientation of the legend. One of \"left\" or \"right\". This determines how the legend is positioned within the scene. The default is \"right\".",
+                    "type": "string"
+                },
+                "offset": {
+                    "description": "The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.",
+                    "type": "number"
+                },
+                "padding": {
+                    "description": "The padding, in pixels, between the lengend and axis.",
+                    "type": "number"
+                },
+                "margin": {
+                    "description": "The margin around the legend, in pixels",
+                    "type": "number"
+                },
+                "gradientStrokeColor": {
+                    "description": "The color of the gradient stroke, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "gradientStrokeWidth": {
+                    "description": "The width of the gradient stroke, in pixels.",
+                    "type": "number"
+                },
+                "gradientHeight": {
+                    "description": "The height of the gradient, in pixels.",
+                    "type": "number"
+                },
+                "gradientWidth": {
+                    "description": "The width of the gradient, in pixels.",
+                    "type": "number"
+                },
+                "labelAlign": {
+                    "description": "The alignment of the legend label, can be left, middle or right.",
+                    "type": "string"
+                },
+                "labelBaseline": {
+                    "description": "The position of the baseline of legend label, can be top, middle or bottom.",
+                    "type": "string"
+                },
+                "labelColor": {
+                    "description": "The color of the legend label, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "labelFont": {
+                    "description": "The font of the lengend label.",
+                    "type": "string"
+                },
+                "labelFontSize": {
+                    "description": "The font size of lengend lable.",
+                    "type": "number"
+                },
+                "labelOffset": {
+                    "description": "The offset of the legend label.",
+                    "type": "number"
+                },
+                "shortTimeLabels": {
+                    "description": "Whether month names and weekday names should be abbreviated.",
+                    "type": "boolean"
+                },
+                "symbolColor": {
+                    "description": "The color of the legend symbol,",
+                    "type": "string"
+                },
+                "symbolShape": {
+                    "description": "The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',\n\n'triangle-up', 'triangle-down'.",
+                    "type": "string"
+                },
+                "symbolSize": {
+                    "description": "The size of the lengend symbol, in pixels.",
+                    "type": "number"
+                },
+                "symbolStrokeWidth": {
+                    "description": "The width of the symbol's stroke.",
+                    "type": "number"
+                },
+                "titleColor": {
+                    "description": "Optional mark property definitions for custom legend styling.\n\nThe color of the legend title, can be in hex color code or regular color name.",
+                    "type": "string"
+                },
+                "titleFont": {
+                    "description": "The font of the legend title.",
+                    "type": "string"
+                },
+                "titleFontSize": {
+                    "description": "The font size of the legend title.",
+                    "type": "number"
+                },
+                "titleFontWeight": {
+                    "description": "The font weight of the legend title.",
+                    "type": "string"
+                },
+                "properties": {
+                    "description": "Optional mark property definitions for custom legend styling."
+                }
+            }
+        },
+        "FacetConfig": {
+            "type": "object",
+            "properties": {
+                "scale": {
+                    "$ref": "#/definitions/FacetScaleConfig"
+                },
+                "axis": {
+                    "$ref": "#/definitions/AxisConfig"
+                },
+                "grid": {
+                    "$ref": "#/definitions/FacetGridConfig"
+                },
+                "cell": {
+                    "$ref": "#/definitions/CellConfig"
+                }
+            }
+        },
+        "FacetScaleConfig": {
+            "type": "object",
+            "properties": {
+                "round": {
+                    "type": "boolean"
+                },
+                "padding": {
+                    "type": "number"
+                }
+            }
+        },
+        "FacetGridConfig": {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "format": "color",
+                    "type": "string"
+                },
+                "opacity": {
+                    "type": "number"
+                },
+                "offset": {
+                    "type": "number"
+                }
+            }
+        },
+        "FacetSpec": {
+            "type": "object",
+            "properties": {
+                "facet": {
+                    "$ref": "#/definitions/Facet"
+                },
+                "spec": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/LayerSpec"
+                        },
+                        {
+                            "$ref": "#/definitions/UnitSpec"
+                        }
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "data": {
+                    "$ref": "#/definitions/Data"
+                },
+                "transform": {
+                    "$ref": "#/definitions/Transform"
+                },
+                "config": {
+                    "$ref": "#/definitions/Config"
+                }
+            },
+            "required": [
+                "facet",
+                "spec"
+            ]
+        },
+        "Facet": {
+            "type": "object",
+            "properties": {
+                "row": {
+                    "$ref": "#/definitions/PositionChannelDef"
+                },
+                "column": {
+                    "$ref": "#/definitions/PositionChannelDef"
+                }
+            }
+        },
+        "LayerSpec": {
+            "type": "object",
+            "properties": {
+                "layers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/UnitSpec"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "data": {
+                    "$ref": "#/definitions/Data"
+                },
+                "transform": {
+                    "$ref": "#/definitions/Transform"
+                },
+                "config": {
+                    "$ref": "#/definitions/Config"
+                }
+            },
+            "required": [
+                "layers"
+            ]
+        },
+        "UnitSpec": {
+            "type": "object",
+            "properties": {
+                "mark": {
+                    "$ref": "#/definitions/Mark"
+                },
+                "encoding": {
+                    "$ref": "#/definitions/UnitEncoding"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "data": {
+                    "$ref": "#/definitions/Data"
+                },
+                "transform": {
+                    "$ref": "#/definitions/Transform"
+                },
+                "config": {
+                    "$ref": "#/definitions/Config"
+                }
+            },
+            "required": [
+                "mark"
+            ]
+        },
+        "UnitEncoding": {
+            "type": "object",
+            "properties": {
+                "x": {
+                    "$ref": "#/definitions/PositionChannelDef"
+                },
+                "y": {
+                    "$ref": "#/definitions/PositionChannelDef"
+                },
+                "color": {
+                    "$ref": "#/definitions/ChannelDefWithLegend"
+                },
+                "opacity": {
+                    "$ref": "#/definitions/ChannelDefWithLegend"
+                },
+                "size": {
+                    "$ref": "#/definitions/ChannelDefWithLegend"
+                },
+                "shape": {
+                    "$ref": "#/definitions/ChannelDefWithLegend"
+                },
+                "detail": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/FieldDef",
+                            "description": "Interface for any kind of FieldDef;\n\nFor simplicity, we do not declare multiple interfaces of FieldDef like\n\nwe do for JSON schema."
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FieldDef",
+                                "description": "Interface for any kind of FieldDef;\n\nFor simplicity, we do not declare multiple interfaces of FieldDef like\n\nwe do for JSON schema."
+                            }
+                        }
+                    ]
+                },
+                "text": {
+                    "$ref": "#/definitions/FieldDef"
+                },
+                "label": {
+                    "$ref": "#/definitions/FieldDef"
+                },
+                "path": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/OrderChannelDef"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OrderChannelDef"
+                            }
+                        }
+                    ]
+                },
+                "order": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/OrderChannelDef"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OrderChannelDef"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/src/schemas/json/vega.json
+++ b/src/schemas/json/vega.json
@@ -1,0 +1,6695 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Vega Visualization Specification Language",
+  "defs": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "x",
+            "y"
+          ]
+        },
+        "scale": {
+          "type": "string"
+        },
+        "orient": {
+          "enum": [
+            "top",
+            "bottom",
+            "left",
+            "right"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "titleOffset": {
+          "type": "number"
+        },
+        "format": {
+          "type": "string"
+        },
+        "formatType": {
+          "enum": [
+            "time",
+            "utc",
+            "string",
+            "number"
+          ]
+        },
+        "ticks": {
+          "type": "number"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "number"
+            ]
+          }
+        },
+        "subdivide": {
+          "type": "number"
+        },
+        "tickPadding": {
+          "type": "number"
+        },
+        "tickSize": {
+          "type": "number"
+        },
+        "tickSizeMajor": {
+          "type": "number"
+        },
+        "tickSizeMinor": {
+          "type": "number"
+        },
+        "tickSizeEnd": {
+          "type": "number"
+        },
+        "offset": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "scale": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": [
+                    "string",
+                    "number"
+                  ]
+                }
+              },
+              "required": [
+                "scale",
+                "value"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "layer": {
+          "enum": [
+            "front",
+            "back"
+          ],
+          "default": "front"
+        },
+        "grid": {
+          "type": "boolean"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "ticks": {
+              "$ref": "#/defs/propset"
+            },
+            "majorTicks": {
+              "$ref": "#/defs/propset"
+            },
+            "minorTicks": {
+              "$ref": "#/defs/propset"
+            },
+            "labels": {
+              "$ref": "#/defs/propset"
+            },
+            "title": {
+              "$ref": "#/defs/propset"
+            },
+            "grid": {
+              "$ref": "#/defs/propset"
+            },
+            "axis": {
+              "$ref": "#/defs/propset"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "scale"
+      ]
+    },
+    "background": {
+      "type": "string"
+    },
+    "data": {
+      "title": "Input data set definition",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "transform": {
+              "$ref": "#/defs/transform"
+            },
+            "modify": {
+              "$ref": "#/defs/modify"
+            },
+            "format": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "json"
+                      ]
+                    },
+                    "parse": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "auto"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {
+                            "enum": [
+                              "number",
+                              "boolean",
+                              "date",
+                              "string"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "property": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "csv",
+                        "tsv"
+                      ]
+                    },
+                    "parse": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "auto"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {
+                            "enum": [
+                              "number",
+                              "boolean",
+                              "date",
+                              "string"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "topojson"
+                          ]
+                        },
+                        "feature": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "topojson"
+                          ]
+                        },
+                        "mesh": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "treejson"
+                      ]
+                    },
+                    "children": {
+                      "type": "string"
+                    },
+                    "parse": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "auto"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {
+                            "enum": [
+                              "number",
+                              "boolean",
+                              "date",
+                              "string"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "name",
+                "modify"
+              ]
+            },
+            {
+              "oneOf": [
+                {
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "source"
+                  ]
+                },
+                {
+                  "properties": {
+                    "values": {
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "values"
+                  ]
+                },
+                {
+                  "properties": {
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "legend": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "string"
+        },
+        "fill": {
+          "type": "string"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "orient": {
+          "enum": [
+            "left",
+            "right"
+          ],
+          "default": "right"
+        },
+        "offset": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array"
+        },
+        "format": {
+          "type": "string"
+        },
+        "formatType": {
+          "enum": [
+            "time",
+            "utc",
+            "string",
+            "number"
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "$ref": "#/defs/propset"
+            },
+            "labels": {
+              "$ref": "#/defs/propset"
+            },
+            "legend": {
+              "$ref": "#/defs/propset"
+            },
+            "symbols": {
+              "$ref": "#/defs/propset"
+            },
+            "gradient": {
+              "$ref": "#/defs/propset"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "size"
+          ]
+        },
+        {
+          "required": [
+            "shape"
+          ]
+        },
+        {
+          "required": [
+            "fill"
+          ]
+        },
+        {
+          "required": [
+            "stroke"
+          ]
+        }
+      ]
+    },
+    "mark": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "rect",
+            "symbol",
+            "path",
+            "arc",
+            "area",
+            "line",
+            "rule",
+            "image",
+            "text",
+            "group"
+          ]
+        },
+        "from": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "string"
+            },
+            "mark": {
+              "type": "string"
+            },
+            "transform": {
+              "$ref": "#/defs/transform"
+            }
+          },
+          "additionalProperties": false
+        },
+        "delay": {
+          "$ref": "#/refs/numberValue"
+        },
+        "ease": {
+          "enum": [
+            "linear-in",
+            "linear-out",
+            "linear-in-out",
+            "linear-out-in",
+            "quad-in",
+            "quad-out",
+            "quad-in-out",
+            "quad-out-in",
+            "cubic-in",
+            "cubic-out",
+            "cubic-in-out",
+            "cubic-out-in",
+            "sin-in",
+            "sin-out",
+            "sin-in-out",
+            "sin-out-in",
+            "exp-in",
+            "exp-out",
+            "exp-in-out",
+            "exp-out-in",
+            "circle-in",
+            "circle-out",
+            "circle-in-out",
+            "circle-out-in",
+            "bounce-in",
+            "bounce-out",
+            "bounce-in-out",
+            "bounce-out-in"
+          ]
+        },
+        "interactive": {
+          "type": "boolean"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "enter": {
+              "$ref": "#/defs/propset"
+            },
+            "update": {
+              "$ref": "#/defs/propset"
+            },
+            "exit": {
+              "$ref": "#/defs/propset"
+            },
+            "hover": {
+              "$ref": "#/defs/propset"
+            }
+          },
+          "additionalProperties": false,
+          "anyOf": [
+            {
+              "required": [
+                "enter"
+              ]
+            },
+            {
+              "required": [
+                "update"
+              ]
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "container": {
+      "type": "object",
+      "properties": {
+        "scene": {
+          "type": "object",
+          "properties": {
+            "fill": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "fillOpacity": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "stroke": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "strokeOpacity": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "strokeWidth": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "strokeDash": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "strokeDashOffset": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            }
+          }
+        },
+        "scales": {
+          "type": "array",
+          "items": {
+            "$ref": "#/defs/scale"
+          }
+        },
+        "axes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/defs/axis"
+          }
+        },
+        "legends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/defs/legend"
+          }
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/defs/groupMark"
+              },
+              {
+                "$ref": "#/defs/visualMark"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "groupMark": {
+      "allOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "group"
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "$ref": "#/defs/mark"
+        },
+        {
+          "$ref": "#/defs/container"
+        }
+      ]
+    },
+    "visualMark": {
+      "allOf": [
+        {
+          "not": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "group"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/defs/mark"
+        }
+      ]
+    },
+    "modify": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "insert",
+                  "remove",
+                  "upsert",
+                  "toggle"
+                ]
+              },
+              "signal": {
+                "type": "string"
+              },
+              "field": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "signal"
+            ]
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "clear"
+                ]
+              },
+              "predicate": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "predicate"
+            ]
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "clear"
+                ]
+              },
+              "test": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "test"
+            ]
+          }
+        ]
+      }
+    },
+    "padding": {
+      "oneOf": [
+        {
+          "enum": [
+            "strict",
+            "auto"
+          ]
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "top": {
+              "type": "number"
+            },
+            "bottom": {
+              "type": "number"
+            },
+            "left": {
+              "type": "number"
+            },
+            "right": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "predicate": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "==",
+                "!=",
+                ">",
+                "<",
+                ">=",
+                "<="
+              ]
+            },
+            "operands": {
+              "type": "array",
+              "items": {
+                "$ref": "#/refs/operand"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": [
+            "name",
+            "type",
+            "operands"
+          ]
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "and",
+                "&&",
+                "or",
+                "||"
+              ]
+            },
+            "operands": {
+              "type": "array",
+              "items": {
+                "$ref": "#/refs/operand"
+              },
+              "minItems": 2
+            }
+          },
+          "required": [
+            "name",
+            "type",
+            "operands"
+          ]
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "in"
+              ]
+            },
+            "item": {
+              "$ref": "#/refs/operand"
+            }
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "range": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/refs/operand"
+                  },
+                  "minItems": 2
+                },
+                "scale": {
+                  "$ref": "#/refs/scopedScale"
+                }
+              },
+              "required": [
+                "range"
+              ]
+            },
+            {
+              "properties": {
+                "data": {
+                  "type": "string"
+                },
+                "field": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "data",
+                "field"
+              ]
+            }
+          ],
+          "required": [
+            "name",
+            "type",
+            "item"
+          ]
+        }
+      ]
+    },
+    "rule": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "predicate": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "test": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "propset": {
+      "title": "Mark property set",
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/refs/numberValue"
+        },
+        "x2": {
+          "$ref": "#/refs/numberValue"
+        },
+        "xc": {
+          "$ref": "#/refs/numberValue"
+        },
+        "width": {
+          "$ref": "#/refs/numberValue"
+        },
+        "y": {
+          "$ref": "#/refs/numberValue"
+        },
+        "y2": {
+          "$ref": "#/refs/numberValue"
+        },
+        "yc": {
+          "$ref": "#/refs/numberValue"
+        },
+        "height": {
+          "$ref": "#/refs/numberValue"
+        },
+        "opacity": {
+          "$ref": "#/refs/numberValue"
+        },
+        "fill": {
+          "$ref": "#/refs/colorValue"
+        },
+        "fillOpacity": {
+          "$ref": "#/refs/numberValue"
+        },
+        "stroke": {
+          "$ref": "#/refs/colorValue"
+        },
+        "strokeWidth": {
+          "$ref": "#/refs/numberValue"
+        },
+        "strokeOpacity": {
+          "$ref": "#/refs/numberValue"
+        },
+        "strokeDash": {
+          "$ref": "#/refs/arrayValue"
+        },
+        "strokeDashOffset": {
+          "$ref": "#/refs/numberValue"
+        },
+        "cursor": {
+          "$ref": "#/refs/stringValue"
+        },
+        "clip": {
+          "$ref": "#/refs/booleanValue"
+        },
+        "size": {
+          "$ref": "#/refs/numberValue"
+        },
+        "shape": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "rule": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/defs/rule"
+                      },
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/refs/stringModifiers"
+                          },
+                          {
+                            "oneOf": [
+                              {
+                                "$ref": "#/refs/signal",
+                                "required": [
+                                  "signal"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "value": {
+                                    "enum": [
+                                      "circle",
+                                      "square",
+                                      "cross",
+                                      "diamond",
+                                      "triangle-up",
+                                      "triangle-down"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "value"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "field": {
+                                    "$ref": "#/refs/field"
+                                  }
+                                },
+                                "required": [
+                                  "field"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "band": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "band"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "rule"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "enum": [
+                                  "circle",
+                                  "square",
+                                  "cross",
+                                  "diamond",
+                                  "triangle-up",
+                                  "triangle-down"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/refs/stringModifiers"
+                },
+                {
+                  "oneOf": [
+                    {
+                      "$ref": "#/refs/signal",
+                      "required": [
+                        "signal"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "value": {
+                          "enum": [
+                            "circle",
+                            "square",
+                            "cross",
+                            "diamond",
+                            "triangle-up",
+                            "triangle-down"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "value"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "field": {
+                          "$ref": "#/refs/field"
+                        }
+                      },
+                      "required": [
+                        "field"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "band": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "band"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "path": {
+          "$ref": "#/refs/stringValue"
+        },
+        "innerRadius": {
+          "$ref": "#/refs/numberValue"
+        },
+        "outerRadius": {
+          "$ref": "#/refs/numberValue"
+        },
+        "startAngle": {
+          "$ref": "#/refs/numberValue"
+        },
+        "endAngle": {
+          "$ref": "#/refs/numberValue"
+        },
+        "interpolate": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "rule": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/defs/rule"
+                      },
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/refs/stringModifiers"
+                          },
+                          {
+                            "oneOf": [
+                              {
+                                "$ref": "#/refs/signal",
+                                "required": [
+                                  "signal"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "value": {
+                                    "enum": [
+                                      "linear",
+                                      "step-before",
+                                      "step-after",
+                                      "basis",
+                                      "basis-open",
+                                      "cardinal",
+                                      "cardinal-open",
+                                      "monotone"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "value"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "field": {
+                                    "$ref": "#/refs/field"
+                                  }
+                                },
+                                "required": [
+                                  "field"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "band": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "band"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "rule"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "enum": [
+                                  "linear",
+                                  "step-before",
+                                  "step-after",
+                                  "basis",
+                                  "basis-open",
+                                  "cardinal",
+                                  "cardinal-open",
+                                  "monotone"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/refs/stringModifiers"
+                },
+                {
+                  "oneOf": [
+                    {
+                      "$ref": "#/refs/signal",
+                      "required": [
+                        "signal"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "value": {
+                          "enum": [
+                            "linear",
+                            "step-before",
+                            "step-after",
+                            "basis",
+                            "basis-open",
+                            "cardinal",
+                            "cardinal-open",
+                            "monotone"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "value"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "field": {
+                          "$ref": "#/refs/field"
+                        }
+                      },
+                      "required": [
+                        "field"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "band": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "band"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "tension": {
+          "$ref": "#/refs/numberValue"
+        },
+        "orient": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "rule": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/defs/rule"
+                      },
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/refs/stringModifiers"
+                          },
+                          {
+                            "oneOf": [
+                              {
+                                "$ref": "#/refs/signal",
+                                "required": [
+                                  "signal"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "value": {
+                                    "enum": [
+                                      "horizontal",
+                                      "vertical"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "value"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "field": {
+                                    "$ref": "#/refs/field"
+                                  }
+                                },
+                                "required": [
+                                  "field"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "band": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "band"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "rule"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "enum": [
+                                  "horizontal",
+                                  "vertical"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/refs/stringModifiers"
+                },
+                {
+                  "oneOf": [
+                    {
+                      "$ref": "#/refs/signal",
+                      "required": [
+                        "signal"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "value": {
+                          "enum": [
+                            "horizontal",
+                            "vertical"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "value"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "field": {
+                          "$ref": "#/refs/field"
+                        }
+                      },
+                      "required": [
+                        "field"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "band": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "band"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "url": {
+          "$ref": "#/refs/stringValue"
+        },
+        "align": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "rule": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/defs/rule"
+                      },
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/refs/stringModifiers"
+                          },
+                          {
+                            "oneOf": [
+                              {
+                                "$ref": "#/refs/signal",
+                                "required": [
+                                  "signal"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "value": {
+                                    "enum": [
+                                      "left",
+                                      "right",
+                                      "center"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "value"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "field": {
+                                    "$ref": "#/refs/field"
+                                  }
+                                },
+                                "required": [
+                                  "field"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "band": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "band"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "rule"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "enum": [
+                                  "left",
+                                  "right",
+                                  "center"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/refs/stringModifiers"
+                },
+                {
+                  "oneOf": [
+                    {
+                      "$ref": "#/refs/signal",
+                      "required": [
+                        "signal"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "value": {
+                          "enum": [
+                            "left",
+                            "right",
+                            "center"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "value"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "field": {
+                          "$ref": "#/refs/field"
+                        }
+                      },
+                      "required": [
+                        "field"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "band": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "band"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "baseline": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "rule": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/defs/rule"
+                      },
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/refs/stringModifiers"
+                          },
+                          {
+                            "oneOf": [
+                              {
+                                "$ref": "#/refs/signal",
+                                "required": [
+                                  "signal"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "value": {
+                                    "enum": [
+                                      "top",
+                                      "middle",
+                                      "bottom",
+                                      "alphabetic"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "value"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "field": {
+                                    "$ref": "#/refs/field"
+                                  }
+                                },
+                                "required": [
+                                  "field"
+                                ]
+                              },
+                              {
+                                "properties": {
+                                  "band": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "band"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "rule"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "enum": [
+                                  "top",
+                                  "middle",
+                                  "bottom",
+                                  "alphabetic"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/refs/stringModifiers"
+                },
+                {
+                  "oneOf": [
+                    {
+                      "$ref": "#/refs/signal",
+                      "required": [
+                        "signal"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "value": {
+                          "enum": [
+                            "top",
+                            "middle",
+                            "bottom",
+                            "alphabetic"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "value"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "field": {
+                          "$ref": "#/refs/field"
+                        }
+                      },
+                      "required": [
+                        "field"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "band": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "band"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "text": {
+          "$ref": "#/refs/stringValue"
+        },
+        "dx": {
+          "$ref": "#/refs/numberValue"
+        },
+        "dy": {
+          "$ref": "#/refs/numberValue"
+        },
+        "radius": {
+          "$ref": "#/refs/numberValue"
+        },
+        "theta": {
+          "$ref": "#/refs/numberValue"
+        },
+        "angle": {
+          "$ref": "#/refs/numberValue"
+        },
+        "font": {
+          "$ref": "#/refs/stringValue"
+        },
+        "fontSize": {
+          "$ref": "#/refs/numberValue"
+        },
+        "fontWeight": {
+          "$ref": "#/refs/stringValue"
+        },
+        "fontStyle": {
+          "$ref": "#/refs/stringValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "signal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "not": {
+            "enum": [
+              "datum",
+              "event",
+              "signals",
+              "width",
+              "height",
+              "padding",
+              "isNaN",
+              "isFinite",
+              "abs",
+              "acos",
+              "asin",
+              "atan",
+              "atan2",
+              "ceil",
+              "cos",
+              "exp",
+              "floor",
+              "log",
+              "max",
+              "min",
+              "pow",
+              "random",
+              "round",
+              "sin",
+              "sqrt",
+              "tan",
+              "clamp",
+              "now",
+              "utc",
+              "datetime",
+              "date",
+              "day",
+              "year",
+              "month",
+              "hours",
+              "minutes",
+              "seconds",
+              "milliseconds",
+              "time",
+              "timezoneoffset",
+              "utcdate",
+              "utcday",
+              "utcyear",
+              "utcmonth",
+              "utchours",
+              "utcminutes",
+              "utcseconds",
+              "utcmilliseconds",
+              "length",
+              "indexof",
+              "lastindexof",
+              "parseFloat",
+              "parseInt",
+              "upper",
+              "lower",
+              "slice",
+              "substring",
+              "replace",
+              "regexp",
+              "test",
+              "if",
+              "eventItem",
+              "eventGroup",
+              "eventX",
+              "eventY",
+              "open",
+              "scale",
+              "iscale",
+              "inrange",
+              "indata",
+              "format",
+              "timeFormat",
+              "utcFormat"
+            ]
+          }
+        },
+        "init": {},
+        "verbose": {
+          "type": "boolean",
+          "default": false
+        },
+        "expr": {
+          "type": "string"
+        },
+        "scale": {
+          "$ref": "#/refs/scopedScale"
+        },
+        "streams": {
+          "$ref": "#/defs/streams"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ]
+    },
+    "spec": {
+      "title": "Vega visualization specification",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/defs/container"
+        },
+        {
+          "properties": {
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            },
+            "viewport": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 2
+            },
+            "background": {
+              "$ref": "#/defs/background"
+            },
+            "padding": {
+              "$ref": "#/defs/padding"
+            },
+            "signals": {
+              "type": "array",
+              "items": {
+                "$ref": "#/defs/signal"
+              }
+            },
+            "predicates": {
+              "type": "array",
+              "items": {
+                "$ref": "#/defs/predicate"
+              }
+            },
+            "data": {
+              "type": "array",
+              "items": {
+                "$ref": "#/defs/data"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "streams": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "expr": {
+            "type": "string"
+          },
+          "scale": {
+            "$ref": "#/refs/scopedScale"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "expr"
+        ]
+      }
+    },
+    "aggregateTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Aggregate transform",
+      "description": "Compute summary aggregate statistics",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "aggregate"
+          ]
+        },
+        "groupby": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/refs/signal"
+              }
+            ]
+          },
+          "description": "A list of fields to split the data into groups."
+        },
+        "summarize": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "description": "An array of aggregate functions.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "values",
+                        "count",
+                        "valid",
+                        "missing",
+                        "distinct",
+                        "sum",
+                        "mean",
+                        "average",
+                        "variance",
+                        "variancep",
+                        "stdev",
+                        "stdevp",
+                        "median",
+                        "q1",
+                        "q3",
+                        "modeskew",
+                        "min",
+                        "max",
+                        "argmin",
+                        "argmax"
+                      ]
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "description": "The name of the field to aggregate.",
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "$ref": "#/refs/signal"
+                      }
+                    ]
+                  },
+                  "ops": {
+                    "type": "array",
+                    "description": "An array of aggregate functions.",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "values",
+                            "count",
+                            "valid",
+                            "missing",
+                            "distinct",
+                            "sum",
+                            "mean",
+                            "average",
+                            "variance",
+                            "variancep",
+                            "stdev",
+                            "stdevp",
+                            "median",
+                            "q1",
+                            "q3",
+                            "modeskew",
+                            "min",
+                            "max",
+                            "argmin",
+                            "argmax"
+                          ]
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    }
+                  },
+                  "as": {
+                    "type": "array",
+                    "description": "An optional array of names to use for the output fields.",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "field",
+                  "ops"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "binTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Bin transform",
+      "description": "Bins values into quantitative bins (e.g., for a histogram).",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "bin"
+          ]
+        },
+        "field": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "The name of the field to bin values from."
+        },
+        "min": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "The minimum bin value to consider."
+        },
+        "max": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "The maximum bin value to consider."
+        },
+        "base": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "The number base to use for automatic bin determination.",
+          "default": 10
+        },
+        "maxbins": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "The maximum number of allowable bins.",
+          "default": 20
+        },
+        "step": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "An exact step size to use between bins. If provided, options such as maxbins will be ignored."
+        },
+        "steps": {
+          "description": "An array of allowable step sizes to choose from.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "minstep": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "A minimum allowable step size (particularly useful for integer values)."
+        },
+        "div": {
+          "description": "An array of scale factors indicating allowable subdivisions.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "default": [
+                5,
+                2
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "start": {
+              "type": "string",
+              "default": "bin_start"
+            },
+            "end": {
+              "type": "string",
+              "default": "bin_end"
+            },
+            "mid": {
+              "type": "string",
+              "default": "bin_mid"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "field"
+      ]
+    },
+    "crossTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Cross transform",
+      "description": "Compute the cross-product of two data sets.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "cross"
+          ]
+        },
+        "with": {
+          "type": "string",
+          "description": "The name of the secondary data set to cross with the primary data. If unspecified, the primary data is crossed with itself."
+        },
+        "diagonal": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "If false, items along the \"diagonal\" of the cross-product (those elements with the same index in their respective array) will not be included in the output.",
+          "default": true
+        },
+        "filter": {
+          "type": "string",
+          "description": "A string containing an expression (in JavaScript syntax) to filter the resulting data elements."
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "left": {
+              "type": "string",
+              "default": "a"
+            },
+            "right": {
+              "type": "string",
+              "default": "b"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "countpatternTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "CountPattern transform",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "countpattern"
+          ]
+        },
+        "field": {
+          "description": "The field containing the text to analyze.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "data"
+        },
+        "pattern": {
+          "description": "A regexp pattern for matching words in text.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "[\\w']+"
+        },
+        "case": {
+          "description": "Text case transformation to apply.",
+          "oneOf": [
+            {
+              "enum": [
+                "lower",
+                "upper",
+                "none"
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "lower"
+        },
+        "stopwords": {
+          "description": "A regexp pattern for matching stopwords to omit.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": ""
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "text": {
+              "type": "string",
+              "default": "text"
+            },
+            "count": {
+              "type": "string",
+              "default": "count"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "linkpathTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "LinkPath transform",
+      "description": "Computes a path definition for connecting nodes within a node-link network or tree diagram.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "linkpath"
+          ]
+        },
+        "sourceX": {
+          "description": "The data field that references the source x-coordinate for this link.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "_source"
+        },
+        "sourceY": {
+          "description": "The data field that references the source y-coordinate for this link.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "_source"
+        },
+        "targetX": {
+          "description": "The data field that references the target x-coordinate for this link.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "_target"
+        },
+        "targetY": {
+          "description": "The data field that references the target y-coordinate for this link.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "_target"
+        },
+        "tension": {
+          "description": "A tension parameter for the \"tightness\" of \"curve\"-shaped links.",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 0.2
+        },
+        "shape": {
+          "description": "The path shape to use",
+          "oneOf": [
+            {
+              "enum": [
+                "line",
+                "curve",
+                "cornerX",
+                "cornerY",
+                "cornerR",
+                "diagonalX",
+                "diagonalY",
+                "diagonalR"
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "line"
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "path": {
+              "type": "string",
+              "default": "layout_path"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "facetTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Facet transform",
+      "description": "A special aggregate transform that organizes a data set into groups or \"facets\".",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "facet"
+          ]
+        },
+        "groupby": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/refs/signal"
+              }
+            ]
+          },
+          "description": "A list of fields to split the data into groups."
+        },
+        "summarize": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "description": "An array of aggregate functions.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "values",
+                        "count",
+                        "valid",
+                        "missing",
+                        "distinct",
+                        "sum",
+                        "mean",
+                        "average",
+                        "variance",
+                        "variancep",
+                        "stdev",
+                        "stdevp",
+                        "median",
+                        "q1",
+                        "q3",
+                        "modeskew",
+                        "min",
+                        "max",
+                        "argmin",
+                        "argmax"
+                      ]
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "description": "The name of the field to aggregate.",
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "$ref": "#/refs/signal"
+                      }
+                    ]
+                  },
+                  "ops": {
+                    "type": "array",
+                    "description": "An array of aggregate functions.",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "values",
+                            "count",
+                            "valid",
+                            "missing",
+                            "distinct",
+                            "sum",
+                            "mean",
+                            "average",
+                            "variance",
+                            "variancep",
+                            "stdev",
+                            "stdevp",
+                            "median",
+                            "q1",
+                            "q3",
+                            "modeskew",
+                            "min",
+                            "max",
+                            "argmin",
+                            "argmax"
+                          ]
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    }
+                  },
+                  "as": {
+                    "type": "array",
+                    "description": "An optional array of names to use for the output fields.",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "field",
+                  "ops"
+                ]
+              }
+            }
+          ]
+        },
+        "transform": {
+          "$ref": "#/defs/transform"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "filterTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Filter transform",
+      "description": "Filters elements from a data set to remove unwanted items.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "filter"
+          ]
+        },
+        "test": {
+          "type": "string",
+          "description": "A string containing an expression (in JavaScript syntax) for the filter predicate."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "test"
+      ]
+    },
+    "foldTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Fold transform",
+      "description": "Collapse (\"fold\") one or more data properties into two properties.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "fold"
+          ]
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "description": "An array of field references indicating the data properties to fold.",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "key": {
+              "type": "string",
+              "default": "key"
+            },
+            "value": {
+              "type": "string",
+              "default": "value"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "fields"
+      ]
+    },
+    "forceTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Force transform",
+      "description": "Performs force-directed layout for network data.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "force"
+          ]
+        },
+        "size": {
+          "description": "The dimensions [width, height] of this force layout.",
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": [
+            500,
+            500
+          ]
+        },
+        "links": {
+          "type": "string",
+          "description": "The name of the link (edge) data set."
+        },
+        "linkDistance": {
+          "description": "Determines the length of edges, in pixels.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 20
+        },
+        "linkStrength": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "Determines the tension of edges (the spring constant).",
+          "default": 1
+        },
+        "charge": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "The strength of the charge each node exerts.",
+          "default": -30
+        },
+        "chargeDistance": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "The maximum distance over which charge forces are applied.",
+          "default": null
+        },
+        "iterations": {
+          "description": "The number of iterations to run the force directed layout.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 500
+        },
+        "friction": {
+          "description": "The strength of the friction force used to stabilize the layout.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 0.9
+        },
+        "theta": {
+          "description": "The theta parameter for the Barnes-Hut algorithm, which is used to compute charge forces between nodes.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 0.8
+        },
+        "gravity": {
+          "description": "The strength of the pseudo-gravity force that pulls nodes towards the center of the layout area.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 0.1
+        },
+        "alpha": {
+          "description": "A \"temperature\" parameter that determines how much node positions are adjusted at each step.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 0.1
+        },
+        "interactive": {
+          "description": "Enables an interactive force-directed layout.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": false
+        },
+        "active": {
+          "description": "A signal representing the active node.",
+          "$ref": "#/refs/signal"
+        },
+        "fixed": {
+          "description": "The name of a datasource containing the IDs of nodes with fixed positions.",
+          "type": "string"
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "x": {
+              "type": "string",
+              "default": "layout_x"
+            },
+            "y": {
+              "type": "string",
+              "default": "layout_y"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "links"
+      ]
+    },
+    "formulaTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Formula transform",
+      "description": "Extends data elements with new values according to a calculation formula.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "formula"
+          ]
+        },
+        "field": {
+          "type": "string",
+          "description": "The property name in which to store the computed formula value."
+        },
+        "expr": {
+          "type": "string",
+          "description": "A string containing an expression (in JavaScript syntax) for the formula."
+        }
+      },
+      "required": [
+        "type",
+        "field",
+        "expr"
+      ]
+    },
+    "geoTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Geo transform",
+      "description": "Performs a cartographic projection. Given longitude and latitude values, sets corresponding x and y properties for a mark.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "geo"
+          ]
+        },
+        "lon": {
+          "description": "The input longitude values.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "lat": {
+          "description": "The input latitude values.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "x": {
+              "type": "string",
+              "default": "layout_x"
+            },
+            "y": {
+              "type": "string",
+              "default": "layout_y"
+            }
+          },
+          "additionalProperties": false
+        },
+        "projection": {
+          "description": "The type of cartographic projection to use.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "mercator"
+        },
+        "center": {
+          "description": "The center of the projection.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "translate": {
+          "description": "The translation of the projection.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "rotate": {
+          "description": "The rotation of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "scale": {
+          "description": "The scale of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "precision": {
+          "description": "The desired precision of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "clipAngle": {
+          "description": "The clip angle of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "clipExtent": {
+          "description": "The clip extent of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "lon",
+        "lat"
+      ],
+      "additionalProperties": false
+    },
+    "geopathTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "GeoPath transform",
+      "description": "Creates paths for geographic regions, such as countries, states and counties.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "geopath"
+          ]
+        },
+        "field": {
+          "description": "The data field containing GeoJSON Feature data.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "path": {
+              "type": "string",
+              "default": "layout_path"
+            }
+          },
+          "additionalProperties": false
+        },
+        "projection": {
+          "description": "The type of cartographic projection to use.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "mercator"
+        },
+        "center": {
+          "description": "The center of the projection.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "translate": {
+          "description": "The translation of the projection.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "rotate": {
+          "description": "The rotation of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "scale": {
+          "description": "The scale of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "precision": {
+          "description": "The desired precision of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "clipAngle": {
+          "description": "The clip angle of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "clipExtent": {
+          "description": "The clip extent of the projection.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "hierarchyTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Hierarchy transform",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "hierarchy"
+          ]
+        },
+        "sort": {
+          "description": "A list of fields to use as sort criteria for sibling nodes.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "children": {
+          "description": "The data field for the children node array",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "children"
+        },
+        "parent": {
+          "description": "The data field for the parent node",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "parent"
+        },
+        "field": {
+          "description": "The value for the area of each leaf-level node for partition layouts.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "mode": {
+          "description": "The layout algorithm mode to use.",
+          "oneOf": [
+            {
+              "enum": [
+                "tidy",
+                "cluster",
+                "partition"
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "tidy"
+        },
+        "orient": {
+          "description": "The layout orientation to use.",
+          "oneOf": [
+            {
+              "enum": [
+                "cartesian",
+                "radial"
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "cartesian"
+        },
+        "size": {
+          "description": "The dimensions of the tree layout",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": [
+            500,
+            500
+          ]
+        },
+        "nodesize": {
+          "description": "Sets a fixed x,y size for each node (overrides the size parameter)",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": null
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "x": {
+              "type": "string",
+              "default": "layout_x"
+            },
+            "y": {
+              "type": "string",
+              "default": "layout_y"
+            },
+            "width": {
+              "type": "string",
+              "default": "layout_width"
+            },
+            "height": {
+              "type": "string",
+              "default": "layout_height"
+            },
+            "depth": {
+              "type": "string",
+              "default": "layout_depth"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "imputeTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Impute transform",
+      "description": "Performs imputation of missing values.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "impute"
+          ]
+        },
+        "method": {
+          "description": "The imputation method to use.",
+          "oneOf": [
+            {
+              "enum": [
+                "value",
+                "mean",
+                "median",
+                "min",
+                "max"
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "value"
+        },
+        "value": {
+          "description": "The value to use for missing data if the method is 'value'.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 0
+        },
+        "field": {
+          "description": "The data field to impute.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "groupby": {
+          "description": "A list of fields to group the data into series.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "orderby": {
+          "description": "A list of fields to determine ordering within series.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "groupby",
+        "orderby",
+        "field"
+      ]
+    },
+    "lookupTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Lookup transform",
+      "description": "Extends a data set by looking up values in another data set.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "lookup"
+          ]
+        },
+        "on": {
+          "type": "string",
+          "description": "The name of the secondary data set on which to lookup values."
+        },
+        "onKey": {
+          "description": "The key field to lookup, or null for index-based lookup.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "keys": {
+          "description": "One or more fields in the primary data set to match against the secondary data set.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/refs/signal"
+              }
+            ]
+          }
+        },
+        "as": {
+          "type": "array",
+          "description": "The names of the fields in which to store looked-up values.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "description": "The default value to use if a lookup match fails."
+        }
+      },
+      "required": [
+        "type",
+        "on",
+        "as",
+        "keys"
+      ],
+      "additionalProperties": false
+    },
+    "pieTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Pie transform",
+      "description": "Computes a pie chart layout.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "pie"
+          ]
+        },
+        "field": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "The data values to encode as angular spans. If this property is omitted, all pie slices will have equal spans."
+        },
+        "startAngle": {
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 6.283185307179586
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 0
+        },
+        "endAngle": {
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 6.283185307179586
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 6.283185307179586
+        },
+        "sort": {
+          "description": " If true, will sort the data prior to computing angles.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": false
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "start": {
+              "type": "string",
+              "default": "layout_start"
+            },
+            "end": {
+              "type": "string",
+              "default": "layout_end"
+            },
+            "mid": {
+              "type": "string",
+              "default": "layout_mid"
+            }
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "rankTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Rank transform",
+      "description": "Computes ascending rank scores for data tuples.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "rank"
+          ]
+        },
+        "field": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "A key field to used to rank tuples. If undefined, tuples will be ranked in their observed order."
+        },
+        "normalize": {
+          "description": "If true, values of the output field will lie in the range [0, 1].",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": false
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "rank": {
+              "type": "string",
+              "default": "rank"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "sortTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Sort transform",
+      "description": "Sorts the values of a data set.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "sort"
+          ]
+        },
+        "by": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "A list of fields to use as sort criteria."
+        }
+      },
+      "required": [
+        "type",
+        "by"
+      ]
+    },
+    "stackTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Stack transform",
+      "description": "Computes layout values for stacked graphs, as in stacked bar charts or stream graphs.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "stack"
+          ]
+        },
+        "groupby": {
+          "description": "A list of fields to split the data into groups (stacks).",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "sortby": {
+          "description": "A list of fields to determine the sort order of stacks.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "field": {
+          "description": "The data field that determines the thickness/height of stacks.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "offset": {
+          "description": "The baseline offset",
+          "oneOf": [
+            {
+              "enum": [
+                "zero",
+                "center",
+                "normalize"
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "zero"
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "start": {
+              "type": "string",
+              "default": "layout_start"
+            },
+            "end": {
+              "type": "string",
+              "default": "layout_end"
+            },
+            "mid": {
+              "type": "string",
+              "default": "layout_mid"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "groupby",
+        "field"
+      ]
+    },
+    "treeifyTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Treeify transform",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "treeify"
+          ]
+        },
+        "groupby": {
+          "description": "An ordered list of fields by which to group tuples into a tree.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "children": {
+              "type": "string",
+              "default": "children"
+            },
+            "parent": {
+              "type": "string",
+              "default": "parent"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "groupby"
+      ]
+    },
+    "treemapTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Treemap transform",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "treemap"
+          ]
+        },
+        "sort": {
+          "description": "A list of fields to use as sort criteria for sibling nodes.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": [
+            "-value"
+          ]
+        },
+        "children": {
+          "description": "The data field for the children node array",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "children"
+        },
+        "parent": {
+          "description": "The data field for the parent node",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "parent"
+        },
+        "field": {
+          "description": "The values to use to determine the area of each leaf-level treemap cell.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "mode": {
+          "description": "The treemap layout algorithm to use.",
+          "oneOf": [
+            {
+              "enum": [
+                "squarify",
+                "slice",
+                "dice",
+                "slice-dice"
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "squarify"
+        },
+        "size": {
+          "description": "The dimensions of the treemap layout",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": [
+            500,
+            500
+          ]
+        },
+        "round": {
+          "description": "If true, treemap cell dimensions will be rounded to integer pixels.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": true
+        },
+        "sticky": {
+          "description": "If true, repeated runs of the treemap will use cached partition boundaries.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": false
+        },
+        "ratio": {
+          "description": "The target aspect ratio for the layout to optimize.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 1.618033988749895
+        },
+        "padding": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 4,
+              "maxItems": 4
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "description": "he padding (in pixels) to provide around internal nodes in the treemap."
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "x": {
+              "type": "string",
+              "default": "layout_x"
+            },
+            "y": {
+              "type": "string",
+              "default": "layout_y"
+            },
+            "width": {
+              "type": "string",
+              "default": "layout_width"
+            },
+            "height": {
+              "type": "string",
+              "default": "layout_height"
+            },
+            "depth": {
+              "type": "string",
+              "default": "layout_depth"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "voronoiTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Voronoi transform",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "voronoi"
+          ]
+        },
+        "clipExtent": {
+          "description": "The min and max points at which to clip the voronoi diagram.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": [
+            [
+              -100000,
+              -100000
+            ],
+            [
+              100000,
+              100000
+            ]
+          ]
+        },
+        "x": {
+          "description": "The input x coordinates.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "y": {
+          "description": "The input y coordinates.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ]
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "path": {
+              "type": "string",
+              "default": "layout_path"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "wordcloudTransform": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "Wordcloud transform",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "wordcloud"
+          ]
+        },
+        "size": {
+          "description": "The dimensions of the wordcloud layout",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": [
+            900,
+            500
+          ]
+        },
+        "font": {
+          "description": "The font face to use for a word.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "sans-serif"
+        },
+        "fontStyle": {
+          "description": "The font style to use for a word.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "normal"
+        },
+        "fontWeight": {
+          "description": "The font weight to use for a word.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "normal"
+        },
+        "fontSize": {
+          "description": "The font size to use for a word.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 14
+        },
+        "fontScale": {
+          "description": "The minimum and maximum scaled font sizes, or null to prevent scaling.",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/refs/signal"
+                  }
+                ]
+              }
+            }
+          ],
+          "default": [
+            10,
+            50
+          ]
+        },
+        "rotate": {
+          "description": "The field or number to set the roration angle (in degrees).",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 0
+        },
+        "text": {
+          "description": "The field containing the text to use for each word.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "data"
+        },
+        "spiral": {
+          "description": "The type of spiral used for positioning words, either 'archimedean' or 'rectangular'.",
+          "oneOf": [
+            {
+              "enum": [
+                "archimedean",
+                "rectangular"
+              ]
+            },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": "archimedean"
+        },
+        "padding": {
+          "description": "The padding around each word.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "object",
+              "oneOf": [
+                {
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              ]
+            },
+            {
+              "$ref": "#/refs/signal"
+            }
+          ],
+          "default": 1
+        },
+        "output": {
+          "type": "object",
+          "description": "Rename the output data fields",
+          "properties": {
+            "x": {
+              "type": "string",
+              "default": "layout_x"
+            },
+            "y": {
+              "type": "string",
+              "default": "layout_y"
+            },
+            "font": {
+              "type": "string",
+              "default": "layout_font"
+            },
+            "fontSize": {
+              "type": "string",
+              "default": "layout_fontSize"
+            },
+            "fontStyle": {
+              "type": "string",
+              "default": "layout_fontStyle"
+            },
+            "fontWeight": {
+              "type": "string",
+              "default": "layout_fontWeight"
+            },
+            "rotate": {
+              "type": "string",
+              "default": "layout_rotate"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "transform": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/defs/aggregateTransform"
+          },
+          {
+            "$ref": "#/defs/binTransform"
+          },
+          {
+            "$ref": "#/defs/crossTransform"
+          },
+          {
+            "$ref": "#/defs/countpatternTransform"
+          },
+          {
+            "$ref": "#/defs/linkpathTransform"
+          },
+          {
+            "$ref": "#/defs/facetTransform"
+          },
+          {
+            "$ref": "#/defs/filterTransform"
+          },
+          {
+            "$ref": "#/defs/foldTransform"
+          },
+          {
+            "$ref": "#/defs/forceTransform"
+          },
+          {
+            "$ref": "#/defs/formulaTransform"
+          },
+          {
+            "$ref": "#/defs/geoTransform"
+          },
+          {
+            "$ref": "#/defs/geopathTransform"
+          },
+          {
+            "$ref": "#/defs/hierarchyTransform"
+          },
+          {
+            "$ref": "#/defs/imputeTransform"
+          },
+          {
+            "$ref": "#/defs/lookupTransform"
+          },
+          {
+            "$ref": "#/defs/pieTransform"
+          },
+          {
+            "$ref": "#/defs/rankTransform"
+          },
+          {
+            "$ref": "#/defs/sortTransform"
+          },
+          {
+            "$ref": "#/defs/stackTransform"
+          },
+          {
+            "$ref": "#/defs/treeifyTransform"
+          },
+          {
+            "$ref": "#/defs/treemapTransform"
+          },
+          {
+            "$ref": "#/defs/voronoiTransform"
+          },
+          {
+            "$ref": "#/defs/wordcloudTransform"
+          }
+        ]
+      }
+    },
+    "scale": {
+      "title": "Scale function",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "linear",
+                "ordinal",
+                "time",
+                "utc",
+                "log",
+                "pow",
+                "sqrt",
+                "quantile",
+                "quantize",
+                "threshold"
+              ],
+              "default": "linear"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/refs/signal"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/refs/data"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "fields": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/refs/data"
+                      }
+                    }
+                  },
+                  "required": [
+                    "fields"
+                  ]
+                }
+              ]
+            },
+            "domainMin": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/refs/data"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "domainMax": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/refs/data"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "rangeMin": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "rangeMax": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/refs/signal"
+                }
+              ]
+            },
+            "reverse": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/refs/data"
+                }
+              ]
+            },
+            "round": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "ordinal"
+                  ]
+                },
+                "range": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "width",
+                        "height",
+                        "shapes",
+                        "category10",
+                        "category20",
+                        "category20b",
+                        "category20c"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "$ref": "#/refs/signal"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    },
+                    {
+                      "$ref": "#/refs/data"
+                    }
+                  ]
+                },
+                "points": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                },
+                "padding": {
+                  "oneOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                },
+                "outerPadding": {
+                  "oneOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                },
+                "bandSize": {
+                  "oneOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "time",
+                    "utc"
+                  ]
+                },
+                "range": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "width",
+                        "height",
+                        "shapes",
+                        "category10",
+                        "category20",
+                        "category20b",
+                        "category20c"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "$ref": "#/refs/signal"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                },
+                "clamp": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                },
+                "nice": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "second",
+                        "minute",
+                        "hour",
+                        "day",
+                        "week",
+                        "month",
+                        "year"
+                      ]
+                    },
+                    {
+                      "$ref": "#/refs/signal"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "linear",
+                        "log",
+                        "pow",
+                        "sqrt",
+                        "quantile",
+                        "quantize",
+                        "threshold"
+                      ],
+                      "default": "linear"
+                    },
+                    "range": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "width",
+                            "height",
+                            "shapes",
+                            "category10",
+                            "category20",
+                            "category20b",
+                            "category20c"
+                          ]
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "$ref": "#/refs/signal"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    },
+                    "clamp": {
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    },
+                    "nice": {
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    },
+                    "zero": {
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "pow"
+                      ]
+                    },
+                    "exponent": {
+                      "oneOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "$ref": "#/refs/signal"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "refs": {
+    "operand": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "value": {}
+          },
+          "required": [
+            "value"
+          ]
+        },
+        {
+          "properties": {
+            "arg": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "arg"
+          ]
+        },
+        {
+          "$ref": "#/refs/signal"
+        },
+        {
+          "properties": {
+            "predicate": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "predicate"
+          ]
+        }
+      ]
+    },
+    "field": {
+      "title": "FieldRef",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/refs/signal"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "datum": {
+                  "$ref": "#/refs/field"
+                }
+              },
+              "required": [
+                "datum"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "group": {
+                  "$ref": "#/refs/field"
+                },
+                "level": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "group"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "parent": {
+                  "$ref": "#/refs/field"
+                },
+                "level": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "parent"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      ]
+    },
+    "scale": {
+      "title": "ScaleRef",
+      "oneOf": [
+        {
+          "$ref": "#/refs/field"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "$ref": "#/refs/field"
+            },
+            "invert": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "stringModifiers": {
+      "properties": {
+        "scale": {
+          "$ref": "#/refs/scale"
+        }
+      }
+    },
+    "numberModifiers": {
+      "properties": {
+        "mult": {
+          "type": "number"
+        },
+        "offset": {
+          "type": "number"
+        },
+        "scale": {
+          "$ref": "#/refs/scale"
+        }
+      }
+    },
+    "value": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "rule": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "type": {}
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "rule"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/defs/rule"
+              },
+              {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/refs/stringModifiers"
+                  },
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/refs/signal",
+                        "required": [
+                          "signal"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "value": {
+                            "type": {}
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "field": {
+                            "$ref": "#/refs/field"
+                          }
+                        },
+                        "required": [
+                          "field"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "band": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "band"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/refs/stringModifiers"
+            },
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/refs/signal",
+                  "required": [
+                    "signal"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": {}
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                {
+                  "properties": {
+                    "field": {
+                      "$ref": "#/refs/field"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "band": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "band"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "numberValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "rule": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/numberModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "rule"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/defs/rule"
+              },
+              {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/refs/numberModifiers"
+                  },
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/refs/signal",
+                        "required": [
+                          "signal"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "value": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "field": {
+                            "$ref": "#/refs/field"
+                          }
+                        },
+                        "required": [
+                          "field"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "band": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "band"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/refs/numberModifiers"
+            },
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/refs/signal",
+                  "required": [
+                    "signal"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                {
+                  "properties": {
+                    "field": {
+                      "$ref": "#/refs/field"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "band": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "band"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "stringValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "rule": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "template": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "template"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "rule"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/defs/rule"
+              },
+              {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/refs/stringModifiers"
+                  },
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/refs/signal",
+                        "required": [
+                          "signal"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "field": {
+                            "$ref": "#/refs/field"
+                          }
+                        },
+                        "required": [
+                          "field"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "band": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "band"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "template": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "template"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/refs/stringModifiers"
+            },
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/refs/signal",
+                  "required": [
+                    "signal"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                {
+                  "properties": {
+                    "field": {
+                      "$ref": "#/refs/field"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "band": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "band"
+                  ]
+                },
+                {
+                  "properties": {
+                    "template": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "template"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "booleanValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "rule": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "rule"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/defs/rule"
+              },
+              {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/refs/stringModifiers"
+                  },
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/refs/signal",
+                        "required": [
+                          "signal"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "value": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "field": {
+                            "$ref": "#/refs/field"
+                          }
+                        },
+                        "required": [
+                          "field"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "band": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "band"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/refs/stringModifiers"
+            },
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/refs/signal",
+                  "required": [
+                    "signal"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                {
+                  "properties": {
+                    "field": {
+                      "$ref": "#/refs/field"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "band": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "band"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "arrayValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "rule": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/defs/rule"
+                  },
+                  {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/refs/stringModifiers"
+                      },
+                      {
+                        "oneOf": [
+                          {
+                            "$ref": "#/refs/signal",
+                            "required": [
+                              "signal"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "value": {
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "value"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "field": {
+                                "$ref": "#/refs/field"
+                              }
+                            },
+                            "required": [
+                              "field"
+                            ]
+                          },
+                          {
+                            "properties": {
+                              "band": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "band"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "rule"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/defs/rule"
+              },
+              {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/refs/stringModifiers"
+                  },
+                  {
+                    "oneOf": [
+                      {
+                        "$ref": "#/refs/signal",
+                        "required": [
+                          "signal"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "value": {
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "field": {
+                            "$ref": "#/refs/field"
+                          }
+                        },
+                        "required": [
+                          "field"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "band": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "band"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/refs/stringModifiers"
+            },
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/refs/signal",
+                  "required": [
+                    "signal"
+                  ]
+                },
+                {
+                  "properties": {
+                    "value": {
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                {
+                  "properties": {
+                    "field": {
+                      "$ref": "#/refs/field"
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                },
+                {
+                  "properties": {
+                    "band": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "band"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "colorValue": {
+      "title": "ColorRef",
+      "oneOf": [
+        {
+          "$ref": "#/refs/stringValue"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "r": {
+              "$ref": "#/refs/numberValue"
+            },
+            "g": {
+              "$ref": "#/refs/numberValue"
+            },
+            "b": {
+              "$ref": "#/refs/numberValue"
+            }
+          },
+          "required": [
+            "r",
+            "g",
+            "b"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "h": {
+              "$ref": "#/refs/numberValue"
+            },
+            "s": {
+              "$ref": "#/refs/numberValue"
+            },
+            "l": {
+              "$ref": "#/refs/numberValue"
+            }
+          },
+          "required": [
+            "h",
+            "s",
+            "l"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "l": {
+              "$ref": "#/refs/numberValue"
+            },
+            "a": {
+              "$ref": "#/refs/numberValue"
+            },
+            "b": {
+              "$ref": "#/refs/numberValue"
+            }
+          },
+          "required": [
+            "l",
+            "a",
+            "b"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "h": {
+              "$ref": "#/refs/numberValue"
+            },
+            "c": {
+              "$ref": "#/refs/numberValue"
+            },
+            "l": {
+              "$ref": "#/refs/numberValue"
+            }
+          },
+          "required": [
+            "h",
+            "c",
+            "l"
+          ]
+        }
+      ]
+    },
+    "signal": {
+      "title": "SignalRef",
+      "type": "object",
+      "properties": {
+        "signal": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "signal"
+      ]
+    },
+    "scopedScale": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "oneOf": [
+                {
+                  "$ref": "#/refs/signal"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "scope": {
+              "oneOf": [
+                {
+                  "$ref": "#/refs/signal"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "invert": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "fields": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/refs/data"
+                  }
+                }
+              },
+              "required": [
+                "fields"
+              ]
+            }
+          ]
+        },
+        "field": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "parent": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "parent"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "parent": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parent"
+                ]
+              }
+            }
+          ]
+        },
+        "sort": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string"
+                },
+                "op": {
+                  "enum": [
+                    "values",
+                    "count",
+                    "valid",
+                    "missing",
+                    "distinct",
+                    "sum",
+                    "mean",
+                    "average",
+                    "variance",
+                    "variancep",
+                    "stdev",
+                    "stdevp",
+                    "median",
+                    "q1",
+                    "q3",
+                    "modeskew",
+                    "min",
+                    "max",
+                    "argmin",
+                    "argmax"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$ref": "#/defs/spec"
+}


### PR DESCRIPTION
Adding schema for [Vega](http://vega.github.io/vega) and [Vega-Lite](http://vega.github.io/vega-lite) visualization specification languages based on JSON format. 

Vega has been recently adopted by tools including [Wikipedia](https://www.mediawiki.org/wiki/Extension:Graph) and [Lyra](http://idl.cs.washington.edu/projects/lyra/).  Vega-lite is recently released higher-level (simpler) version of Vega, and have been integrated to [many applications / languages](http://vega.github.io/vega-lite/usage/applications.html). 

We would love to enable autocompletion of Vega-Lite and Vega specs.  