### PR TITLE
stylelintrc - Add after-comment for ignore in comment-empty-line-before

### DIFF
--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -1369,6 +1369,7 @@
 													"type": "string",
 													"enum": [
 														"between-comments",
+														"after-comment",
 														"stylelint-commands"
 													]
 												}

--- a/src/test/stylelintrc/stylelintrc-test.json
+++ b/src/test/stylelintrc/stylelintrc-test.json
@@ -1,0 +1,16 @@
+{
+    "rules": {
+        "comment-empty-line-before": [
+            "always",
+            {
+                "except": [
+                    "first-nested"
+                ],
+                "ignore": [
+                    "after-comment",
+                    "stylelint-commands"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
closes https://github.com/SchemaStore/schemastore/issues/326

Leaving the deprecated string for backward compatibility reasons.

see:
https://github.com/stylelint/stylelint/commit/7aa2282ec270276bbd52fad48d19518972a2ced5#diff-b569a5c1c7d23bc03d08db74e8983dbe

reference: https://stylelint.io/user-guide/rules/comment-empty-line-before/