### PR TITLE
Use type boolean, not enum "off" for AppVeyor

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -483,9 +483,7 @@
         "build": {
           "oneOf": [
             {
-              "enum": [
-                "off"
-              ]
+              "type": "boolean"
             },
             {
               "type": "object",


### PR DESCRIPTION
off is a YAML keyword for false, not the string "off".