### PR TITLE
Add enum to defaultSource property

### DIFF
--- a/src/schemas/json/typingsrc.json
+++ b/src/schemas/json/typingsrc.json
@@ -20,7 +20,8 @@
     "defaultSource": {
       "type": "string",
       "description": "Override the default installation source (e.g., when doing 'typings install debug')",
-      "default": "npm"
+      "default": "npm",
+      "enum": [ "file", "npm", "github", "bitbucket", "bower", "http", "https" ]
     },
     "githubToken": {
       "type": "string",


### PR DESCRIPTION
Add an enumeration of allowed values to the `defaultSource` property of the `.typingsrc` JSON schema, per the [Configuration doc](https://github.com/typings/typings/blob/master/docs/faq.md#configuration).