### PR TITLE
Fix stylelint at-rule-empty-line-before

### DIFF
--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -854,9 +854,10 @@
 												"items": {
 													"type": "string",
 													"enum": [
-														"all-nested",
+														"after-same-name",
+														"inside-block",
 														"blockless-after-same-name-blockless",
-														"blockless-group",
+														"blockless-after-blockless",
 														"first-nested"
 													]
 												}
@@ -869,9 +870,10 @@
 													"type": "string",
 													"enum": [
 														"after-comment",
-														"all-nested",
+														"first-nested",
+														"inside-block",
 														"blockless-after-same-name-blockless",
-														"blockless-group"
+														"blockless-after-blockless"
 													]
 												}
 											},


### PR DESCRIPTION
[The options](https://stylelint.io/user-guide/rules/at-rule-empty-line-before/#ignore-after-comment-first-nested-inside-block-blockless-after-same-name-blockless-blockless-after-blockless) seems to have changed. Here is the fixed schema.

Tel me if something else need to be changed 😊