### PR TITLE
Add allow_failures under jobs:

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -1291,6 +1291,11 @@
               "items": {
                 "$ref": "#/definitions/job"
               }
+            },
+            "fast_finish": {
+              "type": "boolean",
+              "description":
+                "If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed. To mark the build as finished as soon as possible, add fast_finish: true"
             }
           },
           "additionalProperties": false
@@ -1324,11 +1329,6 @@
               "items": {
                 "$ref": "#/definitions/job"
               }
-            },
-            "fast_finish": {
-              "type": "boolean",
-              "description":
-                "If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed. To mark the build as finished as soon as possible, add fast_finish: true"
             }
           }
         },

--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -1291,11 +1291,6 @@
               "items": {
                 "$ref": "#/definitions/job"
               }
-            },
-            "fast_finish": {
-              "type": "boolean",
-              "description":
-                "If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed. To mark the build as finished as soon as possible, add fast_finish: true"
             }
           },
           "additionalProperties": false

--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -1085,7 +1085,7 @@
                 }
               },
               "required": ["provider", "api_key"]
-            },            
+            },
             {
               "type": "object",
               "properties": {
@@ -1323,6 +1323,17 @@
                   }
                 ]
               }
+            },
+            "allow_failures": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/job"
+              }
+            },
+            "fast_finish": {
+              "type": "boolean",
+              "description":
+                "If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed. To mark the build as finished as soon as possible, add fast_finish: true"
             }
           }
         },


### PR DESCRIPTION
Travis supports `allow_failures` under `jobs:` as well as under `matrix:`, therefore this pull requests adds the missing definition to the schema.