### PR TITLE
Update prisma.json

### DIFF
--- a/src/schemas/json/prisma.json
+++ b/src/schemas/json/prisma.json
@@ -33,16 +33,8 @@
     }
   },
   "properties": {
-    "service": {
-      "description": "Name of the Service",
-      "type": "string",
-      "items": {
-        "type": "string"
-      }
-    },
     "datamodel": {
-      "description":
-        "Type definitions for database models, relations, enums and other types",
+      "description": "Type definitions for database models, relations, enums and other types",
       "type": ["string", "array"],
       "items": {
         "type": ["string", "array"]
@@ -62,26 +54,18 @@
         "type": "boolean"
       }
     },
-    "schema": {
-      "description": "Path to schema.graphql for usage in the Gateway",
-      "type": "string",
+    "generate": {
+      "type": "array",
       "items": {
-        "type": "string"
-      }
-    },
-    "stage": {
-      "description": "Stage to deploy to. Read more here https://goo.gl/J5k76y",
-      "type": "string",
-      "items": {
-        "type": "string"
-      }
-    },
-    "cluster": {
-      "description":
-        "Cluster used for deployment. Read more here https://goo.gl/J5k76y",
-      "type": "string",
-      "items": {
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "generator": {
+            "type": "string"
+          },
+          "output": {
+            "type": "string"
+          }
+        }
       }
     },
     "seed": {
@@ -104,18 +88,15 @@
       }
     },
     "custom": {
-      "description":
-        "Custom field to use in variable interpolations with ${self:custom.field}",
+      "description": "Custom field to use in variable interpolations with ${self:custom.field}",
       "type": "object"
     },
     "hooks": {
-      "description":
-        "Command hooks. Current available hooks are: post-deploy.",
+      "description": "Command hooks. Current available hooks are: post-deploy.",
       "type": "object"
     },
     "endpoint": {
-      "description":
-        "Endpoint the service will be reachable at. This also determines the cluster the service will deployed to.",
+      "description": "Endpoint the service will be reachable at. This also determines the cluster the service will deployed to.",
       "type": "string",
       "items": {
         "type": "string"
@@ -123,5 +104,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["datamodel"]
+  "required": []
 }


### PR DESCRIPTION
- Add `generate` key
- Remove `schema`,  `service`, `stage` and `cluster` as they already have been deprecated 4 months ago
- Make all fields optional: This is needed in order to both successfully run the `introspect` and `deploy` command