### PR TITLE
Fix platform definition for web-manifest.json

### DIFF
--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -172,8 +172,8 @@
 						}
 					}
 				}
-			},
-    }
+			}
+    },
 	  "platform": {
 			"description": "The platform it is associated to.",
 			"enum": [ "play", "itunes", "windows" ]

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -173,10 +173,10 @@
 					}
 				}
 			},
-			"platform": {
-				"description": "The platform it is associated to.",
-				"enum": [ "play", "itunes", "windows" ]
-			}
+    }
+	  "platform": {
+			"description": "The platform it is associated to.",
+			"enum": [ "play", "itunes", "windows" ]
 		}
 	}
 }


### PR DESCRIPTION
There was a bracket misplaced causing the platform type to be undefined while overwriting a reference for the related_application type.