### PR TITLE
package.json - make name and version not required for private modules

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -415,6 +415,19 @@
         }
       ]
     },
-    { "required": [ "name", "version" ] }
+    {
+      "anyOf": [
+        { "required": [ "name", "version" ] },
+        {
+          "not":{
+            "properties": {
+              "private": {
+                "enum": [false]
+              }
+            }
+          }
+        }
+      ]
+    }
   ]
 }

--- a/src/test/package/private.json
+++ b/src/test/package/private.json
@@ -1,0 +1,3 @@
+{
+    "private": true
+}


### PR DESCRIPTION
fixes https://github.com/SchemaStore/schemastore/issues/139

but I am not sure if this is what we want, it is not the requirements as stated in https://docs.npmjs.com/getting-started/using-a-package.json