### PR TITLE
Add schema for .travis.yml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -556,6 +556,12 @@
       "url": "http://json.schemastore.org/templatesources"
     },
     {
+      "name": ".travis.yml",
+      "description": "Travis CI configuration file",
+      "fileMatch": [ ".travis.yml" ],
+      "url": "http://json.schemastore.org/travis"
+    },
+    {
       "name": "tsconfig.json",
       "description": "TypeScript compiler configuration file",
       "fileMatch": [ "tsconfig.json" ],

--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -1,0 +1,1084 @@
+{
+  "title": "JSON schema for Travis CI configuration files",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "definitions": {
+    "slackRoom": {
+      "description": "Your account name, token and optional channel",
+      "type": "string",
+      "pattern": ".+:.+(#.+)?"
+    },
+    "notificationFrequency": {
+      "enum": ["always", "never", "change"]
+    },
+    "step": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "enum": ["skip", "ignore"]
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "service": {
+      "enum": [
+        "cassandra",
+        "couchdb",
+        "elasticsearch",
+        "mariadb",
+        "memcached",
+        "mongodb",
+        "mysql",
+        "neo4j",
+        "postgresql",
+        "rabbitmq",
+        "redis-server",
+        "rethinkdb",
+        "riak"
+      ]
+    },
+    "cache": {
+      "enum": [
+        "bundler",
+        "cargo",
+        "ccache",
+        "cocoapods",
+        "packages",
+        "pip",
+        "yarn"
+      ]
+    },
+    "envVar": {
+      "type": "string",
+      "pattern": "[^=]+=.*"
+    },
+    "job": {
+      "type": "object",
+      "properties": {
+        "language": {
+          "enum": [
+            "android",
+            "clojure",
+            "cpp",
+            "crystal",
+            "csharp",
+            "d",
+            "dart",
+            "elixir",
+            "generic",
+            "go",
+            "groovy",
+            "haskell",
+            "haxe",
+            "java",
+            "nix",
+            "node_js",
+            "objective-c",
+            "perl",
+            "perl6",
+            "php",
+            "python",
+            "r",
+            "ruby",
+            "scala",
+            "smalltalk"
+          ]
+        },
+        "haxe": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scala": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sbt_args": {
+          "type": "string"
+        },
+        "crystal": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "neko": {
+          "type": "string"
+        },
+        "hxml": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "smalltalk": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "perl": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "perl6": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "d": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dart": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dart_task": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "test": {
+                "type": "string"
+              },
+              "install_dartium": {
+                "type": "boolean"
+              },
+              "xvfb": {
+                "type": "boolean"
+              },
+              "dartanalyzer": {
+                "type": "boolean"
+              },
+              "dartfmt": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "ghc": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "lein": {
+          "type": "string"
+        },
+        "android": {
+          "type": "object",
+          "properties": {
+            "components": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "licenses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "node_js": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "compiler": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "enum": ["clang", "gcc"]
+              }
+            },
+            {
+              "enum": ["clang", "gcc"]
+            }
+          ]
+        },
+        "php": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "go": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "jdk": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "solution": {
+          "type": "string",
+          "description":
+            "When the optional solution key is present, Travis will run NuGet package restore and build the given solution."
+        },
+        "mono": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "xcode_project": {
+          "type": "string"
+        },
+        "xcode_workspace": {
+          "type": "string"
+        },
+        "xcode_scheme": {
+          "type": "string"
+        },
+        "xcode_sdk": {
+          "type": "string"
+        },
+        "podfile": {
+          "type": "string",
+          "description":
+            "By default, Travis CI will assume that your Podfile is in the root of the repository. If this is not the case, you can specify where the Podfile is"
+        },
+        "python": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "elixir": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "opt_release": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "rvm": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "gemfile": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "bundler_args": {
+          "type": "string"
+        },
+        "r": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "pandoc_version": {
+          "type": "string"
+        },
+        "brew_packages": {
+          "type": "array",
+          "description":
+            "A list of packages to install via brew. This option is ignored on non-OS X builds.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "r_binary_packages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "r_packages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "bioc_packages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "r_github_packages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "apt_packages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cran": {
+          "type": "string",
+          "description": "CRAN mirror to use for fetching packages"
+        },
+        "repos": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Dictionary of repositories to pass to options(repos)"
+        },
+
+        "os": {
+          "enum": ["osx", "linux"],
+          "description": "The operating system to run the job on"
+        },
+        "osx_image": {
+          "enum": [
+            "xcode6.4",
+            "xcode7.3",
+            "xcode8.1",
+            "xcode8.2",
+            "xcode8.3",
+            "xcode8",
+            "xcode9.1",
+            "xcode9"
+          ],
+          "default": "xcode7.3"
+        },
+        "dist": {
+          "description": "The Ubuntu distribution to use",
+          "enum": ["trusty", "precise"]
+        },
+        "sudo": {
+          "enum": ["required", false]
+        },
+        "addons": {
+          "type": "object",
+          "properties": {
+            "apt": {
+              "type": "object",
+              "description":
+                "To install packages not included in the default container-based-infrastructure you need to use the APT addon, as sudo apt-get is not available",
+              "properties": {
+                "sources": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "sourceline": {
+                            "type": "string",
+                            "description":
+                              "Key-value pairs which will be added to /etc/apt/sources.list"
+                          },
+                          "key_url": {
+                            "type": "string",
+                            "description":
+                              "When APT sources require GPG keys, you can specify this with key_url"
+                          }
+                        },
+                        "required": ["sourceline"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "string",
+                        "description": "Alias defined in source whitelist"
+                      }
+                    ]
+                  }
+                },
+                "packages": {
+                  "type": "array",
+                  "description":
+                    "To install packages from the package whitelist before your custom build steps",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "hosts": {
+              "description":
+                "If your build requires setting up custom hostnames, you can specify a single host or a list of them. Travis CI will automatically setup the hostnames in /etc/hosts for both IPv4 and IPv6.",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "artifacts": {
+              "oneOf": [
+                {
+                  "enum": [true]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "s3_region": {
+                      "type": "string"
+                    },
+                    "paths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "working_dir": {
+                      "type": "string",
+                      "description":
+                        "If you’d like to upload file from a specific directory, you can change your working directory "
+                    },
+                    "debug": {
+                      "type": "boolean",
+                      "description":
+                        "If you’d like to see more detail about what the artifacts addon is doing"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+
+        "cache": {
+          "oneOf": [
+            {
+              "enum": [false]
+            },
+            {
+              "$ref": "#/definitions/cache"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/cache"
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "directories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "timeout": {
+                  "type": "number",
+                  "description": "Upload timeout in seconds",
+                  "default": 1800
+                },
+                "bundler": {
+                  "type": "boolean"
+                },
+                "cocoapods": {
+                  "type": "boolean"
+                },
+                "pip": {
+                  "type": "boolean"
+                },
+                "yarn": {
+                  "type": "boolean"
+                },
+                "ccache": {
+                  "type": "boolean"
+                },
+                "packages": {
+                  "type": "boolean"
+                },
+                "cargo": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+
+        "services": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/service"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/service"
+              }
+            }
+          ]
+        },
+
+        "git": {
+          "type": "object",
+          "properties": {
+            "depth": {
+              "type": "integer",
+              "description": "Set the git clone depth",
+              "default": 50
+            },
+            "submodules": {
+              "type": "boolean",
+              "description": "Control whether submodules should be cloned"
+            },
+            "lfs_skip_smudge": {
+              "type": "boolean",
+              "description":
+                "Skip fetching the git-lfs files during the initial git clone (equivalent to git lfs smudge --skip),"
+            }
+          },
+          "additionalProperties": false
+        },
+
+        "branches": {
+          "type": "object",
+          "description": "Specify which branches to build",
+          "properties": {
+            "except": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "only": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+
+        "env": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/envVar"
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "global": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/envVar"
+                  }
+                },
+                "matrix": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/envVar"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+
+        "before_install": {
+          "$ref": "#/definitions/step"
+        },
+        "install": {
+          "$ref": "#/definitions/step"
+        },
+        "before_script": {
+          "$ref": "#/definitions/step"
+        },
+        "script": {
+          "$ref": "#/definitions/step"
+        },
+        "before_cache": {
+          "$ref": "#/definitions/step"
+        },
+        "after_success": {
+          "$ref": "#/definitions/step"
+        },
+        "after_failure": {
+          "$ref": "#/definitions/step"
+        },
+        "before_deploy": {
+          "$ref": "#/definitions/step"
+        },
+
+        "deploy": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "on": {
+                  "type": "object",
+                  "properties": {
+                    "tags": {
+                      "description":
+                        "Tell Travis CI to only deploy on tagged commits",
+                      "type": "boolean"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "all_branches": {
+                      "type": "boolean"
+                    },
+                    "skip_cleanup": {
+                      "type": "boolean",
+                      "description":
+                        "After your tests ran and before the release, Travis CI will clean up any additional files and changes you made. Maybe that is not what you want, as you might generate some artifacts that are supposed to be released, too."
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "enum": ["npm"]
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "api_key": {
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["provider", "email", "api_key"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "enum": ["surge"]
+                    },
+                    "project": {
+                      "type": "string"
+                    },
+                    "domain": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["provider"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "enum": ["releases"]
+                    },
+                    "api_key": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "string"
+                    },
+                    "password": {
+                      "type": "string"
+                    },
+                    "file": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    },
+                    "file_glob": {
+                      "type": "boolean"
+                    },
+                    "overwrite": {
+                      "type": "boolean",
+                      "description": "If you need to overwrite existing files"
+                    }
+                  },
+                  "required": ["provider"]
+                }
+              ]
+            }
+          ]
+        },
+        "after_deploy": {
+          "$ref": "#/definitions/step"
+        },
+        "after_script": {
+          "$ref": "#/definitions/step"
+        }
+      }
+    }
+  },
+
+  "allOf": [
+    {
+      "$ref": "#/definitions/job"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "notifications": {
+          "type": "object",
+          "properties": {
+            "webhooks": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "urls": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "on_success": {
+                    "$ref": "#/definitions/notificationFrequency"
+                  },
+                  "on_failure": {
+                    "$ref": "#/definitions/notificationFrequency"
+                  },
+                  "on_start": {
+                    "$ref": "#/definitions/notificationFrequency"
+                  },
+                  "on_cancel": {
+                    "$ref": "#/definitions/notificationFrequency"
+                  },
+                  "on_error": {
+                    "$ref": "#/definitions/notificationFrequency"
+                  }
+                }
+              ]
+            },
+            "slack": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/slackRoom"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "rooms": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/slackRoom"
+                      }
+                    },
+                    "on_pull_requests": {
+                      "type": "boolean"
+                    },
+                    "template": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "on_success": {
+                      "$ref": "#/definitions/notificationFrequency"
+                    },
+                    "on_failure": {
+                      "$ref": "#/definitions/notificationFrequency"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "email": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [false]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "recipients": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "on_success": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "change"
+                    },
+                    "on_failure": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    }
+                  }
+                }
+              ]
+            },
+            "irc": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "channels": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "channel_key": {
+                      "type": "string"
+                    },
+                    "nick": {
+                      "type": "string"
+                    },
+                    "password": {
+                      "type": "string"
+                    },
+                    "template": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "on_success": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_failure": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "skip_join": {
+                      "type": "boolean"
+                    },
+                    "use_notice": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "matrix": {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/job"
+              }
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/job"
+              }
+            },
+            "allow_failures": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/job"
+              }
+            },
+            "fast_finish": {
+              "type": "boolean",
+              "description":
+                "If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed. To mark the build as finished as soon as possible, add fast_finish: true"
+            }
+          },
+          "additionalProperties": false
+        },
+        "jobs": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "include": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/job"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "stage": {
+                        "type": "string",
+                        "description": "The name of the build stage",
+                        "default": "test"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "stages": {
+          "type": "array",
+          "description": "Specifies the order of build stages",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "if": {
+                    "description": "Specifies a condition for the stage",
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Every time I create a new open source project I have to go to the Travis documentation to find out what that one property I am looking for was called. It's so easy to get confused with Travis' `script` vs. `test` on Circle, Travis' `env` as an array of `key=value` strings vs an object hash as on AppVeyor etc etc. I think most developers can relate.

A .travis.yml compiles to a JSON representation, so we can validate it with a JSON schema, and the [YAML language server](https://github.com/redhat-developer/yaml-language-server) does exactly that, giving awesome autocomplete and schema validation for YAML files through JSON schemas.

![image](https://user-images.githubusercontent.com/10532611/32624673-c6978df4-c53e-11e7-8f9a-2d91953d57a4.png)

![image](https://user-images.githubusercontent.com/10532611/32624979-cf86094e-c53f-11e7-99ae-1476eb737446.png)

This schema is not perfect (I didn't add all deploy providers), but I went through every other docs page to collect all the possible options I could find.