### PR TITLE
Update for TS 2.4

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -107,8 +107,8 @@
               "type": "string"
             },
             "module": {
-              "description": "Specify module code generation: 'none', 'CommonJS', 'Amd', 'System', 'UMD', or 'es2015'.",
-              "enum": [ "commonjs", "amd", "umd", "system", "es6", "es2015", "none" ]
+              "description": "Specify module code generation: 'none', 'CommonJS', 'Amd', 'System', 'UMD', 'es2015' or 'esnext'.",
+              "enum": [ "commonjs", "amd", "umd", "system", "es6", "es2015", "esnext", "none" ]
             },
             "newLine": {
               "description": "Specifies the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix).",


### PR DESCRIPTION
There's a new "esnext" target currently used to emit `import()` expressions as-is.