### PR TITLE
Add new .gitlab-ci.yaml properties

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -362,8 +362,17 @@
             {
               "enum": ["manual"],
               "description": "Execute the job manually from Gitlab UI or API. Read more: https://docs.gitlab.com/ee/ci/yaml/#when-manual"
+            },
+            {
+              "enum": ["delayed"],
+              "description": "Execute a job after the time limit in 'start_in' expires. Read more: https://docs.gitlab.com/ee/ci/yaml/#when-delayed"
             }
           ]
+        },
+        "start_in": {
+          "type": "string",
+          "description": "Used in conjunction with 'when: delayed' to set how long to delay before starting a job.",
+          "minLength": 1
         },
         "dependencies": {
           "type": "array",
@@ -481,7 +490,24 @@
           "minimum": 0,
           "maximum": 2
         }
-      }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "when": { "enum": ["delayed"] }
+          },
+          "required": ["when", "start_in"]
+        },
+        {
+          "properties": {
+            "when": {
+              "not": {
+                "enum": ["delayed"]
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -72,6 +72,7 @@
         {
           "type": "object",
           "description": "Specifies the docker image to use for the job or globally for all jobs. Job configuration takes precedence over global setting. Requires a certain kind of Gitlab runner executor.",
+          "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string",
@@ -102,6 +103,7 @@
           {
             "type": "object",
             "description": "",
+            "additionalProperties": false,
             "properties": {
               "name": {
                 "type": "string",
@@ -478,6 +480,8 @@
             },
             "reports":{
               "type": "object",
+              "description": "Reports will be uploaded as artifacts, and often displayed in the Gitlab UI, such as in Merge Requests.",
+              "additionalProperties": false,
               "properties": {
                 "junit": {
                   "description": "Path for file(s) that should be parsed as JUnit XML result",
@@ -539,6 +543,7 @@
             { "$ref": "#/definitions/retry_max" },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "max": { "$ref": "#/definitions/retry_max" },
                 "when": {

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -496,6 +496,13 @@
           "default": 0,
           "minimum": 0,
           "maximum": 2
+        },
+        "parallel": {
+          "type": "integer",
+          "description": "Parallel will split up a single job into several, and provide `CI_NODE_INDEX` and `CI_NODE_TOTAL` environment variables for the running jobs.",
+          "default": 0,
+          "minimum": 2,
+          "maximum": 50
         }
       },
       "oneOf": [

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -272,6 +272,13 @@
               "items": {
                 "type": "string"
               }
+            },
+            "changes": {
+              "type": "array",
+              "description": "Filter job creation based on files that were modified in a git push.",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -284,6 +284,49 @@
         }
       ]
     },
+    "retry_max": {
+      "type": "integer",
+      "description": "The number of times the job will be retried if it fails. Defaults to 0 and can max be retried 2 times (3 times total).",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 2
+    },
+    "retry_errors": {
+      "oneOf": [
+        {
+          "enum": ["always"],
+          "description": "Retry on any failure (default)."
+        },
+        {
+          "enum": ["unknown_failure"],
+          "description": "Retry when the failure reason is unknown."
+        },
+        {
+          "enum": ["script_failure"],
+          "description": "Retry when the script failed."
+        },
+        {
+          "enum": ["api_failure"],
+          "description": "Retry on API failure."
+        },
+        {
+          "enum": ["stuck_or_timeout_failure"],
+          "description": "Retry when the job got stuck or timed out."
+        },
+        {
+          "enum": ["runner_system_failure"],
+          "description": "Retry if there was a runner system failure (e.g. setting up the job failed)."
+        },
+        {
+          "enum": ["missing_dependency_failure"],
+          "description": "Retry if a dependency was missing."
+        },
+        {
+          "enum": ["runner_unsupported"],
+          "description": "Retry if the runner was unsupported."
+        }
+      ]
+    },
     "job": {
       "allOf": [
         { "$ref": "#/definitions/job_template" },
@@ -491,11 +534,28 @@
           "pattern": "^\/.+\/$"
         },
         "retry": {
-          "type": "integer",
-          "description": "The number of times the job will be retried if it fails. Defaults to 0 and can max be retried 2 times (3 times total).",
-          "default": 0,
-          "minimum": 0,
-          "maximum": 2
+          "description": "Retry a job if it fails. Can be a simple integer or object definition.",
+          "oneOf": [
+            { "$ref": "#/definitions/retry_max" },
+            {
+              "type": "object",
+              "properties": {
+                "max": { "$ref": "#/definitions/retry_max" },
+                "when": {
+                  "description": "Either a single or array of error types to trigger job retry.",
+                  "oneOf": [
+                    { "$ref": "#/definitions/retry_errors" },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/retry_errors"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
         },
         "parallel": {
           "type": "integer",

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -62,6 +62,19 @@
     "$ref": "#/definitions/job"
   },
   "definitions": {
+    "string_file_list": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "image": {
       "oneOf": [
         {
@@ -492,13 +505,41 @@
                     },
                     {
                       "type": "array",
-                       "description": "A list of paths to XML files that will automatically be concatenated into a single file",
-                       "items": {
-                         "type": "string"
-                       },
+                      "description": "A list of paths to XML files that will automatically be concatenated into a single file",
+                      "items": {
+                        "type": "string"
+                      },
                       "minLength": 1
                     }
                   ]
+                },
+                "codequality": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with code quality report(s) (such as Code Climate)."
+                },
+                "sast": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with SAST vulnerabilities report(s)."
+                },
+                "dependency_scanning": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with Dependency scanning vulnerabilities report(s)."
+                },
+                "container_scanning": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with Container scanning vulnerabilities report(s)."
+                },
+                "dast": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with DAST vulnerabilities report(s)."
+                },
+                "license_management": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with license report(s)."
+                },
+                "performance": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with performance metrics report(s)."
                 }
               }
             }

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -51,7 +51,14 @@
       "when": "on_success",
       "expire_in": "1 week",
       "reports": {
-        "junit": "result.xml"
+        "junit": "result.xml",
+        "codequality": "codequality.json",
+        "sast": "sast.json",
+        "dependency_scanning": "scan.json",
+        "container_scanning": "scan2.json",
+        "dast": "dast.json",
+        "license_management": "license.json",
+        "performance": "performance.json"
       }
     },
     "variables": {
@@ -101,6 +108,18 @@
         "unknown_failure",
         "always"
       ]
+    },
+    "artifacts": {
+      "reports": {
+        "junit": ["result.xml"],
+        "codequality": ["codequality.json"],
+        "sast": ["sast.json"],
+        "dependency_scanning": ["scan.json"],
+        "container_scanning": ["scan2.json"],
+        "dast": ["dast.json"],
+        "license_management": ["license.json"],
+        "performance": ["performance.json"]
+      }
     },
     "coverage": "/Cycles: \\d+\\.\\d+$/",
     "dependencies": []

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -85,6 +85,7 @@
     },
     "stage": "test",
     "script": "npm test",
+    "parallel": 5,
     "coverage": "/Cycles: \\d+\\.\\d+$/",
     "dependencies": []
   },

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -32,6 +32,10 @@
     "stage": "build",
     "script": "npm run build",
     "before_script": ["npm install"],
+    "retry": {
+      "max": 1,
+      "when": "stuck_or_timeout_failure"
+    },
     "cache": {
       "key": "$CI_COMMIT_REF_NAME",
       "paths": [
@@ -86,6 +90,18 @@
     "stage": "test",
     "script": "npm test",
     "parallel": 5,
+    "retry": {
+      "max": 2,
+      "when": [
+        "runner_system_failure",
+        "missing_dependency_failure",
+        "runner_system_failure",
+        "stuck_or_timeout_failure",
+        "script_failure",
+        "unknown_failure",
+        "always"
+      ]
+    },
     "coverage": "/Cycles: \\d+\\.\\d+$/",
     "dependencies": []
   },
@@ -93,6 +109,7 @@
     "script": "docker build -t foo:latest",
     "when": "delayed",
     "start_in": "10 min",
+    "retry": 1,
     "only": {
       "changes": ["Dockerfile", "docker/scripts/*"]
     }

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -69,6 +69,11 @@
     "allow_failure": true,
     "when": "manual"
   },
+  "error-report": {
+    "when": "on_failure",
+    "script": "report error",
+    "stage": "test"
+  },
   "test": {
     "image": {
       "name": "node:latest",
@@ -78,6 +83,14 @@
     "script": "npm test",
     "coverage": "/Cycles: \\d+\\.\\d+$/",
     "dependencies": []
+  },
+  "docker": {
+    "script": "docker build -t foo:latest",
+    "when": "delayed",
+    "start_in": "10 min",
+    "only": {
+      "changes": ["Dockerfile", "docker/scripts/*"]
+    }
   },
   "deploy": {
     "services": [

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -57,6 +57,10 @@
       "kubernetes": "active",
       "variables": [
         "$FOO_BAR == '...'"
+      ],
+      "changes": [
+        "/path/to/file",
+        "/another/file"
       ]
     },
     "except": [


### PR DESCRIPTION
Adds all missing properties I could find from recent releases for Gitlab CI:

- `when: delayed` enum value with `start_in` property and validation
- `only.changes` file list
- `parallel` job property
- Added object/complex format for `retry`
- Added new properties to `artifact.report`
- Also fixed a few missing `additionalProperties: false` flags for objects that can not have additional properties

Closes #573