### PR TITLE
Fixes two typos from "Enusre" to "Ensure"

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -322,7 +322,7 @@
                 "type": "boolean"
             },
             "strictPropertyInitialization": {
-                "description": "Enusre non-undefined class properties are initialized in the constructor. Requires TypeScript version 2.7 or later.",
+                "description": "Ensure non-undefined class properties are initialized in the constructor. Requires TypeScript version 2.7 or later.",
                 "type": "boolean"
             },
             "esModuleInterop": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -412,7 +412,7 @@
                 "type": "boolean"
             },
             "strictPropertyInitialization": {
-                "description": "Enusre non-undefined class properties are initialized in the constructor. Requires TypeScript version 2.7 or later.",
+                "description": "Ensure non-undefined class properties are initialized in the constructor. Requires TypeScript version 2.7 or later.",
                 "type": "boolean"
             },
             "esModuleInterop": {


### PR DESCRIPTION
There is a type in jsconfig.json and tsconfig.json regarding "strictPropertyInitialization" description of which starts with "Enusre" whrereas the word should be "Ensure".