### PR TITLE
add openapi 3.0 schema in catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -498,6 +498,12 @@
       "url": "http://json.schemastore.org/omnisharp"
     },
     {
+      "name": "openapi.json",
+      "description": "A JSON schema for Open API documentation files",
+      "fileMatch": [ "openapi.json", "openapi.yml" ],
+      "url": "https://raw.githubusercontent.com/kogosoftwarellc/open-api/master/packages/openapi-schema-validator/resources/openapi-3.0.json"
+    },
+    {
       "name": "openfin.json",
       "description": "OpenFin application configuration file",
       "url": "http://json.schemastore.org/openfin"


### PR DESCRIPTION
Here is an openapi schema for writing open api documentation. 

See https://github.com/kogosoftwarellc/open-api/issues/238 and https://github.com/OAI/OpenAPI-Specification/issues/1032 for more information. 

I will update the link in the catalog as soon as an official schema will be available. 