### PR TITLE
gitlab-ci.json: allow variables of type integer

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -229,7 +229,7 @@
       "type": "object",
       "description": "Defines environment variables for specific jobs or globally. Job level property overrides global variables. If a job sets `variables: {}`, all global variables are turned off.",
       "additionalProperties": {
-        "type": "string"
+        "type": ["string", "integer"]
       }
     },
     "cache": {


### PR DESCRIPTION
Per GitLab documentation, variable values can be strings or integers:

> Note: Integers (as well as strings) are legal both for variable’s name and value. Floats are not legal and cannot be used.

https://docs.gitlab.com/ee/ci/yaml/#variables