### PR TITLE
TSLint strict-bound-class-methods option.

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -3487,7 +3487,8 @@
                   "type": "string",
                   "enum": [
                     "ignore-interfaces",
-                    "ignore-bound-class-methods"
+                    "ignore-bound-class-methods",
+                    "strict-bound-class-methods"
                   ]
                 }
               ],

--- a/src/test/tslint/tslint-test7.json
+++ b/src/test/tslint/tslint-test7.json
@@ -5,7 +5,8 @@
       "parameters",
       "arguments",
       "statements"
-    ]
+    ],
+    "semicolon": [true, "always", "strict-bound-class-methods"]
   },
   "jsRules": {
     "no-trailing-whitespace": true


### PR DESCRIPTION
Adds `strict-bound-class-methods` option for [TSLint's `semicolon` rule](https://palantir.github.io/tslint/rules/semicolon/).

Opened this to resolve [this issue with editing tslint.json file in VS Code](https://github.com/Microsoft/vscode-tslint/issues/341).