### PR TITLE
Update jshintrc schema

### DIFF
--- a/src/schemas/json/jshintrc.json
+++ b/src/schemas/json/jshintrc.json
@@ -24,7 +24,7 @@
 			"description": "The ECMAScript version to which the code must adhere",
 			"type": "integer",
 			"default": 5,
-			"enum": [3, 5, 6]
+			"enum": [3, 5, 6, 7, 8, 9]
 		},
 		"forin": {
 			"description": "Requires all `for in` loops to filter object's items with obj.hasOwnProperty()",
@@ -54,6 +54,11 @@
 		"latedef": {
 			"description": "Prohibits the use of a variable before it was defined",
 			"enum": [ true, false, "nofunc" ],
+			"default": false
+		},
+		"leanswitch": {
+			"description": "Prohibits unnecessary clauses within `switch` statements",
+			"type": "boolean",
 			"default": false
 		},
 		"maxcomplexity": {
@@ -105,6 +110,16 @@
 			"type": "boolean",
 			"default": false
 		},
+		"noreturnawait": {
+			"description": "Async functions resolve on their return value. In most cases, this makes returning the result of an AwaitExpression (which is itself a Promise instance) unnecessary",
+			"type": "boolean",
+			"default": false
+		},
+		"regexpu": {
+			"description": "Enables warnings for regular rexpressions which do not include the 'u' flag",
+			"type": "boolean",
+			"default": false
+		},
 		"shadow": {
 			"description": "Suppresses warnings about variable shadowing. i.e. declaring a variable that had been already declared somewhere in the outer scope",
 			"type": ["boolean", "string"],
@@ -121,6 +136,11 @@
 			"type": ["boolean", "string"],
 			"default": false,
 			"enum": [true, false, "implied", "global", "func"]
+		},
+		"trailingcomma": {
+			"description": "Warns when a comma is not placed after the last element in an array or object literal",
+			"type": "boolean",
+			"default": false
 		},
 		"undef": {
 			"description": "Prohibits the use of explicitly undeclared variables",

--- a/src/test/jshintrc/jshintrc-test.json
+++ b/src/test/jshintrc/jshintrc-test.json
@@ -26,6 +26,9 @@
 	"undef": true,
 	"unused": true,
 	"strict": false,
+	"leanswitch": true,
+	"noreturnawait": false,
+	"noregexpu": true,
 	"maxparams": false,
 	"maxdepth": false,
 	"maxstatements": false,
@@ -37,6 +40,7 @@
 	"debug": true,
 	"eqnull": false,
 	"es5": false,
+	"esversion": 6,
 	"esnext": false,
 	"moz": false,
 


### PR DESCRIPTION
Documentation here: https://jshint.com/docs/options/

Adds a couple of new options and updates the possible values for `esversion`