### PR TITLE
Remove trailing whitespace from ESLint rule name

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -94,7 +94,7 @@
         "no-unused-expressions": { "$ref": "#/definitions/rule" },
         "no-useless-call": { "$ref": "#/definitions/rule" },
         "no-useless-concat": { "$ref": "#/definitions/rule" },
-        "no-void ": { "$ref": "#/definitions/rule" },
+        "no-void": { "$ref": "#/definitions/rule" },
         "no-warning-comments": { "$ref": "#/definitions/rule" },
         "no-with": { "$ref": "#/definitions/rule" },
         "radix": { "$ref": "#/definitions/rule" },


### PR DESCRIPTION
Removing the trailing whitespace in the `no-void` ESLint best practice rule's name.