### PR TITLE
Update tsconfig.json

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -228,7 +228,7 @@
               "type": "boolean"
             },
             "target": {
-              "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es2015', 'es2016', 'es2017' or 'esnext'.",
+              "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017' or 'esnext'.",
               "type": "string",
               "default": "es3",
               "anyOf": [
@@ -236,6 +236,7 @@
                   "enum": [
                     "es3",
                     "es5",
+                    "es6",
                     "es2015",
                     "es2016",
                     "es2017",


### PR DESCRIPTION
added "es6" to "target" key permitted values.

Very minor thing I know oh well lol `¯\_(ツ)_/¯`

I noticed it with vscode `tsconfig.json` as they were using `es6` and I happened to see the description said only `es3`,`es5` were permitted. Obviously upon further inspection I saw the pattern allows for `es6`, is just missing from description/anyof:enum