### PR TITLE
Updated schema for xunit

### DIFF
--- a/src/schemas/json/xunit.runner.schema.json
+++ b/src/schemas/json/xunit.runner.schema.json
@@ -28,7 +28,7 @@
     "maxParallelThreads": {
       "description": "Configures the maximum number of threads to be used when parallelizing tests within this assembly.",
       "type": "integer",
-      "minimum": 1
+      "minimum": -1
     },
     "methodDisplay": {
       "description": "Configures the default display name for test cases. If you choose 'method', the display name will be just the method (without the class name); if you choose 'classAndMethod', the default display name will be the fully qualified class name and method name.",


### PR DESCRIPTION
The [documentation](https://xunit.github.io/docs/configuring-with-json.html) for xunit.runner.json states that for maxParallelThreads you can set a value of -1.

The schema currently states the minimum value is 1.