### PR TITLE
Fix validation for asmdef files

### DIFF
--- a/src/schemas/json/asmdef.json
+++ b/src/schemas/json/asmdef.json
@@ -57,7 +57,36 @@
     }
   },
   "required": ["name"],
-  "not": {
-    "required": ["includePlatforms", "excludePlatforms"]
-  }
+  "anyOf": [
+    {
+      "properties": {
+        "includePlatforms": {
+          "minItems": 1
+        },
+        "excludePlatforms": {
+          "maxItems": 0
+        }
+      }
+    },
+    {
+      "properties": {
+        "includePlatforms": {
+          "maxItems": 0
+        },
+        "excludePlatforms": {
+          "minItems": 1
+        }
+      }
+    },
+    {
+      "properties": {
+        "includePlatforms": {
+          "maxItems": 0
+        },
+        "excludePlatforms": {
+          "maxItems": 0
+        }
+      }
+    }
+  ]
 }

--- a/src/test/asmdef/test03.asmdef
+++ b/src/test/asmdef/test03.asmdef
@@ -1,0 +1,6 @@
+{
+    "name": "MyLibrary",
+    "references": [ "Utility" ],
+    "includePlatforms": [],
+    "excludePlatforms": []
+}


### PR DESCRIPTION
Unity's documentation states that you can't use `includePlatforms` and `excludePlatforms` in the same file. The keyword there is "use".

The current validation only allows one or the other in the file, but Unity's own serialisation doesn't omit empty lists, and both properties can appear.

This change allows for zero, one or both of the properties to exist, but at most one can have values.