### PR TITLE
Update tslint.json "extends" schema

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -425,7 +425,10 @@
 		},
 		"extends": {
 			"description": "Extend another configuration (built in config OR a node resolvable .json file) ",
-			"type": "string"
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		}
 	}
 }


### PR DESCRIPTION
the suitable types for "extends" has changed from a single string to a string array. See confirmation here: https://palantir.github.io/tslint/usage/tslint-json/