### PR TITLE
Add .clasp.json schema. Fix appsscript.json schema title.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -120,6 +120,12 @@
       "url": "http://json.schemastore.org/cirrus"
     },
     {
+      "name": ".clasp.json",
+      "description": "Google Apps Script CLI project file",
+      "fileMatch": [ ".clasp.json" ],
+      "url": "http://json.schemastore.org/clasp"
+    },
+    {
       "name": "compilerconfig.json",
       "description": "Schema for compilerconfig.json files",
       "fileMatch": [ "compilerconfig.json" ],

--- a/src/schemas/json/appsscript.json
+++ b/src/schemas/json/appsscript.json
@@ -1,5 +1,5 @@
 {
-  "title": "JSON schema Google Apps Script manifest files",
+  "title": "JSON schema for Google Apps Script manifest files",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {

--- a/src/schemas/json/clasp.json
+++ b/src/schemas/json/clasp.json
@@ -1,0 +1,26 @@
+{
+  "title": "JSON schema for Google Apps Script project files",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "scriptId": {
+      "description": "The ID of the Apps Script project",
+      "type": "string",
+      "minLength": 57,
+      "maxLength": 57
+    },
+    "rootDir": {
+      "description": "The relative path to the custom root directory to your Apps Script files.",
+      "default": ".",
+      "type": "string"
+    },
+    "projectId": {
+      "description": "The ID for the Google Cloud Platform project linked to this script",
+      "default": "project-id-xxxxxxxxxxxxxxxxxxx",
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 30
+    }
+  },
+  "required": ["scriptId"]
+}


### PR DESCRIPTION
- Adds the project config file schema for [clasp](https://github.com/google/clasp): `.clasp.json`
  - [TS Interface](https://github.com/google/clasp/blob/9297b98df6c2c11033319b4e440a1fef0ebc84ee/src/utils.ts#L45)
- Patches title for `appsscript.json` to match other schemas.