### PR TITLE
Add Buildkite pipeline.yml schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -108,6 +108,12 @@
       "url": "http://json.schemastore.org/bukkit-plugin"
     },
     {
+      "name": "Buildkite",
+      "description": "Schema for Buildkite pipeline.yml files",
+      "fileMatch": [ "buildkite.yml", "buildkite.yaml", "buildkite.json", "buildkite.*.yml", "buildkite.*.yaml", "buildkite.*.json", ".buildkite/pipeline.yml", ".buildkite/pipeline.yaml", ".buildkite/pipeline.json", ".buildkite/pipeline.*.yml", ".buildkite/pipeline.*.yaml", ".buildkite/pipeline.*.json" ],
+      "url": "https://raw.githubusercontent.com/buildkite/pipeline-schema/master/schema.json"
+    },
+    {
       "name": "bundleconfig.json",
       "description": "Schema for bundleconfig.json files",
       "fileMatch": [ "bundleconfig.json" ],


### PR DESCRIPTION
Adds the [Buildkite](https://buildkite.com/) pipeline.yml schema (https://github.com/buildkite/pipeline-schema) to the catalog.