### PR TITLE
tslint.json: Refactor jsRules to refer to TS rules

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -1225,704 +1225,292 @@
 		"jsruledefinitions": {
 			"properties": {
 				"align": {
-					"description": "Enforces vertical alignment for parameters, arguments and/or statements",
-					"type": [ "array" ],
-					"items": {
-						"enum": [ true, false, "parameters", "arguments", "statements" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/align"
 				},
 				"arrow-parens": {
-					"description": "Requires parentheses around the parameters of arrow function definitions",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/arrow-parens"
 				},
 				"arrow-return-shorthand": {
-					"description": "Suggests to convert `() => { return x; }` to `() => x`.",
-					"type": ["boolean", "array"],
-					"items": {
-						"enum": [ true, false, "multiline" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/arrow-return-shorthand"
 				},
 				"ban": {
-					"description": "Bans the use of specific functions or global methods",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "array" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/ban"
 				},
 				"binary-expression-operand-order": {
-					"description": "In a binary expression, a literal should always be on the right-hand side if possible. For example, prefer 'x + 1' over '1 + x'.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/binary-expression-operand-order"
 				},
 				"class-name": {
-					"description": "Enforces PascalCased class and interface names",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/class-name"
 				},
 				"comment-format": {
-					"description": "Enforces rules for single-line comments",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "check-space", "check-lowercase", "check-uppercase" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/comment-format"
 				},
 				"completed-docs": {
-					"description": "Enforces documentation for important items be filled out",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "classes", "functions", "methods", "properties" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/completed-docs"
 				},
 				"curly": {
-					"description": "Enforces braces for if/for/do/while statements",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "ignore-same-line", "as-needed" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/curly"
 				},
 				"cyclomatic-complexity": {
-					"description": "Enforces a threshold of cyclomatic complexity",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/cyclomatic-complexity"
 				},
 				"deprecation": {
-					"description": "Warns when deprecated APIs are used.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/deprecation"
 				},
 				"encoding": {
-					"description": "Enforces UTF-8 file encoding.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/encoding"
 				},
 				"eofline": {
-					"description": "Enforces the file to end with a newline",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/eofline"
 				},
 				"import-blacklist": {
-					"definition": "Disallows importing the specified modules directly via import and require.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "string" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/import-blacklist"
 				},
 				"import-spacing": {
-					"definition": "Ensures proper spacing between import statement keywords.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/import-spacing"
 				},
 				"file-header": {
-					"description": "Enforces a certain header comment for all files, matched by a regular expression",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "string" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/file-header"
 				},
 				"forin": {
-					"description": "Enforces a for...in statement to be filtered with an if statement",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/forin"
 				},
 				"indent": {
-					"description": "Enforces consistent indentation levels",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer", "string" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/indent"
 				},
 				"jsdoc-format": {
-					"description": "Enforces basic format rules for jsdoc comments",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/jsdoc-format"
 				},
 				"label-position": {
-					"description": "Enforces labels only on sensible statements",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/label-position"
 				},
 				"linebreak-style": {
-					"description": "Enforces a consistent linebreak styl",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "CRLF", "LF" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/linebreak-style"
 				},
 				"max-classes-per-file": {
-					"description": "A file may not contain more than the specified number of classes",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/max-classes-per-file"
 				},
 				"max-file-line-count": {
-					"description": "Requires files to remain under a certain number of lines",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/max-file-line-count"
 				},
 				"max-line-length": {
-					"description": "Sets the maximum length of a line",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/max-line-length"
 				},
 				"member-ordering": {
-					"description": "Enforces chosen member ordering",
-					"type": "array",
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"order": {
-									"oneOf": [
-										{
-											"type": "string",
-											"enum": [
-												"fields-first",
-												"instance-sandwich",
-												"statics-first"
-											]
-										},
-										{
-											"type": "array",
-											"items": {
-												"oneOf": [
-													{
-														"type": "string",
-														"enum": [
-															"static-field",
-															"public-static-field",
-															"private-static-field",
-															"protected-static-field",
-															"static-method",
-															"private-static-method",
-															"public-static-method",
-															"protected-static-method",
-															"instance-field",
-															"public-instance-field",
-															"protected-instance-field",
-															"private-instance-field",
-															"constructor",
-															"public-constructor",
-															"protected-constructor",
-															"private-constructor",
-															"instance-method",
-															"public-instance-method",
-															"protected-instance-method",
-															"private-instance-method"
-														]
-													},
-													{
-														"type": "object",
-														"properties": {
-															"name": {
-																"type": "string"
-															},
-															"kinds": {
-																"type": "array",
-																"items": {
-																	"type": "string",
-																	"enum": [
-																		"static-field",
-																		"public-static-field",
-																		"private-static-field",
-																		"protected-static-field",
-																		"static-method",
-																		"private-static-method",
-																		"public-static-method",
-																		"protected-static-method",
-																		"instance-field",
-																		"public-instance-field",
-																		"protected-instance-field",
-																		"private-instance-field",
-																		"constructor",
-																		"public-constructor",
-																		"protected-constructor",
-																		"private-constructor",
-																		"instance-method",
-																		"public-instance-method",
-																		"protected-instance-method",
-																		"private-instance-method"
-																	]
-																},
-																"maxLength": 15
-															}
-														},
-														"additionalProperties": false
-													}
-												]
-											},
-											"maxLength": 15
-										}
-									]
-								}
-							},
-							"additionalProperties": false
-						}
-					]
-				},
+                  "$ref": "#/definitions/ruledefinitions/properties/member-ordering"
+                },
 				"newline-before-return": {
-					"description": "Enforces blank line before return when not the only line in the block.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/newline-before-return"
 				},
 				"new-parens": {
-					"description": "Requires parentheses when invoking a constructor via the `new` keyword",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/new-parens"
 				},
 				"no-arg": {
-					"description": "Disallows access to arguments.callee",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-arg"
 				},
 				"no-bitwise": {
-					"description": "Disallows bitwise operators",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-bitwise"
 				},
 				"no-conditional-assignment": {
-					"description": "Disallows any type of assignment in any conditionals; this applies to do-while, for, if, and while statements",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-conditional-assignment"
 				},
 				"no-consecutive-blank-lines": {
-					"description": "Disallows one or more blank lines in a row",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/no-consecutive-blank-lines"
 				},
 				"no-console": {
-					"description": "Disallows access to the specified functions on console",
-					"type": "array",
-					"items": {
-						"enum": [
-							true,
-							false,
-							"assert",
-							"count",
-							"debug",
-							"dir",
-							"dirxml",
-							"error",
-							"group",
-							"groupCollapsed",
-							"groupEnd",
-							"info",
-							"log",
-							"profile",
-							"profileEnd",
-							"table",
-							"time",
-							"timeEnd",
-							"timeStamp",
-							"trace",
-							"warn"
-						]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/no-console"
 				},
 				"no-construct": {
-					"description": "Disallows access to the constructors of String, Number and Boolean",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-construct"
 				},
 				"no-debugger": {
-					"description": "Disallows debugger statements",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-debugger"
 				},
 				"no-default-export": {
-					"description": "Disallows default exports in ES6-style modules",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-default-export"
 				},
 				"no-duplicate-imports": {
-					"definition": "Disallows multiple import statements from the same module.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-duplicate-imports"
 				},
 				"no-duplicate-super": {
-					"description": "Warns if 'super()' appears twice in a constructor.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-duplicate-super"
 				},
 				"no-duplicate-variable": {
-					"description": "Disallows duplicate variable declarations in the same block scope",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-duplicate-variable"
 				},
 				"no-empty": {
-					"description": "Disallows empty blocks",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-empty"
 				},
 				"no-eval": {
-					"description": "Disallows `eval` function invocations",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-eval"
 				},
 				"no-for-in-array": {
-					"description": "Disallows iterating over an array with a for-in loop",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-for-in-array"
 				},
 				"no-import-side-effect": {
-					"description": "Avoid import statements with side-effect.",
-					"type": [ "boolean", "array"],
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"ignore-module": {
-									"type": "string"
-								}
-							},
-							"additionalProperties": false
-						}
-					]
+                  "$ref": "#/definitions/ruledefinitions/properties/no-import-side-effect"
 				},
 				"no-invalid-template-strings": {
-					"description": "Warns on use of `${` in non-template strings.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-invalid-template-strings"
 				},
 				"no-invalid-this": {
-					"description": "Disallows using the `this` keyword outside of classes",
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "check-function-in-method" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/no-invalid-this"
 				},
 				"no-irregular-whitespace": {
-					"description": "Disallow irregular whitespace outside of strings and comments",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-irregular-whitespace"
 				},
 				"no-magic-numbers": {
-					"description": "Disallows the use constant number values outside of variable assignments. When no list of allowed values is specified, -1, 0 and 1 are allowed by default.",
-					"type": "array",
-					"items": {
-						"type": ["boolean", "number"]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/no-magic-numbers"
 				},
 				"no-null-keyword": {
-					"description": "Disallows use of the `null` keyword literal",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-null-keyword"
 				},
 				"no-parameter-reassignment": {
-					"definition": "Disallows reassigning parameters.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-parameter-reassignment"
 				},
 				"no-reference": {
-					"description": "Disallows `/// <reference path=>` imports (use ES6-style imports instead)",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-reference"
 				},
 				"no-require-imports": {
-					"description": "Disallows require() style imports",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-require-imports"
 				},
 				"no-shadowed-variable": {
-					"description": "Disallows shadowing variable declarations",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-shadowed-variable"
 				},
 				"no-sparse-arrays": {
-					"description": "Forbids array literals to contain missing elements.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-sparse-arrays"
 				},
 				"no-string-literal": {
-					"description": "Disallows object access via string literals",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-string-literal"
 				},
 				"no-string-throw": {
-					"description": "Flags throwing plain strings or concatenations of strings because only Errors produce proper stack traces.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-string-throw"
 				},
 				"no-submodule-imports": {
-					"description": "Disallows importing any submodule.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-submodule-imports"
 				},
 				"no-switch-case-fall-through": {
-					"description": "Disallows falling through case statements",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-switch-case-fall-through"
 				},
 				"no-trailing-whitespace": {
-					"description": "Disallows trailing whitespace at the end of a line",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-trailing-whitespace"
 				},
 				"no-unnecessary-callback-wrapper": {
-					"description": "Replaces `x => f(x)` with just `f` To catch more cases, enable `only-arrow-functions` and `arrow-return-shorthand` too.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-unnecessary-callback-wrapper"
 				},
 				"no-unnecessary-initializer": {
-					"description": "Forbids a 'var'/'let' statement or destructuring initializer to be initialized to 'undefined'.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-unnecessary-initializer"
 				},
 				"no-unsafe-finally": {
-					"description": "Disallows control flow statements, such as `return`, `continue`, `break` and `throws` in finally blocks",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-unsafe-finally"
 				},
 				"no-unused-expression": {
-					"description": "Disallows unused expression statements",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-unused-expression"
 				},
 				"no-use-before-declare": {
-					"description": "Disallows usage of variables before their declaration",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-use-before-declare"
 				},
 				"no-var-keyword": {
-					"description": "Disallows usage of the var keyword, use let or const instead",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-var-keyword"
 				},
 				"no-void-expression": {
-					"description": "Requires expressions of type `void` to appear in statement position.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/no-void-expression"
 				},
 				"number-literal-format": {
-					"description": "Checks that decimal literals should begin with '0.' instead of just '.', and should not end with a trailing '0'.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/number-literal-format"
 				},
 				"object-literal-key-quotes": {
-					"description": "Enforces consistent object literal property quote style",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "always", "as-needed" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/object-literal-key-quotes"
 				},
 				"object-literal-shorthand": {
-					"description": "Enforces use of ES6 object literal shorthand when possible",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/object-literal-shorthand"
 				},
 				"object-literal-sort-keys": {
-					"description": "Requires keys in object literals to be sorted alphabetically",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/object-literal-sort-keys"
 				},
 				"one-line": {
-					"description": "Enforces the specified tokens to be on the same line as the expression preceding it",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "check-open-brace", "check-catch", "check-finally", "check-else", "check-whitespace" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/one-line"
 				},
 				"one-variable-per-declaration": {
-					"description": "Disallows multiple variable definitions in the same declaration statement",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "ignore-for-loop" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/one-variable-per-declaration"
 				},
 				"only-arrow-functions": {
-					"description": "Disallows traditional (non-arrow) function expressions",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "allow-declarations" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/only-arrow-functions"
 				},
 				"ordered-imports": {
-					"description": "Requires that import statements be alphabetized",
-					"type": "array",
-					"items": {
-						"type": [ "object", "boolean", "string" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/ordered-imports"
 				},
 				"prefer-conditional-expression": {
-					"description": "Recommends to use a conditional expression instead of assigning to the same thing in each branch of an if statement.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "check-else-if" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/prefer-conditional-expression"
 				},
 				"prefer-const": {
-					"description": "Requires that variable declarations use `const` instead of `let` and `var` if possible.",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "array",
-							"items": {
-								"allOf": [
-									{
-										"type": "boolean"
-									},
-									{
-										"type": "object",
-										"properties": {
-											"destructuring": {
-												"type": "string",
-												"enum": [ "any", "all" ]
-											}
-										},
-										"additionalProperties": false
-									}
-								]
-							}
-						}
-					]
+                  "$ref": "#/definitions/ruledefinitions/properties/prefer-const"
 				},
 				"prefer-for-of": {
-					"description": "Recommends a 'for-of' loop over a standard 'for' loop if the index is only used to access the array being iterated",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/prefer-for-of"
 				},
 				"prefer-function-over-method": {
-					"description": "Warns for class methods that do not use 'this'.",
-					"type": [ "boolean", "array"],
-					"items": {
-						"enum": [ true, false, "allow-public", "allow-protected" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/prefer-function-over-method"
 				},
 				"prefer-method-signature": {
-					"description": "Prefer `foo(): void` over `foo: () => void` in interfaces and types.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/prefer-method-signature"
 				},
 				"prefer-object-spread": {
-					"description": "Enforces the use of the ES2015 object spread operator over `Object.assign()` where appropriate.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/prefer-object-spread"
 				},
 				"prefer-switch": {
-					"description": "Prefer a `switch` statement to an `if` statement with simple `===` comparisons.",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "array",
-							"items": {
-								"allOf": [
-									{
-										"type": "boolean"
-									},
-									{
-										"type": "object",
-										"properties": {
-											"min-cases": {
-												"type": "number"
-											}
-										},
-										"additionalProperties": false
-									}
-								]
-							}
-						}
-					]
+                  "$ref": "#/definitions/ruledefinitions/properties/prefer-switch"
 				},
 				"prefer-template": {
-					"description": "Prefer a template expression over string literal concatenation.",
-					"type": [ "boolean", "array"],
-					"items": {
-						"enum": [ true, false, "allow-single-concat" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/prefer-template"
 				},
 				"promise-function-async": {
-					"description": "Requires any function or method that returns a promise to be marked async.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/promise-function-async"
 				},
 				"quotemark": {
-					"description": "Enforces consistent single or double quoted string literals",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "double", "single", "jsx-double", "jsx-single", "avoid-escape" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/quotemark"
 				},
 				"radix": {
-					"description": "Enforces the radix parameter of parseInt",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/radix"
 				},
 				"restrict-plus-operands": {
-					"description": "When adding two variables, operands must both be of type number or of type string",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/restrict-plus-operands"
 				},
 				"return-undefined": {
-					"description": "Prefer `return;` in void functions and `return undefined;` in value-returning functions.",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/return-undefined"
 				},
 				"semicolon": {
-					"description": "Enforces semicolons at the end of every statement",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "always", "never", "ignore-bound-class-methods", "ignore-interfaces" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/semicolon"
 				},
 				"space-before-function-paren": {
-					"description": "Require or disallow a space before function parenthesis.",
-					"type": [ "boolean", "array" ],
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "string",
-							"enum": [ "always", "never" ]
-						},
-						{
-							"type": "object",
-							"properties": {
-								"anonymous": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								},
-								"asyncArrow": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								},
-								"constructor": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								},
-								"method": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								},
-								"named": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								}
-							},
-							"additionalProperties": false
-						}
-					]
+                  "$ref": "#/definitions/ruledefinitions/properties/space-before-function-paren"
 				},
 				"space-within-parens": {
-					"description": "Enforces spaces within parentheses or disallow them.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "number" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/space-within-parens"
 				},
 				"switch-default": {
-					"description": "Enforces a default case in switch statements",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/switch-default"
 				},
 				"switch-final-break": {
-					"description": "Checks whether the final clause of a switch statement ends in 'break;'.",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "always" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/switch-final-break"
 				},
 				"trailing-comma": {
-					"description": "Requires or disallows trailing commas in array and object literals, destructuring assignments, function and tuple typings, named imports and function parameters",
-					"type": "array",
-					"items": {
-						"type": [ "object", "boolean", "string" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/trailing-comma"
 				},
 				"triple-equals": {
-					"description": "Enforces === and !== in favor of == and !=",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "allow-null-check", "allow-undefined-check" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/triple-equals"
 				},
 				"typeof-compare": {
-					"description": "Makes sure result of `typeof` is compared to correct string values",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/typeof-compare"
 				},
 				"use-isnan": {
-					"description": "Enforces use of the `isNaN()` function to check for NaN references instead of a comparison to the `NaN` constant",
-					"type": "boolean"
+					"$ref": "#/definitions/ruledefinitions/properties/use-isnan"
 				},
 				"variable-name": {
-					"description": "Allows only camelCased or UPPER_CASED variable names",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"enum": [ true, false, "check-format", "allow-leading-underscore", "allow-trailing-underscore", "allow-pascal-case", "ban-keywords" ]
-					}
+					"$ref": "#/definitions/ruledefinitions/properties/variable-name"
 				},
 				"whitespace": {
-					"description": "Enforces spacing whitespace",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
-					}
+                  "$ref": "#/definitions/ruledefinitions/properties/whitespace"
 				}
 			},
 			"type": "object"


### PR DESCRIPTION
Refactor jsRules to refer to the schemas of the corresponding TS rules, instead of defining the schema again. This promotes DRY, and reduces the risk of errors.

