### PR TITLE
TSLint schema: add file-name-casing, prefer-while

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -3950,23 +3950,7 @@
                   },
                   "esSpecCompliant": {
                     "description": "Option to forbid trailing comma after rest",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/rule"
-                      },
-                      {
-                        "items": [
-                          {
-                            "type": "boolean"
-                          }
-                        ],
-                        "additionalItems": false,
-                        "properties": {
-                          "severity": {}
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
+                    "type": "boolean"
                   }
                 },
                 "additionalProperties": false

--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -815,6 +815,55 @@
             }
           ]
         },
+        "file-name-casing": {
+          "description": "Enforces a consistent file naming convention.",
+          "definitions": {
+            "options": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "camel-case",
+                    "pascal-case",
+                    "kebab-case"
+                  ]
+                }
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/rules/properties/file-name-casing/definitions/options/items/0"
+                }
+              ],
+              "additionalItems": false,
+              "minLength": 2,
+              "properties": {
+                "options": {
+                  "description": "An option value or an array of multiple option values.",
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/rules/properties/import-blacklist/definitions/options"
+                    },
+                    {
+                      "$ref": "#/definitions/rules/properties/file-name-casing/definitions/options/items/0"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
         "forin": {
           "description": "Requires a `for ... in` statement to be filtered with an `if` statement.",
           "allOf": [
@@ -3417,6 +3466,23 @@
                 },
                 "severity": {}
               },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "prefer-while": {
+          "description": "Prefer while loops instead of for loops without an initializer and incrementor.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/rule"
+            },
+            {
+              "items": [
+                {
+                  "type": "boolean"
+                }
+              ],
+              "additionalItems": false,
               "additionalProperties": false
             }
           ]


### PR DESCRIPTION
* Added [file-name-casing](https://palantir.github.io/tslint/rules/file-name-casing/)
* Added [prefer-while](https://palantir.github.io/tslint/rules/prefer-while/)
* Fixed definition of `esSpecCompliant` in `trailing-comma` introduced [here]( https://github.com/SchemaStore/schemastore/pull/497/commits/cd8410ec0cde45d8ccc4dd05514481163f270abb): it's a simple boolean rule, there shouldn't be an `$allOf` with `"#/definitions/rule"`.