### PR TITLE
Add "include" to Top Level of jsconfig and tsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -277,10 +277,14 @@
     { "$ref": "#/definitions/typeAcquisitionDefinition" },
     { "$ref": "#/definitions/extendsDefinition" },
     {
-      "anyOf": [
+      "oneOf": [
         { "$ref": "#/definitions/filesDefinition" },
-        { "$ref": "#/definitions/excludeDefinition" },
-        { "$ref": "#/definitions/includeDefinition" }
+        {
+          "anyOf" :[
+            { "$ref": "#/definitions/excludeDefinition" },
+            { "$ref": "#/definitions/includeDefinition" }
+          ]
+        }
       ]
     }
   ]

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -28,7 +28,7 @@
         }
       }
     },
-    "includeDefition": {
+    "includeDefinition": {
       "properties": {
         "include": {
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -279,7 +279,8 @@
     {
       "anyOf": [
         { "$ref": "#/definitions/filesDefinition" },
-        { "$ref": "#/definitions/excludeDefinition" }
+        { "$ref": "#/definitions/excludeDefinition" },
+        { "$ref": "#/definitions/includeDefinition" }
       ]
     }
   ]

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -277,14 +277,10 @@
     { "$ref": "#/definitions/typeAcquisitionDefinition" },
     { "$ref": "#/definitions/extendsDefinition" },
     {
-      "oneOf": [
+      "anyOf": [
         { "$ref": "#/definitions/filesDefinition" },
-        {
-          "anyOf" :[
-            { "$ref": "#/definitions/excludeDefinition" },
-            { "$ref": "#/definitions/includeDefinition" }
-          ]
-        }
+        { "$ref": "#/definitions/excludeDefinition" },
+        { "$ref": "#/definitions/includeDefinition" }
       ]
     }
   ]

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -371,10 +371,14 @@
     { "$ref": "#/definitions/typeAcquisitionDefinition" },
     { "$ref": "#/definitions/extendsDefinition" },
     {
-      "anyOf": [
+      "oneOf": [
         { "$ref": "#/definitions/filesDefinition" },
-        { "$ref": "#/definitions/excludeDefinition" },
-        { "$ref": "#/definitions/includeDefinition" }
+        {
+          "anyOf" :[
+            { "$ref": "#/definitions/excludeDefinition" },
+            { "$ref": "#/definitions/includeDefinition" }
+          ]
+        }
       ]
     }
   ]

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -373,7 +373,8 @@
     {
       "anyOf": [
         { "$ref": "#/definitions/filesDefinition" },
-        { "$ref": "#/definitions/excludeDefinition" }
+        { "$ref": "#/definitions/excludeDefinition" },
+        { "$ref": "#/definitions/includeDefinition" }
       ]
     }
   ]

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -371,14 +371,10 @@
     { "$ref": "#/definitions/typeAcquisitionDefinition" },
     { "$ref": "#/definitions/extendsDefinition" },
     {
-      "oneOf": [
+      "anyOf": [
         { "$ref": "#/definitions/filesDefinition" },
-        {
-          "anyOf" :[
-            { "$ref": "#/definitions/excludeDefinition" },
-            { "$ref": "#/definitions/includeDefinition" }
-          ]
-        }
+        { "$ref": "#/definitions/excludeDefinition" },
+        { "$ref": "#/definitions/includeDefinition" }
       ]
     }
   ]


### PR DESCRIPTION
From https://github.com/Microsoft/vscode/issues/13349

I believe that we also need to export the "include" property definition for these schemas

@mhegazy and @yuit from TS can you please take a look?