### PR TITLE
package.json: homepage can be a dot

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -103,7 +103,10 @@
         "homepage": {
           "description": "The url to the project homepage.",
           "type": "string",
-          "format": "uri"
+          "oneOf": [
+            {"format": "uri"},
+            {"enum": ["."]}
+          ]
         },
         "bugs": {
           "description": "The url to your project's issue tracker and / or the email address to which issues should be reported. These are helpful for people who encounter issues with your package.",


### PR DESCRIPTION
Create React App has a documented case where it checks to see if the "homepage" property is ".", so we should support this use-case.

See https://facebook.github.io/create-react-app/docs/deployment#serving-the-same-build-from-different-paths