### PR TITLE
Update launchsettings.json to match VS 2017

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -1,86 +1,138 @@
 {
-	"title": "JSON schema for the ASP.NET DebugSettings.json files.",
-	"$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON schema for the ASP.NET LaunchSettings.json files.",
+  "$schema": "http://json-schema.org/draft-04/schema#",
 
-	"type": "object",
+  "type": "object",
 
-	"definitions": {
-		"profile": {
-			"type": "object",
-			"allOf": [ { "$ref": "#/definitions/content" } ],
-			"anyOf": [
-				{
-					"properties": {
-						"executablePath": {
-							"type": "string",
-							"description": "An absolute path to the to the executable.",
-							"default": "",
-							"minLength": 1
-						}
-					},
-					"not": {
-						"required": [ "commandName" ]
-					}
-				},
-				{
-					"properties": {
-						"commandName": {
-							"type": "string",
-							"description": "The name of the command to call.",
-							"default": "",
-							"minLength": 1
-						}
-					},
-					"not": {
-						"required": [ "executablePath" ]
-					}
-				}
-			]
-		},
+  "definitions": {
+    "profile": {
+      "type": "object",
+      "allOf": [ { "$ref": "#/definitions/profileContent" } ],
+      "required": [ "commandName" ]
+    },
+    "iisSetting": {
+      "type": "object",
+      "allOf": [ { "$ref": "#/definitions/iisSettingContent" } ]
+    },
 
-		"content": {
-			"properties": {
-				"commandLineArgs": {
-					"type": "string",
-					"description": "The arguments to pass to the command.",
-					"default": ""
-				},
-				"workingDirectory": {
-					"type": "string",
-					"description": "Sets the working directory of the command."
-				},
-				"launchBrowser": {
-					"type": "boolean",
-					"description": "Set to true if the browser should be launched.",
-					"default": false
-				},
-				"launchUrl": {
-					"type": "string",
-					"description": "The relative URL to launch in the browser.",
-					"format": "uri"
-				},
-				"environmentVariables": {
-					"type": "object",
-					"description": "Set the environment variables as key/value pairs.",
-					"additionalProperties": {
-						"type": "string"
-					}
-				},
-				"sdkVersion": {
-					"type": "string",
-					"description": "Sets the version of the SDK."
-				}
-			}
-		}
-	},
+    "iisSettingContent": {
+      "properties": {
+        "windowsAuthentication": {
+          "type": "boolean",
+          "description": "Set to true to enable windows authentication for your site in IIS and IIS Express.",
+          "default": false
+        },
+        "anonymousAuthentication": {
+          "type": "boolean",
+          "description": "Set to true to enable anonymous authentication for your site in IIS and IIS Express.",
+          "default": true
+        },
+        "iisExpress": {
+          "type": "object",
+          "description": "Site settings to use with IISExpress profiles.",
+          "allOf": [ { "$ref": "#/definitions/iisBindingContent" } ]
+        }
+      },
+      "iis": {
+        "type": "object",
+        "description": "Site settings to use with IIS profiles.",
+        "allOf": [ { "$ref": "#/definitions/iisBindingContent" } ]
+      }
+    },
 
-	"properties": {
-		"profiles": {
-			"type": "object",
-			"description": "A list of debug profiles",
-			"additionalProperties": {
-				"$ref": "#/definitions/profile"
-			}
-		}
-	}
+    "iisBindingContent": {
+      "properties": {
+        "applicationUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the web site.",
+          "default": ""
+        },
+        "sslPort": {
+          "type": "integer",
+          "maximum": 65535,
+          "minimum": 0,
+          "description": "The SSL Port to use for the web site.",
+          "default": 0
+        }
+      }
+    },
+
+    "profileContent": {
+      "properties": {
+        "commandName": {
+          "type": "string",
+          "description": "Identifies the debug target to run.",
+          "default": "",
+          "minLength": 1
+        },
+        "commandLineArgs": {
+          "type": "string",
+          "description": "The arguments to pass to the target being run.",
+          "default": ""
+        },
+        "executablePath": {
+          "type": "string",
+          "description": "An absolute or relative path to the to the executable.",
+          "default": ""
+        },
+        "workingDirectory": {
+          "type": "string",
+          "description": "Sets the working directory of the command."
+        },
+        "launchBrowser": {
+          "type": "boolean",
+          "description": "Set to true if the browser should be launched.",
+          "default": false
+        },
+        "launchUrl": {
+          "type": "string",
+          "description": "The relative URL to launch in the browser.",
+          "format": "uri"
+        },
+        "environmentVariables": {
+          "type": "object",
+          "description": "Set the environment variables as key/value pairs.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "applicationUrl": {
+          "type": "string",
+          "description": "A semi-colon delimited list of URL(s) to configure for the web server.",
+          "format": "string"
+        },
+        "nativeDebugging": {
+          "type": "boolean",
+          "description": "Set to true to enable native code debugging.",
+          "default": false
+        },
+        "externalUrlConfiguration": {
+          "type": "boolean",
+          "description": "Set to true to disable configuration of the site when running the Asp.Net Core Project profile.",
+          "default": false
+        },
+        "use64Bit": {
+          "type": "boolean",
+          "description": "Set to true to run the 64 bit version of IIS Express, false to run the x86 version.",
+          "default": false
+        }
+      }
+    }
+  },
+
+  "properties": {
+    "profiles": {
+      "type": "object",
+      "description": "A list of debug profiles",
+      "additionalProperties": {
+        "$ref": "#/definitions/profile"
+      }
+    },
+    "iisSettings": {
+      "type": "object",
+      "description": "IIS and IIS Express settings",
+      "allOf": [ { "$ref": "#/definitions/iisSettingContent" } ]
+    }
+  }
 }

--- a/src/test/launchsettings/default.json
+++ b/src/test/launchsettings/default.json
@@ -1,8 +1,7 @@
 {
 	"profiles": {
 		"web": {
-			"executablePath": "safd",
-			"commandLineArgs": "foo"
+			"commandName": "Project"
 		}
 	}
 }


### PR DESCRIPTION
Removed requirement for commandName or excecutablePath but not both. Now commandName is required and executablePath is just another property.
Added support for the iisSettings options
Added missing properties:
- nativeDebugging
- applicationUrl
- use64Bit
- xternalUrlConfiguration

Reworded some of the descriptions.