### PR TITLE
Allow to disable (e.g set to false) TSLint rules

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -14,14 +14,14 @@
 				},
 				"align": {
 					"description": "Enforces vertical alignment for parameters, arguments and/or statements",
-					"type": [ "array" ],
+					"type": [ "boolean", "array" ],
 					"items": {
 						"enum": [ true, false, "parameters", "arguments", "statements", "members", "elements" ]
 					}
 				},
 				"array-type": {
 					"description": "Requires using either 'T[]' or 'Array<T>' for arrays",
-					"type": [ "array" ],
+					"type": [ "boolean", "array" ],
 					"items": {
 						"enum": [ true, false, "array", "array-simple", "generic" ]
 					}
@@ -75,7 +75,7 @@
 				},
 				"comment-format": {
 					"description": "Enforces rules for single-line comments",
-					"type": "array",
+					"type": [ "boolean", "array" ],
 					"minItems": 1,
 					"maxItems": 4,
 					"items": {
@@ -108,7 +108,7 @@
 				},
 				"completed-docs": {
 					"description": "Enforces documentation for important items be filled out",
-					"type": "array",
+					"type": [ "boolean", "array" ],
 					"items": {
 						"enum": [
 							true,
@@ -183,7 +183,7 @@
 				},
 				"interface-name": {
 					"description": "Enforces the rule that interface names must or must not begin with a capital 'I'",
-					"type": "array",
+					"type": [ "boolean", "array" ],
 					"items": {
 						"enum": [ true, false, "always-prefix", "never-prefix" ]
 					}
@@ -213,7 +213,7 @@
 				},
 				"max-classes-per-file": {
 					"description": "A file may not contain more than the specified number of classes",
-					"type": "array",
+					"type": [ "boolean", "array" ],
 					"items": {
 						"type": [ "boolean", "integer" ]
 					}
@@ -242,7 +242,7 @@
 				},
 				"member-ordering": {
 					"description": "Enforces chosen member ordering",
-					"type": "array",
+					"type": [ "boolean", "array" ],
 					"items": [
 						{
 							"type": "boolean"
@@ -386,9 +386,9 @@
 				},
 				"no-console": {
 					"description": "Disallows access to the specified functions on console",
-					"type": "array",
+					"type": [ "boolean", "array" ],
 					"items": {
-						"type": ["boolean", "string"]
+						"type": [ "boolean", "string" ]
 					}
 				},
 				"no-construct": {
@@ -962,7 +962,7 @@
 				},
 				"trailing-comma": {
 					"description": "Requires or disallows trailing commas in array and object literals, destructuring assignments, function and tuple typings, named imports and function parameters",
-					"type": "array",
+					"type": [ "boolean", "array" ],
 					"items": [
 						{
 							"type": "boolean"
@@ -1297,8 +1297,8 @@
 					"$ref": "#/definitions/ruledefinitions/properties/max-line-length"
 				},
 				"member-ordering": {
-                  "$ref": "#/definitions/ruledefinitions/properties/member-ordering"
-                },
+					"$ref": "#/definitions/ruledefinitions/properties/member-ordering"
+				},
 				"newline-before-return": {
 					"$ref": "#/definitions/ruledefinitions/properties/newline-before-return"
 				},

--- a/src/test/tslint/tslint-test10.json
+++ b/src/test/tslint/tslint-test10.json
@@ -1,0 +1,13 @@
+﻿{
+  "rules": {
+    "interface-name": false,
+    "trailing-comma": false,
+    "comment-format": false,
+    "max-classes-per-file": false,
+    "no-console": false,
+    "member-ordering": false,
+    "align": false,
+    "array-type": false,
+    "completed-docs": false
+  }
+}

--- a/src/test/tslint/tslint-test6.json
+++ b/src/test/tslint/tslint-test6.json
@@ -1,6 +1,5 @@
 {
   "jsRules": {
-    "no-trailing-comma": true,
     "no-trailing-whitespace": true
   }
 }

--- a/src/test/tslint/tslint-test7.json
+++ b/src/test/tslint/tslint-test7.json
@@ -8,7 +8,6 @@
     ]
   },
   "jsRules": {
-    "no-trailing-comma": true,
     "no-trailing-whitespace": true
   }
 }


### PR DESCRIPTION
Allow to disable (e.g set to false) TSLint rules + remove `no-trailing-comma` (has been replaced by `trailing-comma`).

Fix the error `Incorrect type. Expected "array"` inside `tslint.json`

See #245, https://github.com/Microsoft/vscode-tslint/issues/132