### PR TITLE
Fix GCE and GKE zone names

### DIFF
--- a/src/schemas/json/cirrus.json
+++ b/src/schemas/json/cirrus.json
@@ -543,13 +543,13 @@
         "zone": {
           "description": "Google Cloud zone where to start a VM.",
           "enum": [
-            "europe_west3_a",
-            "europe_west3_b",
-            "europe_west3_c",
-            "us_central1_a",
-            "us_central1_b",
-            "us_central1_c",
-            "us_central1_f"
+            "europe-west3-a",
+            "europe-west3-b",
+            "europe-west3-c",
+            "us-central1-a",
+            "us-central1-b",
+            "us-central1-c",
+            "us-central1-f"
           ]
         }
       },
@@ -682,13 +682,13 @@
         "zone": {
           "description": "Google Cloud zone of the cluster.",
           "enum": [
-            "europe_west3_a",
-            "europe_west3_b",
-            "europe_west3_c",
-            "us_central1_a",
-            "us_central1_b",
-            "us_central1_c",
-            "us_central1_f"
+            "europe-west3-a",
+            "europe-west3-b",
+            "europe-west3-c",
+            "us-central1-a",
+            "us-central1-b",
+            "us-central1-c",
+            "us-central1-f"
           ]
         }
       },


### PR DESCRIPTION
Google Compute Engine and Kubernetes Engine zone names should use
hyphens, not underscores.  Using underscores results in
"FAILED_PRECONDITION:java.lang.IllegalArgumentException: Only zones
from europe-west1, europe-west2, europe-west3, europe-west4,
us-central1 regions are supported!" in Cirrus CI.