### PR TITLE
schemastore-516 gitlab-ci: services is defined as array of strings

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -66,8 +66,46 @@
       "type": "array",
       "description": "Similar to `image` property, but will link the specified services to the `image` container.",
       "items": {
-        "type": "string",
-        "minLength": 1
+        "oneOf": [
+          {
+            "type": "string",
+            "minLength": 1,
+            "description": "Full name of the image that should be used. It should contain the Registry part if needed."
+          },
+          {
+            "type": "object",
+            "description": "",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Full name of the image that should be used. It should contain the Registry part if needed.",
+                "minLength": 1
+              },
+              "entrypoint": {
+                "type": "array",
+                "description": "Command or script that should be executed as the container's entrypoint. It will be translated to Docker's --entrypoint option while creating the container. The syntax is similar to Dockerfile's ENTRYPOINT directive, where each shell token is a separate string in the array.",
+                "minItems": 1,
+                "items": {
+                  "type": "string"
+                }
+              },
+              "command": {
+                "type": "array",
+                "description": "Command or script that should be used as the container's command. It will be translated to arguments passed to Docker after the image's name. The syntax is similar to Dockerfile's CMD directive, where each shell token is a separate string in the array.",
+                "minItems": 1,
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string",
+                "description": "Additional alias that can be used to access the service from the job's container. Read Accessing the services for more information.",
+                "minLength": 1
+              }
+            },
+            "required": ["name"]
+          }
+        ]
       }
     },
     "before_script": {

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -72,6 +72,19 @@
     "dependencies": []
   },
   "deploy": {
+    "services": [
+      {
+        "name": "sql:latest",
+        "entrypoint": [""],
+        "command": ["/usr/bin/super-sql", "run"],
+        "alias": "super-sql"
+      },
+      "sql:latest",
+      {
+        "name": "sql:latest",
+        "alias": "default-sql"
+      }
+    ],
     "script": "dostuff",
     "stage": "deploy",
     "environment": {


### PR DESCRIPTION
#516 In GitLab and GitLab Runner 9.4 introduced [new settings for service ](https://docs.gitlab.com/ce/ci/docker/using_docker_images.html#setting-a-command-for-the-service).