### PR TITLE
Update ecmaVersion to accept 2018/9

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -462,7 +462,7 @@
           "$ref": "#/properties/ecmaFeatures"
         },
         "ecmaVersion": {
-          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017 ],
+          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018 ],
           "default": 5,
           "description": "Set to 3, 5 (default), 6, 7, or 8 to specify the version of ECMAScript you want to use. Alternatively, set to 2015 (same as 6), 2016 (same as 7), or 2017 (same as 8) to use year-based naming."
         },


### PR DESCRIPTION
Per documentation:
>ecmaVersion - set to 3, 5 (default), 6, 7, 8, or 9 to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), or 2018 (same as 9) to use the year-based naming.