### PR TITLE
fix(babelrc.json): fix the type and description of 'compact'

### DIFF
--- a/src/schemas/json/babelrc.json
+++ b/src/schemas/json/babelrc.json
@@ -28,8 +28,9 @@
 		},
 		"compact": {
 			"default": "auto",
-			"description": "Do not include superfluous whitespace characters and line terminators. When set to \"auto\" compact is set to true on input sizes of >100KB.",
-			"type": "string"
+			"description": "Do not include superfluous whitespace characters and line terminators. When set to \"auto\" compact is set to true on input sizes of >500KB.",
+			"type": ["string", "boolean"],
+      "enum": ["auto", true, false]
 		},
     "env": {
       "default": {},


### PR DESCRIPTION
According to [https://github.com/babel/babel/blob/eb3334a14e1e03b02271d92f238e54fe72e005ba/packages/babel-core/src/config/validation/options.js](https://github.com/babel/babel/blob/eb3334a14e1e03b02271d92f238e54fe72e005ba/packages/babel-core/src/config/validation/options.js),
```js
export type CompactOption = boolean | "auto";
```

So,the value of "compact" should be boolean or "auto".

According to [https://github.com/babel/babel/blob/34327925689f2b9580a7757dfc5bb91600843002/packages/babel-generator/src/index.js](https://github.com/babel/babel/blob/34327925689f2b9580a7757dfc5bb91600843002/packages/babel-generator/src/index.js),
> If `opts.compact = "auto"` and the code is over 500KB, `compact` will be set to `true`.

Therefore, I changed the "description" of "compact".