### PR TITLE
Update tslint.json. Add match-declaration-order to object-literal-sort-keys.

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -697,7 +697,7 @@
 					"type": [ "array", "boolean" ],
 					"items": {
 						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "ignore-case" ]
+						"enum": [ true, false, "ignore-case", "match-declaration-order" ]
 					}
 				},
 				"one-line": {


### PR DESCRIPTION
Support "match-declaration-order" option which was added in [5.7.0](https://github.com/palantir/tslint/releases/tag/5.7.0).