### PR TITLE
[CircleCI] Support custom command names from version 2.1 

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -130,7 +130,7 @@
                 },
                 {
                   "type": "object",
-                  "oneOf": [
+                  "anyOf": [
                     {
                       "type": "object",
                       "additionalProperties": false,
@@ -375,6 +375,14 @@
                           }
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^[a-z][a-z0-9_-]+$": {}
+                      },
+                      "minProperties": 1
                     }
                   ]
                 }
@@ -589,7 +597,7 @@
                   "description":
                     "A workflow may have a schedule indicating it runs at a certain time, for example a nightly build that runs every day at 12am UTC:",
                   "type": "object",
-                  "properties": { 
+                  "properties": {
                     "cron": {
                       "description":
                         "See the [crontab man page](http://pubs.opengroup.org/onlinepubs/7908799/xcu/crontab.html)",
@@ -609,8 +617,8 @@
                   }
                 }
               }
-              
-            }           
+
+            }
           },
           "jobs": {
             "type": "array",

--- a/src/test/circleciconfig/chromeless.json
+++ b/src/test/circleciconfig/chromeless.json
@@ -1,5 +1,20 @@
 {
   "version": 2,
+  "commands": {
+    "build-image": {
+      "description": "Build Docker image, push to Google Container Registry"
+    },
+    "parameters": {
+      "gcloud_service_key": {
+        "type": "string"
+      }
+    },
+    "steps": [
+      {
+        "run": "apk add docker"
+      }
+    ]
+  },
   "workflows": {
     "version": 2,
     "chromeless": {
@@ -79,6 +94,11 @@
             "name": "Codecov",
             "command":
               "node_modules/.bin/nyc report --reporter=json && bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json"
+          }
+        },
+        {
+          "build-image": {
+            "gcloud-service-key": "SERVICE_KEY_STRING"
           }
         }
       ]


### PR DESCRIPTION
Tackles #624 

New CircleCI config allows [defining custom commands](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands), so I updated the schema to support arbitrary step names.