### PR TITLE
Update options for ts 2.6

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -98,10 +98,6 @@
               "description": "Print names of files part of the compilation.",
               "type": "boolean"
             },
-            "locale": {
-              "description": "The locale to use to show error messages, e.g. en-us.",
-              "type": "string"
-            },
             "mapRoot": {
               "description": "Specifies the location where debugger should locate map files instead of generated locations",
               "type": "string"

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -387,6 +387,10 @@
             "checkJs": {
               "description": "Report errors in .js files. Requires TypeScript version 2.3 or later.",
               "type": "boolean"
+            },
+            "strictFunctionTypes": {
+                "description": "Disable bivariant parameter checking for function types.. Requires TypeScript version 2.6 or later.",
+                "type": "boolean"
             }
           }
         }


### PR DESCRIPTION
Add `--strictFunctionTypes`
Also fixes Microsoft/TypeScript#19566: