### PR TITLE
[coffeelint.json] add missing rules and default levels; misc fixes

### DIFF
--- a/src/schemas/json/coffeelint.json
+++ b/src/schemas/json/coffeelint.json
@@ -12,10 +12,7 @@
 				"level": {
 					"description": "Determines the error level",
 					"type": "string",
-					"enum": [ "warn", "error", "ignore" ]
-				},
-				"name": {
-					"type": "string"
+					"enum": [ "error", "warn", "ignore" ]
 				}
 			}
 		}
@@ -23,18 +20,33 @@
 
 	"properties": {
 		"arrow_spacing": {
-			"description": "This rule checks to see that there is spacing before and after the arrow operator that declares a function.",
+			"description": "This rule checks to see that there is spacing before and after the arrow operator that declares a function. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
+		"braces_spacing": {
+			"description": "This rule checks to see that there is the proper spacing inside curly braces. The spacing amount is specified by `spaces`. The spacing amount for empty objects is specified by `empty_object_spaces`. [default level: ignore]",
+			"allOf": [ { "$ref": "#/definitions/base" } ],
+			"properties": {
+				"empty_object_spaces": {
+					"type": "integer",
+					"enum": [0, 1]
+				},
+				"spaces": {
+					"type": "integer",
+					"enum": [0, 1]
+				}
+			}
+		},
 		"camel_case_classes": {
-			"description": "This rule mandates that all class names are CamelCased. Camel casing class names is a generally accepted way of distinguishing constructor functions - which require the 'new' prefix to behave properly - from plain old functions.",
+			"description": "This rule mandates that all class names are CamelCased. Camel casing class names is a generally accepted way of distinguishing constructor functions - which require the `new` prefix to behave properly - from plain old functions. [default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"coffeescript_error": {
+			"description": "[default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"colon_assignment_spacing": {
-			"description": "This rule checks to see that there is spacing before and after the colon in a colon assignment (i.e., classes, objects).",
+			"description": "This rule checks to see that there is spacing before and after the colon in a colon assignment (i.e., classes, objects). [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ],
 			"properties": {
 				"spacing": {
@@ -53,7 +65,7 @@
 			}
 		},
 		"cyclomatic_complexity": {
-			"description": "Examine the complexity of your application.",
+			"description": "Examine the complexity of your application. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ],
 			"properties": {
 				"value": {
@@ -62,15 +74,23 @@
 			}
 		},
 		"duplicate_key": {
-			"description": "Prevents defining duplicate keys in object literals and classes.",
+			"description": "Prevents defining duplicate keys in object literals and classes. [default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"empty_constructor_needs_parens": {
-			"description": "Requires constructors with no parameters to include the parens.",
+			"description": "Requires constructors with no parameters to include the parens. [default level: ignore]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
+		"ensure_comprehensions": {
+			"description": "This rule makes sure that parentheses are around comprehensions. [default level: warn]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
+		"eol_last": {
+			"description": "Checks that the file ends with a single newline. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"indentation": {
-			"description": " This rule imposes a standard number of spaces to be used for indentation. Since whitespace is significant in CoffeeScript, it's critical that a project chooses a standard indentation format and stays consistent. Other roads lead to darkness.",
+			"description": "This rule imposes a standard number of spaces to be used for indentation. Since whitespace is significant in CoffeeScript, it's critical that a project chooses a standard indentation format and stays consistent. Other roads lead to darkness. [default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ],
 			"properties": {
 				"value": {
@@ -80,7 +100,7 @@
 			}
 		},
 		"line_endings": {
-			"description": "This rule ensures your project uses only windows or unix line endings.",
+			"description": "This rule ensures your project uses only windows or unix line endings. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ],
 			"properties": {
 				"value": {
@@ -90,7 +110,7 @@
 			}
 		},
 		"max_line_length": {
-			"description": "This rule imposes a maximum line length on your code.",
+			"description": "This rule imposes a maximum line length on your code. [default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ],
 			"properties": {
 				"value": {
@@ -102,11 +122,11 @@
 			}
 		},
 		"missing_fat_arrows": {
-			"description": "Warns when you use `this` inside a function that wasn't defined with a fat arrow. This rule does not apply to methods defined in a class, since they have `this` bound to the class instance (or the class itself, for class methods).",
+			"description": "Warns when you use `this` inside a function that wasn't defined with a fat arrow. This rule does not apply to methods defined in a class, since they have `this` bound to the class instance (or the class itself, for class methods). [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"newlines_after_classes": {
-			"description": "Checks the number of newlines between classes and other code.",
+			"description": "Checks the number of newlines between classes and other code. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ],
 			"properties": {
 				"value": {
@@ -115,19 +135,23 @@
 			}
 		},
 		"no_backticks": {
-			"description": "Backticks allow snippets of JavaScript to be embedded in CoffeeScript. While some folks consider backticks useful in a few niche circumstances, they should be avoided because so none of JavaScript's \"bad parts\", like with and eval, sneak into CoffeeScript.",
+			"description": "Backticks allow snippets of JavaScript to be embedded in CoffeeScript. While some folks consider backticks useful in a few niche circumstances, they should be avoided because so none of JavaScript's 'bad parts', like with and eval, sneak into CoffeeScript. [default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_debugger": {
-			"description": "This rule detects the `debugger` statement.",
+			"description": "This rule detects the `debugger` statement. [default level: warn]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
+		"no_empty_functions": {
+			"description": "Disallows declaring empty functions. The goal of this rule is that unintentional empty callbacks can be detected. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_empty_param_list": {
-			"description": "This rule prohibits empty parameter lists in function definitions.",
+			"description": "This rule prohibits empty parameter lists in function definitions. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_implicit_braces": {
-			"description": "This rule prohibits implicit braces when declaring object literals. Implicit braces can make code more difficult to understand, especially when used in combination with optional parenthesis.",
+			"description": "This rule prohibits implicit braces when declaring object literals. Implicit braces can make code more difficult to understand, especially when used in combination with optional parenthesis. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ],
 			"properties": {
 				"strict": {
@@ -136,37 +160,49 @@
 			}
 		},
 		"no_implicit_parens": {
-			"description": "This rule prohibits implicit parens on function calls.",
+			"description": "This rule prohibits implicit parens on function calls. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_interpolation_in_single_quotes": {
-			"description": "This rule prohibits string interpolation in a single quoted string.",
+			"description": "This rule prohibits string interpolation in a single quoted string. [default level: ignore]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
+		"no_nested_string_interpolation": {
+			"description": "This rule warns about nested string interpolation, as it tends to make code harder to read and understand. [default level: warn]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_plusplus": {
-			"description": "This rule forbids the increment and decrement arithmetic operators. Some people believe the ++ and -- to be cryptic and the cause of bugs due to misunderstandings of their precedence rules.",
+			"description": "This rule forbids the increment and decrement arithmetic operators. Some people believe the `++` and `--` to be cryptic and the cause of bugs due to misunderstandings of their precedence rules. [default level: ignore]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
+		"no_private_function_fat_arrows": {
+			"description": "Warns when you use the fat arrow for a private function inside a class definition scope. It is not necessary and it does not do anything. [default level: warn]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_stand_alone_at": {
-			"description": "This rule checks that no stand alone @ are in use, they are discouraged.",
+			"description": "This rule checks that no stand alone `@` are in use, they are discouraged. [default level: ignore]",
 			"type": "object",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_tabs": {
-			"description": "This rule forbids tabs in indentation. Enough said.",
+			"description": "This rule forbids tabs in indentation. Enough said. [default level: error]",
 			"type": "object",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
+		"no_this": {
+			"description": "This rule prohibits `this`. Use `@` instead. [default level: ignore]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
 		"no_throwing_strings": {
-			"description": " This rule forbids throwing string literals or interpolations. While JavaScript (and CoffeeScript by extension) allow any expression to be thrown, it is best to only throw  Error objects, because they contain valuable debugging information like the stack trace.",
+			"description": "This rule forbids throwing string literals or interpolations. While JavaScript (and CoffeeScript by extension) allow any expression to be thrown, it is best to only throw `Error` objects, because they contain valuable debugging information like the stack trace. [default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_trailing_semicolons": {
-			"description": "This rule prohibits trailing semicolons, since they are needless cruft in CoffeeScript.",
+			"description": "This rule prohibits trailing semicolons, since they are needless cruft in CoffeeScript. [default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_trailing_whitespace": {
-			"description": "This rule forbids trailing whitespace in your code, since it is needless cruft.",
+			"description": "This rule forbids trailing whitespace in your code, since it is needless cruft. [default level: error]",
 			"allOf": [ { "$ref": "#/definitions/base" } ],
 			"properties": {
 				"allowed_in_comments": {
@@ -178,19 +214,31 @@
 			}
 		},
 		"no_unnecessary_double_quotes": {
-			"description": "This rule prohibits double quotes unless string interpolation is used or the string contains single quotes.",
+			"description": "This rule prohibits double quotes unless string interpolation is used or the string contains single quotes. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"no_unnecessary_fat_arrows": {
-			"description": "Disallows defining functions with fat arrows when `this` is not used within the function. ",
+			"description": "Disallows defining functions with fat arrows when `this` is not used within the function.  [default level: warn]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"non_empty_constructor_needs_parens": {
-			"description": "Requires constructors with parameters to include the parens.",
+			"description": "Requires constructors with parameters to include the parens. [default level: ignore]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
+		"prefer_english_operator": {
+			"description": "This rule prohibits `&&`, `||`, `==`, `!=` and `!`. Use `and`, `or`, `is`, `isnt`, and `not` instead. `!!` (for converting to a boolean) is ignored. [default level: ignore]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		},
 		"space_operators": {
-			"description": "This rule enforces that operators have space around them. ",
+			"description": "This rule enforces that operators have space around them.  [default level: ignore]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
+		"spacing_after_comma": {
+			"description": "This rule checks to make sure you have a space after commas. [default level: ignore]",
+			"allOf": [ { "$ref": "#/definitions/base" } ]
+		},
+		"transform_messes_up_line_numbers": {
+			"description": "This rule detects when changes are made by transform function, and warns that line numbers are probably incorrect. [default level: warn]",
 			"allOf": [ { "$ref": "#/definitions/base" } ]
 		}
 	}


### PR DESCRIPTION
Updated `coffeelint.json` schema to include a few missing rule descriptions, as well as default level for each rule. Also removed `name` property from the `base` definition, and made some extra small fixes to each description (removing extra spaces, adding backticks when needed, etc).