### PR TITLE
Fix TSLint no-empty definition

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -1813,7 +1813,8 @@
                 ]
               },
               "minItems": 1,
-              "maxItems": 1
+              "maxItems": 2,
+              "uniqueItems": true
             }
           },
           "allOf": [
@@ -1829,7 +1830,8 @@
               "additionalItems": {
                 "$ref": "#/definitions/rules/properties/no-empty/definitions/options/items"
               },
-              "maxItems": 2,
+              "maxItems": 3,
+              "uniqueItems": true,
               "properties": {
                 "options": {
                   "description": "An option value or an array of multiple option values.",


### PR DESCRIPTION
Both 'allow-empty-catch' and 'allow-empty-functions' can be set simultaneously.