### PR TITLE
changed azure_rm_deployment properties.parameters type to object.

### DIFF
--- a/src/schemas/json/ansible-stable-2.1.json
+++ b/src/schemas/json/ansible-stable-2.1.json
@@ -9607,7 +9607,7 @@
                 "description": "The resource group name to use or create to host the deployed template"
               },
               "parameters": {
-                "type": "string",
+                "type": "object",
                 "description": "A hash of all the required template variables for the deployment template. This parameter is mutually exclusive with 'parameters_link'. Either one of them is required if \"state\" parameter is \"present\"."
               },
               "deployment_name": {

--- a/src/schemas/json/ansible-stable-2.2.json
+++ b/src/schemas/json/ansible-stable-2.2.json
@@ -13455,7 +13455,7 @@
                 "description": "The resource group name to use or create to host the deployed template"
               },
               "parameters": {
-                "type": "string",
+                "type": "object",
                 "description": "A hash of all the required template variables for the deployment template. This parameter is mutually exclusive with 'parameters_link'. Either one of them is required if \"state\" parameter is \"present\"."
               },
               "deployment_name": {

--- a/src/schemas/json/ansible-stable-2.3.json
+++ b/src/schemas/json/ansible-stable-2.3.json
@@ -18239,7 +18239,7 @@
                 "description": "The resource group name to use or create to host the deployed template"
               },
               "parameters": {
-                "type": "string",
+                "type": "object",
                 "description": "A hash of all the required template variables for the deployment template. This parameter is mutually exclusive with 'parameters_link'. Either one of them is required if \"state\" parameter is \"present\"."
               },
               "deployment_name": {

--- a/src/schemas/json/ansible-stable-2.4.json
+++ b/src/schemas/json/ansible-stable-2.4.json
@@ -6669,7 +6669,7 @@
                 "description": "The resource group name to use or create to host the deployed template"
               },
               "parameters": {
-                "type": "string",
+                "type": "object",
                 "description": "A hash of all the required template variables for the deployment template. This parameter is mutually exclusive with 'parameters_link'. Either one of them is required if \"state\" parameter is \"present\"."
               },
               "deployment_name": {


### PR DESCRIPTION
Hi @shaded-enmity and @madskristensen I was facing some ansible validation issues when using azure_rm_deployment. The schemas in the store specify that properties.parameters should be a string instead of object (it's a hash of all the variables).

I've created this pull request to try to fix this.

Hope it helps!