### PR TITLE
Remove `homepage.format` from package.json schema.

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -102,8 +102,7 @@
         },
         "homepage": {
           "description": "The url to the project homepage.",
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "bugs": {
           "description": "The url to your project's issue tracker and / or the email address to which issues should be reported. These are helpful for people who encounter issues with your package.",


### PR DESCRIPTION
Remove the `"format": "uri"` limit so that the `homepage` field could be set to a relative path.

[Support setting "homepage" to "." to generate relative asset paths](https://github.com/facebook/create-react-app/pull/1489)