### PR TITLE
TsLint: file-name-casing rule fixes

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -818,50 +818,35 @@
         "file-name-casing": {
           "description": "Enforces a consistent file naming convention.",
           "definitions": {
-            "options": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "string",
-                  "enum": [
-                    "camel-case",
-                    "pascal-case",
-                    "kebab-case",
-                    "snake-case"
-                  ]
-                }
+            "file-name-cases": {
+              "type": "string",
+              "enum": [
+                "camel-case",
+                "pascal-case",
+                "kebab-case",
+                "snake-case"
               ]
             }
           },
-          "allOf": [
+          "type": "array",
+          "minItems": 2,
+          "items": [
             {
-              "$ref": "#/definitions/rule"
+              "type": "boolean"
             },
             {
-              "items": [
+              "oneOf": [
                 {
-                  "type": "boolean"
+                  "$ref": "#/definitions/rules/properties/file-name-casing/definitions/file-name-cases"
                 },
                 {
-                  "$ref": "#/definitions/rules/properties/file-name-casing/definitions/options/items/0"
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/definitions/rules/properties/file-name-casing/definitions/file-name-cases"
+                  },
+                  "minProperties": 1
                 }
-              ],
-              "additionalItems": false,
-              "minLength": 2,
-              "properties": {
-                "options": {
-                  "description": "An option value or an array of multiple option values.",
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/rules/properties/import-blacklist/definitions/options"
-                    },
-                    {
-                      "$ref": "#/definitions/rules/properties/file-name-casing/definitions/options/items/0"
-                    }
-                  ]
-                }
-              },
-              "additionalProperties": false
+              ]
             }
           ]
         },

--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -826,7 +826,8 @@
                   "enum": [
                     "camel-case",
                     "pascal-case",
-                    "kebab-case"
+                    "kebab-case",
+                    "snake-case"
                   ]
                 }
               ]

--- a/src/test/tslint/tslint-test21.json
+++ b/src/test/tslint/tslint-test21.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "file-name-casing": [true, "camel-case"]
+    }
+}  

--- a/src/test/tslint/tslint-test22.json
+++ b/src/test/tslint/tslint-test22.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "file-name-casing": [true, {".tsx": "pascal-case", ".ts": "snake-case"}]
+    }
+}  


### PR DESCRIPTION
Updated file-name-casing rule:
- Added `snake-case` option
- Added ability to add multiple filename cases using an object
- Linting rules match existing behaviours (which I think are a bit different to the schema defined [here](https://palantir.github.io/tslint/rules/file-name-casing/))
- Added test case to demonstrate object syntax and string syntax that works

_I originally filed an issue here: https://github.com/Microsoft/vscode-typescript-tslint-plugin/issues/60_