### PR TITLE
adding: tsBuildInfoFile included in TypeScript 3.4

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -89,7 +89,12 @@
             "incremental": {
               "description": "Enable incremental compilation.",
               "type": "boolean"
+            },            
+              "tsBuildInfoFile": {
+              "description": "Specify file to store incremental compilation information.",
+              "type": "string"
             },
+              
             "inlineSourceMap": {
               "description": "Emit a single file with source maps instead of having a separate file.",
               "type": "boolean"


### PR DESCRIPTION
```json
{

  "issue": {
    "asPer": [
      "https://devblogs.microsoft.com/typescript/announcing-typescript-3-4/",
      "https://www.typescriptlang.org/docs/handbook/compiler-options.html"
    ],
    "option": "--tsBuildInfoFile",
    "type": "string",
    "default": ".tsbuildinfo",
    "description": "Specify what file to store incremental build information in."
  },
  "problems": [
    {
      "description": "for the moment receiving this error message:",
      "when": "using : tsc -d --tsBuildInfoFile './build/lib/.tsbuildinfo'",
      "message": "error TS6064: Option 'tsBuildInfoFile' can only be specified in 'tsconfig.json' file."
    },
    {
      "description": "and then this error message if in tsconfig.json:",
      "when": "unsing :    '\"tsBuildInfoFile\": \"./build/lib/.tsbuildinfo\",' ",
      "message": "'Option de compilateur 'tsBuildInfoFile' inconnue.' (unknown option)"
    }
  ],
  "more": [
    " By default with these settings, when we run tsc, TypeScript will look for a file called .tsbuildinfo in the output directory (./lib). If ./lib/.tsbuildinfo doesn’t exist, it’ll be generated. But if it does, tsc will try to use that file to incrementally type-check and update our output files.",
    " These .tsbuildinfo files can be safely deleted and don’t have any impact on our code at runtime – they’re purely used to make compilations faster. We can also name them anything that we want, and place them anywhere we want using the --tsBuildInfoFile flag.",
    {
      "where": "front-end.tsconfig.json",
      "compilerOptions": {
        "incremental": true,
        "tsBuildInfoFile": "./buildcache/front-end",
        "outDir": "./lib"
      },
      "include": ["./src"]
    }
  ]
}
```