### PR TITLE
Add missing lib values to tsconfig.json

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -400,12 +400,14 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [ "es5", "es6", "es2015", "es7", "es2016", "es2017", "es2018", "esnext", "dom", "dom.iterable", "webworker", "scripthost",
+                "enum": [ "es5", "es6", "es2015", "es7", "es2016", "es2017", "es2018", "es2019", "es2020", "esnext", "dom", "dom.iterable", "webworker", "webworker.importscripts", "scripthost",
                           "es2015.core", "es2015.collection", "es2015.generator", "es2015.iterable", "es2015.promise", "es2015.proxy", "es2015.reflect", "es2015.symbol", "es2015.symbol.wellknown",
                           "es2016.array.include",
                           "es2017.object", "es2017.intl", "es2017.sharedmemory", "es2017.string", "es2017.typedarrays",
-                          "es2018.intl", "es2018.promise", "es2018.regexp",
-                          "esnext.asynciterable", "esnext.array", "esnext.intl", "esnext.symbol"]
+                          "es2018.asynciterable", "es2018.intl", "es2018.promise", "es2018.regexp",
+                          "es2019.array", "es2019.object", "es2019.string", "es2019.symbol",
+                          "es2020.string", "es2020.symbol.wellknown",
+                          "esnext.asynciterable", "esnext.array", "esnext.bigint", "esnext.intl", "esnext.symbol"]
               }
             },
             "strictNullChecks": {


### PR DESCRIPTION
These values are not listed in https://www.typescriptlang.org/docs/handbook/compiler-options.html but, they are supported as shown by `tsc --help --all` (TypeScript 3.5.1)

```shell
 --lib    Specify library files to be included in the compilation.

'es5' 'es6' 'es2015' 'es7' 'es2016' 'es2017' 'es2018' 'es2019' 'es2020' 'esnext' 'dom'
'dom.iterable' 'webworker' 'webworker.importscripts' 'scripthost' 'es2015.core' 
'es2015.collection' 'es2015.generator' 'es2015.iterable' 'es2015.promise' 'es2015.proxy' 
'es2015.reflect' 'es2015.symbol' 'es2015.symbol.wellknown' 'es2016.array.include' 
'es2017.object' 'es2017.sharedmemory' 'es2017.string' 'es2017.intl' 'es2017.typedarrays' 
'es2018.asynciterable' 'es2018.intl' 'es2018.promise' 'es2018.regexp' 'es2019.array' 
'es2019.object' 'es2019.string' 'es2019.symbol' 'es2020.string' 'es2020.symbol.wellknown' 
'esnext.array' 'esnext.symbol' 'esnext.asynciterable' 'esnext.intl' 'esnext.bigint'
```