### PR TITLE
Fixed fileMatch values in sarif-1.0.0.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -477,7 +477,7 @@
     {
       "name": "sarif-1.0.0.json",
       "description": "Static Analysis Results Interchange Format (SARIF)",
-      "fileMatch": [ "*.sarif,*.sarif.json" ],
+      "fileMatch": [ "*.sarif", "*.sarif.json" ],
       "url": "http://json.schemastore.org/sarif",
       "versions": {
         "1.0.0-beta.4": "http://json.schemastore.org/sarif-1.0.0-beta.4.json",


### PR DESCRIPTION
I also think the $schema property in this file is missused. 

I believe it is currently saying this file IS a schema and that it uses the custom schema format "http://json.schemastore.org/schema-catalog"
The docs in the standard are a little difficult to read, but this link describes it better https://spacetelescope.github.io/understanding-json-schema/reference/schema.html

Where as I belive your intent is to say this is a data file and it conforms to the JSON schemea found at "http://json.schemastore.org/schema-catalog". However as far as I'm aware their is no formal way to specifiy this.