### PR TITLE
jsconfig and tsconfig: add es2018 as valid target option

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -211,9 +211,9 @@
               "type": "boolean"
             },
             "target": {
-              "description": "Specifies which default library (lib.d.ts) to use. When down-level compiling, specifies the code being generated. Permitted values are 'es3', 'es5', 'es2015', 'es2016', 'es2017' or 'esnext'.",
+              "description": "Specifies which default library (lib.d.ts) to use. When down-level compiling, specifies the code being generated. Permitted values are 'es3', 'es5', 'es2015', 'es2016', 'es2017', 'es2018' or 'esnext'.",
               "type": "string",
-              "pattern": "^([eE][sS]([356]|(201[567])|[nN][eE][xX][tT]))$",
+              "pattern": "^([eE][sS]([356]|(201[5678])|[nN][eE][xX][tT]))$",
               "default": "es2015"
             },
             "watch": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -228,7 +228,7 @@
               "type": "boolean"
             },
             "target": {
-              "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017' or 'esnext'.",
+              "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018' or 'esnext'.",
               "type": "string",
               "default": "es3",
               "anyOf": [
@@ -240,10 +240,11 @@
                     "es2015",
                     "es2016",
                     "es2017",
+                    "es2018",
                     "esnext"
                   ]
                 }, {
-                  "pattern": "^([eE][sS]([356]|(201[567])|[nN][eE][xX][tT]))$"
+                  "pattern": "^([eE][sS]([356]|(201[5678])|[nN][eE][xX][tT]))$"
                 }
               ]
             },


### PR DESCRIPTION
Fixes #403

TypeScript 2.7 now supports `"target": "es2018"`: https://github.com/Microsoft/TypeScript/pull/20385