### PR TITLE
Update target to options supported in typescript 2.2

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -209,7 +209,7 @@
             "target": {
               "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', or 'es2015'.",
               "type": "string",
-              "pattern": "^([eE][sS]([356]|(2015)))$",
+              "pattern": "^([eE][sS]([356]|(201[567])|[nN][eE][xX][tT]))$",
               "default": "es3"
             },
             "watch": {


### PR DESCRIPTION
https://github.com/Microsoft/TypeScript/blob/7b9a42f9/src/compiler/commandLineParser.ts#L261-L269

Too bad JS regexps don't support `(?i:)`... why can't anyone be actually perl-compatible 😕 