### PR TITLE
Allow 'cache: npm' on .travis.yml

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -72,7 +72,8 @@
         "cocoapods",
         "packages",
         "pip",
-        "yarn"
+        "yarn",
+        "npm"
       ]
     },
     "envVars": {
@@ -782,6 +783,9 @@
                   "type": "boolean"
                 },
                 "cargo": {
+                  "type": "boolean"
+                },
+                "npm": {
                   "type": "boolean"
                 }
               },


### PR DESCRIPTION
fix below
> Value is not accepted. Valid values: false, "bundler", "cargo", "ccache", "cocoapods", "packages", "pip", "yarn".