### PR TITLE
Add missing description and type to parserOptions property

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -460,6 +460,8 @@
       "type": "string"
     },
     "parserOptions": {
+      "description": "The JavaScript language options to be supported",
+      "type": "object",
       "properties": {
         "ecmaFeatures": {
           "$ref": "#/properties/ecmaFeatures"


### PR DESCRIPTION
Add the missing `type` and `description` properties to the `parserOptions` property of the `.eslintrc` JSON schema.