### PR TITLE
Update webextension.json chrome_url_overrides

### DIFF
--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -89,12 +89,12 @@
       "description": "Use the chrome_url_overrides key to provide a custom replacement for the documents loaded into various special pages usually provided by the browser itself.",
       "type": "object",
       "properties": {
-        "bookmark": {
-          "description": "Provide a replacement for the page that shows the bookmarks. ",
+        "bookmarks": {
+          "description": "Provide a replacement for the page that shows the bookmarks.",
           "type": "string"
         },
         "history": {
-          "description": "Provide a replacement for the page that shows the browsing history. ",
+          "description": "Provide a replacement for the page that shows the browsing history.",
           "type": "string"
         },
         "newtab": {


### PR DESCRIPTION
`bookmarks` is the correct property name. It was incorrect on MDN