### PR TITLE
fix: update pattern.json name regular expression

### DIFF
--- a/src/schemas/json/pattern.json
+++ b/src/schemas/json/pattern.json
@@ -17,7 +17,7 @@
 			"description": "Machine readable name of the pattern",
 			"type": "string",
 			"minLength": 1,
-			"pattern": "^[[a-z]*[-]?[a-z]*]*$"
+			"pattern": "^[a-z]+(?:-[a-z]+)*$"
 		},
 		"displayName": {
 			"description": "Human readable name of the pattern",


### PR DESCRIPTION
This fixes e.g. pattern names with multiple dashes like `powerlayer-text-image-content`.

cc @marionebl 