### PR TITLE
Adding schema for the Visual Studio Live Share config file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -703,6 +703,12 @@
       "url": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
+      "name": "vsls.json",
+      "description": "Visual Studio Live Share configuration file",
+      "fileMatch": [ ".vsls.json" ],
+      "url": "http://json.schemastore.org/vsls"
+    },
+    {
       "name": "vs-2017.3.host.json",
       "description": "JSON schema for Visual Studio template host file",
       "fileMatch": [ "vs-2017.3.host.json" ],

--- a/src/schemas/json/vsls.json
+++ b/src/schemas/json/vsls.json
@@ -1,0 +1,23 @@
+{  
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON schema for Visual Studio Live Share config files",
+    "type": "object",
+    "properties": {
+        "excludeFiles": {
+            "description": "An array of globs which indicate the files that should be completely unavailable to guests when you share (e.g. secrets).",
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "gitignore": {
+            "description": "Indicates how .gitignore files should be treated with respects to excluding/hiding files from guests.",
+            "type": "string",
+            "default": "hide",
+            "enum": ["none", "hide", "exclude"]
+        },
+        "hideFiles": {
+            "description": "An array of globs which indicate the files that should be hidden from guest's file trees, but still accessible (e.g. when following the host).",
+            "type": "array",
+            "items": { "type": "string" }
+        }
+    }    
+}


### PR DESCRIPTION
This PR simply adds the schema for the Visual Studio Live Share config file (`.vsls.json`).

CC @madskristensen 