### PR TITLE
Travis: multiple webhook URLs are allowed

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -1275,8 +1275,19 @@
                   "type": "object",
                   "properties": {
                     "urls": {
-                      "type": "string",
-                      "format": "uri"
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      ]
                     }
                   },
                   "on_success": {


### PR DESCRIPTION
documented here: https://docs.travis-ci.com/user/notifications#configuring-webhook-notifications

used in practice here: https://travis-ci.org/shinyblink/sled/builds/476129878
(travis.yml here: https://github.com/shinyblink/sled/blob/master/.travis.yml)