### PR TITLE
Use Boolean Defaults Instead of Strings in Js/Tsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -218,7 +218,7 @@
             "disableSizeLimit": {
               "description": "Disable size limit for JavaScript project. Requires TypeScript version 2.0 or later.",
               "type": "boolean",
-              "default": "false"
+              "default": false
             },
             "lib": {
               "description": "Specify library file to be included in the compilation. Requires TypeScript version 2.0 or later.",
@@ -248,7 +248,7 @@
             "enable": {
               "description": "Enable auto type acquisition",
               "type": "boolean",
-              "default": "true"
+              "default": true
             },
             "include": {
               "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -342,7 +342,7 @@
             "enable": {
               "description": "Enable auto type acquisition",
               "type": "boolean",
-              "default": "false"
+              "default": false
             },
             "include": {
               "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",


### PR DESCRIPTION
A few default values in the jsconfig and tsconfig schemas use default string values `"true"` and `"false"` as the default for booleans. These defaults should be boolean values instead