### PR TITLE
Fix name and add fileMatch for WebExtensions

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -779,8 +779,9 @@
       "url": "http://json.schemastore.org/vsix-publish"
     },
     {
-      "name": "Web Extensions",
-      "description": "JSON schema for Web Extensions manifest files",
+      "name": "WebExtensions",
+      "description": "JSON schema for WebExtension manifest files",
+      "fileMatch": [ "manifest.json" ],
       "url": "http://json.schemastore.org/webextension"
     },
     {


### PR DESCRIPTION
The MDN docs refer to the extension as "WebExtensions" (no space) and explicitly specify not to have a space in between to make it easier to search for it (though I can't find that specification right now).

Also adds a `fileMatch` for the schema.