### PR TITLE
fix incorrect type on service and firewalld modules

### DIFF
--- a/src/schemas/json/ansible-stable-2.0.json
+++ b/src/schemas/json/ansible-stable-2.0.json
@@ -9925,7 +9925,7 @@
                 "description": "Additional arguments provided on the command line"
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "state": {
@@ -23373,7 +23373,7 @@
                 "description": "Should this port accept(enabled) or reject(disabled) connections."
               },
               "permanent": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Should this configuration be in the running firewalld configuration or persist across reboots."
               },
               "timeout": {

--- a/src/schemas/json/ansible-stable-2.1.json
+++ b/src/schemas/json/ansible-stable-2.1.json
@@ -11577,7 +11577,7 @@
                 "description": "Additional arguments provided on the command line"
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "state": {
@@ -27208,7 +27208,7 @@
                 "description": "Should this port accept(enabled) or reject(disabled) connections."
               },
               "permanent": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Should this configuration be in the running firewalld configuration or persist across reboots."
               },
               "timeout": {

--- a/src/schemas/json/ansible-stable-2.2.json
+++ b/src/schemas/json/ansible-stable-2.2.json
@@ -10654,7 +10654,7 @@
                 "description": "Name of the service."
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "daemon_reload": {
@@ -16006,7 +16006,7 @@
                 "description": "Additional arguments provided on the command line"
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "state": {
@@ -37712,7 +37712,7 @@
                 "description": "Should this port accept(enabled) or reject(disabled) connections."
               },
               "permanent": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Should this configuration be in the running firewalld configuration or persist across reboots."
               },
               "timeout": {

--- a/src/schemas/json/ansible-stable-2.3.json
+++ b/src/schemas/json/ansible-stable-2.3.json
@@ -1666,7 +1666,7 @@
                 "description": "C(started)/C(stopped) are idempotent actions that will not run commands unless necessary. C(restarted) will always bounce the service. C(reloaded) will always reload."
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "name": {
@@ -14577,7 +14577,7 @@
                 "description": "Name of the service."
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "daemon_reload": {
@@ -44930,7 +44930,7 @@
                 "description": "Additional arguments provided on the command line"
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "state": {
@@ -50800,7 +50800,7 @@
                 "description": "Should this port accept(enabled) or reject(disabled) connections."
               },
               "permanent": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Should this configuration be in the running firewalld configuration or persist across reboots. As of Ansible version 2.3, permanent operations can operate on firewalld configs when it's not running (requires firewalld >= 3.0.9)"
               },
               "timeout": {

--- a/src/schemas/json/ansible-stable-2.4.json
+++ b/src/schemas/json/ansible-stable-2.4.json
@@ -18022,7 +18022,7 @@
                 "description": "Should this port accept(enabled) or reject(disabled) connections."
               },
               "permanent": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Should this configuration be in the running firewalld configuration or persist across reboots. As of Ansible version 2.3, permanent operations can operate on firewalld configs when it's not running (requires firewalld >= 3.0.9). (NOTE: If this is false, immediate is assumed true.)\n"
               },
               "timeout": {
@@ -45322,7 +45322,7 @@
                 "description": "Name of the service."
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "daemon_reload": {
@@ -46565,7 +46565,7 @@
                 "description": "Additional arguments provided on the command line"
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "state": {
@@ -59477,7 +59477,7 @@
                 "description": "C(started)/C(stopped) are idempotent actions that will not run commands unless necessary. C(restarted) will always bounce the service. C(reloaded) will always reload."
               },
               "enabled": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether the service should start on boot. B(At least one of state and enabled are required.)"
               },
               "name": {


### PR DESCRIPTION
Hi @shaded-enmity and @madskristensen I was facing some ansible validation issues when using service and firewalld modules. The schemas in the store specify that properties.parameters should be a string instead of boolean 

reference: https://github.com/redhat-developer/vscode-yaml/issues/96

I've created this pull request to fix this so linting is doesn't report issues... 
but still need to trace back to the root of the issue either schema generator or ansible core!

Thanks!