### PR TITLE
CircleCI: Add name property to restore_cache and save_cache

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -205,6 +205,10 @@
                               "description":
                                 "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)",
                               "enum": ["always", "on_success", "on_fail"]
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "Title of the step to be shown in the CircleCI UI (default: 'Saving Cache')"
                             }
                           }
                         }
@@ -224,6 +228,10 @@
                                 "key": {
                                   "type": "string",
                                   "description": "Single cache key to restore"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "description": "Title of the step to be shown in the CircleCI UI (default: 'Restoring Cache')"
                                 }
                               }
                             },


### PR DESCRIPTION
According to the documentation on circleci.com both restore_cache
and save_cache has an optional name property:

https://circleci.com/docs/2.0/configuration-reference/#restore_cache
https://circleci.com/docs/2.0/configuration-reference/#save_cache