### PR TITLE
fix: update semver regexp for patternplate pattern

### DIFF
--- a/src/schemas/json/pattern.json
+++ b/src/schemas/json/pattern.json
@@ -27,7 +27,7 @@
 		"version": {
 			"description": "Semantic version of the pattern",
 			"type": "string",
-			"pattern": "^\\d\\.\\d\\.\\d(-[a-z]*){0,1}$"
+			"pattern": "^\\d+\\.\\d+\\.\\d+(-[a-z]*){0,1}$"
 		},
 		"versions": {
 			"description": "Available semantic versions of the pattern",
@@ -36,7 +36,7 @@
 			"items": {
 				"description": "Semantic version of the pattern",
 				"type": "string",
-				"pattern": "^\\d\\.\\d\\.\\d(-[a-z]*){0,1}$"
+				"pattern": "^\\d+\\.\\d+\\.\\d+(-[a-z]*){0,1}$"
 			}
 		},
 		"flag": {


### PR DESCRIPTION
The version and versions field should allow multiple numbers, such as 1.0.12

cc: @marionebl 