### PR TITLE
Update jsbeautifyrc and add nested version.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -209,6 +209,12 @@
       "url": "http://json.schemastore.org/jsbeautifyrc"
     },
     {
+      "name": ".jsbeautifyrc-nested",
+      "description": "js-beautify configuration file allowing nested `js`, `css`, and `html` attributes",
+      "fileMatch": [ ".jsbeautifyrc" ],
+      "url": "http://json.schemastore.org/jsbeautifyrc-nested"
+    },
+    {
       "name": ".jscsrc",
       "description": "JSCS configuration file",
       "fileMatch": [ ".jscsrc", "jscsrc.json" ],

--- a/src/schemas/json/jsbeautifyrc-nested.json
+++ b/src/schemas/json/jsbeautifyrc-nested.json
@@ -1,0 +1,39 @@
+{
+  "title": "JSON schema for beautifyrc",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://json.schemastore.org/jsbeautifyrc-nested",
+  "type": "object",
+  "allOf": [
+    { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/CHJProperties" },
+    { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/HJProperties" },
+    { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/CProperties" },
+    { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/HProperties" },
+    { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/JProperties" },
+    {
+      "properties": {
+        "css": {
+          "type": "object",
+          "allOf": [
+            { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/CHJProperties" },
+            { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/CProperties" }
+            ]
+        },
+        "js": {
+          "type": "object",
+          "allOf": [
+            { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/CHJProperties" },
+            { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/HJProperties" },
+            { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/JProperties" }
+            ]
+        },
+        "html": {
+          "type": "object",
+          "allOf": [
+            { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/CHJProperties" },
+            { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/HJProperties" },
+            { "$ref": "http://json.schemastore.org/jsbeautifyrc#/definitions/HProperties" }
+            ]
+        }
+      }
+    }]
+}

--- a/src/schemas/json/jsbeautifyrc.json
+++ b/src/schemas/json/jsbeautifyrc.json
@@ -32,17 +32,17 @@
           "description": "Ensure newline at end of file. [JS,CSS,HTML]",
           "type": "boolean",
           "default": false
+        },
+        "preserve_newlines": {
+          "description": "Preserve line-breaks. [JS,CSS,HTML]",
+          "type": "boolean",
+          "default": true
         }
       }
     },
     "HJProperties": {
       "type": "object",
       "properties": {
-        "preserve_newlines": {
-          "description": "Preserve line-breaks. [JS,HTML]",
-          "type": "boolean",
-          "default": true
-        },
         "max_preserve_newlines": {
           "description": "Number of line-breaks to be preserved in one chunk. [JS,HTML]",
           "type": "integer",

--- a/src/schemas/json/jsbeautifyrc.json
+++ b/src/schemas/json/jsbeautifyrc.json
@@ -1,164 +1,242 @@
 {
-	"title": "JSON schema for jsbeautifyrc: js-beautify's configuration file",
-	"$schema": "http://json-schema.org/draft-04/schema#",
-	
-	"type": "object",
-	
-	"properties": {
-		"indent_size": {
-			"description": "Indent size. [JS,CSS,HTML]",
-			"type": "integer",
-			"default": 4
-		},
-		"indent_char": {
-			"description": "Indentation character. [JS,CSS,HTML]",
-			"type": "string",
-			"default": " ",
-			"maxLength": 1
-		},
-		"indent_with_tabs": {
-			"description": "Indent with tabs, overrides 'indent_size' and 'indent_char' [JS,CSS,HTML]",
-			"type": "boolean",
-			"default": false
-		},
-		"eol": {
-			"description": "Character(s) to use as line terminators. [JS,CSS,HTML]",
-			"type": "string",
-			"default": "\\n"
-		},
-		"preserve_newlines": {
-			"description": "Preserve line-breaks. [JS,HTML]",
-			"type": "boolean",
-			"default": true
-		},
-		"max_preserve_newlines": {
-			"description": "Number of line-breaks to be preserved in one chunk. [JS,HTML]",
-			"type": "integer",
-			"default": 10
-		},
-		"indent_level": {
-			"description": "Initial indentation level. [JS]",
-			"type": "integer",
-			"default": 0
-		},
-		"space_in_paren": {
-			"description": "Add padding spaces within parentheses, ie. f( a, b ). [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"jslint_happy": {
-			"description": "Enable jslint-stricter mode. (Forces 'space_after_anon_function') [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"space_after_anon_function": {
-			"description": "Add a space before an anonymous function's parens, ie. function (). [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"brace_style": {
-			"description": "[collapse|expand|end-expand|none] [JS,HTML]",
-			"type": "string",
-			"default": "collapse",
-			"enum": [
-				"collapse", "expand", "end-expand", "none"
-			]
-		},
-		"break_chained_methods": {
-			"description": "Break chained method calls across subsequent lines. [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"keep_array_indentation": {
-			"description": "Preserve array indentation. [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"keep_function_indentation": {
-			"description": "Preserve function indentation. [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"space_before_conditional": {
-			"description": "Ensure a space before conditional statement. [JS]",
-			"type": "boolean",
-			"default": true
-		},
-		"unescape_strings": {
-			"description": "Decode printable characters encoded in xNN notation. [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"wrap_line_length": {
-			"description": "Wrap lines at next opportunity after N characters. [JS,HTML]",
-			"type": "integer",
-			"default": 0
-		},
-		"wrap_attributes": {
-			"description": "Wrap attributes to new lines. [HTML]",
-			"type": "string",
-			"default": "auto",
-			"enum": [
-			"auto", "force"
-		]
-		},
-		"wrap_attributes_indent_size": {
-			"description": "Indent wrapped attributes to after N characters. Defaults to 'indent_size'. [HTML]",
-			"type": "number"
-		},
-		"end_with_newline": {
-			"description": "Ensure newline at end of file. [JS,HTML]",
-			"type": "boolean",
-			"default": false
-		},
-		"indent_inner_html": {
-			"description": "Indent <head> and <body> sections. [HTML]",
-			"type": "boolean",
-			"default": false
-		},
-		"indent_scripts": {
-			"description": "[keep|separate|normal] [HTML]",
-			"type": "string",
-			"default": "normal",
-			"enum": [
-			"keep", "separate", "normal"
-		]
-		},
-		"unformatted": {
-			"description": "List of tags that should not be reformatted. [HTML]",
-			"type": "array",
-			"items": {
-				"type": "string"
-			},
-			"default": ["inline"]
-		},
-		"extra_liners": {
-			"description": "List of tags that should have an extra newline before them. [HTML]",
-			"type": "array",
-			"items": {
-				"type": "string"
-			},
-			"default": ["head", "body", "/html"]
-		},
-		"comma_first": {
-			"description": "Put commas at the beginning of new line instead of end. [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"e4x": {
-			"description": "Pass E4X xml literals through untouched. [JS]",
-			"type": "boolean",
-			"default": false
-		},
-		"newline_between_rules": {
-			"description": "Add a newline between CSS rules. [CSS]",
-			"type": "boolean",
-			"default": false
-		},
-		"selector_separator_newline": {
-			"description": "Add a newline between multiple selectors. [CSS]",
-			"type": "boolean",
-			"default": true
-		}
-	}
+  "title": "JSON schema for beautifyrc",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://json.schemastore.org/jsbeautifyrc",
+  "type": "object",
+  "definitions": {
+    "CHJProperties": {
+      "type": "object",
+      "properties": {
+        "indent_size": {
+          "description": "Indent size. [JS,CSS,HTML]",
+          "type": "integer",
+          "default": 4
+        },
+        "indent_char": {
+          "description": "Indentation character. [JS,CSS,HTML]",
+          "type": "string",
+          "default": " ",
+          "maxLength": 1
+        },
+        "eol": {
+          "description": "Character(s) to use as line terminators. [JS,CSS,HTML]",
+          "type": "string",
+          "default": "\n"
+        },
+        "indent_with_tabs": {
+          "description": "Indent with tabs, overrides 'indent_size' and 'indent_char' [JS,CSS,HTML]",
+          "type": "boolean",
+          "default": false
+        },
+        "end_with_newline": {
+          "description": "Ensure newline at end of file. [JS,CSS,HTML]",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "HJProperties": {
+      "type": "object",
+      "properties": {
+        "preserve_newlines": {
+          "description": "Preserve line-breaks. [JS,HTML]",
+          "type": "boolean",
+          "default": true
+        },
+        "max_preserve_newlines": {
+          "description": "Number of line-breaks to be preserved in one chunk. [JS,HTML]",
+          "type": "integer",
+          "default": 10
+        },
+        "brace_style": {
+          "description": "[collapse|collapse|expand|end-expand|none][,preserve-inline]  [JS,HTML]",
+          "type": "string",
+          "default": "collapse",
+          "enum": ["collapse", "expand", "end-expand", "none", "collapse,preserve-inline", "expand,preserve-inline",
+            "end-expand,preserve-inline", "none,preserve-inline"
+          ]
+        },
+        "wrap_line_length": {
+          "description": "Wrap lines at next opportunity after N characters. [JS,HTML]",
+          "type": "integer",
+          "default": 0
+        }
+      }
+    },
+    "CProperties": {
+      "type": "object",
+      "properties": {
+        "selector_separator_newline": {
+          "description": "Add a newline between multiple selectors. [CSS]",
+          "type": "boolean",
+          "default": true
+        },
+        "newline_between_rules": {
+          "description": "Add a newline between CSS rules. [CSS]",
+          "type": "boolean",
+          "default": false
+        },
+        "space_around_selector_separator": {
+          "description": "(Deprecated: use space_around_combinator) [CSS]",
+          "type": "boolean",
+          "default": false
+        },
+        "space_around_combinator": {
+          "description": "Ensure space around selector separators (>+~). [CSS]",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "HProperties": {
+      "type": "object",
+      "properties": {
+        "wrap_attributes": {
+          "description": "Wrap attributes to new lines. [HTML]",
+          "type": "string",
+          "default": "auto",
+          "enum": ["auto", "force", "force-aligned", "force-expand-multiline"]
+        },
+        "wrap_attributes_indent_size": {
+          "description": "Indent wrapped attributes to after N characters. Defaults to 'indent_size'. [HTML]",
+          "type": "number"
+        },
+        "indent_inner_html": {
+          "description": "Indent <head> and <body> sections. [HTML]",
+          "type": "boolean",
+          "default": false
+        },
+        "indent_scripts": {
+          "description": "[keep|separate|normal] [HTML]",
+          "type": "string",
+          "default": "normal",
+          "enum": ["keep", "separate", "normal"]
+        },
+        "unformatted": {
+          "description": "List of tags that should not be reformatted. [HTML]",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["a", "abbr", "area", "audio", "b", "bdi", "bdo", "br", "button", "canvas", "cite", "code", "data",
+            "datalist", "del", "dfn", "em", "embed", "i", "iframe", "img", "input", "ins", "kbd", "keygen", "label",
+            "map",
+            "mark", "math", "meter", "noscript", "object", "output", "progress", "q", "ruby", "s", "samp", "select",
+            "small",
+            "span", "strong", "sub", "sup", "svg", "template", "textarea", "time", "u", "var", "video", "wbr", "text",
+            "acronym", "address", "big", "dt", "ins", "strike", "tt"
+          ]
+        },
+        "content_unformatted": {
+          "description": "List of tags who's content should not be reformatted. [HTML]",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["pre"]
+        },
+        "extra_liners": {
+          "description": "List of tags that should have an extra newline before them. [HTML]",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["head", "body", "/html"]
+        },
+        "indent_body_inner_html": {
+          "description": "Indent elements within html <body> element. [HTML]",
+          "type": "boolean",
+          "default": true
+        },
+        "indent_head_inner_html": {
+          "description": "Indent elements within html <head> element. [HTML]",
+          "type": "boolean",
+          "default": true
+        },
+        "indent_handlebars": {
+          "description": "format and indent {{#foo}} and {{/foo}}. [HTML]",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "JProperties": {
+      "type": "object",
+      "properties": {
+        "indent_level": {
+          "description": "Initial indentation level. [JS]",
+          "type": "integer",
+          "default": 0
+        },
+        "space_in_paren": {
+          "description": "Add padding spaces within parentheses, ie. f( a, b ). [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "space_in_empty_paren": {
+          "description": "Leave space in empty parentheses, ie. f( ). [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "jslint_happy": {
+          "description": "Enable jslint-stricter mode. (Forces 'space_after_anon_function') [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "space_after_anon_function": {
+          "description": "Add a space before an anonymous function's parens, ie. function (). [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "break_chained_methods": {
+          "description": "Break chained method calls across subsequent lines. [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "keep_array_indentation": {
+          "description": "Preserve array indentation. [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "keep_function_indentation": {
+          "description": "Preserve function indentation. [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "space_before_conditional": {
+          "description": "Ensure a space before conditional statement. [JS]",
+          "type": "boolean",
+          "default": true
+        },
+        "unescape_strings": {
+          "description": "Decode printable characters encoded in xNN notation. [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "comma_first": {
+          "description": "Put commas at the beginning of new line instead of end. [JS]",
+          "type": "boolean",
+          "default": false
+        },
+        "operator_position": {
+          "description": "Move operators to before or after a new line, or keep as is. [JS]",
+          "type": "string",
+          "enum": ["before-newline", "after-newline", "preserve-newline"],
+          "default": "before-newline"
+        },
+        "e4x": {
+          "description": "Pass E4X xml literals through untouched. [JS]",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  },
+  "allOf": [
+    { "$ref": "#/definitions/CHJProperties" },
+    { "$ref": "#/definitions/HJProperties" },
+    { "$ref": "#/definitions/CProperties" },
+    { "$ref": "#/definitions/HProperties" },
+    { "$ref": "#/definitions/JProperties" }
+  ]
 }


### PR DESCRIPTION
Converts the jsbeautifyrc version to use definition blocks so that the nested version can pull straight from it.

Many IDE plugins allow the three code types to have their own nested values. This enables both the standard setup or the nested version to be used, and easily maintained in just the main file.