### PR TITLE
Add frameworks description and update runtimes description

### DIFF
--- a/src/schemas/json/nuget-project.json
+++ b/src/schemas/json/nuget-project.json
@@ -45,12 +45,13 @@
 
     "frameworks": {
       "type": "object",
+      "description": "The frameworks on which your project will run.",
       "additionalProperties": { "$ref": "#/definitions/configType" }
     },
 
     "runtimes": {
       "type": "object",
-      "description": "A list of supported runtime platforms.",
+      "description": "The Operating System and Architectures on which your application will be running.",
 
       "properties": {
         "centos.7-x64": { "type": "object" },


### PR DESCRIPTION
Add a missing description for the NuGet `project.json` schema's `frameworks` property, and update the `runtimes` description to match that found in the official NuGet docs.