### PR TITLE
Add stylelintrc schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -390,6 +390,12 @@
       "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
     },
     {
+      "name": ".stylelintrc",
+      "description": "Configuration file for stylelint",
+      "fileMatch": [ ".stylelintrc", "stylelintrc.json", ".stylelintrc.json" ],
+      "url": "http://json.schemastore.org/stylelintrc"
+    }
+    {
       "name": "Swagger API 2.0",
       "description": "Swagger API 2.0 schema",
       "fileMatch": [ "swagger.json" ],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -394,7 +394,7 @@
       "description": "Configuration file for stylelint",
       "fileMatch": [ ".stylelintrc", "stylelintrc.json", ".stylelintrc.json" ],
       "url": "http://json.schemastore.org/stylelintrc"
-    }
+    },
     {
       "name": "Swagger API 2.0",
       "description": "Swagger API 2.0 schema",

--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -1,0 +1,3869 @@
+{
+	"title": "JSON schema for the Stylelint configuration files",
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"type": "object",
+	"definitions": {
+		"alwaysMultiLineRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"always",
+						"always-multi-line",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"always",
+									"always-multi-line",
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"alwaysNeverRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"always",
+						"never",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"always",
+									"never",
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"arrayStringRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": [
+						"null",
+						"string"
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"array",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									[],
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/simpleArrayStringRule"
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"booleanRule": {
+			"default": true,
+			"type": [
+				"null",
+				"boolean",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "boolean",
+					"enum": [
+						true,
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"boolean",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "boolean",
+								"enum": [
+									true,
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"coreRule": {
+			"properties": {
+				"message": {
+					"description": "Custom message that will be used in errors and warnings",
+					"type": "string"
+				},
+				"severity": {
+					"description": "Message status",
+					"type": "string",
+					"enum": [
+						"warning",
+						"error"
+					]
+				}
+			}
+		},
+		"integerRule": {
+			"type": [
+				"null",
+				"integer",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": [
+						"null",
+						"integer"
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"integer",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "integer",
+								"enum": [
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"lowerUpperRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"lower",
+						"upper",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"lower",
+									"upper",
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"newlineRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"always",
+						"always-multi-line",
+						"never-multi-line",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"always",
+									"always-multi-line",
+									"never-multi-line",
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"newlineSpaceRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"always",
+						"never",
+						"always-single-line",
+						"never-single-line",
+						"always-multi-line",
+						"never-multi-line",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"always",
+									"never",
+									"always-single-line",
+									"never-single-line",
+									"always-multi-line",
+									"never-multi-line",
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"newlineSpaceWithIgnoreRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"always",
+						"never",
+						"always-single-line",
+						"never-single-line",
+						"always-multi-line",
+						"never-multi-line",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"always",
+									"always-single-line",
+									"never-single-line",
+									"always-multi-line",
+									"never-multi-line",
+									{}
+								]
+							},
+							{
+								"type": "object",
+								"allOf": [
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								],
+								"properties": {
+									"ignoreAtRules": {
+										"$ref": "#/definitions/simpleStringOrArrayStringRule"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		"objectRule": {
+			"type": [
+				"null",
+				"object",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "object",
+					"patternProperties": {
+						".*": {
+							"$ref": "#/definitions/simpleArrayStringRule"
+						}
+					}
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "object",
+								"allOf": [
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								],
+								"patternProperties": {
+									"^((?!message|severity).)*$": {
+										"$ref": "#/definitions/simpleArrayStringRule"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		"simpleArrayStringRule": {
+			"type": "array",
+			"minItems": 1,
+			"uniqueItems": true,
+			"items": {
+				"type": "string"
+			}
+		},
+		"simpleStringOrArrayStringRule": {
+			"type": [
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"$ref": "#/definitions/simpleArrayStringRule"
+				}
+			]
+		},
+		"singleDoubleRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"single",
+						"double",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"single",
+									"double",
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"spaceRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"always",
+						"never",
+						"always-single-line",
+						"never-single-line",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"always",
+									"never",
+									"always-single-line",
+									"never-single-line",
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"stringRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": [
+						"null",
+						"string"
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									{}
+								]
+							},
+							{
+								"$ref": "#/definitions/coreRule"
+							}
+						]
+					}
+				}
+			]
+		},
+		"unitRule": {
+			"type": [
+				"null",
+				"string",
+				"array"
+			],
+			"oneOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string",
+					"enum": [
+						"em",
+						"ex",
+						"px",
+						"%",
+						"rem",
+						"vw",
+						"vh",
+						"vm",
+						"vmin",
+						"vmax",
+						"ch",
+						"in",
+						"cm",
+						"mm",
+						"q",
+						"pt",
+						"pc",
+						"deg",
+						"grad",
+						"rad",
+						"turn",
+						"ms",
+						"s",
+						"Hz",
+						"kHz",
+						"dpi",
+						"dpcm",
+						"dppx",
+						[]
+					]
+				},
+				{
+					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": [
+							"string",
+							"array",
+							"object"
+						],
+						"anyOf": [
+							{
+								"type": "string",
+								"enum": [
+									"em",
+									"ex",
+									"px",
+									"%",
+									"rem",
+									"vw",
+									"vh",
+									"vm",
+									"vmin",
+									"vmax",
+									"ch",
+									"in",
+									"cm",
+									"mm",
+									"q",
+									"pt",
+									"pc",
+									"deg",
+									"grad",
+									"rad",
+									"turn",
+									"ms",
+									"s",
+									"Hz",
+									"kHz",
+									"dpi",
+									"dpcm",
+									"dppx",
+									[],
+									{}
+								]
+							},
+							{
+								"type": "array",
+								"uniqueItems": true,
+								"minItems": 1,
+								"items": {
+									"type": "string",
+									"enum": [
+										"em",
+										"ex",
+										"px",
+										"%",
+										"rem",
+										"vw",
+										"vh",
+										"vm",
+										"vmin",
+										"vmax",
+										"ch",
+										"in",
+										"cm",
+										"mm",
+										"q",
+										"pt",
+										"pc",
+										"deg",
+										"grad",
+										"rad",
+										"turn",
+										"ms",
+										"s",
+										"Hz",
+										"kHz",
+										"dpi",
+										"dpcm",
+										"dppx"
+									]
+								}
+							},
+							{
+								"type": "object",
+								"allOf": [
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								],
+								"properties": {
+									"ignoreProperties": {
+										"description": "Ignore units in the values of declarations with the specified properties",
+										"type": "object",
+										"patternProperties": {
+											"(em|ex|ch|vw|vh|cm|mm|in|pt|pc|px|rem|vmin|vmax|%)": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		"atRule": {
+			"properties": {
+				"at-rule-blacklist": {
+					"description": "Specify a blacklist of disallowed at-rules",
+					"$ref": "#/definitions/arrayStringRule"
+				},
+				"at-rule-empty-line-before": {
+					"description": "Require or disallow an empty line before at-rules",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"never",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"never",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"except": {
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"all-nested",
+														"blockless-after-same-name-blockless",
+														"blockless-group",
+														"first-nested"
+													]
+												}
+											},
+											"ignore": {
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"after-comment",
+														"all-nested",
+														"blockless-after-same-name-blockless",
+														"blockless-group"
+													]
+												}
+											},
+											"ignoreAtRules": {
+												"$ref": "#/definitions/simpleStringOrArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"at-rule-name-case": {
+					"description": "Specify lowercase or uppercase for at-rules names",
+					"$ref": "#/definitions/lowerUpperRule"
+				},
+				"at-rule-name-newline-after": {
+					"description": "Require a newline after at-rule names",
+					"$ref": "#/definitions/alwaysMultiLineRule"
+				},
+				"at-rule-name-space-after": {
+					"description": "Require a single space after at-rule names",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"always-single-line",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"always-single-line",
+											{}
+										]
+									},
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								]
+							}
+						}
+					]
+				},
+				"at-rule-no-unknown": {
+					"description": "Disallow unknown at-rules",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignoreAtRules": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"at-rule-no-vendor-prefix": {
+					"description": "Disallow vendor prefixes for at-rules",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"at-rule-semicolon-newline-after": {
+					"description": "Require a newline after the semicolon of at-rules",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											{}
+										]
+									},
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								]
+							}
+						}
+					]
+				},
+				"at-rule-whitelist": {
+					"description": "Specify a whitelist of allowed at-rules",
+					"$ref": "#/definitions/arrayStringRule"
+				}
+			}
+		},
+		"block": {
+			"properties": {
+				"block-closing-brace-empty-line-before": {
+					"description": "Require or disallow an empty line before the closing brace of blocks",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always-multi-line",
+								"never",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always-multi-line",
+											"never",
+											{}
+										]
+									},
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								]
+							}
+						}
+					]
+				},
+				"block-closing-brace-newline-after": {
+					"description": "Require a newline or disallow whitespace after the closing brace of blocks",
+					"$ref": "#/definitions/newlineSpaceWithIgnoreRule"
+				},
+				"block-closing-brace-newline-before": {
+					"description": "Require a newline or disallow whitespace before the closing brace of blocks",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"block-closing-brace-space-afte": {
+					"description": "Require a single space or disallow whitespace after the closing brace of blocks",
+					"$ref": "#/definitions/newlineSpaceRule"
+				},
+				"block-closing-brace-space-before": {
+					"description": "Require a single space or disallow whitespace before the closing brace of blocks",
+					"$ref": "#/definitions/newlineSpaceRule"
+				},
+				"block-no-empty": {
+					"description": "Disallow empty blocks",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"block-no-single-line": {
+					"description": "Disallow single-line blocks",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"block-opening-brace-newline-after": {
+					"description": "Require a newline after the opening brace of blocks",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"block-opening-brace-newline-before": {
+					"description": "Require a newline or disallow whitespace before the opening brace of blocks",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"always-single-line",
+								"never-single-line",
+								"always-multi-line",
+								"never-multi-line",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"always-single-line",
+											"never-single-line",
+											"always-multi-line",
+											"never-multi-line",
+											{}
+										]
+									},
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								]
+							}
+						}
+					]
+				},
+				"block-opening-brace-space-afte": {
+					"description": "Require a single space or disallow whitespace after the opening brace of blocks",
+					"$ref": "#/definitions/newlineSpaceRule"
+				},
+				"block-opening-brace-space-before": {
+					"description": "Require a single space or disallow whitespace before the opening brace of blocks",
+					"$ref": "#/definitions/newlineSpaceWithIgnoreRule"
+				}
+			}
+		},
+		"color": {
+			"properties": {
+				"color-hex-case": {
+					"description": "Specify lowercase or uppercase for hex colors",
+					"$ref": "#/definitions/lowerUpperRule"
+				},
+				"color-hex-length": {
+					"description": "Specify short or long notation for hex colors",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"short",
+								"long",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"short",
+											"long",
+											{}
+										]
+									},
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								]
+							}
+						}
+					]
+				},
+				"color-named": {
+					"description": "Require (where possible) or disallow named colors",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always-where-possible",
+								"never",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always-where-possible",
+											"never",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignore": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"color-no-hex": {
+					"description": "Disallow hex colors",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"color-no-invalid-hex": {
+					"description": "Disallow invalid hex colors",
+					"$ref": "#/definitions/booleanRule"
+				}
+			}
+		},
+		"comment": {
+			"properties": {
+				"comment-empty-line-before": {
+					"description": "Require or disallow an empty line before comments",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"never",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"never",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"except": {
+												"description": "Reverse the primary option for comments that are nested and the first child of their parent node",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"first-nested"
+													]
+												}
+											},
+											"ignore": {
+												"description": "Don't require an empty line between comments",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"between-comments",
+														"stylelint-commands"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"comment-no-empty": {
+					"description": "Disallow empty comments",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"comment-whitespace-inside": {
+					"description": "Require or disallow whitespace on the inside of comment markers",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"comment-word-blacklist": {
+					"description": "Specify a blacklist of disallowed words within comments",
+					"$ref": "#/definitions/arrayStringRule"
+				}
+			}
+		},
+		"customMedia": {
+			"properties": {
+				"custom-media-pattern": {
+					"description": "Specify a pattern for custom media query names",
+					"$ref": "#/definitions/stringRule"
+				}
+			}
+		},
+		"customProperty": {
+			"properties": {
+				"custom-property-empty-line-before": {
+					"description": "Require or disallow an empty line before custom properties",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"never",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"never",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"except": {
+												"description": "Reverse the primary option for custom properties that come after a comment, custom property or first child of their parent node",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"after-comment",
+														"after-custom-property",
+														"first-nested"
+													]
+												}
+											},
+											"ignore": {
+												"description": "Ignore custom properties that are preceded by comments or inside single-line blocks",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"after-comment",
+														"inside-single-line-block"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"custom-property-no-outside-root": {
+					"description": "Disallow custom properties outside of `:root` rules",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"custom-property-pattern": {
+					"description": "Specify a pattern for custom properties",
+					"$ref": "#/definitions/stringRule"
+				}
+			}
+		},
+		"declaration": {
+			"properties": {
+				"declaration-bang-space-after": {
+					"description": "Require a single space or disallow whitespace after the bang of declarations",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"declaration-bang-space-before": {
+					"description": "Require a single space or disallow whitespace before the bang of declarations",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"declaration-colon-newline-after": {
+					"description": "Require a newline or disallow whitespace after the colon of declarations",
+					"$ref": "#/definitions/alwaysMultiLineRule"
+				},
+				"declaration-colon-space-after": {
+					"description": "Require a single space or disallow whitespace after the colon of declarations",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"never",
+								"always-single-line",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"never",
+											"always-single-line",
+											{}
+										]
+									},
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								]
+							}
+						}
+					]
+				},
+				"declaration-colon-space-before": {
+					"description": "Require a single space or disallow whitespace before the colon of declarations",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"declaration-empty-line-before": {
+					"description": "Require or disallow an empty line before declarations",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"never",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"never",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"except": {
+												"type": "array",
+												"minItems": 1,
+												"uniqueItems": true,
+												"items": {
+													"type": "string",
+													"enum": [
+														"after-comment",
+														"after-declaration",
+														"first-nested"
+													]
+												}
+											},
+											"ignore": {
+												"type": "array",
+												"minItems": 1,
+												"uniqueItems": true,
+												"items": {
+													"type": "string",
+													"enum": [
+														"after-comment",
+														"inside-single-line-block"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"declaration-no-important": {
+					"description": "Disallow `!important` within declarations",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"declaration-property-unit-blacklist": {
+					"description": "Specify a blacklist of disallowed property and unit pairs within declarations",
+					"$ref": "#/definitions/objectRule"
+				},
+				"declaration-property-unit-whitelist": {
+					"description": "Specify a whitelist of allowed property and unit pairs within declarations",
+					"$ref": "#/definitions/objectRule"
+				},
+				"declaration-property-value-blacklist": {
+					"description": "Specify a blacklist of disallowed property and value pairs within declarations",
+					"$ref": "#/definitions/objectRule"
+				},
+				"declaration-property-value-whitelist": {
+					"description": "Specify a whitelist of allowed property and value pairs within declarations",
+					"$ref": "#/definitions/objectRule"
+				}
+			}
+		},
+		"declarationBlock": {
+			"properties": {
+				"declaration-block-no-duplicate-properties": {
+					"description": "Disallow duplicate properties within declaration blocks",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignore": {
+												"type": "array",
+												"minItems": 1,
+												"uniqueItems": true,
+												"items": {
+													"type": "string",
+													"enum": [
+														"consecutive-duplicates",
+														"consecutive-duplicates-with-different-values"
+													]
+												}
+											},
+											"ignoreProperties": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"declaration-block-no-ignored-properties": {
+					"description": "Disallow property values that are ignored due to another property value in the same rule",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"declaration-block-no-redundant-longhand-properties": {
+					"description": "Disallow longhand properties that can be combined into one shorthand property",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignoreShorthands": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"declaration-block-no-shorthand-property-overrides": {
+					"description": "Disallow shorthand properties that override related longhand properties",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"declaration-block-properties-order": {
+					"description": "Specify the order of properties within declaration blocks",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"alphabetical",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 1,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"array",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"alphabetical",
+											[],
+											{}
+										]
+									},
+									{
+										"type": "string"
+									},
+									{
+										"$ref": "#/definitions/simpleArrayStringRule"
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"dependencies": {
+											"order": [
+												"properties"
+											],
+											"properties": [
+												"order"
+											]
+										},
+										"properties": {
+											"unspecified": {
+												"description": "These options only apply if you've defined your own array of properties",
+												"type": "string",
+												"enum": [
+													"top",
+													"bottom",
+													"bottomAlphabetical",
+													"ignore"
+												]
+											},
+											"order": {
+												"type": "string",
+												"enum": [
+													"strict",
+													"flexible"
+												]
+											},
+											"properties": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"declaration-block-semicolon-newline-after": {
+					"description": "Require a newline or disallow whitespace after the semicolons of declaration blocks",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"declaration-block-semicolon-newline-before": {
+					"description": "Require a newline or disallow whitespace before the semicolons of declaration blocks",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"declaration-block-semicolon-space-after": {
+					"description": "Require a single space or disallow whitespace after the semicolons of declaration blocks",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"declaration-block-semicolon-space-before": {
+					"description": "Require a single space or disallow whitespace before the semicolons of declaration blocks",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"declaration-block-single-line-max-declarations": {
+					"description": "Limit the number of declaration within a single line declaration block",
+					"$ref": "#/definitions/integerRule"
+				},
+				"declaration-block-trailing-semicolon": {
+					"description": "Require or disallow a trailing semicolon within declaration blocks",
+					"$ref": "#/definitions/alwaysNeverRule"
+				}
+			}
+		},
+		"font": {
+			"properties": {
+				"font-family-name-quotes": {
+					"description": "Specify whether or not quotation marks should be used around font family names",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always-where-required",
+								"always-where-recommended",
+								"always-unless-keyword",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always-where-required",
+											"always-where-recommended",
+											"always-unless-keyword",
+											{}
+										]
+									},
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								]
+							}
+						}
+					]
+				},
+				"font-weight-notation": {
+					"description": "Require numeric or named (where possible) `font-weight` values. Also, when named values are expected, require only valid names",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"numeric",
+								"named-where-possible",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"numeric",
+											"named-where-possible",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignore": {
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"relative"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		"function": {
+			"properties": {
+				"function-blacklist": {
+					"description": "Specify a blacklist of disallowed functions",
+					"$ref": "#/definitions/arrayStringRule"
+				},
+				"function-calc-no-unspaced-operator": {
+					"description": "Disallow an unspaced operator within `calc` functions",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"function-comma-newline-after": {
+					"description": "Require a newline or disallow whitespace after the commas of functions",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"function-comma-newline-before": {
+					"description": "Require a newline or disallow whitespace before the commas of functions",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"function-comma-space-after": {
+					"description": "Require a single space or disallow whitespace after the commas of functions",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"function-comma-space-before": {
+					"description": "Require a single space or disallow whitespace before the commas of functions",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"function-linear-gradient-no-nonstandard-direction": {
+					"description": "Disallow direction values in `linear-gradient()` calls that are not valid according to the standard syntax",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"function-max-empty-lines": {
+					"description": "Limit the number of adjacent empty lines within functions",
+					"$ref": "#/definitions/integerRule"
+				},
+				"function-name-case": {
+					"description": "Specify lowercase or uppercase for function names",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"lower",
+								"upper",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"lower",
+											"upper",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"description": "Ignore case of function names",
+										"properties": {
+											"ignoreFunctions": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"function-parentheses-newline-inside": {
+					"description": "Require a newline or disallow whitespace on the inside of the parentheses of functions",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"function-parentheses-space-inside": {
+					"description": "Require a single space or disallow whitespace on the inside of the parentheses of functions",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"function-url-data-uris": {
+					"description": "Require or disallow data URIs for urls",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"function-url-no-scheme-relative": {
+					"description": "Disallow scheme-relative urls",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"function-url-quotes": {
+					"description": "Require or disallow quotes for urls",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"function-url-scheme-whitelist": {
+					"description": "Specify a whitelist of allowed url schemes",
+					"$ref": "#/definitions/arrayStringRule"
+				},
+				"function-whitelist": {
+					"description": "Specify a whitelist of allowed functions",
+					"$ref": "#/definitions/arrayStringRule"
+				},
+				"function-whitespace-after": {
+					"description": "Require or disallow whitespace after functions",
+					"$ref": "#/definitions/alwaysNeverRule"
+				}
+			}
+		},
+		"generalSheet": {
+			"properties": {
+				"indentation": {
+					"description": "Specify indentation",
+					"type": [
+						"null",
+						"integer",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": [
+								"null",
+								"integer"
+							]
+						},
+						{
+							"type": "string",
+							"enum": [
+								"tab",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 1,
+							"uniqueItems": true,
+							"items": {
+								"type": "integer"
+							}
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"integer",
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "integer"
+									},
+									{
+										"type": "string",
+										"enum": [
+											"tab",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"indentInsideParens": {
+												"description": "If `true`, the closing brace of a block (rule or at-rule) will be expected at the same indentation level as the block's inner nodes",
+												"type": "string",
+												"enum": [
+													"twice",
+													"once-at-root-twice-in-block"
+												]
+											},
+											"except": {
+												"description": "Do not indent for these things",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"block",
+														"param",
+														"value"
+													]
+												}
+											},
+											"ignore": {
+												"description": "Ignore the indentation inside parentheses",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"inside-parens",
+														"param",
+														"value"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"max-empty-lines": {
+					"description": "Limit the number of adjacent empty lines",
+					"$ref": "#/definitions/integerRule"
+				},
+				"max-line-length": {
+					"description": "Limit the length of a line",
+					"type": [
+						"null",
+						"integer",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": [
+								"null",
+								"integer"
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"integer",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "integer"
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignore": {
+												"type": [
+													"string",
+													"array"
+												],
+												"anyOf": [
+													{
+														"type": "string",
+														"enum": [
+															"non-comments",
+															"comments"
+														]
+													},
+													{
+														"type": "array",
+														"uniqueItems": true,
+														"minItems": 1,
+														"items": {
+															"type": "string",
+															"enum": [
+																"non-comments",
+																"comments"
+															]
+														}
+													}
+												]
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"max-nesting-depth": {
+					"description": "Limit the allowed nesting depth",
+					"type": [
+						"null",
+						"integer",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": [
+								"null",
+								"integer"
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"integer",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "integer"
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignore": {
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"at-rules-without-declaration-blocks"
+													]
+												}
+											},
+											"ignoreAtRules": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"no-browser-hacks": {
+					"description": "Disallow browser hacks that are irrelevant to the browsers you are targeting",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"browsers": {
+												"$ref": "#/definitions/simpleStringOrArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"no-descending-specificity": {
+					"description": "Disallow selectors of lower specificity from coming after overriding selectors of higher specificity",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"no-duplicate-selectors": {
+					"description": "Disallow duplicate selectors within a stylesheet",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"no-empty-source": {
+					"description": "Disallow empty sources",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"no-eol-whitespace": {
+					"description": "Disallow end-of-line whitespace",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignore": {
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"empty-lines"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"no-extra-semicolons": {
+					"description": "Dissalow extra semicolons",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"no-indistinguishable-colors": {
+					"description": "Disallow colors that are suspiciously close to being identical",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"threshold": {
+												"type": "integer",
+												"default": 3,
+												"minimum": 0,
+												"maximum": 100
+											},
+											"ignore": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											},
+											"whitelist": {
+												"description": "An array of color pairs to ignore. Each pair is an array with two items",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"$ref": "#/definitions/simpleArrayStringRule"
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"no-invalid-double-slash-comments": {
+					"description": "Disallow double-slash comments `(//...)` which are not supported by CSS and could lead to unexpected results",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"no-missing-end-of-source-newline": {
+					"description": "Disallow missing end-of-source newlines",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"no-unknown-animations": {
+					"description": "Disallow animation names that do not correspond to a `@keyframes` declaration",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"no-unsupported-browser-features": {
+					"description": "Disallow features that are unsupported by the browsers that you are targeting",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"browsers": {
+												"type": "string"
+											},
+											"ignore": {
+												"$ref": "#/definitions/simpleStringOrArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		"keyframeDeclaration": {
+			"properties": {
+				"keyframe-declaration-no-important": {
+					"description": "Disallow !important within keyframe declarations",
+					"$ref": "#/definitions/booleanRule"
+				}
+			}
+		},
+		"length": {
+			"properties": {
+				"length-zero-no-unit": {
+					"description": "Disallow units for zero lengths",
+					"$ref": "#/definitions/booleanRule"
+				}
+			}
+		},
+		"mediaFeature": {
+			"properties": {
+				"media-feature-colon-space-after": {
+					"description": "Require a single space or disallow whitespace after the colon in media features",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"media-feature-colon-space-before": {
+					"description": "Require a single space or disallow whitespace before the colon in media features",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"media-feature-name-case": {
+					"description": "Specify lowercase or uppercase for media feature names",
+					"$ref": "#/definitions/lowerUpperRule"
+				},
+				"media-feature-name-no-unknown": {
+					"description": "Disallow unknown media feature names",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignoreMediaFeatureNames": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"media-feature-name-no-vendor-prefix": {
+					"description": "Disallow vendor prefixes for media feature names",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"media-feature-no-missing-punctuation": {
+					"description": "Disallow missing punctuation for non-boolean media features",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"media-feature-parentheses-space-inside": {
+					"description": "Require a single space or disallow whitespace on the inside of the parentheses within media features",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"media-feature-range-operator-space-after": {
+					"description": "Require a single space or disallow whitespace after the range operator in media features",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"media-feature-range-operator-space-before": {
+					"description": "Require a single space or disallow whitespace before the range operator in media features",
+					"$ref": "#/definitions/alwaysNeverRule"
+				}
+			}
+		},
+		"mediaQueryList": {
+			"properties": {
+				"media-query-list-comma-newline-after": {
+					"description": "Require a newline or disallow whitespace after the commas of media query lists",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"media-query-list-comma-newline-before": {
+					"description": "Require a newline or disallow whitespace before the commas of media query lists",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"media-query-list-comma-space-after": {
+					"description": "Require a single space or disallow whitespace after the commas of media query lists",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"media-query-list-comma-space-before": {
+					"description": "Require a single space or disallow whitespace before the commas of media query lists",
+					"$ref": "#/definitions/spaceRule"
+				}
+			}
+		},
+		"number": {
+			"properties": {
+				"number-leading-zero": {
+					"description": "Require or disallow a leading zero for fractional numbers less than 1",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"number-max-precision": {
+					"description": "Limit the number of decimal places allowed in numbers",
+					"$ref": "#/definitions/integerRule"
+				},
+				"number-no-trailing-zeros": {
+					"description": "Disallow trailing zeros in numbers",
+					"$ref": "#/definitions/booleanRule"
+				}
+			}
+		},
+		"property": {
+			"properties": {
+				"property-blacklist": {
+					"description": "Specify a blacklist of disallowed properties",
+					"$ref": "#/definitions/arrayStringRule"
+				},
+				"property-case": {
+					"description": "Specify lowercase or uppercase for properties",
+					"$ref": "#/definitions/lowerUpperRule"
+				},
+				"property-no-unknown": {
+					"description": "Disallow unknown properties",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignoreProperties": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											},
+											"checkPrefixed": {
+												"description": "If `true`, this rule will check vendor-prefixed properties",
+												"type": "boolean"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"property-no-vendor-prefix": {
+					"description": "Disallow vendor prefixes for properties",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"property-whitelist": {
+					"description": "Specify a whitelist of allowed properties",
+					"$ref": "#/definitions/arrayStringRule"
+				}
+			}
+		},
+		"rootRule": {
+			"properties": {
+				"root-no-standard-properties": {
+					"description": "Disallow standard properties inside `:root` rules",
+					"$ref": "#/definitions/booleanRule"
+				}
+			}
+		},
+		"rule": {
+			"properties": {
+				"rule-nested-empty-line-before": {
+					"description": "Require or disallow an empty line before nested rules",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"never",
+								"always-multi-line",
+								"never-multi-line",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"never",
+											"always-multi-line",
+											"never-multi-line",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"except": {
+												"description": "Reverse the primary option if the rule is the first in a block",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"first-nested"
+													]
+												}
+											},
+											"ignore": {
+												"description": "Ignore rules that come after a comment",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"after-comment"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"rule-non-nested-empty-line-before": {
+					"description": "Require or disallow an empty line before non-nested rules",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always",
+								"never",
+								"always-multi-line",
+								"never-multi-line",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always",
+											"never",
+											"always-multi-line",
+											"never-multi-line",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"except": {
+												"description": "Reverse the primary option if the rule is the first in a block",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"after-single-line-comment"
+													]
+												}
+											},
+											"ignore": {
+												"description": "Ignore rules that come after a comment",
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"after-comment"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		"selector": {
+			"properties": {
+				"selector-attribute-brackets-space-inside": {
+					"description": "Require a single space or disallow whitespace on the inside of the brackets within attribute selector",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"selector-attribute-operator-blacklist": {
+					"description": "Specify a blacklist of disallowed attribute operators",
+					"$ref": "#/definitions/arrayStringRule"
+				},
+				"selector-attribute-operator-space-after": {
+					"description": "Require a single space or disallow whitespace after operators within attribute selectors",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"selector-attribute-operator-space-before": {
+					"description": "Require a single space or disallow whitespace before operators within attribute selectors",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"selector-attribute-operator-whitelist": {
+					"description": "Specify a whitelist of allowed attribute operators",
+					"$ref": "#/definitions/arrayStringRule"
+				},
+				"selector-attribute-quotes": {
+					"description": "Require or disallow quotes for attribute values",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"selector-class-pattern": {
+					"description": "Specify a pattern for class selectors",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": [
+								"null",
+								"string"
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"resolveNestedSelectors": {
+												"description": "This option will resolve nested selectors with `&` interpolation",
+												"type": "boolean",
+												"default": false
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"selector-combinator-space-after": {
+					"description": "Require a single space or disallow whitespace after the combinators of selectors",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"selector-combinator-space-before": {
+					"description": "Require a single space or disallow whitespace before the combinators of selectors",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"selector-descendant-combinator-no-non-space": {
+					"description": "Disallow non-space characters for descendant combinators of selectors",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"selector-id-pattern": {
+					"description": "Specify a pattern for id selectors",
+					"$ref": "#/definitions/stringRule"
+				},
+				"selector-max-compound-selectors": {
+					"description": "Limit the number of compound selectors in a selector",
+					"$ref": "#/definitions/integerRule"
+				},
+				"selector-max-specificity": {
+					"description": "Limit the specificity of selectors",
+					"$ref": "#/definitions/stringRule"
+				},
+				"selector-nested-pattern": {
+					"description": "Specify a pattern for the selectors of rules nested within rules",
+					"$ref": "#/definitions/stringRule"
+				},
+				"selector-no-attribute": {
+					"description": "Disallow attribute selectors",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"selector-no-combinator": {
+					"description": "Disallow combinators in selectors",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"selector-no-id": {
+					"description": "Disallow id selectors",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"selector-no-qualifying-type": {
+					"description": "Disallow qualifying a selector by type",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignore": {
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"attribute",
+														"class",
+														"id"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"selector-no-type": {
+					"description": "Disallow type selectors",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignore": {
+												"type": "array",
+												"uniqueItems": true,
+												"minItems": 1,
+												"items": {
+													"type": "string",
+													"enum": [
+														"compounded",
+														"descendant"
+													]
+												}
+											},
+											"ignoreTypes": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"selector-no-universal": {
+					"description": "Disallow the universal selector",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"selector-no-vendor-prefix": {
+					"description": "Disallow vendor prefixes for selectors",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"selector-pseudo-class-case": {
+					"description": "Specify lowercase or uppercase for pseudo-class selectors",
+					"$ref": "#/definitions/lowerUpperRule"
+				},
+				"selector-pseudo-class-no-unknown": {
+					"description": "Disallow unknown pseudo-class selectors",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignorePseudoClasses": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"selector-pseudo-class-parentheses-space-inside": {
+					"description": "Require a single space or disallow whitespace on the inside of the parentheses within pseudo-class selectors",
+					"$ref": "#/definitions/alwaysNeverRule"
+				},
+				"selector-pseudo-class-whitelist": {
+					"description": "Specify a whitelist of allowed pseudo-class selectors",
+					"$ref": "#/definitions/arrayStringRule"
+				},
+				"selector-pseudo-element-case": {
+					"description": "Specify lowercase or uppercase for pseudo-element selectors",
+					"$ref": "#/definitions/lowerUpperRule"
+				},
+				"selector-pseudo-element-colon-notation": {
+					"description": "Specify single or double colon notation for applicable pseudo-elements",
+					"$ref": "#/definitions/singleDoubleRule"
+				},
+				"selector-pseudo-element-no-unknown": {
+					"description": "Disallow unknown pseudo-element selectors",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignorePseudoElements": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"selector-root-no-composition": {
+					"description": "Disallow the composition of :root in selectors",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"selector-type-case": {
+					"description": "Specify lowercase or uppercase for type selectors",
+					"$ref": "#/definitions/lowerUpperRule"
+				},
+				"selector-type-no-unknown": {
+					"description": "Disallow unknown type selectors",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignoreTypes": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"selector-max-empty-lines": {
+					"description": "Limit the number of adjacent empty lines within selectors",
+					"$ref": "#/definitions/integerRule"
+				}
+			}
+		},
+		"selectorList": {
+			"properties": {
+				"selector-list-comma-newline-after": {
+					"description": "Require a newline or disallow whitespace after the commas of selector lists",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"selector-list-comma-newline-before": {
+					"description": "Require a newline or disallow whitespace before the commas of selector lists",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"selector-list-comma-space-after": {
+					"description": "Require a single space or disallow whitespace after the commas of selector lists",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"selector-list-comma-space-before": {
+					"description": "Require a single space or disallow whitespace before the commas of selector lists",
+					"$ref": "#/definitions/spaceRule"
+				}
+			}
+		},
+		"shorthandProperty": {
+			"properties": {
+				"shorthand-property-no-redundant-values": {
+					"description": "Disallow redundant values in shorthand properties",
+					"$ref": "#/definitions/booleanRule"
+				}
+			}
+		},
+		"string": {
+			"properties": {
+				"string-no-newline": {
+					"description": "Disallow (unescaped) newlines in strings",
+					"$ref": "#/definitions/booleanRule"
+				},
+				"string-quotes": {
+					"description": "Specify single or double quotes around strings",
+					"$ref": "#/definitions/singleDoubleRule"
+				}
+			}
+		},
+		"stylelintDisableComment": {
+			"properties": {
+				"stylelint-disable-reason": {
+					"description": "Require a reason comment before or after `stylelint-disable` comments",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"always-before",
+								"always-after",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"always-before",
+											"always-after",
+											{}
+										]
+									},
+									{
+										"$ref": "#/definitions/coreRule"
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		"time": {
+			"properties": {
+				"time-no-imperceptible": {
+					"description": "Disallow `animation` and `transition` less than or equal to 100ms",
+					"$ref": "#/definitions/booleanRule"
+				}
+			}
+		},
+		"unit": {
+			"properties": {
+				"unit-blacklist": {
+					"description": "Specify a blacklist of disallowed units",
+					"$ref": "#/definitions/unitRule"
+				},
+				"unit-case": {
+					"description": "Specify lowercase or uppercase for units",
+					"$ref": "#/definitions/lowerUpperRule"
+				},
+				"unit-no-unknown": {
+					"description": "Disallow unknown units",
+					"type": [
+						"null",
+						"boolean",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "boolean",
+							"enum": [
+								true,
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"boolean",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "boolean",
+										"enum": [
+											true,
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignoreUnits": {
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"unit-whitelist": {
+					"description": "Specify a whitelist of allowed units",
+					"$ref": "#/definitions/unitRule"
+				}
+			}
+		},
+		"value": {
+			"properties": {
+				"value-keyword-case": {
+					"description": "Specify lowercase or uppercase for keywords values",
+					"type": [
+						"null",
+						"string",
+						"array"
+					],
+					"oneOf": [
+						{
+							"type": "null"
+						},
+						{
+							"type": "string",
+							"enum": [
+								"lower",
+								"upper",
+								[]
+							]
+						},
+						{
+							"type": "array",
+							"minItems": 2,
+							"maxItems": 2,
+							"uniqueItems": true,
+							"items": {
+								"type": [
+									"string",
+									"object"
+								],
+								"anyOf": [
+									{
+										"type": "string",
+										"enum": [
+											"lower",
+											"upper",
+											{}
+										]
+									},
+									{
+										"type": "object",
+										"allOf": [
+											{
+												"$ref": "#/definitions/coreRule"
+											}
+										],
+										"properties": {
+											"ignoreKeywords": {
+												"description": "Ignore case of keywords values",
+												"$ref": "#/definitions/simpleArrayStringRule"
+											}
+										}
+									}
+								]
+							}
+						}
+					]
+				},
+				"value-no-vendor-prefix": {
+					"description": "Disallow vendor prefixes for values",
+					"$ref": "#/definitions/booleanRule"
+				}
+			}
+		},
+		"valueList": {
+			"properties": {
+				"value-list-comma-newline-after": {
+					"description": "Require a newline or disallow whitespace after the commas of value lists",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"value-list-comma-newline-before": {
+					"description": "Require a newline or disallow whitespace before the commas of value lists",
+					"$ref": "#/definitions/newlineRule"
+				},
+				"value-list-comma-space-after": {
+					"description": "Require a single space or disallow whitespace after the commas of value lists",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"value-list-comma-space-before": {
+					"description": "Require a single space or disallow whitespace before the commas of value lists",
+					"$ref": "#/definitions/spaceRule"
+				},
+				"value-list-max-empty-lines": {
+					"description": "Limit the number of adjacent empty lines within value lists",
+					"$ref": "#/definitions/integerRule"
+				}
+			}
+		}
+	},
+	"properties": {
+		"extends": {
+			"description": "Your configuration can extend an existing configuration(s) (whether your own or a third-party config)",
+			"$ref": "#/definitions/simpleStringOrArrayStringRule"
+		},
+		"plugins": {
+			"description": "Plugins are rules or sets of rules built by the community that support methodologies, toolsets, non-standard CSS features, or very specific use cases",
+			"$ref": "#/definitions/simpleArrayStringRule"
+		},
+		"processors": {
+			"description": "Plugins are rules or sets of rules built by the community that support methodologies, toolsets, non-standard CSS features, or very specific use cases",
+			"$ref": "#/definitions/simpleArrayStringRule"
+		},
+		"ignoreFiles": {
+			"description": "Provide a glob or array of globs to ignore specific files",
+			"$ref": "#/definitions/simpleStringOrArrayStringRule"
+		},
+		"defaultSeverity": {
+			"description": "The default severity level for all rules that do not have a severity specified in their secondary options",
+			"type": "string",
+			"enum": [
+				"warning",
+				"error"
+			]
+		},
+		"rules": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/atRule"
+				},
+				{
+					"$ref": "#/definitions/block"
+				},
+				{
+					"$ref": "#/definitions/color"
+				},
+				{
+					"$ref": "#/definitions/comment"
+				},
+				{
+					"$ref": "#/definitions/customMedia"
+				},
+				{
+					"$ref": "#/definitions/customProperty"
+				},
+				{
+					"$ref": "#/definitions/declaration"
+				},
+				{
+					"$ref": "#/definitions/declarationBlock"
+				},
+				{
+					"$ref": "#/definitions/font"
+				},
+				{
+					"$ref": "#/definitions/function"
+				},
+				{
+					"$ref": "#/definitions/generalSheet"
+				},
+				{
+					"$ref": "#/definitions/keyframeDeclaration"
+				},
+				{
+					"$ref": "#/definitions/length"
+				},
+				{
+					"$ref": "#/definitions/mediaFeature"
+				},
+				{
+					"$ref": "#/definitions/mediaQueryList"
+				},
+				{
+					"$ref": "#/definitions/number"
+				},
+				{
+					"$ref": "#/definitions/property"
+				},
+				{
+					"$ref": "#/definitions/rootRule"
+				},
+				{
+					"$ref": "#/definitions/rule"
+				},
+				{
+					"$ref": "#/definitions/selector"
+				},
+				{
+					"$ref": "#/definitions/selectorList"
+				},
+				{
+					"$ref": "#/definitions/shorthandProperty"
+				},
+				{
+					"$ref": "#/definitions/string"
+				},
+				{
+					"$ref": "#/definitions/stylelintDisableComment"
+				},
+				{
+					"$ref": "#/definitions/time"
+				},
+				{
+					"$ref": "#/definitions/unit"
+				},
+				{
+					"$ref": "#/definitions/value"
+				},
+				{
+					"$ref": "#/definitions/valueList"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
The generated schema is difficult to read, so I would advise view source files: https://github.com/mrmlnc/schema-stylelint

A small note:

  * `blocks` - rules divided in accordance with [stylelint site](http://stylelint.io/user-guide/rules/).
  * `helpers` - primitive rules that are used in `$ref`.
  * `tests` - tests for all rules.
  * `template.json` - main (entry) file.

I tried to optimize the size of schema using additional rules (`helpers` directory in source files) and tabs.

Please, let me know if I need to provide any more details.

