### PR TITLE
Add references to tsconfig.json

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -62,6 +62,10 @@
               "description": "The character set of the input files.",
               "type": "string"
             },
+            "composite": {
+              "description": "Enables building for project references.",
+              "type": "boolean"
+            },
             "declaration": {
               "description": "Generates corresponding d.ts files.",
               "type": "boolean"
@@ -485,9 +489,26 @@
           }
         }
       }
+    },
+    "referencesDefinition": {
+      "properties": {
+        "references": {
+          "type": "array",
+          "description": "Referenced projects. Requires TypeScript version 3.0 or later.",
+          "items": {
+            "type": "object",
+            "description": "Project reference.",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path to referenced tsconfig or to folder containing tsconfig."
+              }
+            }
+          }
+        }
+      }
     }
   },
-
   "type": "object",
   "allOf": [
     { "$ref": "#/definitions/compilerOptionsDefinition" },
@@ -498,7 +519,8 @@
       "anyOf": [
         { "$ref": "#/definitions/filesDefinition" },
         { "$ref": "#/definitions/excludeDefinition" },
-        { "$ref": "#/definitions/includeDefinition" }
+        { "$ref": "#/definitions/includeDefinition" },
+        { "$ref": "#/definitions/referencesDefinition" }
       ]
     }
   ]


### PR DESCRIPTION
Support project references in tsconfig.json. This and the composite field were added in TS 3.0: https://github.com/Microsoft/TypeScript/issues/3469#issuecomment-400439520