### PR TITLE
[circleci] remove required version from workflows

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -566,11 +566,10 @@
       "description":
         "Used for orchestrating all jobs. Each workflow consists of the workflow name as a key and a map as a value",
       "type": "object",
-      "required": ["version"],
       "properties": {
         "version": {
           "description":
-            "The Workflows `version` field is used to issue warnings for deprecation or breaking changes during Beta.",
+            "The Workflows `version` field is used to issue warnings for deprecation or breaking changes during v2 Beta. It is deprecated as of CircleCI v2.1",
           "enum": [2]
         }
       },


### PR DESCRIPTION
Version field is no longer needed as of v2.1 for CircleCI