### PR TITLE
Case insensitive "lib" property

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -292,8 +292,15 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [ "es5", "es6", "es2015", "es7", "es2016", "es2017", "es2018", "esnext", "dom", "dom.iterable", "webworker", "scripthost", "es2015.core", "es2015.collection", "es2015.generator", "es2015.iterable",
-                    "es2015.promise", "es2015.proxy", "es2015.reflect", "es2015.symbol", "es2015.symbol.wellknown", "es2016.array.include", "es2017.object", "es2017.sharedmemory", "es2017.typedarrays", "es2018.promise", "esnext.regexp", "esnext.array", "esnext.asynciterable"]
+                "anyOf": [
+                  {
+                    "enum": [ "dom", "dom.iterable", "webworker", "scripthost", "es2015.core", "es2015.collection", "es2015.generator", "es2015.iterable", "es2015.promise", "es2015.proxy", "es2015.reflect", "es2015.symbol",
+                              "es2015.symbol.wellknown", "es2016.array.include", "es2017.object", "es2017.sharedmemory", "es2017.typedarrays", "es2018.promise", "es2018.regexp", "esnext.array", "esnext.asynciterable"]
+                  },
+                  {
+                    "pattern": "^([eE][sS]([567]|(201[5678])|[nN][eE][xX][tT]))$"
+                  }
+                ],
               }
             },
             "strictNullChecks": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -383,8 +383,15 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [ "es5", "es6", "es2015", "es7", "es2016", "es2017", "es2018", "esnext", "dom", "dom.iterable", "webworker", "scripthost", "es2015.core", "es2015.collection", "es2015.generator", "es2015.iterable",
-                        "es2015.promise", "es2015.proxy", "es2015.reflect", "es2015.symbol", "es2015.symbol.wellknown", "es2016.array.include", "es2017.object", "es2017.sharedmemory", "es2017.string", "es2017.typedarrays", "es2018.promise", "es2018.regexp", "esnext.array", "esnext.asynciterable"]
+                "anyOf": [
+                  {
+                    "enum": [ "dom", "dom.iterable", "webworker", "scripthost", "es2015.core", "es2015.collection", "es2015.generator", "es2015.iterable", "es2015.promise", "es2015.proxy", "es2015.reflect", "es2015.symbol",
+                              "es2015.symbol.wellknown", "es2016.array.include", "es2017.object", "es2017.sharedmemory", "es2017.typedarrays", "es2018.promise", "es2018.regexp", "esnext.array", "esnext.asynciterable"]
+                  },
+                  {
+                    "pattern": "^([eE][sS]([567]|(201[5678])|[nN][eE][xX][tT]))$"
+                  }
+                ],
               }
             },
             "strictNullChecks": {


### PR DESCRIPTION
This addresses #449. I used the compiler options listed here as reference: https://www.typescriptlang.org/docs/handbook/compiler-options.html. 

This doesn't make the property completely case insensitive, as it would have taken an extremely long and complex regex to handle all the possible values. Instead, it is case insensitive for the `"es5", "es6", "es2015", "es7", "es2016", "es2017", "es2018", "esnext"` values, mimicking the behavior for the `"target"` option.

I also removed `es2017.string` from the enums because it wasn't listed in the documentation linked above.