### PR TITLE
Update Gitlab schema with extends keyword

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -53,6 +53,11 @@
       "description": "A special job used to upload static sites to Gitlab pages. Requires a `public/` directory with `artifacts.path` pointing to it."
     }
   },
+  "patternProperties": {
+    "^[.]": {
+      "$ref": "#/definitions/job_template"
+    }
+  },
   "additionalProperties": {
     "$ref": "#/definitions/job"
   },
@@ -273,6 +278,17 @@
       ]
     },
     "job": {
+      "allOf": [
+        { "$ref": "#/definitions/job_template" },
+        {
+          "anyOf": [
+            { "required": ["script"] },
+            { "required": ["extends"] }
+          ]
+        }
+      ]
+    },
+    "job_template": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -306,6 +322,10 @@
         "only": {
           "$ref": "#/definitions/filter",
           "description": "Job will run *only* when these filtering options match."
+        },
+        "extends": {
+          "type": "string",
+          "description": "The name of a job to inherit configuration from."
         },
         "except": {
           "$ref": "#/definitions/filter",
@@ -461,8 +481,7 @@
           "minimum": 0,
           "maximum": 2
         }
-      },
-      "required": ["script"]
+      }
     }
   }
 }

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -103,5 +103,16 @@
     "only": [
       "master"
     ]
+  },
+  ".performance-tmpl": {
+    "variables": {
+      "SCRIPT_NOT_REQUIRED": "true"
+    }
+  },
+  "performance-a": {
+    "extends": ".performance-tmpl"
+  },
+  "performance-b": {
+    "extends": ".performance-tmpl"
   }
 }


### PR DESCRIPTION
- Jobs (properties) that start with `.` will be treated as job templates, which do not require `script`
- Jobs must have either `script` or `extends`.
- If a job uses `extends`, it does _not_ check that either the job or template has `script` property

Closes #553