### PR TITLE
added string schema type to the eslint globals

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -477,7 +477,18 @@
       "type": "object",
 
       "additionalProperties": {
-        "type": "boolean"
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "readable", "writeable"
+            ]
+          },
+          {
+            "description": "The boolean values false and true are deprecated, they are equivalent to \"readable\" and \"writeable\", respectively.",
+            "type": "boolean"
+          }
+        ]
       }
     },
     "parser": {


### PR DESCRIPTION
Check it please :), found that mismatch in the WebStorm v183.5429.34 and ESLint v5.12.0.