### PR TITLE
Fix: Visual Studio Sees tslint.json Schema As Invalid, Gives Error Message

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -1103,11 +1103,16 @@
               "items": [
                 {
                   "type": "boolean"
+                }, 
+                {
+                  "$ref": "#/definitions/rules/properties/max-classes-per-file/definitions/options/items/0"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/max-classes-per-file/definitions/options/items/1"
                 }
               ],
-              "additionalItems": {
-                "$ref": "#/definitions/rules/properties/max-classes-per-file/definitions/options/items"
-              },
+              "additionalItems": false,
+              "minItems": 2,
               "maxItems": 3,
               "properties": {
                 "options": {
@@ -1117,7 +1122,7 @@
                       "$ref": "#/definitions/rules/properties/max-classes-per-file/definitions/options"
                     },
                     {
-                      "$ref": "#/definitions/rules/properties/max-classes-per-file/definitions/options/items"
+                      "$ref": "#/definitions/rules/properties/max-classes-per-file/definitions/options/items/0"
                     }
                   ]
                 },

--- a/src/test/tslint/tslint-test16.json
+++ b/src/test/tslint/tslint-test16.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "max-classes-per-file": [ true, 1, "exclude-class-expressions" ]
+  }
+}

--- a/src/test/tslint/tslint-test17.json
+++ b/src/test/tslint/tslint-test17.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "max-classes-per-file": { "options": [ 3, "exclude-class-expressions" ] }
+  }
+}


### PR DESCRIPTION
If you try to use the tslint.json schema in Visual Studio you get the message 'There are problems with this document's schema impacting one or more items in the document'.

In fact JSON.NET Schema won't even parse the tslint.json schema that's in the repo: try pasting it into the [online validator](https://www.jsonschemavalidator.net/) as a schema.

I'm not sure it is actually invalid, although it's definitely wrong.  tv4 is more forgiving and at least parses it.  This is why the tests all pass in the SchemaStore solution.

**This PR fixes the problem.**  It also includes a couple of tests for the offending part of the schema, which is the max-classes-per-file rule.

This behavior happens because we have ended up with an 'additionalItems { "$ref": ...}' where the ... is a tuple definition [ ] not a schema definition \{ \}.  I think tv4 thinks the tuple is OK, but then doesn't work in any sensible way, whilst JSON.NET just says 'this is clearly wrong'.  We also have a similar problem with a $ref in a oneOf for some object properties in the same rule.  This problem has been there since mid-April 2018.
