### PR TITLE
Add Cypress configuration file schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -123,6 +123,12 @@
       "url": "http://json.schemastore.org/contribute"
     },
     {
+      "name": "cypress.json",
+      "description": "Cypress.io test runner configuration file",
+      "fileMatch": [ "cypress.json" ],
+      "url": "https://raw.githubusercontent.com/cypress-io/cypress/develop/cli/schema/cypress.schema.json"
+    },
+    {
       "name": ".creatomic",
       "description": "A config for Atomic Design 4 React generator",
       "fileMatch": [ ".creatomic" ],


### PR DESCRIPTION
For Cypress.io test runner configuration file `cypress.json`. The schema file is at our GitHub repo and the entry just points at it.