### PR TITLE
More accurate package.json name regex

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -83,7 +83,7 @@
           "type": "string",
           "maxLength": 214,
           "minLength": 1,
-          "pattern": "^[^A-Z]+$"
+          "pattern": "^(?:@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*$"
         },
         "version": {
           "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency.",


### PR DESCRIPTION
_This issue was originally posted at https://github.com/aspnet/JavaScriptServices/issues/1232._

As of VS2017, the package.json `name` field is required to match the regex `^[^A-Z]+$` and have a length not more than 214 characters.

![image](https://user-images.githubusercontent.com/4096676/29739052-1769e680-89fa-11e7-8880-be8fde33423f.png)

I propose that this regex be changed to
```regex
^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$
```

This regex follows the guidelines at https://docs.npmjs.com/files/package.json better. I have added some simple unit tests for it over at https://regex101.com/r/QgADad/3/tests.

The following lines can also be handled by the regex itself by prepending `(?=.{1,214}$)`, but I have not made this change in case these fields serve other purposes too.
```json
"maxLength": 214,
"minLength": 1
```

Please let me know if you would like me to clarify the regex in any way. It is much more complex than the existing one, but also more accurate.

**Ref**:
https://stackoverflow.com/questions/695438/safe-characters-for-friendly-url
https://stackoverflow.com/questions/11197549/regular-expression-limit-string-size