### PR TITLE
Fix required property name "libraries"

### DIFF
--- a/src/schemas/json/libman.json
+++ b/src/schemas/json/libman.json
@@ -3,10 +3,10 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
 
   "type": "object",
-  "required": [ "packages" ],
+  "required": [ "libraries" ],
 
   "definitions": {
-    "library": {
+    "libraryEntry": {
       "required": [ "library" ],
 
       "properties": {
@@ -40,7 +40,7 @@
 
     "specifiedProvider": {
       "properties": {
-        "packages": {
+        "libraries": {
           "items": {
             "required": [ "provider" ]
           }
@@ -60,7 +60,7 @@
 
     "specifiedDestination": {
       "properties": {
-        "packages": {
+        "libraries": {
           "items": {
             "required": [ "destination" ]
           }
@@ -80,11 +80,11 @@
   },
 
   "properties": {
-    "packages": {
-      "description": "A list of library packages.",
+    "libraries": {
+      "description": "A list of library references.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/library"
+        "$ref": "#/definitions/libraryEntry"
       }
     },
     "version": {

--- a/src/test/libman/withDefaultDestination.json
+++ b/src/test/libman/withDefaultDestination.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "defaultDestination": "js/lib",
   "defaultProvider": "cdnjs",
-  "packages": [
+  "libraries": [
     {
       "library": "jquery@3.1.1"
     },

--- a/src/test/libman/withDefaultProvider.json
+++ b/src/test/libman/withDefaultProvider.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "defaultProvider": "cdnjs",
-  "packages": [
+  "libraries": [
     {
       "library": "jquery@3.1.1",
       "destination": "js/lib",

--- a/src/test/libman/withoutDefaultDestination.json
+++ b/src/test/libman/withoutDefaultDestination.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "packages": [
+  "libraries": [
     {
       "provider": "cdnjs",
       "library": "jquery@3.1.1",

--- a/src/test/libman/withoutDefaultProvider.json
+++ b/src/test/libman/withoutDefaultProvider.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "packages": [
+  "libraries": [
     {
       "provider": "cdnjs",
       "library": "jquery@3.1.1",


### PR DESCRIPTION
This was missed when updating the libman.json schema to the new spec.

Also renaming definition to "libraryEntry" to make it less confusing with the "library" property name.