### PR TITLE
package.json schema: Remove 'format: uri' from repository

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -218,8 +218,7 @@
               "type": "string"
             },
             "url": {
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             }
           }
         },


### PR DESCRIPTION
According to https://docs.npmjs.com/files/package.json, the repository property is not a strict URI but can also use shortcut forms such as 
`"npm/npm"`, `"gist:11081aaa281"`, `"bitbucket:example/repo"`, `"gitlab:another/repo" `

Therefore, to avoid validation errors, I suggest removing the 'format: uri' from the repository property.