### PR TITLE
Add capitalized-comments and require-await rules to .eslintrc schema

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -125,6 +125,7 @@
         "no-warning-comments": { "$ref": "#/definitions/rule", "description": "Disallow specified warning terms in comments" },
         "no-with": { "$ref": "#/definitions/rule", "description": "Disallow with statements" },
         "radix": { "$ref": "#/definitions/rule", "description": "Enforce the consistent use of the radix argument when using parseInt()" },
+        "require-await": { "$ref": "#/definitions/rule", "description": "Disallow async functions which have no await expression" },
         "vars-on-top": { "$ref": "#/definitions/rule", "description": "Require var declarations be placed at the top of their containing scope" },
         "wrap-iife": { "$ref": "#/definitions/rule", "description": "Require parentheses around immediate function invocations" },
         "yoda": { "$ref": "#/definitions/rule", "description": "Require or Disallow “Yoda” conditions" }
@@ -171,6 +172,7 @@
         "block-spacing": { "$ref": "#/definitions/rule", "description": "Enforce consistent spacing inside single-line blocks" },
         "brace-style": { "$ref": "#/definitions/rule", "description": "Enforce consistent brace style for blocks" },
         "camelcase": { "$ref": "#/definitions/rule", "description": "Enforce camelcase naming convention" },
+        "capitalized-comments": { "$ref": "#/definitions/rule", "description": "Enforce or disallow capitalization of the first letter of a comment" },
         "comma-dangle": { "$ref": "#/definitions/rule", "description": "Require or disallow trailing commas" },
         "comma-spacing": { "$ref": "#/definitions/rule", "description": "Enforce consistent spacing before and after commas" },
         "comma-style": { "$ref": "#/definitions/rule", "description": "Enforce consistent comma style" },


### PR DESCRIPTION
Add support for the following 2 rules which were introduced in the [3.11.0](http://eslint.org/blog/2016/11/eslint-v3.11.0-released#new-rules) release of ESLint:

1. `capitalized-comments`
1. `require-await`