### PR TITLE
package.json: accept lack of "name", "version" or "private:true" properties

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -413,20 +413,6 @@
           }
         }
       ]
-    },
-    {
-      "anyOf": [
-        { "required": [ "name", "version" ] },
-        {
-          "not":{
-            "properties": {
-              "private": {
-                "enum": [false]
-              }
-            }
-          }
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Some npm commands, like `npm install` don't require "name", "version" or "private:true" properties be defined. Let's relax this requirement in JSON schema too.