### PR TITLE
Add (better?) “fileMatch” for web application manifest: “*.webmanifest”

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -465,7 +465,7 @@
     {
       "name": "Web Manifest",
       "description": "Web Application manifest file",
-      "fileMatch": [ "manifest.json" ],
+      "fileMatch": [ "manifest.json", "*.webmanifest" ],
       "url": "http://json.schemastore.org/web-manifest"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -464,7 +464,7 @@
     },
     {
       "name": "Web Manifest",
-      "description": "Web Appliation manifest file",
+      "description": "Web Application manifest file",
       "fileMatch": [ "manifest.json" ],
       "url": "http://json.schemastore.org/web-manifest"
     },


### PR DESCRIPTION
cf [W3C's “Web App Manifest” (working draft), &sect;13.1: “Media type registration”](https://www.w3.org/TR/appmanifest/#media-type-registration).