### PR TITLE
Fix azure-iot-edge-deployment-1.0 json schema

### DIFF
--- a/src/schemas/json/azure-iot-edge-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-1.0.json
@@ -299,7 +299,7 @@
                     ],
                     "properties": {
                         "value": {
-                            "type": "string"
+                            "type": ["number", "string", "boolean"]
                         }
                     }
                 }


### PR DESCRIPTION
Allow environment variable values to be number, string or boolean