### PR TITLE
fix URLs for angular cli and debugsettings schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7,7 +7,7 @@
       "name": ".angular-cli.json",
       "description": "Angular CLI configuration file",
       "fileMatch": [ ".angular-cli.json", "angular-cli.json" ],
-      "url": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/@angular/cli/lib/config/schema.json"
+      "url": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/schema.json"
     },
     {
       "name": "Ansible",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -194,7 +194,7 @@
       "name": "debugsettings.json",
       "description": "A JSON schema for the ASP.NET DebugSettings.json files",
       "fileMatch": [ "debugsettings.json" ],
-      "url": "http://json.schemastore.org/launchsettings"
+      "url": "http://json.schemastore.org/debugsettings"
     },
     {
       "name": "docfx.json",


### PR DESCRIPTION
1) Angular CLI package was renamed, and the schema file was moved. Current URL gives 404. This PR fixes the URL to point to the new location.

2) Schema for debugsettings.json points to a wrong place.