### PR TITLE
Fixes #190

### DIFF
--- a/src/schemas/json/babelrc.json
+++ b/src/schemas/json/babelrc.json
@@ -93,7 +93,11 @@
 			"description": "List of plugins to load and use",
 			"type": "array",
 			"items": {
-				"type": "string"
+				"type": ["string", "array"],
+	        "items": {
+            "description": "the plugin name in .[0] and the options object in .[1]",
+		        "type": [ "string", "object" ]
+	        }
 			}
 		},
 		"presets": {


### PR DESCRIPTION
Note: The alignment of `[ "string" , "object" ]` to the expectation that a two element array with a first element of string and a second of object is a coincidence.  It's just that both types are necessary.  In my testing, type `string` is not a subtype of `object` in this type system.