### PR TITLE
Update port:name type in vs-2017.3.host.json schema

### DIFF
--- a/src/schemas/json/vs-2017.3.host.json
+++ b/src/schemas/json/vs-2017.3.host.json
@@ -45,7 +45,7 @@
       "type": "object",
       "properties": {
         "name": {
-          "enum": [ "HttpsPort", "KestrelPort", "IISExpressPort" ]
+          "type": "string"
         },
         "useHttps": {
           "type": "boolean"


### PR DESCRIPTION
Values here can be associated with values from the template.json file, so the are not restricted to a particular enumeration.