### PR TITLE
Fix invalid xunit.runner.schema URL

### DIFF
--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
                     "http://json.schemastore.org/grunt-task": grunt.file.readJSON("schemas/json/grunt-task.json"),
                     "http://json.schemastore.org/jsonld": grunt.file.readJSON("schemas/json/jsonld.json"),
                     "http://json.schemastore.org/schema-org-thing": grunt.file.readJSON("schemas/json/schema-org-thing.json"),
-                    "http://json-schemastore.org/xunit.runner.schema": grunt.file.readJSON("schemas/json/xunit.runner.schema.json")
+                    "http://json.schemastore.org/xunit.runner.schema": grunt.file.readJSON("schemas/json/xunit.runner.schema.json")
                 }
             }
         },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -554,7 +554,7 @@
       "name": "xunit.runner.json",
       "description": "xUnit.net runner configuration file",
       "fileMatch": [ "xunit.runner.json" ],
-      "url": "http://json-schema.org/xunit.runner.schema"
+      "url": "http://json.schemastore.org/xunit.runner.schema"
     }
   ]
 }


### PR DESCRIPTION
Fix an invalid `xunit.runner.json` schema URL introduced in https://github.com/SchemaStore/schemastore/pull/270.