### PR TITLE
Add new 'no-tabs' ESLint rule

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -209,6 +209,7 @@
         "no-plusplus": { "$ref": "#/definitions/rule" },
         "no-restricted-syntax": { "$ref": "#/definitions/rule" },
         "no-spaced-func": { "$ref": "#/definitions/rule" },
+        "no-tabs": { "$ref": "#/definitions/rule" },
         "no-ternary": { "$ref": "#/definitions/rule" },
         "no-trailing-spaces": { "$ref": "#/definitions/rule" },
         "no-underscore-dangle": { "$ref": "#/definitions/rule" },


### PR DESCRIPTION
Adding a new `no-tabs` rule to the ESLint JSON schema. See the rule's documentation [here](http://eslint.org/docs/rules/no-tabs).