### PR TITLE
fix tslint.json

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -442,7 +442,7 @@
 					"description": "Enforces semicolons at the end of every statement",
           			"type": "array",
           			"items": {
-            			"enum": [ true, false, "always", "never"]
+            			"enum": [ true, false, "always", "never", "ignore-bound-class-methods", "ignore-interfaces"]
           			}
 				},
 				"switch-default": {


### PR DESCRIPTION
Add semicolon options for tslint.json.
ref: [Rule: semicolon](https://palantir.github.io/tslint/rules/semicolon/)
rel: [Semicolon rule config reports as invalid in VSCode](https://github.com/palantir/tslint/issues/1822)