### PR TITLE
Update TSLint schema to include linter options

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -5619,6 +5619,19 @@
         "none"
       ],
       "default": "error"
+    },
+    "linterOptions": {
+      "description": "Additional linter options.",
+      "type": "object",
+      "properties": {
+        "exclude": {
+          "description": "An array of globs. Any file matching these globs will not be linted. All exclude patterns are relative to the configuration file they were specified in.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }      
     }
   }
 }

--- a/src/test/tslint/tslint-test20.json
+++ b/src/test/tslint/tslint-test20.json
@@ -1,0 +1,7 @@
+{
+    "linterOptions": {
+        "exclude": [
+            "node_modules/**"
+        ]
+    }
+}


### PR DESCRIPTION
Hello,

I noticed `linterOptions` was missing in the TSLint schema, so this pull request simply adds it.

Also threw in another test to cover this new addition.