### PR TITLE
Added after-declaration to stylelint declaration-empty-line-before rule

### DIFF
--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -1627,6 +1627,7 @@
 													"type": "string",
 													"enum": [
 														"after-comment",
+														"after-declaration",
 														"inside-single-line-block"
 													]
 												}


### PR DESCRIPTION
Schema: .stylelintrc
URL: http://json.schemastore.org/stylelintrc

*As reflected in the documentation and code.*
Added `"after-declaration"` to the `"ignore"` block of the `"declaration-empty-line-before"` rule.