### PR TITLE
Update tslint schema based on tslint 5.9.1

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -258,6 +258,26 @@
             }
           ]
         },
+        "ban-comma-operator": {
+          "description": "Bans the comma operator.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "binary-expression-operand-order": {
           "description": "In a binary expression, a literal should always be on the right-hand side if possible.\nFor example, prefer 'x + 1' over '1 + x'.",
           "allOf": [
@@ -1295,6 +1315,26 @@
             }
           ]
         },
+        "newline-per-chained-call": {
+          "description": "Requires that chained method calls be broken apart onto separate lines.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "new-parens": {
           "description": "Requires parentheses when invoking a constructor via the `new` keyword.",
           "allOf": [
@@ -1564,6 +1604,26 @@
             }
           ]
         },
+        "no-duplicate-switch-case": {
+          "description": "Prevents duplicate cases in switch statements.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "no-duplicate-variable": {
           "description": "Disallows duplicate variable declarations in the same block scope.",
           "definitions": {
@@ -1605,6 +1665,26 @@
                     }
                   ]
                 },
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-dynamic-delete": {
+          "description": "Bans usage of the delete operator with computed key expressions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
                 "severity": {}
               },
               "additionalProperties": false
@@ -1692,6 +1772,54 @@
               ],
               "additionalItems": false,
               "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-implicit-dependencies": {
+          "description": "Disallows importing modules that are not listed as dependency in the project’s package.json.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "dev",
+                  "optional"
+                ]
+              },
+              "minItems": 0,
+              "maxItems": 2
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "maxItems": 3,
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options/items"
+              },
+              "properties": {
+                "options": {
+                  "description": "An option value or an array of multiple option values.",
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options"
+                    },
+                    {
+                      "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options/items"
+                    }
+                  ]
+                },
                 "severity": {}
               },
               "additionalProperties": false
@@ -1921,6 +2049,26 @@
         },
         "no-reference": {
           "description": "Disallows `/// <reference path=>` imports (use ES6-style imports instead).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-return-await": {
+          "description": "Disallows unnecessary `return await`.",
           "allOf": [
             {
               "$ref": "#/definitions/rule"
@@ -2277,6 +2425,50 @@
               ],
               "additionalItems": false,
               "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "no-unnecessary-class": {
+          "description": "Disallows classes that are not strictly necessary.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minLength": 0,
+              "maxLength": 3
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/rules/properties/no-unnecessary-class/definitions/options/items"
+              },
+              "maxItems": 4,
+              "properties": {
+                "options": {
+                  "description": "An option value or an array of multiple option values.",
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/no-unnecessary-class/definitions/options"
+                    },
+                    {
+                      "$ref": "#/definitions/rules/properties/no-unnecessary-class/definitions/options/items"
+                    }
+                  ]
+                },
                 "severity": {}
               },
               "additionalProperties": false
@@ -4576,6 +4768,26 @@
             }
           ]
         },
+        "no-redundant-jsdoc": {
+          "description": "Forbids JSDoc which duplicates TypeScript functionality.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
+              "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "no-reference-import": {
           "description": "Don't `<reference types=\"foo\" />` if you import `foo` anyway.",
           "allOf": [
@@ -4779,6 +4991,51 @@
               ],
               "additionalItems": false,
               "properties": {
+                "severity": {}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-readonly": {
+          "description": "Requires that private variables are marked as `readonly` if they’re never modified outside of the constructor.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "only-inline-lambdas"
+                ],
+                "type": "string"
+              }
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/prefer-readonly/definitions/options/items"
+              },
+              "maxItems": 2,
+              "properties": {
+                "options": {
+                  "description": "An option value or an array of multiple option values.",
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/tsRules/properties/prefer-readonly/definitions/options"
+                    },
+                    {
+                      "$ref": "#/definitions/tsRules/properties/prefer-readonly/definitions/options/items"
+                    }
+                  ]
+                },
                 "severity": {}
               },
               "additionalProperties": false


### PR DESCRIPTION
Update tslint schema based on current version (v5.9.1). The added rules are:

[ban-comma-operator](https://palantir.github.io/tslint/rules/ban-comma-operator/)
[newline-per-chained-call](https://palantir.github.io/tslint/rules/newline-per-chained-call/)
[no-duplicate-switch-case](https://palantir.github.io/tslint/rules/no-duplicate-switch-case/)
[no-dynamic-delete](https://palantir.github.io/tslint/rules/no-dynamic-delete/)
[no-implicit-dependencies](https://palantir.github.io/tslint/rules/no-implicit-dependencies/)
[no-return-await](https://palantir.github.io/tslint/rules/no-return-await/)
[no-unnecessary-class](https://palantir.github.io/tslint/rules/no-unnecessary-class/)
[no-redundant-jsdoc](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/)
[prefer-readonly](https://palantir.github.io/tslint/rules/prefer-readonly/)