### PR TITLE
package.manifest.json - Add gridEditors

### DIFF
--- a/src/schemas/json/package.manifest.json
+++ b/src/schemas/json/package.manifest.json
@@ -69,7 +69,7 @@
 				}
 			}
 		},
-		"grideditors": {
+		"gridEditor": {
 			"type": "object",
 			"required": [ "name", "alias", "view" ],
 			"properties": {
@@ -220,7 +220,7 @@
 			"description": "Returns an array of grid editor objects, each object specifies a grid editor to make available in the Grid Layout property editor.",
 			"minItems": 1,
 			"items": {
-				"$ref": "#/definitions/gridEditors"
+				"$ref": "#/definitions/gridEditor"
 			}
 		}
 	}

--- a/src/schemas/json/package.manifest.json
+++ b/src/schemas/json/package.manifest.json
@@ -69,6 +69,61 @@
 				}
 			}
 		},
+		"grideditors": {
+			"type": "object",
+			"required": [ "name", "alias", "view" ],
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "The friendly name of the grid editor, shown in the Umbraco backoffice"
+				},
+				"alias": {
+					"type": "string",
+					"description": "This must be a unique alias to your grid editor"
+				},
+				"icon": {
+					"type": "string",
+					"description": "A CSS class for the icon to be used in the 'Select Editor' dialog eg: icon-autofill"
+				},
+				"view": {
+					"type": "string",
+					"description": "This is backoffice HTML view for your grid editor. Either refers to one of the built-in view (textstring, rte, embed, macro, media) or the full path to a custom view eg.: '~/App_Plugins/FolderName/editor.html'"
+				},
+				"render": {
+					"type": "string",
+					"description": "This is front end razor view for your grid editor. Accepts full path to a custom view eg.: '~/App_Plugins/FolderName/editor.cshtml"
+				},
+				"config": {
+					"type": "object",
+					"description": "Configuration for the grid editor. Can be used with textstring and media views or for custom configuration properties",
+					"minProperties": 1,
+					"properties": {
+						"style": {
+							"type": "string",
+							"description": "If used with the textstring view this accepts inline css to style the textstring box eg.: font-size: 30px; line-height: 40px; font-weight: bold"
+						},
+						"markup": {
+							"type": "string",
+							"description": "If used with the textstring view this allows wrapping the value in custom markup eg.: <h2>#value#</h2>"
+						},
+						"size": {
+							"type": "object",
+							"description": "If used with the media view this accepts hight and width key/value pairs for cropping",
+							"properties": {
+								"height": {
+									"type": "integer",
+									"description": "Height of image in pixels"
+								},
+								"width": {
+									"type": "integer",
+									"description": "Width of image in pixels"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"preValues": {
 			"type": "object",
 			"properties": {
@@ -158,6 +213,14 @@
 			"minItems": 1,
 			"items": {
 				"$ref": "#/definitions/editors"
+			}
+		},
+		"gridEditors": {
+			"type": "array",
+			"description": "Returns an array of grid editor objects, each object specifies a grid editor to make available in the Grid Layout property editor.",
+			"minItems": 1,
+			"items": {
+				"$ref": "#/definitions/gridEditors"
 			}
 		}
 	}


### PR DESCRIPTION
Adds missing schema for grid editors in the Umbraco package.manifest. See https://our.umbraco.org/Documentation/Getting-Started/Backoffice/Property-Editors/Built-in-Property-Editors/Grid-Layout/build-your-own-editor for reference.