### PR TITLE
Create toolinfo.1.1.0-draft04.json

### DIFF
--- a/src/schemas/json/toolinfo.1.1.0-draft04.json
+++ b/src/schemas/json/toolinfo.1.1.0-draft04.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Wikimedia Tool",
+  "description": "A tool is a piece of software that helps facilitate contribution toward, or consumption of, Wikimedia projects and associated data, not including the core wiki software and its extensions",
+  "version": "1.1.0-draft04",
+  "authors": [
+    "Hay Kranen",
+    "James Hare"
+  ],
+  "definitions": {
+    "tool": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "@comment": "Unique identifier for tools. Must be unique for every tool. It is recommended you prefix your tool names to reduce the risk of clashes."
+        },
+        "title": {
+          "type": "string",
+          "@comment": "Human readable tool name. Recommended limit of 25 characters."
+        },
+        "subtitle": {
+          "type": "string",
+          "maxLength": 250,
+          "@comment": "Longer than the full title but shorter than the description. It should add some additional context to the title."
+        },
+        "wikidata_item": {
+          "type": "string",
+          "pattern": "^Q%5Cd+$",
+          "@comment": "The Wikidata item ID for this tool."
+        },
+        "openhub_id": {
+          "type": "string",
+          "@comment": "The project ID on OpenHub. Given a URL https://openhub.net/p/foo, the project ID is `foo`."
+        },
+        "description": {
+          "type": "string",
+          "@comment": "A longer description of the tool. The recommended length for a description is 3-5 sentences. Future versions of this schema will impose a character limit."
+        },
+        "url": {
+          "type": "uri",
+          "@comment": "A direct link to the tool or to instructions on how to use or install the tool."
+        },
+        "keywords": {
+          "type": "string",
+          "@commment": "Comma-delineated list of keywords. This parameter is deprecated and will be removed in the next version."
+        },
+        "author": {
+          "type": "string",
+          "@comment": "The primary tool developer."
+        },
+        "repository": {
+          "type": "uri",
+          "@comment": "A link to the repository where the tool code is hosted."
+        },
+        "bot_username": {
+          "type": "string",
+          "@comment": "If the tool is a bot, the Wikimedia username of the bot. Do not include 'User:' or similar prefixes."
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false,
+          "@comment": "If true, the use of this tool is officially discouraged. The `replaced_by` parameter can be used to define a replacement."
+        },
+        "replaced_by": {
+          "type": "uri",
+          "@comment": "If this tool is deprecated, this parameter should be used to link to the replacement tool."
+        },
+        "experimental": {
+          "type": "boolean",
+          "default": false,
+          "@comment": "If true, this tool is unstable and can change or go offline at any time."
+        },
+        "for_wikis": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/wiki"
+              }
+            },
+            {
+              "type": "string",
+              "$ref": "#/definitions/wiki"
+            }
+          ],
+          "default": "*",
+          "@comment": "A string or array of strings describing the wiki(s) this tool can be used on. Use hostnames such as `zh.wiktionary.org`. Use asterisks as wildcards. For example, `*.wikisource.org` means 'this tool works on all Wikisource wikis.' `*` means 'this works on all wikis, including Wikimedia wikis.'"
+        },
+        "icon": {
+          "$ref": "#/definitions/commons_file",
+          "@comment": "A link to a Wikimedia Commons file description page for an icon that depicts the tool."
+        },
+        "license": {
+          "$ref": "https://tools.wmflabs.org/spdx/schema/licenses.json#/definitions/license",
+          "@comment": "The software license the tool code's is available under. Use a standard SPDX license keyword."
+        },
+        "sponsor": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "@comment": "Organization that sponsored the tool's development."
+        },
+        "supported_languages": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/language"
+              }
+            },
+            {
+              "type": "string",
+              "$ref": "#/definitions/language"
+            }
+          ],
+          "default": "en",
+          "@comment": "The language(s) the tool's interface has been translated into. Use ISO 639 language codes like `zh` and `scn`. If not defined it is assumed the tool is only available in English."
+        },
+        "technology_used": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "@comment": "A string or array of strings listing technologies (programming languages, development frameworks, etc.) used in creating the tool."
+        },
+        "tool_type": {
+          "type": "string",
+          "enum": [
+            "web app",
+            "desktop app",
+            "bot",
+            "gadget",
+            "user script",
+            "other"
+          ],
+          "@comment": "The manner in which the tool is used. Select one from the list of options."
+        },
+        "api_url": {
+          "type": "uri",
+          "@comment": "A link to the tool's API, if available."
+        },
+        "developer_docs_url": {
+          "type": "uri",
+          "@comment": "A link to the tool's developer documentation, if available."
+        },
+        "feedback_url": {
+          "type": "uri",
+          "@comment": "A link to where tool users can leave feedback."
+        },
+        "privacy_policy_url": {
+          "type": "uri",
+          "@comment": "A link to the tool's privacy policy, if available."
+        },
+        "translate_url": {
+          "type": "uri",
+          "@comment": "A link to the tool translation interface."
+        },
+        "bugtracker_url": {
+          "type": "uri",
+          "@comment": "A link to the tool's bug tracker on GitHub, Bitbucket, Phabricator, etc."
+        },
+        "toolinfo_version": {
+          "type": "integer",
+          "default": 1,
+          "@comment": "The major version number of the Toolinfo schema used. The default value assumed is 1, referring to versions 1.0.0 and 1.1.0."
+        },
+        "toolinfo_language": {
+          "$ref": "#/definitions/language",
+          "default": "en",
+          "@comment": "The language the toolinfo record is written if, if not the default value of English. Use ISO 639 language codes."
+        }
+      },
+      "required": [
+        "name",
+        "title",
+        "description",
+        "url"
+      ]
+    },
+    "wiki": {
+      "type": "string",
+      "pattern": "^(%5C*|(.*)?%5C.?(mediawiki|wiktionary|wiki(pedia|quote|books|source|news|versity|data|voyage|tech|media|mediafoundation))%5C.org)$"
+    },
+    "commons_file": {
+      "type": "uri",
+      "pattern": "^https://commons.wikimedia.org/wiki/File:.+%5C..+$"
+    },
+    "language": {
+      "type": "string",
+      "pattern": "^(x-.*|[A-Za-z]{2,3}(-.*)?)$"
+    }
+  },
+  "oneOf": [
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/tool"
+      }
+    },
+    {
+      "type": "object",
+      "$ref": "#/definitions/tool"
+    }
+  ]
+}


### PR DESCRIPTION
The toolinfo schema is part of Toolhub, an effort by the Wikimedia Foundation to create a directory of tools used by Wikipedia volunteers and volunteers for similar wiki websites run by the Foundation. More information is available at <https://meta.wikimedia.org/wiki/Toolhub> and specifically its data model <https://meta.wikimedia.org/wiki/Toolhub/Data_model>. I am the current product manager in charge of this work.

As we do not have an officially published version of the schema yet, I am submitting this draft, mostly so I can get your feedback ahead of time ahead of publication. This feedback could be about the design of the schema in general or something particular to its incorporation in the Schema Store.

Please let me know of your thoughts. Thank you!