### PR TITLE
Add new tsconfig lib options

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -394,9 +394,9 @@
                 "enum": [ "es5", "es6", "es2015", "es7", "es2016", "es2017", "es2018", "esnext", "dom", "dom.iterable", "webworker", "scripthost",
                           "es2015.core", "es2015.collection", "es2015.generator", "es2015.iterable", "es2015.promise", "es2015.proxy", "es2015.reflect", "es2015.symbol", "es2015.symbol.wellknown",
                           "es2016.array.include",
-                          "es2017.object", "es2017.sharedmemory", "es2017.string", "es2017.typedarrays", "es2017.intl",
-                          "es2018.promise", "es2018.regexp", "es2018.intl",
-                          "esnext.array", "esnext.asynciterable"]
+                          "es2017.object", "es2017.intl", "es2017.sharedmemory", "es2017.typedarrays",
+                          "es2018.intl", "es2018.promise", "es2018.regexp",
+                          "esnext.asynciterable", "esnext.array", "esnext.intl", "esnext.symbol"]
               }
             },
             "strictNullChecks": {


### PR DESCRIPTION
* Add `esnext.intl` and `esnext.symbol`
* Remove `es2017.string`
* Reorder entries
All based on https://www.typescriptlang.org/docs/handbook/compiler-options.html

See https://github.com/SchemaStore/schemastore/issues/508