### PR TITLE
Update prisma.json

### DIFF
--- a/src/schemas/json/prisma.json
+++ b/src/schemas/json/prisma.json
@@ -107,8 +107,21 @@
       "description":
         "Custom field to use in variable interpolations with ${self:custom.field}",
       "type": "object"
+    },
+    "hooks": {
+      "description":
+        "Command hooks. Current available hooks are: post-deploy.",
+      "type": "object"
+    },
+    "endpoint": {
+      "description":
+        "Endpoint the service will be reachable at. This also determines the cluster the service will deployed to.",
+      "type": "string",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,
-  "required": ["service", "datamodel", "stage"]
+  "required": ["datamodel"]
 }


### PR DESCRIPTION
Updated prisma yaml definition schema, based on https://github.com/graphcool/prisma-json-schema/blob/master/src/schema.json
We added 2 new fields: `hooks` and `endpoint` and made `service` and `stage` optional.