### PR TITLE
Update tsconfig.json with new compiler options

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -150,6 +150,10 @@
               "description": "Do not add triple-slash references or module import targets to the list of compiled files.",
               "type": "boolean"
             },
+            "noStrictGenericChecks": {
+              "description": "Disable strict checking of generic signatures in function types.",
+              "type": "boolean"
+            },
             "skipDefaultLibCheck": {
               "type": "boolean"
             },
@@ -167,6 +171,10 @@
             },
             "preserveConstEnums": {
               "description": "Do not erase const enum declarations in generated code.",
+              "type": "boolean"
+            },
+            "preserveSymlinks": {
+              "description": "Do not resolve symlinks to their real path; treat a symlinked file like a real one.",
               "type": "boolean"
             },
             "pretty": {


### PR DESCRIPTION
`--noStrictGenericChecks` was new to TypeScript 2.4.
`--preserveSymlinks` will be new to TypeScript 2.5, whose `@rc` release will be coming out sometime this week.
CC @paulvanbrenk 