### PR TITLE
Fix angular prefix schemas for tslint.json

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -48,7 +48,7 @@
 					"description": "Enforces all components to have a uniform prefix",
 					"type": "array",
 					"items": {
-						"enum": [ true, false, "sg" ]
+						"type": [ "boolean", "string" ]
 					}
 				},
 				"component-selector-type": {
@@ -77,7 +77,7 @@
 					"description": "Enforces all directives to have a uniform prefix",
 					"type": "array",
 					"items": {
-						"enum": [ true, false, "sg" ]
+						"type": [ "boolean", "string" ]
 					}
 				},
 				"directive-selector-type": {
@@ -306,7 +306,7 @@
 					"description": "Enforces naming conventions for Pipes",
 					"type": "array",
 					"items": {
-						"enum": [ true, "camelCase", "sg" ]
+						"type": [ "boolean", "string" ]
 					}
 				},
 				"quotemark": {


### PR DESCRIPTION
This fixes #217 by relaxing the possible values that can be used in the arrays for `pipe-naming`, `directive-selector-prefix` and `component-selector-prefix` rules.