### PR TITLE
Travis-CI: remove jwt addons

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -774,20 +774,6 @@
                 }
               ]
             },
-            "jwt": {
-              "description": "JWT addon",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/possiblySecretString"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/possiblySecretString"
-                  }
-                }
-              ]
-            },
             "sonarcloud": {
               "description": "SonarCloud addon",
               "type": "object",


### PR DESCRIPTION
see:
https://docs.travis-ci.com/user/jwt

The JWT addons is deprecated and will be discontinued on April 17, 2018.