### PR TITLE
Update Typings JSON schemas to 1.0 release

### DIFF
--- a/src/schemas/json/typings.json
+++ b/src/schemas/json/typings.json
@@ -22,8 +22,8 @@
       "type": "array",
       "items": { "type": "string" }
     },
-    "ambient": {
-      "description": "Denote that this definition _must_ be installed as ambient.",
+    "global": {
+      "description": "Denote that this definition _must_ be installed as global.",
       "type": "boolean"
     },
     "postmessage": {
@@ -55,14 +55,14 @@
         "type": "string"
       }
     },
-    "ambientDependencies": {
+    "globalDependencies": {
       "description": "A map of global dependencies required by the project.",
       "type": "object",
       "additionalProperties": {
         "type": "string"
       }
     },
-    "ambientDevDependencies": {
+    "globalDevDependencies": {
       "description": "A map of global dependencies required by the project during development.",
       "type": "object",
       "additionalProperties": {

--- a/src/schemas/json/typingsrc.json
+++ b/src/schemas/json/typingsrc.json
@@ -17,11 +17,6 @@
       "type": "string",
       "description": "Public x509 certificate to use"
     },
-    "defaultAmbientSource": {
-      "type": "string",
-      "description": "Override the default ambient installation source (e.g., when doing 'typings install node -A')",
-      "default": "dt"
-    },
     "defaultSource": {
       "type": "string",
       "description": "Override the default installation source (e.g., when doing 'typings install debug')",


### PR DESCRIPTION
Update the `typings.json` and `.typingsrc` JSON schemas to conform to the changes introduced in the Typings 1.0 release, as documented [here](https://github.com/typings/typings#updating-from-0x-to-10).