### PR TITLE
Add CircleCI version 2.1 version parameter (but not whole config)

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -107,7 +107,7 @@
       "description":
         "The version field is intended to be used in order to issue warnings for deprecation or breaking changes.",
       "default": 2,
-      "enum": [2]
+      "enum": [2, 2.1]
     },
     "jobs": {
       "type": "object",


### PR DESCRIPTION
I've added the 2.1 version parameter to the schema, but it may be better not to merge this because:

* You want to support the whole schema before allowing the 2.1 version
* This new version should live in its own schema.