### PR TITLE
Fix the schema for Angular related rules

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -86,7 +86,10 @@
 				},
 				"component-class-suffix": {
 					"description": "Enforces all components having the suffix of 'Component'",
-					"type": "boolean"
+					"type": ["boolean", "array"],
+					"items": {
+						"type": ["boolean", "string"]
+					}
 				},
 				"component-selector-name": {
 					"description": "Enforces naming conventions for components",
@@ -122,7 +125,10 @@
 				},
 				"directive-class-suffix": {
 					"description": "Enforces all components having the suffix of 'Directive'",
-					"type": "boolean"
+					"type": ["boolean", "array"],
+					"items": {
+						"type": ["boolean", "string"]
+					}
 				},
 				"directive-selector-name": {
 					"description": "Enforces naming conventions for directives",
@@ -581,7 +587,10 @@
 				},
 				"component-class-suffix": {
 					"description": "Enforces all components having the suffix of 'Component'",
-					"type": "boolean"
+					"type": ["boolean", "array"],
+					"items": {
+						"type": ["boolean", "string"]
+					}
 				},
 				"component-selector-name": {
 					"description": "Enforces naming conventions for components",
@@ -617,7 +626,10 @@
 				},
 				"directive-class-suffix": {
 					"description": "Enforces all components having the suffix of 'Directive'",
-					"type": "boolean"
+					"type": ["boolean", "array"],
+					"items": {
+						"type": ["boolean", "string"]
+					}
 				},
 				"directive-selector-name": {
 					"description": "Enforces naming conventions for directives",


### PR DESCRIPTION
Based on https://github.com/mgechev/codelyzer/issues/310

>```
>"component-class-suffix": true,
>"directive-class-suffix": true,
>```
>
>or
>
>```
>"component-class-suffix": [true, "Component"],
>"directive-class-suffix": [true, "Directive"],
>```