### PR TITLE
Update ecmaVersion property in .eslintrc schema

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -467,9 +467,9 @@
           "$ref": "#/properties/ecmaFeatures"
         },
         "ecmaVersion": {
-          "enum": [ 3, 5, 6, 7 ],
+          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017 ],
           "default": 5,
-          "description": "set to 3, 5 (default), 6, or 7 to specify the version of ECMAScript you want to use"
+          "description": "Set to 3, 5 (default), 6, 7, or 8 to specify the version of ECMAScript you want to use. Alternatively, set to 2015 (same as 6), 2016 (same as 7), or 2017 (same as 8) to use year-based naming."
         },
         "sourceType": {
           "enum": [ "script", "module" ],


### PR DESCRIPTION
Update the `ecmaVersion` property to support ECMAScript 2017, per the [official docs](http://eslint.org/docs/user-guide/configuring#specifying-parser-options). Also, add description and other missing values to the property's enum array.