### PR TITLE
Adding JSONBuddy editor to list

### DIFF
--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -78,6 +78,7 @@
         <li>Visual Studio Code</li>
         <li>Visual Studio for Mac</li>
         <li>WebStorm</li>
+        <li>JSONBuddy</li>
     </ul>
 
     <p>Any schema on SchemaStore.org will automatically be synchronized to the supporting editors.</p>


### PR DESCRIPTION
Starting with version 4.2 JSONBuddy has built-in support for all JSON
schemas available at schemastore.org. The list of schemas is
synchronized automatically and JSON instance documents are assigned
based on filename matching.