### PR TITLE
Allow use of "off" for ESLint globals

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -481,7 +481,7 @@
           {
             "type": "string",
             "enum": [
-              "readonly", "writable"
+              "readonly", "writable", "off"
             ]
           },
           {


### PR DESCRIPTION
The value of `"off"` exists as a way to disable previously enabled globals.

See https://eslint.org/docs/user-guide/configuring#specifying-globals