### PR TITLE
Add `id` on headings to give anchor points

### DIFF
--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -11,7 +11,7 @@
 </article>
 
 <article>
-	<h3>Auto completion</h3>
+	<h3 id="auto-completion">Auto completion</h3>
 	<p>
 		<img src="~/img/autocomplete.png" width="354" height="171" alt="JSON schema auto completion" class="left" />
 		In supported JSON editors like Visual Studio and Visual Studio Code,
@@ -25,7 +25,7 @@
 </article>
 
 <article>
-	<h3>Tooltips</h3>
+	<h3 id="tooltips">Tooltips</h3>
 	<p>
 		<img src="~/img/tooltip.png" width="411" height="98" alt="JSON schema tooltip" class="right" />
 		When a JSON editor supports schemas, tooltips can help inform the user
@@ -34,7 +34,7 @@
 </article>
 
 <article>
-	<h3>Public API</h3>
+	<h3 id="api">Public API</h3>
 	<p>
 		<img src="/img/api.png" width="256" height="88" alt="Public API for JSON Schemas" class="left" />
 		The JSON <a href="~/api/json/catalog.json">API</a> contains a list of JSON Schema files for known JSON file formats.
@@ -63,7 +63,7 @@
 </article>
 
 <article>
-    <h3>Supporting editors</h3>
+    <h3 id="editors">Supporting editors</h3>
     <p>
         Various editors and IDEs has direct support for schemas hosted on SchemaStore.org.
     </p>
@@ -84,7 +84,7 @@
 </article>
 
 <article>
-    <h3>Contribute</h3>
+    <h3 id="contribute">Contribute</h3>
     <p>
         <img src="/img/octocat.png" width="250" height="208" alt="Hosted on GitHub" class="right" />
         The goal of this API is to include schemas for all commonly


### PR DESCRIPTION
Add `id` on headings to give anchor points, allowing for links to specific parts of the page.