### PR TITLE
Fix definition of "triggers" key to include "schedule"

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -581,26 +581,37 @@
           "triggers": {
             "description":
               "Specifies which triggers will cause this workflow to be executed. Default behavior is to trigger the workflow when pushing to a branch.",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "cron": {
-                "description":
-                  "See the [crontab man page](http://pubs.opengroup.org/onlinepubs/7908799/xcu/crontab.html)",
-                "type": "string"
-              },
-              "filters": {
-                "description":
-                  "A map defining rules for execution on specific branches",
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "branches": {
-                    "$ref": "#/definitions/filter"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "schedule": {
+                  "description":
+                    "A workflow may have a schedule indicating it runs at a certain time, for example a nightly build that runs every day at 12am UTC:",
+                  "type": "object",
+                  "properties": { 
+                    "cron": {
+                      "description":
+                        "See the [crontab man page](http://pubs.opengroup.org/onlinepubs/7908799/xcu/crontab.html)",
+                      "type": "string"
+                    },
+                    "filters": {
+                      "description":
+                        "A map defining rules for execution on specific branches",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "branches": {
+                          "$ref": "#/definitions/filter"
+                         }
+                      }
+                    }
                   }
                 }
               }
-            }
+              
+            }           
           },
           "jobs": {
             "type": "array",


### PR DESCRIPTION
# triggers
https://circleci.com/docs/2.0/configuration-reference/#triggers

|Key | Required | Type | Description
|-- | -- | -- | --
|triggers | N | Array | Should currently be schedule.

------
# schedule
https://circleci.com/docs/2.0/configuration-reference/#schedule
A workflow may have a schedule indicating it runs at a certain time, for example a nightly build that runs every day at 12am UTC:
```yaml
workflows:
   version: 2
   nightly:
     triggers:
       - schedule:
           cron: "0 0 * * *"
           filters:
             branches:
               only:
                 - master
                 - beta
     jobs:
       - test
```
------
# cron


|Key | Required | Type | Description
|-- | -- | -- | --
|cron | Y | String | See the crontab man page.


