### PR TITLE
Add schema for .backportrc.json configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -92,7 +92,7 @@
       "name": ".backportrc.json",
       "description": "Backport configuration file",
       "fileMatch": [ ".backportrc.json" ],
-      "url": "http://json.schemastore.org/backport"
+      "url": "http://json.schemastore.org/backportrc"
     },        
     {
       "name": "batect.yml",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -89,6 +89,12 @@
       "url": "http://json.schemastore.org/babelrc"
     },
     {
+      "name": ".backportrc.json",
+      "description": "Backport configuration file",
+      "fileMatch": [ ".backportrc.json" ],
+      "url": "http://json.schemastore.org/backport"
+    },        
+    {
       "name": "batect.yml",
       "description": "batect configuration file",
       "fileMatch": [ "batect.yml" ],

--- a/src/schemas/json/backportrc.json
+++ b/src/schemas/json/backportrc.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "JSON schema for Backport config file",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["upstream", "branches"],
+  "properties": {
+    "upsteam": {
+      "description": "Identifier for the Github project as `{owner}/{repoName}`",
+      "type": "string"
+    },
+    "branches": {
+      "description": "Branches to backport to",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "checked": { "type": "boolean" }
+            },
+            "required": ["name", "boolean"]
+          }
+        ]
+      }
+    },
+    "labels": {
+      "description": "Labels that will be added to the pull request",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "all": {
+      "description": "Whether to only show the current user's commits or commits from anyone",
+      "type": "boolean"
+    }
+  }
+}

--- a/src/schemas/json/backportrc.json
+++ b/src/schemas/json/backportrc.json
@@ -21,7 +21,7 @@
               "name": { "type": "string" },
               "checked": { "type": "boolean" }
             },
-            "required": ["name", "boolean"]
+            "required": ["name", "checked"]
           }
         ]
       }


### PR DESCRIPTION
Hi there,

I'm the maintainer of [backport](https://github.com/sqren/backport) - a cli tool that makes the process of backporting commits easier.

`backport` is normally run inside a project folder that contains a `.backportrc.json` file. An example of that file:

```json
{
  "upstream": "elastic/elasticsearch",
  "branches": [{ "name": "7.x", "checked": true }, "7.0", "6.7", "6.6", "6.5", "6.4", "6.3", "6.2", "6.1", "6.0", "5.6"],
  "labels": ["backport"]
}
```

This is my first json-schema contribution so please let me know if anything needs fixin' 🔨
Thanks!
