### PR TITLE
Allow prettierrc to be a string

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Schema for .prettierrc",
-  "type": "object",
+  "type": ["object", "string"],
   "definitions": {
     "optionsDefinition": {
       "type": "object",
@@ -228,8 +228,14 @@
       }
     }
   },
-  "allOf": [
-    { "$ref": "#/definitions/optionsDefinition" },
-    { "$ref": "#/definitions/overridesDefinition" }
+  "oneOf": [
+    { "type": "string" },
+    {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/optionsDefinition" },
+        { "$ref": "#/definitions/overridesDefinition" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Version 1.17 of Prettier [allows shared configurations](https://prettier.io/blog/2019/04/12/1.17.0.html#support-shared-configurations-5963-by-azz), where the configuration is a single string, instead of an object.