### PR TITLE
[jsconfig.json] Add properties to configure type checking

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -117,6 +117,22 @@
               "description": "When down-level compiling, do not emit outputs if any type checking errors were reported.",
               "type": "boolean"
             },
+            "noImplicitAny": {
+              "description": "Warn on expressions and declarations with an implied 'any' type.",
+              "type": "boolean"
+            },
+            "noImplicitThis": {
+              "description": "Raise error on 'this' expressions with an implied any type.",
+              "type": "boolean"
+            },
+            "noUnusedLocals": {
+              "description": "Report errors on unused locals. Requires TypeScript version 2.0 or later.",
+              "type": "boolean"
+            },
+            "noUnusedParameters": {
+              "description": "Report errors on unused parameters. Requires TypeScript version 2.0 or later.",
+              "type": "boolean"
+            },
             "noLib": {
               "description": "Do not include the default library file (lib.d.ts).",
               "type": "boolean"
@@ -165,6 +181,14 @@
               "description": "When down-level compiling, specifies the location where debugger should locate JavaScript files instead of source locations.",
               "type": "string"
             },
+            "suppressExcessPropertyErrors": {
+              "description": "Suppress excess property checks for object literals.",
+              "type": "boolean"
+            },
+            "suppressImplicitAnyIndexErrors": {
+              "description": "Suppress noImplicitAny errors for indexing objects lacking index signatures.",
+              "type": "boolean"
+            },
             "stripInternal": {
               "description": "When down-level compiling, do not emit declarations for code that has an '@internal' annotation.",
               "type": "boolean"
@@ -189,6 +213,10 @@
             },
             "allowUnusedLabels": {
               "description": "Do not report errors on unused labels.",
+              "type": "boolean"
+            },
+            "noImplicitReturns": {
+              "description": "Report error when not all code paths in function return a value.",
               "type": "boolean"
             },
             "noFallthroughCasesInSwitch": {
@@ -244,10 +272,22 @@
                         "es2015.promise", "es2015.proxy", "es2015.reflect", "es2015.symbol", "es2015.symbol.wellknown", "es2016.array.include", "es2017.object", "es2017.sharedmemory", "esnext.asynciterable"]
               }
             },
+            "strictNullChecks": {
+              "description": "Enable strict null checks. Requires TypeScript version 2.0 or later.",
+              "type": "boolean"
+            },
             "maxNodeModuleJsDepth": {
               "description": "The maximum dependency depth to search under node_modules and load JavaScript files.",
               "type": "number",
               "default": 2
+            },
+            "alwaysStrict": {
+              "description": "Parse in strict mode and emit 'use strict' for each source file. Requires TypeScript version 2.1 or later.",
+              "type": "boolean"
+            },
+            "strict": {
+              "description": "Enable all strict type checking options. Requires TypeScript version 2.3 or later.",
+              "type": "boolean"
             },
             "checkJs": {
               "description": "Report errors in .js files.",


### PR DESCRIPTION
Add properties to configure more or less type checking when in new checkJs mode (the same as in tsconfig.json schema)

Fixes #303