### PR TITLE
tslint: no-unnecessary-type-assertion accepts list of strings after bool

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -4968,6 +4968,16 @@
         },
         "no-unnecessary-type-assertion": {
           "description": "Warns if a type assertion does not change the type of an expression.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
           "allOf": [
             {
               "$ref": "#/definitions/rule"
@@ -4978,8 +4988,22 @@
                   "type": "boolean"
                 }
               ],
-              "additionalItems": false,
+              "additionalItems": {
+                "$ref": "#/definitions/tsRules/properties/no-unnecessary-type-assertion/definitions/options/items"
+              },
+              "uniqueItems": true,
               "properties": {
+                "options": {
+                  "description": "An option value or an array of multiple option values.",
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/tsRules/properties/no-unnecessary-type-assertion/definitions/options"
+                    },
+                    {
+                      "$ref": "#/definitions/tsRules/properties/no-unnecessary-type-assertion/definitions/options/items"
+                    }
+                  ]
+                },
                 "severity": {}
               },
               "additionalProperties": false

--- a/src/test/tslint/tslint-test15.json
+++ b/src/test/tslint/tslint-test15.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unnecessary-type-assertion": [ true, "ms", "s" ]
+  }
+}


### PR DESCRIPTION
This is updated schema for tslint
