### PR TITLE
Type jsconfig/tsconfig paths as string[]

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -254,7 +254,14 @@
             },
             "paths": {
               "description": "Specify path mapping to be computed relative to baseUrl option.",
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Path mapping to be computed relative to baseUrl option."
+                }
+              }
             },
             "rootDirs": {
               "description": "Specify list of root directory to be used when resolving modules.",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -301,7 +301,14 @@
             },
             "paths": {
               "description": "Specify path mapping to be computed relative to baseUrl option.",
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Path mapping to be computed relative to baseUrl option."
+                }
+              }
             },
             "plugins": {
               "description": "List of TypeScript language server plugins to load. Requires TypeScript version 2.3 or later.",


### PR DESCRIPTION
Fixes #398

Types `compilerOptions.paths` as an array of strings