### PR TITLE
Fix newLine property in tsconfig to support lowercase value

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -115,7 +115,18 @@
             },
             "newLine": {
               "description": "Specifies the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix).",
-              "enum": [ "CRLF", "LF" ]
+              "type": "string",
+              "anyOf": [
+                {
+                  "enum": [
+                    "CRLF",
+                    "LF"
+                  ]
+                },
+                {
+                  "pattern": "^(CRLF|LF|crlf|lf)$"
+                }
+              ]
             },
             "noEmit": {
               "description": "Do not emit output.",

--- a/src/test/tsconfig/tsconfig-newline.json
+++ b/src/test/tsconfig/tsconfig-newline.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+      "newLine": "crlf"
+  }
+}


### PR DESCRIPTION
The documentation of the CLI options of TypeScript states that `newLine` is one of `crlf` or `lf`. Specifying this in `tsconfig.json`, the schema enforces `CRLF` or `LF`. I did a PR which also allows the lowercase variant.

// FYI @mhegazy 