### PR TITLE
Update TSLint JSON schema

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -1,1550 +1,4855 @@
-﻿{
-	"title": "JSON schema for the TSLint configuration files",
-	"$schema": "http://json-schema.org/draft-04/schema#",
-
-	"type": "object",
-	"additionalProperties": true,
-
-	"definitions": {
-		"ruledefinitions": {
-			"properties": {
-				"adjacent-overload-signatures": {
-					"description": "Enforces function overloads to be consecutive",
-					"type": "boolean"
-				},
-				"align": {
-					"description": "Enforces vertical alignment for parameters, arguments and/or statements",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "parameters", "arguments", "statements", "members", "elements" ]
-					}
-				},
-				"array-type": {
-					"description": "Requires using either 'T[]' or 'Array<T>' for arrays",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "array", "array-simple", "generic" ]
-					}
-				},
-				"arrow-parens": {
-					"description": "Requires parentheses around the parameters of arrow function definitions",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "ban-single-arg-parens" ]
-					}
-				},
-				"arrow-return-shorthand": {
-					"description": "Suggests to convert `() => { return x; }` to `() => x`.",
-					"type": ["boolean", "array"],
-					"items": {
-						"enum": [ true, false, "multiline" ]
-					}
-				},
-				"await-promise": {
-					"description": "Warns for an awaited value that is not a Promise.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "string"]
-					}
-				},
-				"ban": {
-					"description": "Bans the use of specific functions or global methods",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "array" ]
-					}
-				},
-				"ban-types": {
-					"description": "Bans specific types from being used. Does not ban the corresponding runtime objects from being used.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "array"]
-					}
-				},
-				"binary-expression-operand-order": {
-					"description": "In a binary expression, a literal should always be on the right-hand side if possible. For example, prefer 'x + 1' over '1 + x'.",
-					"type": "boolean"
-				},
-				"callable-types": {
-					"description": "An interface or literal type with just a call signature can be written as a function type.",
-					"type": "boolean"
-				},
-				"class-name": {
-					"description": "Enforces PascalCased class and interface names",
-					"type": "boolean"
-				},
-				"comment-format": {
-					"description": "Enforces rules for single-line comments",
-					"type": [ "boolean", "array" ],
-					"minItems": 1,
-					"maxItems": 4,
-					"items": {
-						"anyOf": [
-							{
-								"type": [ "boolean", "string" ],
-								"enum": [ true, false, "check-space", "check-lowercase", "check-uppercase" ]
-							},
-							{
-								"type": "object",
-								"minProperties": 1,
-								"maxProperties": 1,
-								"additionalProperties": false,
-								"properties": {
-									"ignore-words": {
-										"description": "Words that will be ignored at the beginning of comment",
-										"type": "array",
-										"items": {
-											"type": "string"
-										}
-									},
-									"ignore-pattern": {
-										"description": "RegExp pattern that will be ignored at the beginning of comment",
-										"type": "string"
-									}
-								}
-							}
-						]
-					}
-				},
-				"completed-docs": {
-					"description": "Enforces documentation for important items be filled out",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [
-							true,
-							false,
-							"classes",
-							"enums",
-							"enum-members",
-							"functions",
-							"interfaces",
-							"methods",
-							"namespaces",
-							"properties",
-							"types",
-							"variables"
-						]
-					}
-				},
-				"curly": {
-					"description": "Enforces braces for if/for/do/while statements",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "ignore-same-line", "as-needed" ]
-					}
-				},
-				"cyclomatic-complexity": {
-					"description": "Enforces a threshold of cyclomatic complexity",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
-				},
-				"deprecation": {
-					"description": "Warns when deprecated APIs are used.",
-					"type": "boolean"
-				},
-				"encoding": {
-					"description": "Enforces UTF-8 file encoding.",
-					"type": "boolean"
-				},
-				"eofline": {
-					"description": "Enforces the file to end with a newline",
-					"type": "boolean"
-				},
-				"file-header": {
-					"description": "Enforces a certain header comment for all files, matched by a regular expression",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "string" ]
-					}
-				},
-				"forin": {
-					"description": "Enforces a for...in statement to be filtered with an if statement",
-					"type": "boolean"
-				},
-				"import-blacklist": {
-					"definition": "Disallows importing the specified modules directly via import and require.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "string" ]
-					}
-				},
-				"import-spacing": {
-					"definition": "Ensures proper spacing between import statement keywords.",
-					"type": "boolean"
-				},
-				"indent": {
-					"description": "Enforces consistent indentation levels",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer", "string" ]
-					}
-				},
-				"interface-name": {
-					"description": "Enforces the rule that interface names must or must not begin with a capital 'I'",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "always-prefix", "never-prefix" ]
-					}
-				},
-				"interface-over-type-literal": {
-					"description": "Prefer an interface declaration over a type literal (`type T = { ... }`)",
-					"type": "boolean"
-				},
-				"jsdoc-format": {
-					"description": "Enforces basic format rules for jsdoc comments",
-					"type": "boolean"
-				},
-				"label-position": {
-					"description": "Enforces labels only on sensible statements",
-					"type": "boolean"
-				},
-				"linebreak-style": {
-					"description": "Enforces a consistent linebreak style.",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "CRLF", "LF" ]
-					}
-				},
-				"match-default-export-name": {
-					"description": "Requires that a default import have the same name as the declaration it imports. Does nothing for anonymous default exports.",
-					"type": "boolean"
-				},
-				"max-classes-per-file": {
-					"description": "A file may not contain more than the specified number of classes",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
-				},
-				"max-file-line-count": {
-					"description": "Requires files to remain under a certain number of lines",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
-				},
-				"max-line-length": {
-					"description": "Sets the maximum length of a line",
-					"type": "array",
-					"items": {
-						"type": [ "boolean", "integer" ]
-					}
-				},
-				"member-access": {
-					"description": "Enforces using explicit visibility on class members",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "check-accessor", "check-constructor", "no-public" ]
-					}
-				},
-				"member-ordering": {
-					"description": "Enforces chosen member ordering",
-					"type": [ "boolean", "array" ],
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"order": {
-									"oneOf": [
-										{
-											"type": "string",
-											"enum": [
-												"fields-first",
-												"instance-sandwich",
-												"statics-first"
-											]
-										},
-										{
-											"type": "array",
-											"items": {
-												"oneOf": [
-													{
-														"type": "string",
-														"enum": [
-															"static-field",
-															"public-static-field",
-															"private-static-field",
-															"protected-static-field",
-															"static-method",
-															"private-static-method",
-															"public-static-method",
-															"protected-static-method",
-															"instance-field",
-															"public-instance-field",
-															"protected-instance-field",
-															"private-instance-field",
-															"constructor",
-															"public-constructor",
-															"protected-constructor",
-															"private-constructor",
-															"instance-method",
-															"public-instance-method",
-															"protected-instance-method",
-															"private-instance-method"
-														]
-													},
-													{
-														"type": "object",
-														"properties": {
-															"name": {
-																"type": "string"
-															},
-															"kinds": {
-																"type": "array",
-																"items": {
-																	"type": "string",
-																	"enum": [
-																		"static-field",
-																		"public-static-field",
-																		"private-static-field",
-																		"protected-static-field",
-																		"static-method",
-																		"private-static-method",
-																		"public-static-method",
-																		"protected-static-method",
-																		"instance-field",
-																		"public-instance-field",
-																		"protected-instance-field",
-																		"private-instance-field",
-																		"constructor",
-																		"public-constructor",
-																		"protected-constructor",
-																		"private-constructor",
-																		"instance-method",
-																		"public-instance-method",
-																		"protected-instance-method",
-																		"private-instance-method"
-																	]
-																},
-																"maxLength": 15
-															}
-														},
-														"additionalProperties": false
-													}
-												]
-											},
-											"maxLength": 15
-										}
-									]
-								}
-							},
-							"additionalProperties": false
-						}
-					]
-				},
-				"newline-before-return": {
-					"description": "Enforces blank line before return when not the only line in the block.",
-					"type": "boolean"
-				},
-				"new-parens": {
-					"description": "Requires parentheses when invoking a constructor via the `new` keyword",
-					"type": "boolean"
-				},
-				"no-angle-bracket-type-assertion": {
-					"description": "Requires the use of `as Type` for type assertions instead of `<Type>`",
-					"type": "boolean"
-				},
-				"no-any": {
-					"description": "Disallows usages of any as a type decoration",
-					"type": "boolean"
-				},
-				"no-arg": {
-					"description": "Disallows access to arguments.callee",
-					"type": "boolean"
-				},
-				"no-bitwise": {
-					"description": "Disallows bitwise operators",
-					"type": "boolean"
-				},
-				"no-boolean-literal-compare": {
-					"description": "Warns on comparison to a boolean literal, as in `x === true`.",
-					"type": "boolean"
-				},
-				"no-conditional-assignment": {
-					"description": "Disallows any type of assignment in any conditionals; this applies to do-while, for, if, and while statements",
-					"type": "boolean"
-				},
-				"no-consecutive-blank-lines": {
-					"description": "Disallows one or more blank lines in a row",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "array",
-							"items": {
-								"type": [ "boolean", "integer" ]
-							}
-						}
-					]
-				},
-				"no-console": {
-					"description": "Disallows access to the specified functions on console",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "string" ]
-					}
-				},
-				"no-construct": {
-					"description": "Disallows access to the constructors of String, Number and Boolean",
-					"type": "boolean"
-				},
-				"no-debugger": {
-					"description": "Disallows debugger statements",
-					"type": "boolean"
-				},
-				"no-default-export": {
-					"description": "Disallows default exports in ES6-style modules",
-					"type": "boolean"
-				},
-				"no-duplicate-imports": {
-					"definition": "Disallows multiple import statements from the same module.",
-					"type": "boolean"
-				},
-				"no-duplicate-super": {
-					"description": "Warns if 'super()' appears twice in a constructor.",
-					"type": "boolean"
-				},
-				"no-duplicate-variable": {
-					"description": "Disallows duplicate variable declarations in the same block scope",
-					"type": "boolean"
-				},
-				"no-empty": {
-					"description": "Disallows empty blocks",
-					"type": "boolean"
-				},
-				"no-empty-interface": {
-					"description": "Forbids empty interfaces.",
-					"type": "boolean"
-				},
-				"no-eval": {
-					"description": "Disallows `eval` function invocations",
-					"type": "boolean"
-				},
-				"no-import-side-effect": {
-					"description": "Avoid import statements with side-effect.",
-					"type": [ "boolean", "array"],
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"ignore-module": {
-									"type": "string"
-								}
-							},
-							"additionalProperties": false
-						}
-					]
-				},
-				"no-floating-promises": {
-					"description": "Promises returned by functions must be handled appropriately.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "string" ]
-					}
-				},
-				"no-for-in-array": {
-					"description": "Disallows iterating over an array with a for-in loop",
-					"type": "boolean"
-				},
-				"no-inferrable-types": {
-					"description": "Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "array",
-							"items": {
-								"enum": [ true, false, "ignore-params", "ignore-properties" ]
-							}
-						}
-					]
-				},
-				"no-inferred-empty-object-type": {
-					"description": "Disallow type inference of {} (empty object type) at function and constructor call sites",
-					"type": "boolean"
-				},
-				"no-internal-module": {
-					"description": "Disallows internal module, use namespace instead",
-					"type": "boolean"
-				},
-				"no-invalid-template-strings": {
-					"description": "Warns on use of `${` in non-template strings.",
-					"type": "boolean"
-				},
-				"no-invalid-this": {
-					"description": "Disallows using the `this` keyword outside of classes",
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "check-function-in-method" ]
-					}
-				},
-				"no-irregular-whitespace": {
-					"description": "Disallow irregular whitespace outside of strings and comments",
-					"type": "boolean"
-				},
-				"no-magic-numbers": {
-					"description": "Disallows the use constant number values outside of variable assignments. When no list of allowed values is specified, -1, 0 and 1 are allowed by default.",
-					"type": "array",
-					"items": {
-						"type": ["boolean", "number"]
-					}
-				},
-				"no-mergeable-namespace": {
-					"description": "Disallows mergeable namespaces in the same file",
-					"type": "boolean"
-				},
-				"no-misused-new": {
-					"description": "Warns on apparent attempts to define constructors for interfaces or `new` for classes.",
-					"type": "boolean"
-				},
-				"no-namespace": {
-					"description": "Disallows use of internal `module`s and `namespace`s",
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "allow-declarations" ]
-					}
-				},
-				"no-non-null-assertion": {
-					"description": "Disallows non-null assertions.",
-					"type": "boolean"
-				},
-				"no-null-keyword": {
-					"description": "Disallows use of the `null` keyword literal",
-					"type": "boolean"
-				},
-				"no-object-literal-type-assertion": {
-					"description": "Forbids an object literal to appear in a type assertion expression. Casting to `any` is still allowed.",
-					"type": "boolean"
-				},
-				"no-parameter-properties": {
-					"description": "Disallows parameter properties in class constructors",
-					"type": "boolean"
-				},
-				"no-parameter-reassignment": {
-					"definition": "Disallows reassigning parameters.",
-					"type": "boolean"
-				},
-				"no-reference": {
-					"description": "Disallows `/// <reference path=>` imports (use ES6-style imports instead)",
-					"type": "boolean"
-				},
-				"no-reference-import": {
-					"description": "Don't `<reference types=\"foo\" />` if you import `foo` anyway.",
-					"type": "boolean"
-				},
-				"no-require-imports": {
-					"description": "Disallows require() style imports",
-					"type": "boolean"
-				},
-				"no-shadowed-variable": {
-					"description": "Disallows shadowing variable declarations",
-					"type": "boolean"
-				},
-				"no-sparse-arrays": {
-					"description": "Forbids array literals to contain missing elements.",
-					"type": "boolean"
-				},
-				"no-string-literal": {
-					"description": "Disallows object access via string literals",
-					"type": "boolean"
-				},
-				"no-string-throw": {
-					"description": "Flags throwing plain strings or concatenations of strings because only Errors produce proper stack traces.",
-					"type": "boolean"
-				},
-				"no-submodule-imports": {
-					"description": "Disallows importing any submodule.",
-					"type": "boolean"
-				},
-				"no-switch-case-fall-through": {
-					"description": "Disallows falling through case statements",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"class": {"type": "boolean"},
-								"enum": {"type": "boolean"},
-								"function": {"type": "boolean"},
-								"import": {"type": "boolean"},
-								"interface": {"type": "boolean"},
-								"namespace": {"type": "boolean"},
-								"typeAlias": {"type": "boolean"},
-								"typeParameter": {"type": "boolean"}
-							}
-						}
-					]
-				},
-				"no-this-assignment": {
-					"description": "Disallows unnecessary references to this.",
-					"type": [ "boolean", "array"],
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"allow-destructuring": {
-									"type": "boolean"
-								},
-								"allowed-names": {
-									"type": "string"
-								}
-							},
-							"additionalProperties": false
-						}
-					]
-				},
-				"no-trailing-whitespace": {
-					"description": "Disallows trailing whitespace at the end of a line",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "ignore-comments", "ignore-jsdoc", "ignore-template-strings" ]
-					}
-				},
-				"no-unbound-method": {
-					"description": "Warns when a method is used as outside of a method call.",
-					"type": "boolean"
-				},
-				"no-unnecessary-callback-wrapper": {
-					"description": "Replaces `x => f(x)` with just `f` To catch more cases, enable `only-arrow-functions` and `arrow-return-shorthand` too.",
-					"type": "boolean"
-				},
-				"no-unnecessary-initializer": {
-					"description": "Forbids a 'var'/'let' statement or destructuring initializer to be initialized to 'undefined'.",
-					"type": "boolean"
-				},
-				"no-unnecessary-qualifier": {
-					"description": "Warns when a namespace qualifier (`A.x`) is unnecessary.",
-					"type": "boolean"
-				},
-				"no-unnecessary-type-assertion": {
-					"description": "Warns if a type assertion does not change the type of an expression.",
-					"type": "boolean"
-				},
-				"no-unsafe-any": {
-					"description": "Warns when using an expression of type 'any' in a dynamic way. Uses are only allowed if they would work for `{} | null | undefined`. Type casts and tests are allowed. Expressions that work on all values (such as `\"\" + x`) are allowed.",
-					"type": "boolean"
-				},
-				"no-unsafe-finally": {
-					"description": "Disallows control flow statements, such as `return`, `continue`, `break` and `throws` in finally blocks",
-					"type": "boolean"
-				},
-				"no-unused-expression": {
-					"description": "Disallows unused expression statements",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "allow-fast-null-checks", "allow-new", "allow-tagged-template" ]
-					}
-				},
-				"no-unused-new": {
-					"description": "Disallows unused 'new' expression statements",
-					"type": "boolean"
-				},
-				"no-unused-variable": {
-					"description": "Disallows unused imports, variables, functions and private class members",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string", "object" ]
-					}
-				},
-				"no-use-before-declare": {
-					"description": "Disallows usage of variables before their declaration",
-					"type": "boolean"
-				},
-				"no-var-keyword": {
-					"description": "Disallows usage of the var keyword, use let or const instead",
-					"type": "boolean"
-				},
-				"no-var-requires": {
-					"description": "Disallows the use of require statements except in import statements",
-					"type": "boolean"
-				},
-				"no-void-expression": {
-					"description": "Requires expressions of type `void` to appear in statement position.",
-					"type": "boolean"
-				},
-				"number-literal-format": {
-					"description": "Checks that decimal literals should begin with '0.' instead of just '.', and should not end with a trailing '0'.",
-					"type": "boolean"
-				},
-				"object-literal-key-quotes": {
-					"description": "Enforces consistent object literal property quote style",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "always", "as-needed", "consistent", "consistent-as-needed" ]
-					}
-				},
-				"object-literal-shorthand": {
-					"description": "Enforces use of ES6 object literal shorthand when possible",
-					"type": "boolean"
-				},
-				"object-literal-sort-keys": {
-					"description": "Requires keys in object literals to be sorted alphabetically",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "ignore-case", "match-declaration-order" ]
-					}
-				},
-				"one-line": {
-					"description": "Enforces the specified tokens to be on the same line as the expression preceding it",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "check-open-brace", "check-catch", "check-finally", "check-else", "check-whitespace" ]
-					}
-				},
-				"one-variable-per-declaration": {
-					"description": "Disallows multiple variable definitions in the same declaration statement",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "ignore-for-loop" ]
-					}
-				},
-				"only-arrow-functions": {
-					"description": "Disallows traditional (non-arrow) function expressions",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "allow-declarations", "allow-named-functions" ]
-					}
-				},
-				"ordered-imports": {
-					"description": "Requires that import statements be alphabetized",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "array",
-							"items": {
-								"allOf": [
-									{
-										"type": "boolean"
-									},
-									{
-										"type": "object",
-										"properties": {
-											"import-sources-order": {
-												"type": "string",
-												"enum": [
-													"case-insensitive",
-													"lowercase-first",
-													"lowercase-last",
-													"any"
-												]
-											},
-											"named-imports-order": {
-												"type": "string",
-												"enum": [
-													"case-insensitive",
-													"lowercase-first",
-													"lowercase-last",
-													"any"
-												]
-											}
-										},
-										"additionalProperties": false
-									}
-								]
-							}
-						}
-					]
-				},
-				"prefer-conditional-expression": {
-					"description": "Recommends to use a conditional expression instead of assigning to the same thing in each branch of an if statement.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [ true, false, "check-else-if" ]
-					}
-				},
-				"prefer-const": {
-					"description": "Requires that variable declarations use `const` instead of `let` and `var` if possible.",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "array",
-							"items": {
-								"allOf": [
-									{
-										"type": "boolean"
-									},
-									{
-										"type": "object",
-										"properties": {
-											"destructuring": {
-												"type": "string",
-												"enum": [ "any", "all" ]
-											}
-										},
-										"additionalProperties": false
-									}
-								]
-							}
-						}
-					]
-				},
-				"prefer-for-of": {
-					"description": "Recommends a 'for-of' loop over a standard 'for' loop if the index is only used to access the array being iterated",
-					"type": "boolean"
-				},
-				"prefer-function-over-method": {
-					"description": "Warns for class methods that do not use 'this'.",
-					"type": [ "boolean", "array"],
-					"items": {
-						"enum": [ true, false, "allow-public", "allow-protected" ]
-					}
-				},
-				"prefer-method-signature": {
-					"description": "Prefer `foo(): void` over `foo: () => void` in interfaces and types.",
-					"type": "boolean"
-				},
-				"prefer-object-spread": {
-					"description": "Enforces the use of the ES2015 object spread operator over `Object.assign()` where appropriate.",
-					"type": "boolean"
-				},
-				"prefer-switch": {
-					"description": "Prefer a `switch` statement to an `if` statement with simple `===` comparisons.",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "array",
-							"items": {
-								"allOf": [
-									{
-										"type": "boolean"
-									},
-									{
-										"type": "object",
-										"properties": {
-											"min-cases": {
-												"type": "number"
-											}
-										},
-										"additionalProperties": false
-									}
-								]
-							}
-						}
-					]
-				},
-				"prefer-template": {
-					"description": "Prefer a template expression over string literal concatenation.",
-					"type": [ "boolean", "array"],
-					"items": {
-						"enum": [ true, false, "allow-single-concat" ]
-					}
-				},
-				"promise-function-async": {
-					"description": "Requires any function or method that returns a promise to be marked async.",
-					"type": "boolean"
-				},
-				"quotemark": {
-					"description": "Enforces consistent single or double quoted string literals",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "double", "single", "jsx-double", "jsx-single", "avoid-template", "avoid-escape" ]
-					}
-				},
-				"radix": {
-					"description": "Enforces the radix parameter of parseInt",
-					"type": "boolean"
-				},
-				"restrict-plus-operands": {
-					"description": "When adding two variables, operands must both be of type number or of type string",
-					"type": "boolean"
-				},
-				"return-undefined": {
-					"description": "Prefer `return;` in void functions and `return undefined;` in value-returning functions.",
-					"type": "boolean"
-				},
-				"semicolon": {
-					"description": "Enforces semicolons at the end of every statement",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "always", "never", "ignore-bound-class-methods", "ignore-interfaces" ]
-					}
-				},
-				"space-before-function-paren": {
-					"description": "Require or disallow a space before function parenthesis.",
-					"type": [ "boolean", "array" ],
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "string",
-							"enum": [ "always", "never" ]
-						},
-						{
-							"type": "object",
-							"properties": {
-								"anonymous": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								},
-								"asyncArrow": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								},
-								"constructor": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								},
-								"method": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								},
-								"named": {
-									"type": "string",
-									"enum": [ "always", "never" ]
-								}
-							},
-							"additionalProperties": false
-						}
-					]
-				},
-				"space-within-parens": {
-					"description": "Enforces spaces within parentheses or disallow them.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"type": [ "boolean", "number" ]
-					}
-				},
-				"strict-boolean-expressions": {
-					"description": "Restricts the types allowed in boolean expressions. By default only booleans are allowed.",
-					"type": [ "boolean", "array" ],
-					"items": {
-						"enum": [
-							true,
-							false,
-							"allow-null-union",
-							"allow-undefined-union",
-							"allow-string",
-							"allow-number",
-							"allow-boolean-or-undefined"
-						]
-					},
-					"minLength": 0,
-					"maxLength": 5
-				},
-				"strict-type-predicates": {
-					"description": "Warns for type predicates that are always true or always false.",
-					"type": "boolean"
-				},
-				"switch-default": {
-					"description": "Enforces a default case in switch statements",
-					"type": "boolean"
-				},
-				"switch-final-break": {
-					"description": "Checks whether the final clause of a switch statement ends in 'break;'.",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "always" ]
-					}
-				},
-				"trailing-comma": {
-					"description": "Requires or disallows trailing commas in array and object literals, destructuring assignments, function and tuple typings, named imports and function parameters",
-					"type": [ "boolean", "array" ],
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"multiline": {
-									"anyOf": [
-										{
-											"type": "string",
-											"enum": [
-												"always",
-												"never"
-											]
-										},
-										{
-											"type": "object",
-											"properties": {
-												"arrays": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"exports": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"functions": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"imports": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"objects": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"typeLiterals": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												}
-											}
-										}
-									]
-								},
-								"singleline": {
-									"anyOf": [
-										{
-											"type": "string",
-											"enum": [
-												"always",
-												"never"
-											]
-										},
-										{
-											"type": "object",
-											"properties": {
-												"arrays": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"exports": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"functions": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"imports": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"objects": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												},
-												"typeLiterals": {
-													"type": "string",
-													"enum": [ "always", "never", "ignore" ]
-												}
-											}
-										}
-									]
-								}
-							},
-							"additionalProperties": false
-						}					]
-				},
-				"triple-equals": {
-					"description": "Enforces === and !== in favor of == and !=",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"type": [ "boolean", "string" ],
-						"enum": [ true, false, "allow-null-check", "allow-undefined-check" ]
-					}
-				},
-				"typedef": {
-					"description": "Enforces type definitions to exist",
-					"type": "array",
-					"items": {
-						"enum": [
-							true,
-							false,
-							"call-signature",
-							"arrow-call-signature",
-							"parameter",
-							"arrow-parameter",
-							"property-declaration",
-							"variable-declaration",
-							"member-variable-declaration",
-							"object-destructuring",
-							"array-destructuring"
-						]
-					}
-				},
-				"typedef-whitespace": {
-					"description": "Enforces spacing whitespace for type definitions",
-					"type": "array",
-					"items": [
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"call-signature": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								},
-								"index-signature": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								},
-								"parameter": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								},
-								"property-declaration": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								},
-								"variable-declaration": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								}
-							},
-							"additionalProperties": false
-						},
-						{
-							"type": "object",
-							"properties": {
-								"call-signature": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								},
-								"index-signature": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								},
-								"parameter": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								},
-								"property-declaration": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								},
-								"variable-declaration": {
-									"type": "string",
-									"enum": [
-										"nospace",
-										"onespace",
-										"space"
-									]
-								}
-							},
-							"additionalProperties": false
-						}
-					]
-				},
-				"type-literal-delimiter": {
-					"description": "Checks that type literal members are separated by semicolons. Enforces a trailing semicolon for multiline type literals.",
-					"type": "boolean"
-				},
-
-				"typeof-compare": {
-					"description": "Makes sure result of `typeof` is compared to correct string values",
-					"type": "boolean"
-				},
-				"unified-signatures": {
-					"description": "Warns for any two overloads that could be unified into one by using a union or an optional/rest parameter.",
-					"type": "boolean"
-				},
-				"use-default-type-parameter": {
-					"description": "Warns if an explicitly specified type argument is the default for that type parameter.",
-					"type": "boolean"
-				},
-
-				"use-isnan": {
-					"description": "Enforces use of the `isNaN()` function to check for NaN references instead of a comparison to the `NaN` constant",
-					"type": "boolean"
-				},
-				"variable-name": {
-					"description": "Allows only camelCased or UPPER_CASED variable names",
-					"type": [ "array", "boolean" ],
-					"items": {
-						"enum": [ true, false, "check-format", "allow-leading-underscore", "allow-trailing-underscore", "allow-pascal-case", "allow-snake-case", "ban-keywords" ]
-					}
-				},
-				"whitespace": {
-					"description": "Enforces spacing whitespace",
-					"type": "array",
-					"items": {
-						"enum": [ true, false, "check-branch", "check-decl", "check-operator", "check-module", "check-separator",
-							"check-rest-spread", "check-type", "check-typecast", "check-type-operator", "check-preblock" ]
-					}
-				}
-			},
-			"type": "object"
-		},
-		"jsruledefinitions": {
-			"properties": {
-				"align": {
-					"$ref": "#/definitions/ruledefinitions/properties/align"
-				},
-				"arrow-parens": {
-					"$ref": "#/definitions/ruledefinitions/properties/arrow-parens"
-				},
-				"arrow-return-shorthand": {
-					"$ref": "#/definitions/ruledefinitions/properties/arrow-return-shorthand"
-				},
-				"ban": {
-					"$ref": "#/definitions/ruledefinitions/properties/ban"
-				},
-				"binary-expression-operand-order": {
-					"$ref": "#/definitions/ruledefinitions/properties/binary-expression-operand-order"
-				},
-				"class-name": {
-					"$ref": "#/definitions/ruledefinitions/properties/class-name"
-				},
-				"comment-format": {
-					"$ref": "#/definitions/ruledefinitions/properties/comment-format"
-				},
-				"completed-docs": {
-					"$ref": "#/definitions/ruledefinitions/properties/completed-docs"
-				},
-				"curly": {
-					"$ref": "#/definitions/ruledefinitions/properties/curly"
-				},
-				"cyclomatic-complexity": {
-					"$ref": "#/definitions/ruledefinitions/properties/cyclomatic-complexity"
-				},
-				"deprecation": {
-					"$ref": "#/definitions/ruledefinitions/properties/deprecation"
-				},
-				"encoding": {
-					"$ref": "#/definitions/ruledefinitions/properties/encoding"
-				},
-				"eofline": {
-					"$ref": "#/definitions/ruledefinitions/properties/eofline"
-				},
-				"import-blacklist": {
-					"$ref": "#/definitions/ruledefinitions/properties/import-blacklist"
-				},
-				"import-spacing": {
-					"$ref": "#/definitions/ruledefinitions/properties/import-spacing"
-				},
-				"file-header": {
-					"$ref": "#/definitions/ruledefinitions/properties/file-header"
-				},
-				"forin": {
-					"$ref": "#/definitions/ruledefinitions/properties/forin"
-				},
-				"indent": {
-					"$ref": "#/definitions/ruledefinitions/properties/indent"
-				},
-				"jsdoc-format": {
-					"$ref": "#/definitions/ruledefinitions/properties/jsdoc-format"
-				},
-				"label-position": {
-					"$ref": "#/definitions/ruledefinitions/properties/label-position"
-				},
-				"linebreak-style": {
-					"$ref": "#/definitions/ruledefinitions/properties/linebreak-style"
-				},
-				"max-classes-per-file": {
-					"$ref": "#/definitions/ruledefinitions/properties/max-classes-per-file"
-				},
-				"max-file-line-count": {
-					"$ref": "#/definitions/ruledefinitions/properties/max-file-line-count"
-				},
-				"max-line-length": {
-					"$ref": "#/definitions/ruledefinitions/properties/max-line-length"
-				},
-				"member-ordering": {
-					"$ref": "#/definitions/ruledefinitions/properties/member-ordering"
-				},
-				"newline-before-return": {
-					"$ref": "#/definitions/ruledefinitions/properties/newline-before-return"
-				},
-				"new-parens": {
-					"$ref": "#/definitions/ruledefinitions/properties/new-parens"
-				},
-				"no-arg": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-arg"
-				},
-				"no-bitwise": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-bitwise"
-				},
-				"no-conditional-assignment": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-conditional-assignment"
-				},
-				"no-consecutive-blank-lines": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-consecutive-blank-lines"
-				},
-				"no-console": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-console"
-				},
-				"no-construct": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-construct"
-				},
-				"no-debugger": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-debugger"
-				},
-				"no-default-export": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-default-export"
-				},
-				"no-duplicate-imports": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-duplicate-imports"
-				},
-				"no-duplicate-super": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-duplicate-super"
-				},
-				"no-duplicate-variable": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-duplicate-variable"
-				},
-				"no-empty": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-empty"
-				},
-				"no-eval": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-eval"
-				},
-				"no-for-in-array": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-for-in-array"
-				},
-				"no-import-side-effect": {
-                  "$ref": "#/definitions/ruledefinitions/properties/no-import-side-effect"
-				},
-				"no-invalid-template-strings": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-invalid-template-strings"
-				},
-				"no-invalid-this": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-invalid-this"
-				},
-				"no-irregular-whitespace": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-irregular-whitespace"
-				},
-				"no-magic-numbers": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-magic-numbers"
-				},
-				"no-null-keyword": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-null-keyword"
-				},
-				"no-parameter-reassignment": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-parameter-reassignment"
-				},
-				"no-reference": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-reference"
-				},
-				"no-require-imports": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-require-imports"
-				},
-				"no-shadowed-variable": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-shadowed-variable"
-				},
-				"no-sparse-arrays": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-sparse-arrays"
-				},
-				"no-string-literal": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-string-literal"
-				},
-				"no-string-throw": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-string-throw"
-				},
-				"no-submodule-imports": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-submodule-imports"
-				},
-				"no-switch-case-fall-through": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-switch-case-fall-through"
-				},
-				"no-trailing-whitespace": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-trailing-whitespace"
-				},
-				"no-unnecessary-callback-wrapper": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-unnecessary-callback-wrapper"
-				},
-				"no-unnecessary-initializer": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-unnecessary-initializer"
-				},
-				"no-unsafe-finally": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-unsafe-finally"
-				},
-				"no-unused-expression": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-unused-expression"
-				},
-				"no-use-before-declare": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-use-before-declare"
-				},
-				"no-var-keyword": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-var-keyword"
-				},
-				"no-void-expression": {
-					"$ref": "#/definitions/ruledefinitions/properties/no-void-expression"
-				},
-				"number-literal-format": {
-					"$ref": "#/definitions/ruledefinitions/properties/number-literal-format"
-				},
-				"object-literal-key-quotes": {
-					"$ref": "#/definitions/ruledefinitions/properties/object-literal-key-quotes"
-				},
-				"object-literal-shorthand": {
-					"$ref": "#/definitions/ruledefinitions/properties/object-literal-shorthand"
-				},
-				"object-literal-sort-keys": {
-					"$ref": "#/definitions/ruledefinitions/properties/object-literal-sort-keys"
-				},
-				"one-line": {
-					"$ref": "#/definitions/ruledefinitions/properties/one-line"
-				},
-				"one-variable-per-declaration": {
-					"$ref": "#/definitions/ruledefinitions/properties/one-variable-per-declaration"
-				},
-				"only-arrow-functions": {
-					"$ref": "#/definitions/ruledefinitions/properties/only-arrow-functions"
-				},
-				"ordered-imports": {
-					"$ref": "#/definitions/ruledefinitions/properties/ordered-imports"
-				},
-				"prefer-conditional-expression": {
-					"$ref": "#/definitions/ruledefinitions/properties/prefer-conditional-expression"
-				},
-				"prefer-const": {
-                  "$ref": "#/definitions/ruledefinitions/properties/prefer-const"
-				},
-				"prefer-for-of": {
-					"$ref": "#/definitions/ruledefinitions/properties/prefer-for-of"
-				},
-				"prefer-function-over-method": {
-					"$ref": "#/definitions/ruledefinitions/properties/prefer-function-over-method"
-				},
-				"prefer-method-signature": {
-					"$ref": "#/definitions/ruledefinitions/properties/prefer-method-signature"
-				},
-				"prefer-object-spread": {
-					"$ref": "#/definitions/ruledefinitions/properties/prefer-object-spread"
-				},
-				"prefer-switch": {
-                  "$ref": "#/definitions/ruledefinitions/properties/prefer-switch"
-				},
-				"prefer-template": {
-					"$ref": "#/definitions/ruledefinitions/properties/prefer-template"
-				},
-				"promise-function-async": {
-					"$ref": "#/definitions/ruledefinitions/properties/promise-function-async"
-				},
-				"quotemark": {
-					"$ref": "#/definitions/ruledefinitions/properties/quotemark"
-				},
-				"radix": {
-					"$ref": "#/definitions/ruledefinitions/properties/radix"
-				},
-				"restrict-plus-operands": {
-					"$ref": "#/definitions/ruledefinitions/properties/restrict-plus-operands"
-				},
-				"return-undefined": {
-					"$ref": "#/definitions/ruledefinitions/properties/return-undefined"
-				},
-				"semicolon": {
-					"$ref": "#/definitions/ruledefinitions/properties/semicolon"
-				},
-				"space-before-function-paren": {
-                  "$ref": "#/definitions/ruledefinitions/properties/space-before-function-paren"
-				},
-				"space-within-parens": {
-					"$ref": "#/definitions/ruledefinitions/properties/space-within-parens"
-				},
-				"switch-default": {
-					"$ref": "#/definitions/ruledefinitions/properties/switch-default"
-				},
-				"switch-final-break": {
-					"$ref": "#/definitions/ruledefinitions/properties/switch-final-break"
-				},
-				"trailing-comma": {
-					"$ref": "#/definitions/ruledefinitions/properties/trailing-comma"
-				},
-				"triple-equals": {
-					"$ref": "#/definitions/ruledefinitions/properties/triple-equals"
-				},
-				"typeof-compare": {
-					"$ref": "#/definitions/ruledefinitions/properties/typeof-compare"
-				},
-				"use-isnan": {
-					"$ref": "#/definitions/ruledefinitions/properties/use-isnan"
-				},
-				"variable-name": {
-					"$ref": "#/definitions/ruledefinitions/properties/variable-name"
-				},
-				"whitespace": {
-                  "$ref": "#/definitions/ruledefinitions/properties/whitespace"
-				}
-			},
-			"type": "object"
-		}
-	},
-
-	"properties": {
-		"rulesDirectory": {
-			"description": "The directory where the codelytics rules live",
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		},
-		"rules": {
-			"$ref": "#/definitions/ruledefinitions"
-		},
-		"jsRules": {
-			"$ref": "#/definitions/jsruledefinitions"
-		},
-		"extends": {
-			"description": "Extend another configuration (built in config OR a node resolvable .json file) ",
-			"type": [ "array", "string" ],
-			"items": {
-				"type": "string"
-			}
-		},
-		"defaultSeverity": {
-			"type": "string",
-			"enum": [ "error", "warning", "off" ],
-			"default": "error"
-		}
-	}
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON schema for the TSLint configuration files.",
+  "type": "object",
+  "definitions": {
+    "rule": {
+      "type": [
+        "boolean",
+        "object",
+        "array"
+      ],
+      "items": [
+        {
+          "type": "boolean"
+        }
+      ],
+      "properties": {
+        "options": {
+          "description": "An option value or an array of multiple option values."
+        },
+        "severity": {
+          "description": "Severity level. Level \"error\" will cause exit code 2.",
+          "type": "string",
+          "enum": [
+            "default",
+            "error",
+            "warning",
+            "warn",
+            "off",
+            "none"
+          ],
+          "default": "default"
+        }
+      },
+      "minItems": 1
+    },
+    "rules": {
+      "properties": {
+        "align": {
+          "description": "Enforces vertical alignment.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "arguments",
+                  "elements",
+                  "members",
+                  "parameters",
+                  "statements"
+                ]
+              },
+              "minItems": 1,
+              "maxItems": 5
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/align/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 6,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/align/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "arrow-parens": {
+          "description": "Requires parentheses around the parameters of arrow function definitions.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "ban-single-arg-parens"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/arrow-parens/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/arrow-parens/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/arrow-parens/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "arrow-return-shorthand": {
+          "description": "Suggests to convert `() => { return x; }` to `() => x`.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "multiline"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/arrow-return-shorthand/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/arrow-return-shorthand/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/arrow-return-shorthand/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ban": {
+          "description": "Bans the use of specific functions or global methods.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 3
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 1
+                          }
+                        ]
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/ban/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/ban/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "binary-expression-operand-order": {
+          "description": "In a binary expression, a literal should always be on the right-hand side if possible.\nFor example, prefer 'x + 1' over '1 + x'.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "class-name": {
+          "description": "Enforces PascalCased class and interface names.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "comment-format": {
+          "description": "Enforces formatting rules for single-line comments.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "check-space",
+                      "check-lowercase",
+                      "check-uppercase"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ignore-words": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "ignore-pattern": {
+                        "type": "string"
+                      }
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                  }
+                ]
+              },
+              "minItems": 1,
+              "maxItems": 4
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/comment-format/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 5,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/comment-format/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "completed-docs": {
+          "description": "Enforces documentation for important items be filled out.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "classes",
+                      "functions",
+                      "methods",
+                      "properties"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "classes": {
+                        "properties": {
+                          "visibilities": {
+                            "enum": [
+                              "all",
+                              "exported",
+                              "internal"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "enums": {
+                        "properties": {
+                          "visibilities": {
+                            "enum": [
+                              "all",
+                              "exported",
+                              "internal"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "enum-members": {
+                        "properties": {
+                          "visibilities": {
+                            "enum": [
+                              "all",
+                              "exported",
+                              "internal"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "functions": {
+                        "properties": {
+                          "visibilities": {
+                            "enum": [
+                              "all",
+                              "exported",
+                              "internal"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "interfaces": {
+                        "properties": {
+                          "visibilities": {
+                            "enum": [
+                              "all",
+                              "exported",
+                              "internal"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "methods": {
+                        "properties": {
+                          "locations": {
+                            "enum": [
+                              "all",
+                              "instance",
+                              "static"
+                            ],
+                            "type": "string"
+                          },
+                          "privacies": {
+                            "enum": [
+                              "all",
+                              "private",
+                              "protected",
+                              "public"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "namespaces": {
+                        "properties": {
+                          "visibilities": {
+                            "enum": [
+                              "all",
+                              "exported",
+                              "internal"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "properties": {
+                        "properties": {
+                          "locations": {
+                            "enum": [
+                              "all",
+                              "instance",
+                              "static"
+                            ],
+                            "type": "string"
+                          },
+                          "privacies": {
+                            "enum": [
+                              "all",
+                              "private",
+                              "protected",
+                              "public"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "types": {
+                        "properties": {
+                          "visibilities": {
+                            "enum": [
+                              "all",
+                              "exported",
+                              "internal"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "variables": {
+                        "properties": {
+                          "visibilities": {
+                            "enum": [
+                              "all",
+                              "exported",
+                              "internal"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/completed-docs/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/completed-docs/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "curly": {
+          "description": "Enforces braces for `if`/`for`/`do`/`while` statements.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "as-needed",
+                  "ignore-same-line"
+                ]
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/curly/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/curly/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "cyclomatic-complexity": {
+          "description": "Enforces a threshold of cyclomatic complexity.",
+          "definitions": {
+            "options": {
+              "type": "number",
+              "minimum": 2
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/cyclomatic-complexity/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/cyclomatic-complexity/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/cyclomatic-complexity/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "deprecation": {
+          "description": "Warns when deprecated APIs are used.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "encoding": {
+          "description": "Enforces UTF-8 file encoding.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "eofline": {
+          "description": "Ensures the file ends with a newline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "file-header": {
+          "description": "Enforces a certain header comment for all files, matched by a regular expression.",
+          "definitions": {
+            "options": {
+              "type": "string"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/file-header/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/file-header/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/file-header/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "forin": {
+          "description": "Requires a `for ... in` statement to be filtered with an `if` statement.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "import-blacklist": {
+          "description": "Disallows importing the specified modules directly via `import` and `require`.\nInstead only sub modules may be imported from that module.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/import-blacklist/definitions/options/items"
+              },
+              "minItems": 1,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/import-blacklist/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "import-spacing": {
+          "description": "Ensures proper spacing between import statement keywords",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "indent": {
+          "description": "Enforces indentation with tabs or spaces.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "tabs",
+                    "spaces"
+                  ]
+                },
+                {
+                  "type": "number",
+                  "enum": [
+                    2,
+                    4
+                  ]
+                }
+              ],
+              "maxItems": 5
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "tabs",
+                      "spaces"
+                    ]
+                  },
+                  {
+                    "type": "number",
+                    "enum": [
+                      2,
+                      4
+                    ]
+                  }
+                ]
+              },
+              "minItems": 1,
+              "maxItems": 6,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/indent/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "jsdoc-format": {
+          "description": "Enforces basic format rules for JSDoc comments.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "label-position": {
+          "description": "Only allows labels in sensible locations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "linebreak-style": {
+          "description": "Enforces a consistent linebreak style.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "LF",
+                "CRLF"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/linebreak-style/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/linebreak-style/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/linebreak-style/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "max-classes-per-file": {
+          "description": "A file may not contain more than the specified number of classes",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "number",
+                  "minimum": 1
+                }
+              ],
+              "additionalItems": false,
+              "minItems": 1,
+              "maxItems": 2
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 1
+                  }
+                ]
+              },
+              "minItems": 1,
+              "maxItems": 3,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/max-classes-per-file/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "max-file-line-count": {
+          "description": "Requires files to remain under a certain number of lines",
+          "definitions": {
+            "options": {
+              "type": "number",
+              "minimum": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/max-file-line-count/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/max-file-line-count/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/max-file-line-count/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "max-line-length": {
+          "description": "Requires lines to be under a certain max length.",
+          "definitions": {
+            "options": {
+              "type": "number",
+              "minimum": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/max-line-length/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/max-line-length/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/max-line-length/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "member-ordering": {
+          "description": "Enforces member ordering.",
+          "definitions": {
+            "kind": {
+                "type": "string",
+                "enum": [
+                  "public-static-field",
+                  "public-static-method",
+                  "protected-static-field",
+                  "protected-static-method",
+                  "private-static-field",
+                  "private-static-method",
+                  "public-instance-field",
+                  "protected-instance-field",
+                  "private-instance-field",
+                  "public-constructor",
+                  "protected-constructor",
+                  "private-constructor",
+                  "public-instance-method",
+                  "protected-instance-method",
+                  "private-instance-method"
+                ]
+            },
+            "options": {
+              "type": "object",
+              "properties": {
+                "order": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "fields-first",
+                        "instance-sandwich",
+                        "statics-first"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/rules/properties/member-ordering/definitions/kind"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "kinds": {
+                                "type": "array",
+                                "items": {
+                                  "$ref": "#/definitions/rules/properties/member-ordering/definitions/kind"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      "maxLength": 15
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/member-ordering/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/member-ordering/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/member-ordering/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "newline-before-return": {
+          "description": "Enforces blank line before return when not the only line in the block.",
+          "definitions": {
+            "options": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/newline-before-return/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/newline-before-return/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/newline-before-return/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "new-parens": {
+          "description": "Requires parentheses when invoking a constructor via the `new` keyword.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-arg": {
+          "description": "Disallows use of `arguments.callee`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-bitwise": {
+          "description": "Disallows bitwise operators.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-conditional-assignment": {
+          "description": "Disallows any type of assignment in conditionals.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-consecutive-blank-lines": {
+          "description": "Disallows one or more blank lines in a row.",
+          "definitions": {
+            "options": {
+              "type": "number",
+              "minimum": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/no-consecutive-blank-lines/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/no-consecutive-blank-lines/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/no-consecutive-blank-lines/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-console": {
+          "description": "Bans the use of specified `console` methods.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-console/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/no-console/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-construct": {
+          "description": "Disallows access to the constructors of `String`, `Number`, and `Boolean`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-debugger": {
+          "description": "Disallows `debugger` statements.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-default-export": {
+          "description": "Disallows default exports in ES6-style modules.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-duplicate-imports": {
+          "description": "Disallows multiple import statements from the same module.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-duplicate-super": {
+          "description": "Warns if 'super()' appears twice in a constructor.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-duplicate-variable": {
+          "description": "Disallows duplicate variable declarations in the same block scope.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "check-parameters"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/no-duplicate-variable/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/no-duplicate-variable/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/no-duplicate-variable/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-empty": {
+          "description": "Disallows empty blocks.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "allow-empty-catch"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/no-empty/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/no-empty/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/no-empty/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-eval": {
+          "description": "Disallows `eval` function invocations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-for-in-array": {
+          "description": "Disallows iterating over an array with a for-in loop.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-import-side-effect": {
+          "description": "Avoid import statements with side-effect.",
+          "definitions": {
+            "options": {
+              "items": {
+                "properties": {
+                  "ignore-module": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array",
+              "maxItems": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-import-side-effect/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 2,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/no-import-side-effect/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-invalid-template-strings": {
+          "description": "Warns on use of `${` in non-template strings.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-invalid-this": {
+          "description": "Disallows using the `this` keyword outside of classes.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "check-function-in-method"
+                ]
+              },
+              "maxItems": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-invalid-this/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 2,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/no-invalid-this/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-irregular-whitespace": {
+          "description": "Disallow irregular whitespace outside of strings and comments",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-magic-numbers": {
+          "description": "Disallows the use constant number values outside of variable assignments.\nWhen no list of allowed values is specified, -1, 0 and 1 are allowed by default.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-magic-numbers/definitions/options/items"
+              },
+              "minItems": 1,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/no-magic-numbers/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-null-keyword": {
+          "description": "Disallows use of the `null` keyword literal.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-parameter-reassignment": {
+          "description": "Disallows reassigning parameters.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-reference": {
+          "description": "Disallows `/// <reference path=>` imports (use ES6-style imports instead).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-require-imports": {
+          "description": "Disallows invocation of `require()`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-shadowed-variable": {
+          "description": "Disallows shadowing variable declarations.",
+          "definitions": {
+            "options": {
+              "type": "object",
+              "properties": {
+                "class": {
+                  "type": "boolean"
+                },
+                "enum": {
+                  "type": "boolean"
+                },
+                "function": {
+                  "type": "boolean"
+                },
+                "import": {
+                  "type": "boolean"
+                },
+                "interface": {
+                  "type": "boolean"
+                },
+                "namespace": {
+                  "type": "boolean"
+                },
+                "typeAlias": {
+                  "type": "boolean"
+                },
+                "typeParameter": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/no-shadowed-variable/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/no-shadowed-variable/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/no-shadowed-variable/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-sparse-arrays": {
+          "description": "Forbids array literals to contain missing elements.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-string-literal": {
+          "description": "Forbids unnecessary string literal property access.\nAllows `obj[\"prop-erty\"]` (can't be a regular property access).\nDisallows `obj[\"property\"]` (should be `obj.property`).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-string-throw": {
+          "description": "Flags throwing plain strings or concatenations of strings because only Errors produce proper stack traces.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-submodule-imports": {
+          "description": "Disallows importing any submodule.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-submodule-imports/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/no-submodule-imports/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-switch-case-fall-through": {
+          "description": "Disallows falling through case statements.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-this-assignment": {
+          "description": "Disallows unnecessary references to `this`.",
+          "definitions": {
+            "options": {
+              "additionalProperties": false,
+              "properties": {
+                "allow-destructuring": {
+                  "type": "boolean"
+                },
+                "allowed-names": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "type": "object"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/no-this-assignment/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/no-this-assignment/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/no-this-assignment/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-trailing-whitespace": {
+          "description": "Disallows trailing whitespace at the end of a line.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "ignore-comments",
+                  "ignore-jsdoc",
+                  "ignore-template-strings"
+                ]
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-trailing-whitespace/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/no-trailing-whitespace/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-unnecessary-callback-wrapper": {
+          "description": "Replaces `x => f(x)` with just `f`.\nTo catch more cases, enable `only-arrow-functions` and `arrow-return-shorthand` too.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unnecessary-initializer": {
+          "description": "Forbids a 'var'/'let' statement or destructuring initializer to be initialized to 'undefined'.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unsafe-finally": {
+          "description": "Disallows control flow statements, such as `return`, `continue` `break` and `throws` in finally blocks.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unused-expression": {
+          "description": "Disallows unused expression statements.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "allow-fast-null-checks",
+                  "allow-new",
+                  "allow-tagged-template"
+                ]
+              },
+              "maxItems": 3
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-unused-expression/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 4,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/no-unused-expression/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-use-before-declare": {
+          "description": "Disallows usage of variables before their declaration.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-var-keyword": {
+          "description": "Disallows usage of the `var` keyword.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-void-expression": {
+          "description": "Requires expressions of type `void` to appear in statement position.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "ignore-arrow-function-shorthand"
+                ]
+              },
+              "maxItems": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-void-expression/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 2,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/no-void-expression/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "number-literal-format": {
+          "description": "Checks that decimal literals should begin with '0.' instead of just '.', and should not end with a trailing '0'.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "object-literal-key-quotes": {
+          "description": "Enforces consistent object literal property quote style.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "always",
+                "as-needed",
+                "consistent",
+                "consistent-as-needed"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/object-literal-key-quotes/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/object-literal-key-quotes/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/object-literal-key-quotes/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "object-literal-shorthand": {
+          "description": "Enforces use of ES6 object literal shorthand when possible.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "object-literal-sort-keys": {
+          "description": "Checks ordering of keys in object literals.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "ignore-case",
+                "match-declaration-order"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/object-literal-sort-keys/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/object-literal-sort-keys/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/object-literal-sort-keys/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "one-line": {
+          "description": "Requires the specified tokens to be on the same line as the expression preceding them.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "check-catch",
+                  "check-finally",
+                  "check-else",
+                  "check-open-brace",
+                  "check-whitespace"
+                ]
+              },
+              "maxItems": 5
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/one-line/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 6,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/one-line/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "one-variable-per-declaration": {
+          "description": "Disallows multiple variable definitions in the same declaration statement.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "ignore-for-loop"
+                ]
+              },
+              "maxItems": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/one-variable-per-declaration/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 2,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/one-variable-per-declaration/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "only-arrow-functions": {
+          "description": "Disallows traditional (non-arrow) function expressions.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "allow-declarations",
+                  "allow-named-functions"
+                ]
+              },
+              "maxItems": 2
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/only-arrow-functions/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 3,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/only-arrow-functions/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "ordered-imports": {
+          "description": "Requires that import statements be alphabetized.",
+          "definitions": {
+            "options": {
+              "type": "object",
+              "properties": {
+                "import-sources-order": {
+                  "type": "string",
+                  "enum": [
+                    "case-insensitive",
+                    "lowercase-first",
+                    "lowercase-last",
+                    "any"
+                  ]
+                },
+                "named-imports-order": {
+                  "type": "string",
+                  "enum": [
+                    "case-insensitive",
+                    "lowercase-first",
+                    "lowercase-last",
+                    "any"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/ordered-imports/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/ordered-imports/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/ordered-imports/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-conditional-expression": {
+          "description": "Recommends to use a conditional expression instead of assigning to the same thing in each branch of an if statement.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "check-else-if"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/prefer-conditional-expression/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/prefer-conditional-expression/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/prefer-conditional-expression/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-const": {
+          "description": "Requires that variable declarations use `const` instead of `let` and `var` if possible.",
+          "definitions": {
+            "options": {
+              "type": "object",
+              "properties": {
+                "destructuring": {
+                  "type": "string",
+                  "enum": [
+                    "all",
+                    "any"
+                  ]
+                }
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/prefer-const/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/prefer-const/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/prefer-const/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-for-of": {
+          "description": "Recommends a 'for-of' loop over a standard 'for' loop if the index is only used to access the array being iterated.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-function-over-method": {
+          "description": "Warns for class methods that do not use 'this'.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "allow-public",
+                "allow-protected"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/prefer-function-over-method/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/prefer-function-over-method/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/prefer-function-over-method/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-method-signature": {
+          "description": "Prefer `foo(): void` over `foo: () => void` in interfaces and types.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-object-spread": {
+          "description": "Enforces the use of the ES2015 object spread operator over `Object.assign()` where appropriate.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-switch": {
+          "description": "Prefer a `switch` statement to an `if` statement with simple `===` comparisons.",
+          "definitions": {
+            "options": {
+              "type": "object",
+              "properties": {
+                "min-cases": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/prefer-switch/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/prefer-switch/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/prefer-switch/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-template": {
+          "description": "Prefer a template expression over string literal concatenation.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "allow-single-concat"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/prefer-template/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/prefer-template/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/prefer-template/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "promise-function-async": {
+          "description": "Requires any function or method that returns a promise to be marked async.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "quotemark": {
+          "description": "Requires single or double quotes for string literals.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "single",
+                  "double",
+                  "jsx-single",
+                  "jsx-double",
+                  "avoid-escape",
+                  "avoid-template"
+                ]
+              },
+              "maxItems": 5
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/quotemark/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 6,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/quotemark/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "radix": {
+          "description": "Requires the radix parameter to be specified when calling `parseInt`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "restrict-plus-operands": {
+          "description": "When adding two variables, operands must both be of type number or of type string.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "return-undefined": {
+          "description": "Prefer `return;` in void functions and `return undefined;` in value-returning functions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "semicolon": {
+          "description": "Enforces consistent semicolon usage at the end of every statement.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ignore-interfaces",
+                    "ignore-bound-class-methods"
+                  ]
+                }
+              ],
+              "additionalItems": false
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "always",
+                      "never"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "ignore-interfaces",
+                      "ignore-bound-class-methods"
+                    ]
+                  }
+                ]
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/semicolon/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "space-before-function-paren": {
+          "description": "Require or disallow a space before function parenthesis",
+          "definitions": {
+            "options": {
+              "properties": {
+                "anonymous": {
+                  "enum": [
+                    "always",
+                    "never"
+                  ],
+                  "type": "string"
+                },
+                "asyncArrow": {
+                  "enum": [
+                    "always",
+                    "never"
+                  ],
+                  "type": "string"
+                },
+                "constructor": {
+                  "enum": [
+                    "always",
+                    "never"
+                  ],
+                  "type": "string"
+                },
+                "method": {
+                  "enum": [
+                    "always",
+                    "never"
+                  ],
+                  "type": "string"
+                },
+                "named": {
+                  "enum": [
+                    "always",
+                    "never"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/space-before-function-paren/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/space-before-function-paren/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/space-before-function-paren/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "space-within-parens": {
+          "description": "Enforces spaces within parentheses or disallow them.",
+          "definitions": {
+            "options": {
+              "type": "number",
+              "min": 0
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/space-within-parens/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/space-within-parens/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/space-within-parens/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "switch-default": {
+          "description": "Require a `default` case in all `switch` statements.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "switch-final-break": {
+          "description": "Checks whether the final clause of a switch statement ends in `break;`.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "always"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/switch-final-break/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/switch-final-break/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/switch-final-break/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "trailing-comma": {
+          "description": "Requires or disallows trailing commas in array and object literals, destructuring assignments, function typings, named imports and exports and function parameters.",
+          "definitions": {
+            "options": {
+              "type": "object",
+              "properties": {
+                "multiline": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "always",
+                        "never"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "arrays": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "exports": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "functions": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "imports": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "objects": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "typeLiterals": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "singleline": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "always",
+                        "never"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "arrays": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "exports": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "functions": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "imports": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "objects": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        },
+                        "typeLiterals": {
+                          "type": "string",
+                          "enum": [
+                            "always",
+                            "never",
+                            "ignore"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/trailing-comma/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/trailing-comma/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/rules/properties/trailing-comma/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "triple-equals": {
+          "description": "Requires `===` and `!==` in place of `==` and `!=`.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "allow-null-check",
+                  "allow-undefined-check"
+                ]
+              },
+              "maxItems": 2
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/triple-equals/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 3,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/triple-equals/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "typeof-compare": {
+          "description": "Makes sure result of `typeof` is compared to correct string values",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "use-isnan": {
+          "description": "Enforces use of the `isNaN()` function to check for NaN references instead of a comparison to the `NaN` constant.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "variable-name": {
+          "description": "Checks variable names for various errors.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "check-format",
+                  "allow-leading-underscore",
+                  "allow-trailing-underscore",
+                  "allow-pascal-case",
+                  "allow-snake-case",
+                  "ban-keywords"
+                ]
+              },
+              "maxItems": 5
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/variable-name/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 6,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/variable-name/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "whitespace": {
+          "description": "Enforces whitespace style conventions.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "check-branch",
+                  "check-decl",
+                  "check-operator",
+                  "check-module",
+                  "check-separator",
+                  "check-rest-spread",
+                  "check-type",
+                  "check-typecast",
+                  "check-type-operator",
+                  "check-preblock"
+                ]
+              },
+              "maxItems": 10
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/whitespace/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 11,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/rules/properties/whitespace/definitions/options"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/rule"
+      }
+    },
+    "tsRules": {
+      "properties": {
+        "adjacent-overload-signatures": {
+          "description": "Enforces function overloads to be consecutive.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "array-type": {
+          "description": "Requires using either 'T[]' or 'Array<T>' for arrays.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "array",
+                "generic",
+                "array-simple"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/tsRules/properties/array-type/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/tsRules/properties/array-type/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/tsRules/properties/array-type/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "await-promise": {
+          "description": "Warns for an awaited value that is not a Promise.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/await-promise/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/await-promise/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "ban-types": {
+          "description": "Bans specific types from being used. Does not ban the corresponding runtime objects from being used.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "maxItems": 2
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/ban-types/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/ban-types/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "callable-types": {
+          "description": "An interface or literal type with just a call signature can be written as a function type.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "interface-name": {
+          "description": "Requires interface names to begin with a capital 'I'",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "always-prefix",
+                "never-prefix"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/tsRules/properties/interface-name/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/tsRules/properties/interface-name/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/tsRules/properties/interface-name/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "interface-over-type-literal": {
+          "description": "Prefer an interface declaration over a type literal (`type T = { ... }`)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "match-default-export-name": {
+          "description": "Requires that a default import have the same name as the declaration it imports.\nDoes nothing for anonymous default exports.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "member-access": {
+          "description": "Requires explicit visibility declarations for class members.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "no-public",
+                  "check-accessor",
+                  "check-constructor"
+                ]
+              },
+              "maxItems": 3
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/member-access/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 4,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/member-access/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-angle-bracket-type-assertion": {
+          "description": "Requires the use of `as Type` for type assertions instead of `<Type>`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-any": {
+          "description": "Disallows usages of `any` as a type declaration.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-boolean-literal-compare": {
+          "description": "Warns on comparison to a boolean literal, as in `x === true`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-empty-interface": {
+          "description": "Forbids empty interfaces.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-floating-promises": {
+          "description": "Promises returned by functions must be handled appropriately.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/no-floating-promises/definitions/options/items"
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/no-floating-promises/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-inferrable-types": {
+          "description": "Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "ignore-params",
+                  "ignore-properties"
+                ]
+              },
+              "maxItems": 2
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/no-inferrable-types/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 3,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/no-inferrable-types/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-inferred-empty-object-type": {
+          "description": "Disallow type inference of {} (empty object type) at function and constructor call sites",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-internal-module": {
+          "description": "Disallows internal `module`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-mergeable-namespace": {
+          "description": "Disallows mergeable namespaces in the same file.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-misused-new": {
+          "description": "Warns on apparent attempts to define constructors for interfaces or `new` for classes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-namespace": {
+          "description": "Disallows use of internal `module`s and `namespace`s.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "allow-declarations"
+                ]
+              },
+              "maxItems": 1
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/no-namespace/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 2,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/no-namespace/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-non-null-assertion": {
+          "description": "Disallows non-null assertions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-object-literal-type-assertion": {
+          "description": "Forbids an object literal to appear in a type assertion expression.\nCasting to `any` is still allowed.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-parameter-properties": {
+          "description": "Disallows parameter properties in class constructors.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-reference-import": {
+          "description": "Don't `<reference types=\"foo\" />` if you import `foo` anyway.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unbound-method": {
+          "description": "Warns when a method is used as outside of a method call.",
+          "definitions": {
+            "options": {
+              "type": "string",
+              "enum": [
+                "ignore-static"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/tsRules/properties/no-unbound-method/definitions/options"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/tsRules/properties/no-unbound-method/definitions/options"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/tsRules/properties/no-unbound-method/definitions/options"
+                      },
+                      "maxItems": 1
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unnecessary-qualifier": {
+          "description": "Warns when a namespace qualifier (`A.x`) is unnecessary.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unnecessary-type-assertion": {
+          "description": "Warns if a type assertion does not change the type of an expression.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unsafe-any": {
+          "description": "Warns when using an expression of type 'any' in a dynamic way.\nUses are only allowed if they would work for `{} | null | undefined`.\nType casts and tests are allowed.\nExpressions that work on all values (such as `\"\" + x`) are allowed.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unused-variable": {
+          "description": "Disallows unused imports, variables, functions and private class members. Similar to tsc's --noUnusedParameters and --noUnusedLocals options, but does not interrupt code compilation.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "check-parameters"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ignore-pattern": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "maxItems": 3
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/no-unused-variable/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 4,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/no-unused-variable/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "no-var-requires": {
+          "description": "Disallows the use of require statements except in import statements.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "strict-boolean-expressions": {
+          "description": "Restricts the types allowed in boolean expressions. By default only booleans are allowed.\n\nThe following nodes are checked:\n* Arguments to the `!`, `&&`, and `||` operators\n* The condition in a conditional expression (`cond ? x : y`)\n* Conditions for `if`, `for`, `while`, and `do-while` statements.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "allow-null-union",
+                  "allow-undefined-union",
+                  "allow-string",
+                  "allow-number",
+                  "allow-boolean-or-undefined"
+                ]
+              },
+              "maxItems": 5
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/strict-boolean-expressions/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 6,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/strict-boolean-expressions/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "strict-type-predicates": {
+          "description": "Warns for type predicates that are always true or always false.\nWorks for 'typeof' comparisons to constants (e.g. 'typeof foo === \"string\"'), and equality comparison to 'null'/'undefined'.\n(TypeScript won't let you compare '1 === 2', but it has an exception for '1 === undefined'.)\nDoes not yet work for 'instanceof'.\nDoes *not* warn for 'if (x.y)' where 'x.y' is always truthy. For that, see strict-boolean-expressions.\n\nThis rule requires `strictNullChecks` to work properly.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "typedef": {
+          "description": "Requires type definitions to exist.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "call-signature",
+                  "arrow-call-signature",
+                  "parameter",
+                  "arrow-parameter",
+                  "property-declaration",
+                  "variable-declaration",
+                  "member-variable-declaration",
+                  "object-destructuring",
+                  "array-destructuring"
+                ]
+              },
+              "maxItems": 7
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/typedef/definitions/options/items"
+              },
+              "minItems": 1,
+              "maxItems": 8,
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/typedef/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "typedef-whitespace": {
+          "description": "Requires or disallows whitespace for type definitions.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "call-signature": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    },
+                    "index-signature": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    },
+                    "parameter": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    },
+                    "property-declaration": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    },
+                    "variable-declaration": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "call-signature": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    },
+                    "index-signature": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    },
+                    "parameter": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    },
+                    "property-declaration": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    },
+                    "variable-declaration": {
+                      "type": "string",
+                      "enum": [
+                        "nospace",
+                        "onespace",
+                        "space"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "additionalItems": false
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "call-signature": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      },
+                      "index-signature": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      },
+                      "parameter": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      },
+                      "property-declaration": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      },
+                      "variable-declaration": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "call-signature": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      },
+                      "index-signature": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      },
+                      "parameter": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      },
+                      "property-declaration": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      },
+                      "variable-declaration": {
+                        "type": "string",
+                        "enum": [
+                          "nospace",
+                          "onespace",
+                          "space"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "properties": {
+                "severity": {},
+                "options": {
+                  "$ref": "#/definitions/tsRules/properties/typedef-whitespace/definitions/options"
+                }
+              }
+            }
+          ]
+        },
+        "type-literal-delimiter": {
+          "description": "Checks that type literal members are separated by semicolons.\nEnforces a trailing semicolon for multiline type literals.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "unified-signatures": {
+          "description": "Warns for any two overloads that could be unified into one by using a union or an optional/rest parameter.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "use-default-type-parameter": {
+          "description": "Warns if an explicitly specified type argument is the default for that type parameter.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    }
+  },
+  "properties": {
+    "extends": {
+      "description": "The name of a built-in configuration preset, or a path or array of paths to other configuration files which are extended by this configuration. This value is handled using node module resolution semantics.",
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "rulesDirectory": {
+      "description": "A path to a directory or an array of paths to directories of custom rules. These values are handled using node module resolution semantics, if an `index.js` is placed in your rules directory.",
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "rules": {
+      "description": "A map of rules that will be used to lint TypeScript files. These rules are applied to `.ts` and `.tsx` files.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/tsRules"
+        },
+        {
+          "$ref": "#/definitions/rules"
+        }
+      ]
+    },
+    "jsRules": {
+      "description": "A map of rules that will be used to lint JavaScript files. These rules are applied to `.js` and `.jsx` files.",
+      "$ref": "#/definitions/rules"
+    },
+    "defaultSeverity": {
+      "description": "The severity level used when a rule specifies \"default\" as its severity level. If undefined, \"error\" is used.",
+      "type": "string",
+      "enum": [
+        "error",
+        "warning",
+        "warn",
+        "off",
+        "none"
+      ],
+      "default": "error"
+    }
+  }
 }

--- a/src/test/tslint/tslint-test2.json
+++ b/src/test/tslint/tslint-test2.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "rules": {
   "align": [true,
         "parameters",
@@ -26,9 +26,15 @@
       true,
       {
         "order": [
-          "static-field",
-          "instance-field",
-          "constructor",
+          "public-static-field",
+          "protected-static-field",
+          "private-static-field",
+          "public-instance-field",
+          "protected-instance-field",
+          "private-instance-field",
+          "public-constructor",
+          "protected-constructor",
+          "private-constructor",
           "public-instance-method",
           "protected-instance-method",
           "private-instance-method"

--- a/src/test/tslint/tslint-test3.json
+++ b/src/test/tslint/tslint-test3.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "rulesDirectory": [ "node_modules/codelyzer" ],
   "rules": {
     "align": [
@@ -35,7 +35,9 @@
               "protected-static-method"
             ]
           },
-          "constructor"
+          "public-constructor",
+          "protected-constructor",
+          "private-constructor"
         ]
       }
     ],


### PR DESCRIPTION
I was bothered by how outdated the TSLint schema was, so I spent the last day writing a small script that pulls all the built-in rule options schemas from the TSLint source code. The updated tslint.json schema is the result of the generated code, after some finishing touches to patch up inconsistencies. Notably, the schema now supports all three supported forms for expressing rules:
```json
"rule-name": true,
"rule-name": [true, "option-1", "option-2"],
"rule-name": {
    "options": ["option-1", "option-2"],
    "severity": "warning"
}
```

Two of the test files had to be updated because some of their options did not match the internal TSLint spec for the member-ordering rule, which resulted in the new schema failing the tests.

Hopefully this should also alleviate some of the problems mentioned at #245 