### PR TITLE
Add es2019 and es2020 targets to tsconfig.json

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -249,7 +249,7 @@
               "type": "boolean"
             },
             "target": {
-              "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018' or 'esnext'.",
+              "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020' or 'esnext'.",
               "type": "string",
               "default": "es3",
               "anyOf": [
@@ -262,10 +262,12 @@
                     "es2016",
                     "es2017",
                     "es2018",
+                    "es2019",
+                    "es2020",
                     "esnext"
                   ]
                 }, {
-                  "pattern": "^([eE][sS]([356]|(201[5678])|[nN][eE][xX][tT]))$"
+                  "pattern": "^([eE][sS]([356]|(20(1[56789]|20))|[nN][eE][xX][tT]))$"
                 }
               ]
             },


### PR DESCRIPTION
These values are not listed in https://www.typescriptlang.org/docs/handbook/compiler-options.html, but they are supported, as shown by `tsc -t` (TypeScript 3.5.1).

```
error TS6044: Compiler option 'target' expects an argument.
error TS6046: Argument for '--target' option must be: 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'esnext'.
```