### PR TITLE
Remove incorrect "format": "uri" from tsconfig.json and jsconfig.json

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -9,8 +9,7 @@
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       },
@@ -24,8 +23,7 @@
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       }
@@ -36,8 +34,7 @@
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       }
@@ -99,8 +96,7 @@
             },
             "mapRoot": {
               "description": "When down-level compiling, specifies the location where debugger should locate map files instead of generated locations.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "module": {
               "description": "When down-level compiling, specify module code generation: 'CommonJS', 'Amd', 'System', 'UMD', 'es6', or 'es2015'.",
@@ -140,13 +136,11 @@
             },
             "outFile": {
               "description": "When down-level compiling, concatenate and emit output to single file.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "outDir": {
               "description": "When down-level compiling, redirect output structure to the directory.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "pretty": {
               "description": "When down-level compiling, stylize errors and messages using color and context (experimental).",
@@ -158,8 +152,7 @@
             },
             "rootDir": {
               "description": "When down-level compiling, specifies the root directory of input files. Use to control the output directory structure with --outDir.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "isolatedModules": {
               "description": "When down-level compiling, unconditionally emit imports for unresolved files.",
@@ -171,8 +164,7 @@
             },
             "sourceRoot": {
               "description": "When down-level compiling, specifies the location where debugger should locate JavaScript files instead of source locations.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "stripInternal": {
               "description": "When down-level compiling, do not emit declarations for code that has an '@internal' annotation.",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -9,8 +9,7 @@
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       }
@@ -21,8 +20,7 @@
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       }
@@ -33,8 +31,7 @@
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "type": "array",
           "items": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       }
@@ -108,8 +105,7 @@
             },
             "mapRoot": {
               "description": "Specifies the location where debugger should locate map files instead of generated locations",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "module": {
               "description": "Specify module code generation: 'none', 'CommonJS', 'Amd', 'System', 'UMD', or 'es2015'.",
@@ -164,13 +160,11 @@
             },
             "outFile": {
               "description": "Concatenate and emit output to single file.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "outDir": {
               "description": "Redirect output structure to the directory.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "preserveConstEnums": {
               "description": "Do not erase const enum declarations in generated code.",
@@ -186,8 +180,7 @@
             },
             "rootDir": {
               "description": "Specifies the root directory of input files. Use to control the output directory structure with --outDir.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "isolatedModules": {
               "description": "Unconditionally emit imports for unresolved files.",
@@ -199,8 +192,7 @@
             },
             "sourceRoot": {
               "description": "Specifies the location where debugger should locate TypeScript files instead of source locations.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "suppressExcessPropertyErrors": {
               "description": "Suppress excess property checks for object literals.",
@@ -260,8 +252,7 @@
             },
             "baseUrl": {
               "description": "Base directory to resolve non-relative module names.",
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             },
             "paths": {
               "description": "Specify path mapping to be computed relative to baseUrl option.",


### PR DESCRIPTION
The file names in tsconfig.json can be relative names, which are not invalid uris. Deleting them.

// cc @mhegazy @dbaeumer 