### PR TITLE
Add Unity assembly definition file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -28,6 +28,12 @@
       "url": "http://json.schemastore.org/appveyor"
     },
     {
+      "name": ".asmdef",
+      "description": "Unity 3D assembly definition file",
+      "fileMatch": [ "*.asmdef" ],
+      "url": "http://json.schemastore.org/asmdef"
+    },
+    {
       "name": "babelrc.json",
       "description": "Babel configuration file",
       "fileMatch": [ ".babelrc" ],

--- a/src/schemas/json/asmdef.json
+++ b/src/schemas/json/asmdef.json
@@ -1,0 +1,41 @@
+{
+  "schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Unity Assembly Definition",
+  "description": "Defines an assembly in the Unity compilation pipeline",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the assembly being defined",
+      "type": "string"
+    },
+    "references": {
+      "description": "",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "includePlatforms": {
+      "description": "",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "excludePlatforms": {
+      "description": "",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    }
+  },
+  "required": ["name"],
+  "not": {
+    "required": ["includePlatforms", "excludePlatforms"]
+  }
+}

--- a/src/schemas/json/asmdef.json
+++ b/src/schemas/json/asmdef.json
@@ -19,19 +19,39 @@
     },
     "includePlatforms": {
       "description": "Platforms to target",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
+      "$ref": "#/definitions/platformValues"
     },
     "excludePlatforms": {
       "description": "Platforms that are explicitly not targeted",
+      "$ref": "#/definitions/platformValues"
+    }
+  },
+  "definitions": {
+    "platformValues": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
+        "enum": [
+          "StandaloneOSX",
+          "StandaloneWindows",
+          "iOS",
+          "Android",
+          "StandaloneLinux",
+          "StandaloneWindows64",
+          "WebGL",
+          "WSAPlayer",
+          "StandaloneLinux64",
+          "StandaloneLinuxUniversal",
+          "Tizen",
+          "PSP2",
+          "PS4",
+          "XboxOne",
+          "N3DS",
+          "WiiU",
+          "tvOS",
+          "Switch"
+        ]
+      }
     }
   },
   "required": ["name"],

--- a/src/schemas/json/asmdef.json
+++ b/src/schemas/json/asmdef.json
@@ -9,7 +9,7 @@
       "type": "string"
     },
     "references": {
-      "description": "",
+      "description": "A list of names of assemblies to reference",
       "type": "array",
       "items": {
         "type": "string"
@@ -18,7 +18,7 @@
       "uniqueItems": true
     },
     "includePlatforms": {
-      "description": "",
+      "description": "Platforms to target",
       "type": "array",
       "items": {
         "type": "string"
@@ -26,7 +26,7 @@
       "uniqueItems": true
     },
     "excludePlatforms": {
-      "description": "",
+      "description": "Platforms that are explicitly not targeted",
       "type": "array",
       "items": {
         "type": "string"

--- a/src/schemas/json/asmdef.json
+++ b/src/schemas/json/asmdef.json
@@ -6,13 +6,15 @@
   "properties": {
     "name": {
       "description": "The name of the assembly being defined",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "references": {
       "description": "A list of names of assemblies to reference",
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "minItems": 1,
       "uniqueItems": true

--- a/src/test/asmdef/test01.asmdef
+++ b/src/test/asmdef/test01.asmdef
@@ -1,0 +1,5 @@
+{
+    "name": "MyLibrary",
+    "references": [ "Utility" ],
+    "includePlatforms": ["Android", "iOS"]
+}

--- a/src/test/asmdef/test02.asmdef
+++ b/src/test/asmdef/test02.asmdef
@@ -1,0 +1,5 @@
+{
+    "name": "MyLibrary2",
+    "references": [ "Utility" ],
+    "excludePlatforms": ["WebGL"]
+}


### PR DESCRIPTION
For Unity 3D 2017.3. See the [Unity documentation](https://docs.unity3d.com/2017.3/Documentation/Manual/ScriptCompilationAssemblyDefinitionFiles.html)