### PR TITLE
tslint schema: adding enums for curly rule

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -114,7 +114,10 @@
 				},
 				"curly": {
 					"description": "Enforces braces for if/for/do/while statements",
-					"type": "boolean"
+					"type": [ "boolean", "array" ],
+					"items": {
+						"enum": [ true, false, "ignore-same-line", "as-needed" ]
+					}
 				},
 				"cyclomatic-complexity": {
 					"description": "Enforces a threshold of cyclomatic complexity",
@@ -724,7 +727,10 @@
 				},
 				"curly": {
 					"description": "Enforces braces for if/for/do/while statements",
-					"type": "boolean"
+					"type": [ "boolean", "array" ],
+					"items": {
+						"enum": [ true, false, "ignore-same-line", "as-needed" ]
+					}
 				},
 				"cyclomatic-complexity": {
 					"description": "Enforces a threshold of cyclomatic complexity",


### PR DESCRIPTION
Adding the enums `as-needed` and `ignore-same-line` for the `curly` rule as detailed in https://palantir.github.io/tslint/rules/curly/