### PR TITLE
Add support for extends property in .babelrc schema

### DIFF
--- a/src/schemas/json/babelrc.json
+++ b/src/schemas/json/babelrc.json
@@ -7,7 +7,7 @@
 			"default": true,
 			"description": "Include the AST in the returned object",
 			"type": "boolean"
-		},	
+		},
 		"auxiliaryCommentAfter":{
 			"description": "Attach a comment after all non-user injected code.",
 			"type": "string"
@@ -31,11 +31,15 @@
 			"description": "Do not include superfluous whitespace characters and line terminators. When set to \"auto\" compact is set to true on input sizes of >100KB.",
 			"type": "string"
 		},
-		"env": {
-			"default": {},
-			"description": "This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the enviroment variable BABEL_ENV is set to \"production\". If BABEL_ENV isn't set then NODE_ENV will be used, if it's not set then it defaults to \"development\"",
-			"type": "object"
-		},
+    "env": {
+      "default": {},
+      "description": "This is an object of keys that represent different environments. For example, you may have: `{ env: { production: { /* specific options */ } } }` which will use those options when the enviroment variable BABEL_ENV is set to \"production\". If BABEL_ENV isn't set then NODE_ENV will be used, if it's not set then it defaults to \"development\"",
+      "type": "object"
+    },
+    "extends": {
+      "description": "A path to a .babelrc file to extend",
+      "type": "string"
+    },
 		"filename": {
 			"default": "unknown",
 			"description": "Filename for use in errors etc.",
@@ -47,7 +51,7 @@
 		},
 		"highlightCode": {
 			"description": "ANSI highlight syntax error code frames",
-			"type": "boolean"	
+			"type": "boolean"
 		},
 		"ignore": {
 			"description": "Opposite of the \"only\" option",
@@ -67,7 +71,7 @@
 		},
 		"moduleId": {
 			"description": "Specify a custom name for module ids.",
-			"type": "string"	
+			"type": "string"
 		},
 		"moduleIds": {
 			"default": false,
@@ -114,7 +118,7 @@
 			"default": false,
 			"description": "If truthy, adds a map property to returned output. If set to \"inline\", a comment with a sourceMappingURL directive is added to the bottom of the returned code. If set to \"both\" then a map property is returned as well as a source map comment appended.",
 			"type": ["string"],
-			"enum": ["both", "inline"]	
+			"enum": ["both", "inline"]
 		},
 		"sourceMapTarget": {
 			"description": "Set file on returned source map. (defaults to \"filenameRelative\")",
@@ -122,7 +126,7 @@
 		},
 		"sourceRoot": {
 			"description": "The root from which all sources are relative. (defaults to \"moduleRoot\")",
-			"type": "string"		
+			"type": "string"
 		}
 	}
 }


### PR DESCRIPTION
This PR adds support for the `extends` property in the `.babelrc` JSON schema, as documented [here](http://babeljs.io/docs/usage/options/).