### PR TITLE
Updated object-literal-sort-keys rule to contain all accepted values

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -2903,11 +2903,13 @@
                 "type": "string",
                 "enum": [
                   "ignore-case",
-                  "match-declaration-order"
+                  "locale-compare",
+                  "match-declaration-order",
+                  "shorthand-first"
                 ]
               },
               "minItems": 1,
-              "maxItems": 2,
+              "maxItems": 4,
               "uniqueItems": true
             }
           },
@@ -2924,7 +2926,7 @@
               "additionalItems": {
                 "$ref": "#/definitions/rules/properties/object-literal-sort-keys/definitions/options/items"
               },
-              "maxItems": 3,
+              "maxItems": 5,
               "uniqueItems": true,
               "properties": {
                 "options": {


### PR DESCRIPTION
The accepted values are listed here
https://palantir.github.io/tslint/rules/object-literal-sort-keys/