### PR TITLE
Add schema for apple-app-site-association

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10,6 +10,12 @@
       "url": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/@angular/cli/lib/config/schema.json"
     },
     {
+      "name": "apple-app-site-association",
+      "description": "Apple Universal Link, App Site Association",
+      "fileMatch": [ "apple-app-site-association" ],
+      "url": "http://json.schemastore.org/apple-app-site-association"
+    },
+    {
       "name": "babelrc.json",
       "description": "Babel configuration file",
       "fileMatch": [ ".babelrc" ],

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -7,7 +7,7 @@
             "type": "object",
             "properties": {
                 "apps": {
-                    "type": "array",
+                    "enum": [[]],
                     "description": "Must be an empty array"
                 },
                 "details": {

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Apple Universal Link, App Site Association",
+    "type": "object",
+    "properties": {
+        "applinks": {
+            "type": "object",
+            "properties": {
+                "apps": {
+                    "type": "array",
+                    "description": "Must be an empty array"
+                },
+                "details": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "appID": {
+                                "type": "string",
+                                "description": "The value of the appID key is the team ID or app ID prefix, followed by the bundle ID"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "description": "Ordered list of paths to open in the mobile app. Prefix with 'NOT ' to remove a path"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": ["apps", "details"]
+        }
+    },
+    "required": ["applinks"]
+}

--- a/src/test/apple-app-site-association/apple-app-site-association_getting-started
+++ b/src/test/apple-app-site-association/apple-app-site-association_getting-started
@@ -1,0 +1,15 @@
+{
+    "applinks": {
+        "apps": [],
+        "details": [
+            {
+                "appID": "9JA89QQLNQ.com.apple.wwdc",
+                "paths": [ "/wwdc/news/", "/videos/wwdc/2015/*"]
+            },
+            {
+                "appID": "ABCD1234.com.apple.wwdc",
+                "paths": [ "*" ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
The file format is described here:
https://developer.apple.com/library/content/documentation/General/Conceptual/AppSearch/UniversalLinks.html

I used Apple's example as test.