### PR TITLE
Fixing function.json schema and adding DocumentDB sqlQuery

### DIFF
--- a/src/schemas/json/function.json
+++ b/src/schemas/json/function.json
@@ -3,13 +3,29 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "disabled": {
+      "type": "boolean",
+      "description": "If set to true, marks the function as disabled (it cannot be triggered)."
+    },
+    "excluded": {
+      "type": "boolean",
+      "description": "If set to true, the function will not be loaded, compiled, or triggered."
+    },
+    "scriptFile": {
+      "type": "string",
+      "description": "Optional path to function script file."
+    },
+    "entryPoint": {
+      "type": "string",
+      "description": "Optional named entry point."
+    },
     "bindings": {
       "type": "array",
       "description": "A list of function bindings.",
       "items": {
         "oneOf": [
           { "$ref": "#/definitions/dynamicBinding" },
-          { 
+          {
             "oneOf": [
               { "$ref": "#/definitions/serviceBusBinding" },
               { "$ref": "#/definitions/blobBinding" },
@@ -30,22 +46,6 @@
         "allOf": [
           { "$ref": "#/definitions/bindingBase" }
         ]
-      },
-      "disabled": {
-        "type": "boolean",
-        "description": "If set to true, marks the function as disabled (it cannot be triggered)."
-      },
-      "excluded": {
-        "type": "boolean",
-        "description": "If set to true, the function will not be loaded, compiled, or triggered."
-      },
-      "scriptFile": {
-        "type": "string",
-        "description": "Optional path to function script file."
-      },
-      "entryPoint": {
-        "type": "string",
-        "description": "Optional named entry point."
       }
     }
   },
@@ -345,6 +345,10 @@
             "id": {
               "type": "string",
               "description": "This is the id for the record to retrieve."
+            },
+            "sqlQuery": {
+              "type": "string",
+              "description": "This is the query to run against the collection."
             }
           }
         },


### PR DESCRIPTION
Moving `function.json` properties to the appropriate location and adding the `sqlQuery` property for the DocumentDB binding.

Tried to set `additionalProperties` to true but that didn't seem to have any effect on tests or VS validation.