### PR TITLE
Upgrade the composer.json schema

### DIFF
--- a/src/schemas/json/composer.json
+++ b/src/schemas/json/composer.json
@@ -33,6 +33,10 @@
             "description": "Homepage URL for the project.",
             "format": "uri"
         },
+        "readme": {
+            "type": "string",
+            "description": "Relative path to the readme document."
+        },
         "version": {
             "type": "string",
             "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes."
@@ -46,63 +50,49 @@
             "description": "License name. Or an array of license names."
         },
         "authors": {
-            "type": "array",
-            "description": "List of authors that contributed to the package. This is typically the main maintainers, not the full list.",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": [ "name"],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Full name of the author."
-                    },
-                    "email": {
-                        "type": "string",
-                        "description": "Email address of the author.",
-                        "format": "email"
-                    },
-                    "homepage": {
-                        "type": "string",
-                        "description": "Homepage URL for the author.",
-                        "format": "uri"
-                    },
-                    "role": {
-                        "type": "string",
-                        "description": "Author's role in the project."
-                    }
-                }
-            }
+            "$ref": "#/definitions/authors"
         },
         "require": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that are required to run this package.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "replace": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that can be replaced by this package.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "conflict": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that conflict with this package.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "provide": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that this package provides in addition to this package's name.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "require-dev": {
             "type": "object",
             "description": "This is a hash of package name (keys) and version constraints (values) that this package requires for developing it (testing tools and such).",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "suggest": {
             "type": "object",
             "description": "This is a hash of package name (keys) and descriptions (values) that this package suggests work well with it (this will be suggested to the user during installation).",
-            "additionalProperties": true
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "config": {
             "type": "object",
@@ -134,11 +124,20 @@
                 "github-oauth": {
                     "type": "object",
                     "description": "A hash of domain name => github API oauth tokens, typically {\"github.com\":\"<token>\"}.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "gitlab-oauth": {
                     "type": "object",
                     "description": "A hash of domain name => gitlab API oauth tokens, typically {\"gitlab.com\":\"<token>\"}.",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "gitlab-token": {
+                    "type": "object",
+                    "description": "A hash of domain name => gitlab private tokens, typically {\"gitlab.com\":\"<token>\"}.",
                     "additionalProperties": true
                 },
                 "disable-tls": {
@@ -160,7 +159,20 @@
                 "http-basic": {
                     "type": "object",
                     "description": "A hash of domain name => {\"username\": \"...\", \"password\": \"...\"}.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": "object",
+                        "required": ["username", "password"],
+                        "properties": {
+                            "username": {
+                                "type": "string",
+                                "description": "The username used for HTTP Basic authentication"
+                            },
+                            "password": {
+                                "type": "string",
+                                "description": "The password used for HTTP Basic authentication"
+                            }
+                        }
+                    }
                 },
                 "store-auths": {
                     "type": ["string", "boolean"],
@@ -169,7 +181,9 @@
                 "platform": {
                     "type": "object",
                     "description": "This is a hash of package name (keys) and version (values) that will be used to mock the platform packages on this machine.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "vendor-dir": {
                     "type": "string",
@@ -235,6 +249,10 @@
                     "type": "boolean",
                     "description": "If true, the composer autoloader will not scan the filesystem for classes that are not found in the class map, defaults to false."
                 },
+                "apcu-autoloader": {
+                    "type": "boolean",
+                    "description": "If true, the Composer autoloader will check for APCu and use it to cache found/not-found classes when the extension is enabled, defaults to false."
+                },
                 "github-domains": {
                     "type": "array",
                     "description": "A list of domains to use in github mode. This is used for GitHub Enterprise setups, defaults to [\"github.com\"].",
@@ -260,6 +278,14 @@
                 "archive-dir": {
                     "type": "string",
                     "description": "The default archive path when not provided on cli, defaults to \".\"."
+                },
+                "htaccess-protect": {
+                    "type": "boolean",
+                    "description": "Defaults to true. If set to false, Composer will not create .htaccess files in the composer home, cache, and data directories."
+                },
+                "sort-packages": {
+                    "type": "boolean",
+                    "description": "Defaults to false. If set to true, Composer will sort packages when adding/updating a new dependency."
                 }
             }
         },
@@ -269,32 +295,7 @@
             "additionalProperties": true
         },
         "autoload": {
-            "type": "object",
-            "description": "Description of how the package can be autoloaded.",
-            "properties": {
-                "psr-0": {
-                    "type": "object",
-                    "description": "This is a hash of namespaces (keys) and the directories they can be found into (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": true
-                },
-                "psr-4": {
-                    "type": "object",
-                    "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": true
-                },
-                "classmap": {
-                    "type": "array",
-                    "description": "This is an array of directories that contain classes to be included in the class-map generation process."
-                },
-                "files": {
-                    "type": "array",
-                    "description": "This is an array of files that are always required on every request."
-                },
-                "exclude-from-classmap": {
-                    "type": "array",
-                    "description": "This is an array of patterns to exclude from autoload classmap generation. (e.g. \"exclude-from-classmap\": [\"/test/\", \"/tests/\", \"/Tests/\"]"
-                }
-            }
+            "$ref": "#/definitions/autoload"
         },
         "autoload-dev": {
             "type": "object",
@@ -303,12 +304,22 @@
                 "psr-0": {
                     "type": "object",
                     "description": "This is a hash of namespaces (keys) and the directories they can be found into (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "psr-4": {
                     "type": "object",
                     "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "classmap": {
                     "type": "array",
@@ -333,7 +344,23 @@
         "repositories": {
             "type": ["object", "array"],
             "description": "A set of additional repositories where packages can be found.",
-            "additionalProperties": true
+            "additionalProperties": {
+                "oneOf": [
+                    { "$ref": "#/definitions/repository" },
+                    { "type": "boolean", "enum": [false] }
+                ]
+            },
+            "items": {
+                "oneOf": [
+                    { "$ref": "#/definitions/repository" },
+                    {
+                        "type": "object",
+                        "additionalProperties": { "type": "boolean", "enum": [false] },
+                        "minProperties": 1,
+                        "maxProperties": 1
+                    }
+                ]
+            }
         },
         "minimum-stability": {
             "type": ["string"],
@@ -345,8 +372,8 @@
             "description": "If set to true, stable packages will be preferred to dev packages when possible, even if the minimum-stability allows unstable packages."
         },
         "bin": {
-            "type": ["array"],
-            "description": "A set of files that should be treated as binaries and symlinked into bin-dir (from config).",
+            "type": ["string", "array"],
+            "description": "A set of files, or a single file, that should be treated as binaries and symlinked into bin-dir (from config).",
             "items": {
                 "type": "string"
             }
@@ -360,7 +387,7 @@
         },
         "scripts": {
             "type": ["object"],
-            "description": "Scripts listeners that will be executed before/after some events.",
+            "description": "Script listeners that will be executed before/after some events.",
             "properties": {
                 "pre-install-cmd": {
                     "type": ["array", "string"],
@@ -428,6 +455,13 @@
                 }
             }
         },
+        "scripts-descriptions": {
+            "type": ["object"],
+            "description": "Descriptions for custom commands, shown in console help.",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "support": {
             "type": "object",
             "properties": {
@@ -487,6 +521,318 @@
         "_comment": {
             "type": ["array", "string"],
             "description": "A key to store comments in"
+        }
+    },
+    "definitions": {
+        "authors": {
+            "type": "array",
+            "description": "List of authors that contributed to the package. This is typically the main maintainers, not the full list.",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [ "name"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Full name of the author."
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "Email address of the author.",
+                        "format": "email"
+                    },
+                    "homepage": {
+                        "type": "string",
+                        "description": "Homepage URL for the author.",
+                        "format": "uri"
+                    },
+                    "role": {
+                        "type": "string",
+                        "description": "Author's role in the project."
+                    }
+                }
+            }
+        },
+        "autoload": {
+            "type": "object",
+            "description": "Description of how the package can be autoloaded.",
+            "properties": {
+                "psr-0": {
+                    "type": "object",
+                    "description": "This is a hash of namespaces (keys) and the directories they can be found in (values, can be arrays of paths) by the autoloader.",
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "psr-4": {
+                    "type": "object",
+                    "description": "This is a hash of namespaces (keys) and the PSR-4 directories they can map to (values, can be arrays of paths) by the autoloader.",
+                    "additionalProperties": {
+                        "type": ["string", "array"],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "classmap": {
+                    "type": "array",
+                    "description": "This is an array of directories that contain classes to be included in the class-map generation process."
+                },
+                "files": {
+                    "type": "array",
+                    "description": "This is an array of files that are always required on every request."
+                },
+                "exclude-from-classmap": {
+                    "type": "array",
+                    "description": "This is an array of patterns to exclude from autoload classmap generation. (e.g. \"exclude-from-classmap\": [\"/test/\", \"/tests/\", \"/Tests/\"]"
+                }
+            }
+        },
+        "repository": {
+            "type": "object",
+            "oneOf": [
+                { "$ref": "#/definitions/composer-repository" },
+                { "$ref": "#/definitions/vcs-repository" },
+                { "$ref": "#/definitions/path-repository" },
+                { "$ref": "#/definitions/artifact-repository" },
+                { "$ref": "#/definitions/pear-repository" },
+                { "$ref": "#/definitions/package-repository" }
+            ]
+        },
+        "composer-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["composer"] },
+                "url": { "type": "string" },
+                "options": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "allow_ssl_downgrade": { "type": "boolean" },
+                "force-lazy-providers": { "type": "boolean" }
+            }
+        },
+        "vcs-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["vcs", "github", "git", "gitlab", "git-bitbucket", "hg", "hg-bitbucket", "fossil", "perforce", "svn"] },
+                "url": { "type": "string" },
+                "no-api": { "type": "boolean" },
+                "secure-http": { "type": "boolean" },
+                "svn-cache-credentials": { "type": "boolean" },
+                "trunk-path": { "type": ["string", "boolean"] },
+                "branches-path": { "type": ["string", "boolean"] },
+                "tags-path": { "type": ["string", "boolean"] },
+                "package-path": { "type": "string" },
+                "depot": { "type": "string" },
+                "branch": { "type": "string" },
+                "unique_perforce_client_name": { "type": "string" },
+                "p4user": { "type": "string" },
+                "p4password": { "type": "string" }
+            }
+        },
+        "path-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["path"] },
+                "url": { "type": "string" },
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "symlink": { "type": ["boolean", "null"] }
+                    },
+                    "additionalProperties": true
+                }
+            }
+        },
+        "artifact-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["artifact"] },
+                "url": { "type": "string" }
+            }
+        },
+        "pear-repository": {
+            "type": "object",
+            "required": ["type", "url"],
+            "properties": {
+                "type": { "type": "string", "enum": ["pear"] },
+                "url": { "type": "string" },
+                "vendor-alias": { "type": "string" }
+            }
+        },
+        "package-repository": {
+            "type": "object",
+            "required": ["type", "package"],
+            "properties": {
+                "type": { "type": "string", "enum": ["package"] },
+                "package": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/inline-package" },
+                        {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/inline-package" }
+                        }
+                    ]
+                }
+            }
+        },
+        "inline-package": {
+            "type": "object",
+            "required": ["name", "version"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Package name, including 'vendor-name/' prefix."
+                },
+                "type": {
+                    "type": "string"
+                },
+                "target-dir": {
+                    "description": "DEPRECATED: Forces the package to be installed into the given subdirectory path. This is used for autoloading PSR-0 packages that do not contain their full path. Use forward slashes for cross-platform compatibility.",
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "homepage": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "string"
+                },
+                "license": {
+                    "type": [
+                        "string",
+                        "array"
+                    ]
+                },
+                "authors": {
+                    "$ref": "#/definitions/authors"
+                },
+                "require": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "replace": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "conflict": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "provide": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "require-dev": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "suggest": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "extra": {
+                    "type": ["object", "array"],
+                    "additionalProperties": true
+                },
+                "autoload": {
+                    "$ref": "#/definitions/autoload"
+                },
+                "archive": {
+                    "type": ["object"],
+                    "properties": {
+                        "exclude": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "bin": {
+                    "type": ["string", "array"],
+                    "description": "A set of files, or a single file, that should be treated as binaries and symlinked into bin-dir (from config).",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include-path": {
+                    "type": ["array"],
+                    "description": "DEPRECATED: A list of directories which should get added to PHP's include path. This is only present to support legacy projects, and all new code should preferably use autoloading.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "type": "object",
+                    "required": ["type", "url", "reference"],
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "reference": {
+                            "type": "string"
+                        },
+                        "mirrors": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "dist": {
+                    "type": "object",
+                    "required": ["type", "url"],
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "reference": {
+                            "type": "string"
+                        },
+                        "shasum": {
+                            "type": "string"
+                        },
+                        "mirrors": {
+                            "type": "array"
+                        }
+                    }
+                }
+            },
+            "additionalProperties": true
         }
     }
 }


### PR DESCRIPTION
the composer.json schema present in schemastore is very old, and Composer improved it a lot since then (adding new properties, fixing some mistakes for some properties, improving validation of some parts which were previously untyped).
This brings in the uptodate schema.