### PR TITLE
Add batect to schema catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -66,6 +66,12 @@
       "url": "http://json.schemastore.org/babelrc"
     },
     {
+      "name": "batect.yml",
+      "description": "batect configuration file",
+      "fileMatch": [ "batect.yml" ],
+      "url": "https://batect.charleskorn.com/configSchema.json"
+    },
+    {
       "name": ".bootstraprc",
       "description": "Webpack bootstrap-loader configuration file",
       "fileMatch": [ ".bootstraprc" ],


### PR DESCRIPTION
This adds [batect](https://github.com/charleskorn/batect)'s configuration format to the list of known schemas.