### PR TITLE
Added test for after_script and before_script with extends and script.

### DIFF
--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -159,12 +159,15 @@
     ]
   },
   ".performance-tmpl": {
+    "after_script": ["echo after"],
+    "before_script": ["echo before"],
     "variables": {
       "SCRIPT_NOT_REQUIRED": "true"
     }
   },
   "performance-a": {
-    "extends": ".performance-tmpl"
+    "extends": ".performance-tmpl",
+    "script": "echo test"
   },
   "performance-b": {
     "extends": ".performance-tmpl"


### PR DESCRIPTION
I created an issue for PhpStorm over at [Jetbrains Youtrack](https://youtrack.jetbrains.com/issue/WI-44529) where I believe this test helps that issue move forward.

I am using `extends` together with `before_script` and that gives a warning in PhpStorm. The test passes in this repo though, so I'm guessing the bug is in PhpStorm.

Minimal `.gitlab-ci.yml` code that gives a warning (that this PR is trying to provide a test for)
```
a:
  extends: .b
  script: "echo"
```