### PR TITLE
Add babelrc preset array item type

### DIFF
--- a/src/schemas/json/babelrc.json
+++ b/src/schemas/json/babelrc.json
@@ -104,7 +104,11 @@
 			"description": "List of presets (a set of plugins) to load and use",
 			"type": "array",
 			"items": {
-				"type": "string"
+				"type": ["string", "array"],
+				"items": {
+					"description": "the preset name in .[0] and the options object in .[1]",
+					"type": ["string", "object"]
+				}
 			}
 		},
 		"retainLines": {


### PR DESCRIPTION
Add support for

```json
{
  "presets": [
    ["env", {
      "targets": {
        "chrome": 52
      }
    }]
  ]
}
```

https://github.com/babel/babel-preset-env#target-only-chrome-52