### PR TITLE
Umbraco package.manifest: Added "weight" property to "dashboard" definition

### DIFF
--- a/src/schemas/json/package.manifest-8.0.0.json
+++ b/src/schemas/json/package.manifest-8.0.0.json
@@ -183,6 +183,10 @@
       "additionalProperties": false,
       "required": [ "name", "alias", "view", "sections" ],
       "properties": {
+        "weight": {
+          "type": "integer",
+          "description": "The weight (sort order) of the dashboard. Defaults to 100 if not specified."
+        },
         "name": {
           "type": "string",
           "description": "The friendly name of the dashboard, shown in the Umbraco backoffice",

--- a/src/schemas/json/package.manifest.json
+++ b/src/schemas/json/package.manifest.json
@@ -183,6 +183,10 @@
       "additionalProperties": false,
       "required": [ "name", "alias", "view", "sections" ],
       "properties": {
+        "weight": {
+          "type": "integer",
+          "description": "The weight (sort order) of the dashboard. Defaults to 100 if not specified."
+        },
         "name": {
           "type": "string",
           "description": "The friendly name of the dashboard, shown in the Umbraco backoffice",


### PR DESCRIPTION
Umbraco 8 supports specifying a `weight` property for a dashboard, but this isn't included in the `dashboard` definition. I've updated it to include this.

I'm not sure how approval goes for this repository, but if required, @warrenbuckley from Umbraco should be able to confirm this 😉 