### PR TITLE
Add new keepOneSpaceWhenCollapsing property to bundleconfig.json schema

### DIFF
--- a/src/schemas/json/bundleconfig.json
+++ b/src/schemas/json/bundleconfig.json
@@ -111,6 +111,11 @@
               "type": "boolean",
               "default": true
             },
+            "keepOneSpaceWhenCollapsing": {
+              "description": "HTML only. Indicating whether to keep one space when collapsing.",
+              "type": "boolean",
+              "default": false
+            },
             "minifyEmbeddedCssCode": {
               "description": "HTML only. Minify CSS code in style tags.",
               "type": "boolean",


### PR DESCRIPTION
Add the `keepOneSpaceWhenCollapsing` property to the `bundleconfig.json` schema. This PR complements the already merged changes to address issue https://github.com/madskristensen/BundlerMinifier/issues/199.