### PR TITLE
Add prisma.yml support

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -421,6 +421,12 @@
       }
     },
     {
+      "name": "prisma.yml",
+      "description": "prisma.yml service definition file",
+      "fileMatch": [ "prisma.yml" ],
+      "url": "http://json.schemastore.org/prisma"
+    },
+    {
       "name": "project.json",
       "description": "ASP.NET vNext project configuration file",
       "fileMatch": [ "project.json" ],

--- a/src/schemas/json/prisma.json
+++ b/src/schemas/json/prisma.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "JSON schema for Prisma prisma.yml files",
+  "definitions": {
+    "subscription": {
+      "description": "A piece of code that you should run.",
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string"
+        },
+        "webhook": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "headers": {
+                  "type": "object"
+                }
+              },
+              "required": ["url"]
+            }
+          ]
+        }
+      },
+      "required": ["query", "webhook"]
+    }
+  },
+  "properties": {
+    "service": {
+      "description": "Name of the Service",
+      "type": "string",
+      "items": {
+        "type": "string"
+      }
+    },
+    "datamodel": {
+      "description":
+        "Type definitions for database models, relations, enums and other types",
+      "type": ["string", "array"],
+      "items": {
+        "type": ["string", "array"]
+      }
+    },
+    "secret": {
+      "description": "Secret for securing the API Endpoint",
+      "type": "string",
+      "items": {
+        "type": "string"
+      }
+    },
+    "disableAuth": {
+      "description": "Disable authentication for the endpoint",
+      "type": "boolean",
+      "items": {
+        "type": "boolean"
+      }
+    },
+    "schema": {
+      "description": "Path to schema.graphql for usage in the Gateway",
+      "type": "string",
+      "items": {
+        "type": "string"
+      }
+    },
+    "stage": {
+      "description": "Stage to deploy to. Read more here https://goo.gl/J5k76y",
+      "type": "string",
+      "items": {
+        "type": "string"
+      }
+    },
+    "cluster": {
+      "description":
+        "Cluster used for deployment. Read more here https://goo.gl/J5k76y",
+      "type": "string",
+      "items": {
+        "type": "string"
+      }
+    },
+    "seed": {
+      "description": "Database seed",
+      "type": "object",
+      "properties": {
+        "import": {
+          "type": "string"
+        },
+        "run": {
+          "type": "string"
+        }
+      }
+    },
+    "subscriptions": {
+      "description": "All server-side subscriptions",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/subscription"
+      }
+    },
+    "custom": {
+      "description":
+        "Custom field to use in variable interpolations with ${self:custom.field}",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["service", "datamodel", "stage"]
+}


### PR DESCRIPTION
Add json schema for `prisma.yml` of the GraphQL database layer [Prisma](https://www.prismagraphql.com/).
Taken from https://github.com/graphcool/prisma-json-schema