### PR TITLE
Added gitlab-ci support for junit reports. 

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -374,6 +374,28 @@
               "type": "string",
               "description": "How long artifacts should be kept. They are saved 30 days by default. Artifacts that have expired are removed periodically via cron job. Supports a wide variety of formats, e.g. '1 week', '3 mins 4 sec', '2 hrs 20 min', '2h20min', '6 mos 1 day', '47 yrs 6 mos and 4d', '3 weeks and 2 days'.",
               "default": "30 days"
+            },
+            "reports":{
+              "type": "object",
+              "properties": {
+                "junit": {
+                  "description": "Path for file(s) that should be parsed as JUnit XML result",
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "Path to a single XML file"
+                    },
+                    {
+                      "type": "array",
+                       "description": "A list of paths to XML files that will automatically be concatenated into a single file",
+                       "items": {
+                         "type": "string"
+                       },
+                      "minLength": 1
+                    }
+                  ]
+                }
+              }
             }
           }
         },

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -43,7 +43,10 @@
       ],
       "name": "bundles",
       "when": "on_success",
-      "expire_in": "1 week"
+      "expire_in": "1 week",
+      "reports": {
+        "junit": "result.xml"
+      }
     },
     "variables": {
       "FOO_BAR": "..."


### PR DESCRIPTION
Gitlab has added support for artifact:reports:junit 
see https://docs.gitlab.com/ce/ci/junit_test_reports.html
