### PR TITLE
removing languageWorker.maxMessageLength from host.json schema

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -371,12 +371,6 @@
           "description": "Configuration settings for Language Workers.",
           "type": "object",
           "properties": {
-            "maxMessageLength": {
-              "description": "Defines maximum message size in MegaBytes (MB) for the streaming messages between the functions host and a language worker",
-              "type": "integer",
-              "minimum": 4,
-              "default": 32
-            },
             "workersDirectory": {
               "description": "Specifies full path of the directory for language workers",
               "type": "string"


### PR DESCRIPTION
Corresponds to https://github.com/Azure/Azure-Functions/pull/1071