### PR TITLE
Use enum for tsconfig compilerOptions.target

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -208,8 +208,21 @@
             "target": {
               "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es2015', 'es2016', 'es2017' or 'esnext'.",
               "type": "string",
-              "pattern": "^([eE][sS]([356]|(201[567])|[nN][eE][xX][tT]))$",
-              "default": "es3"
+              "default": "es3",
+              "anyOf": [
+                {
+                  "enum": [
+                    "es3",
+                    "es5",
+                    "es2015",
+                    "es2016",
+                    "es2017",
+                    "esnext"
+                  ]
+                }, {
+                  "pattern": "^([eE][sS]([356]|(201[567])|[nN][eE][xX][tT]))$"
+                }
+              ]
             },
             "watch": {
               "description": "Watch input files.",


### PR DESCRIPTION
Resubmit of #237
Adds enum values to the `target` compiler option in `tsconfig.json` files.

`anyOf` is used to support case insensitivity as was noted in #237