### PR TITLE
Add "allow-named-functions" option to "only-arrow-functions" rule

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -438,7 +438,7 @@
 					"description": "Disallows traditional (non-arrow) function expressions",
 					"type": "array",
 					"items": {
-						"enum": [ true, false, "allow-declarations" ]
+						"enum": [ true, false, "allow-declarations", "allow-named-functions" ]
 					}
 				},
 				"ordered-imports": {


### PR DESCRIPTION
This option has been commited to the TSLint project on Dec 13, 2016.