### PR TITLE
update xunit.runner.schema.json to the same upstream file

### DIFF
--- a/src/schemas/json/xunit.runner.schema.json
+++ b/src/schemas/json/xunit.runner.schema.json
@@ -28,7 +28,7 @@
     "maxParallelThreads": {
       "description": "Configures the maximum number of threads to be used when parallelizing tests within this assembly.",
       "type": "integer",
-      "minimum": -1
+      "minimum": 1
     },
     "methodDisplay": {
       "description": "Configures the default display name for test cases. If you choose 'method', the display name will be just the method (without the class name); if you choose 'classAndMethod', the default display name will be the fully qualified class name and method name.",


### PR DESCRIPTION
The issue:

start the test with
```
./node_modules/.bin/grunt
```
will download: http://xunit.github.io/schema/v2.3/xunit.runner.schema.json
to file 'schemas/json/xunit.runner.schema.json'
This upstream file is not identical as the one in the present schema store.

Every time 'grunt' is being run, the GIT program will show that this file is change.
With this 'fix' the GIT will not show anymore file change after running 'grunt'
