### PR TITLE
Update eslintrc.json to accept ecmaVersion 2019/10

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -502,9 +502,9 @@
           "$ref": "#/properties/ecmaFeatures"
         },
         "ecmaVersion": {
-          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018 ],
+          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018, 10, 2019 ],
           "default": 5,
-          "description": "Set to 3, 5 (default), 6, 7, 8, or 9 to specify the version of ECMAScript you want to use. Alternatively, set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), or 2018 (same as 9) to use year-based naming."
+          "description": "Set to 3, 5 (default), 6, 7, 8, 9, or 10 to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), or 2019 (same as 10) to use the year-based naming."
         },
         "sourceType": {
           "enum": [ "script", "module" ],


### PR DESCRIPTION
Per [documentation](https://eslint.org/docs/user-guide/configuring):
> Set to 3, 5 (default), 6, 7, 8, 9, or 10 to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), or 2019 (same as 10) to use the year-based naming.