### PR TITLE
fix: add missing notification options for .travis-ci

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -7,6 +7,42 @@
       "type": "string",
       "minLength": 1
     },
+    "notRequiredNonEmptyString": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/nonEmptyString"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "arrayOfNonEmptyStrings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/nonEmptyString"
+      }
+    },
+    "nonEmptyStringOrArrayOfNonEmptyStrings": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/nonEmptyString"
+        },
+        {
+          "$ref": "#/definitions/arrayOfNonEmptyStrings"
+        }
+      ]
+    },
+    "notRequiredNonEmptyStringOrArrayOfNonEmptyStrings": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "stringArrayUnique": {
       "type": "array",
       "uniqueItems": true,
@@ -84,7 +120,7 @@
       "pattern": ".+:.+(#.+)?"
     },
     "notificationFrequency": {
-      "enum": ["always", "never", "change"]
+      "enum": [ "always", "never", "change" ]
     },
     "step": {
       "anyOf": [
@@ -92,7 +128,7 @@
           "type": "boolean"
         },
         {
-          "enum": ["skip", "ignore"]
+          "enum": [ "skip", "ignore" ]
         },
         {
           "type": "string"
@@ -372,11 +408,11 @@
             {
               "type": "array",
               "items": {
-                "enum": ["clang", "gcc"]
+                "enum": [ "clang", "gcc" ]
               }
             },
             {
-              "enum": ["clang", "gcc"]
+              "enum": [ "clang", "gcc" ]
             }
           ]
         },
@@ -421,13 +457,12 @@
         },
         "solution": {
           "type": "string",
-          "description":
-            "When the optional solution key is present, Travis will run NuGet package restore and build the given solution."
+          "description": "When the optional solution key is present, Travis will run NuGet package restore and build the given solution."
         },
         "mono": {
           "oneOf": [
             {
-              "enum": ["none"]
+              "enum": [ "none" ]
             },
             {
               "type": "array",
@@ -451,8 +486,7 @@
         },
         "podfile": {
           "type": "string",
-          "description":
-            "By default, Travis CI will assume that your Podfile is in the root of the repository. If this is not the case, you can specify where the Podfile is"
+          "description": "By default, Travis CI will assume that your Podfile is in the root of the repository. If this is not the case, you can specify where the Podfile is"
         },
         "python": {
           "oneOf": [
@@ -575,8 +609,7 @@
         },
         "brew_packages": {
           "type": "array",
-          "description":
-            "A list of packages to install via brew. This option is ignored on non-OS X builds.",
+          "description": "A list of packages to install via brew. This option is ignored on non-OS X builds.",
           "items": {
             "type": "string"
           }
@@ -627,12 +660,12 @@
           "description": "The operating system to run the job on",
           "oneOf": [
             {
-              "enum": ["osx", "linux", "windows"]
+              "enum": [ "osx", "linux", "windows" ]
             },
             {
               "type": "array",
               "items": {
-                "enum": ["osx", "linux", "windows"]
+                "enum": [ "osx", "linux", "windows" ]
               }
             }
           ]
@@ -653,23 +686,21 @@
         },
         "dist": {
           "description": "The Ubuntu distribution to use",
-          "enum": ["precise", "trusty", "xenial"]
+          "enum": [ "precise", "trusty", "xenial" ]
         },
         "sudo": {
-          "enum": [true, false, "", "required", "enabled"]
+          "enum": [ true, false, "", "required", "enabled" ]
         },
         "addons": {
           "type": "object",
           "properties": {
             "apt": {
               "type": "object",
-              "description":
-                "To install packages not included in the default container-based-infrastructure you need to use the APT addon, as sudo apt-get is not available",
+              "description": "To install packages not included in the default container-based-infrastructure you need to use the APT addon, as sudo apt-get is not available",
               "properties": {
                 "update": {
                   "type": "boolean",
-                  "description":
-                    "To update the list of available packages"
+                  "description": "To update the list of available packages"
                 },
                 "sources": {
                   "type": "array",
@@ -680,16 +711,14 @@
                         "properties": {
                           "sourceline": {
                             "type": "string",
-                            "description":
-                              "Key-value pairs which will be added to /etc/apt/sources.list"
+                            "description": "Key-value pairs which will be added to /etc/apt/sources.list"
                           },
                           "key_url": {
                             "type": "string",
-                            "description":
-                              "When APT sources require GPG keys, you can specify this with key_url"
+                            "description": "When APT sources require GPG keys, you can specify this with key_url"
                           }
                         },
-                        "required": ["sourceline"],
+                        "required": [ "sourceline" ],
                         "additionalProperties": false
                       },
                       {
@@ -701,8 +730,7 @@
                 },
                 "packages": {
                   "type": "array",
-                  "description":
-                    "To install packages from the package whitelist before your custom build steps",
+                  "description": "To install packages from the package whitelist before your custom build steps",
                   "items": {
                     "type": "string"
                   }
@@ -711,8 +739,7 @@
               "additionalProperties": false
             },
             "hosts": {
-              "description":
-                "If your build requires setting up custom hostnames, you can specify a single host or a list of them. Travis CI will automatically setup the hostnames in /etc/hosts for both IPv4 and IPv6.",
+              "description": "If your build requires setting up custom hostnames, you can specify a single host or a list of them. Travis CI will automatically setup the hostnames in /etc/hosts for both IPv4 and IPv6.",
               "oneOf": [
                 {
                   "type": "array",
@@ -728,7 +755,7 @@
             "artifacts": {
               "oneOf": [
                 {
-                  "enum": [true]
+                  "enum": [ true ]
                 },
                 {
                   "type": "object",
@@ -744,13 +771,11 @@
                     },
                     "working_dir": {
                       "type": "string",
-                      "description":
-                        "If you’d like to upload file from a specific directory, you can change your working directory "
+                      "description": "If you’d like to upload file from a specific directory, you can change your working directory "
                     },
                     "debug": {
                       "type": "boolean",
-                      "description":
-                        "If you’d like to see more detail about what the artifacts addon is doing"
+                      "description": "If you’d like to see more detail about what the artifacts addon is doing"
                     }
                   }
                 }
@@ -771,7 +796,7 @@
             "chrome": {
               "description": "Chrome addon",
               "type": "string",
-              "enum": ["stable", "beta"]
+              "enum": [ "stable", "beta" ]
             },
             "rethinkdb": {
               "description": "RethinkDB addon",
@@ -864,7 +889,7 @@
                 "taps": {
                   "$ref": "#/definitions/stringOrStringArrayUnique"
                 },
-                 "packages": {
+                "packages": {
                   "$ref": "#/definitions/stringOrStringArrayUnique"
                 },
                 "casks": {
@@ -985,7 +1010,7 @@
         "cache": {
           "oneOf": [
             {
-              "enum": [false]
+              "enum": [ false ]
             },
             {
               "$ref": "#/definitions/cache"
@@ -1082,7 +1107,7 @@
                   "default": 50
                 },
                 {
-                  "enum": [false]
+                  "enum": [ false ]
                 }
               ]
             },
@@ -1096,8 +1121,7 @@
             },
             "lfs_skip_smudge": {
               "type": "boolean",
-              "description":
-                "Skip fetching the git-lfs files during the initial git clone (equivalent to git lfs smudge --skip),"
+              "description": "Skip fetching the git-lfs files during the initial git clone (equivalent to git lfs smudge --skip),"
             }
           },
           "additionalProperties": false
@@ -1235,19 +1259,19 @@
               "type": "object",
               "properties": {
                 "provider": {
-                  "enum": ["script"]
+                  "enum": [ "script" ]
                 },
                 "script": {
                   "type": "string"
                 }
               },
-              "required": ["provider", "script"]
+              "required": [ "provider", "script" ]
             },
             {
               "type": "object",
               "properties": {
                 "provider": {
-                  "enum": ["npm"]
+                  "enum": [ "npm" ]
                 },
                 "email": {
                   "$ref": "#/definitions/possiblySecretString"
@@ -1259,13 +1283,13 @@
                   "type": "string"
                 }
               },
-              "required": ["provider", "email", "api_key"]
+              "required": [ "provider", "email", "api_key" ]
             },
             {
               "type": "object",
               "properties": {
                 "provider": {
-                  "enum": ["surge"]
+                  "enum": [ "surge" ]
                 },
                 "project": {
                   "type": "string"
@@ -1274,13 +1298,13 @@
                   "type": "string"
                 }
               },
-              "required": ["provider"]
+              "required": [ "provider" ]
             },
             {
               "type": "object",
               "properties": {
                 "provider": {
-                  "enum": ["releases"]
+                  "enum": [ "releases" ]
                 },
                 "api_key": {
                   "$ref": "#/definitions/possiblySecretString"
@@ -1312,7 +1336,7 @@
                   "description": "If you need to overwrite existing files"
                 }
               },
-              "required": ["provider"]
+              "required": [ "provider" ]
             },
             {
               "type": "object",
@@ -1325,63 +1349,63 @@
                 },
                 "api_key": {
                   "description": "heroku auth token",
-                  "anyOf":[
+                  "anyOf": [
                     {
                       "$ref": "#/definitions/possiblySecretString"
                     },
                     {
-                      "type":"object",
+                      "type": "object",
                       "additionalProperties": {
                         "$ref": "#/definitions/possiblySecretString"
                       }
                     }
                   ]
                 },
-                "app":{
-                  "oneOf":[
+                "app": {
+                  "oneOf": [
                     {
-                      "type":"string",
+                      "type": "string",
                       "description": "Deploy master branch to heroku app"
                     },
                     {
-                      "type":"object",
+                      "type": "object",
                       "description": "Deploy the different branch to the different heroku app",
-                      "additionalProperties":{
-                        "type":"string"
+                      "additionalProperties": {
+                        "type": "string"
                       }
                     }
                   ]
                 },
-                "run":{
+                "run": {
                   "description": "to run a command on Heroku after a successful deploy",
-                  "oneOf":[
+                  "oneOf": [
                     {
-                      "type":"string"
+                      "type": "string"
                     },
                     {
-                      "type":"array",
+                      "type": "array",
                       "items": {
-                        "type":"string"
+                        "type": "string"
                       }
                     }
                   ]
                 },
-                "skip_cleanup":{
-                  "type":"boolean",
+                "skip_cleanup": {
+                  "type": "boolean",
                   "description": "Travis CI default will clean up any additional files and changes you made, you can by it to skip the clean up"
                 },
-                "strategy":{
-                  "enum": ["api", "git"],
+                "strategy": {
+                  "enum": [ "api", "git" ],
                   "description": "Travis CI supports different mechanisms for deploying to Heroku: api is default"
                 }
               },
-              "required": ["provider", "api_key"]
+              "required": [ "provider", "api_key" ]
             },
             {
               "type": "object",
               "properties": {
                 "provider": {
-                  "enum": ["s3"]
+                  "enum": [ "s3" ]
                 },
                 "access_key_id": {
                   "$ref": "#/definitions/possiblySecretString"
@@ -1432,7 +1456,7 @@
                   "type": "string"
                 }
               },
-              "required": ["provider", "access_key_id", "secret_access_key", "bucket"]
+              "required": [ "provider", "access_key_id", "secret_access_key", "bucket" ]
             },
             {
               "type": "object",
@@ -1440,11 +1464,11 @@
                 "provider": {
                   "type": "string",
                   "not": {
-                    "enum": ["script", "npm", "surge", "releases", "heroku", "s3"]
+                    "enum": [ "script", "npm", "surge", "releases", "heroku", "s3" ]
                   }
                 }
               },
-              "required": ["provider"]
+              "required": [ "provider" ]
             }
           ]
         }
@@ -1465,15 +1489,20 @@
             "webhooks": {
               "oneOf": [
                 {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "uri"
-                  }
+                  "$ref": "#/definitions/arrayOfNonEmptyStrings"
+                },
+                {
+                  "type": "boolean"
                 },
                 {
                   "type": "object",
                   "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
                     "urls": {
                       "oneOf": [
                         {
@@ -1491,19 +1520,24 @@
                     }
                   },
                   "on_success": {
-                    "$ref": "#/definitions/notificationFrequency"
+                    "$ref": "#/definitions/notificationFrequency",
+                    "default": "always"
                   },
                   "on_failure": {
-                    "$ref": "#/definitions/notificationFrequency"
+                    "$ref": "#/definitions/notificationFrequency",
+                    "default": "always"
                   },
                   "on_start": {
-                    "$ref": "#/definitions/notificationFrequency"
+                    "$ref": "#/definitions/notificationFrequency",
+                    "default": "never"
                   },
                   "on_cancel": {
-                    "$ref": "#/definitions/notificationFrequency"
+                    "$ref": "#/definitions/notificationFrequency",
+                    "default": "always"
                   },
                   "on_error": {
-                    "$ref": "#/definitions/notificationFrequency"
+                    "$ref": "#/definitions/notificationFrequency",
+                    "default": "always"
                   }
                 }
               ]
@@ -1514,8 +1548,17 @@
                   "$ref": "#/definitions/slackRoom"
                 },
                 {
+                  "type": "boolean"
+                },
+                {
                   "type": "object",
                   "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
                     "rooms": {
                       "type": "array",
                       "items": {
@@ -1526,16 +1569,25 @@
                       "type": "boolean"
                     },
                     "template": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref": "#/definitions/notRequiredNonEmptyStringOrArrayOfNonEmptyStrings"
                     },
                     "on_success": {
                       "$ref": "#/definitions/notificationFrequency"
                     },
                     "on_failure": {
                       "$ref": "#/definitions/notificationFrequency"
+                    },
+                    "on_start": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "never"
+                    },
+                    "on_cancel": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_error": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
                     }
                   },
                   "additionalProperties": false
@@ -1545,28 +1597,40 @@
             "email": {
               "oneOf": [
                 {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "$ref": "#/definitions/arrayOfNonEmptyStrings"
                 },
                 {
-                  "enum": [false]
+                  "type": "boolean"
                 },
                 {
                   "type": "object",
                   "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
                     "recipients": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
                     },
                     "on_success": {
                       "$ref": "#/definitions/notificationFrequency",
                       "default": "change"
                     },
                     "on_failure": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_start": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "never"
+                    },
+                    "on_cancel": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_error": {
                       "$ref": "#/definitions/notificationFrequency",
                       "default": "always"
                     }
@@ -1577,37 +1641,34 @@
             "irc": {
               "oneOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
                 },
                 {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "boolean"
                 },
                 {
                   "type": "object",
                   "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
                     "channels": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
                     },
                     "channel_key": {
-                      "type": "string"
+                      "$ref": "#/definitions/nonEmptyString"
                     },
                     "nick": {
-                      "type": "string"
+                      "$ref": "#/definitions/nonEmptyString"
                     },
                     "password": {
-                      "type": "string"
+                      "$ref": "#/definitions/nonEmptyString"
                     },
                     "template": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "$ref": "#/definitions/notRequiredNonEmptyStringOrArrayOfNonEmptyStrings"
                     },
                     "on_success": {
                       "$ref": "#/definitions/notificationFrequency",
@@ -1617,11 +1678,214 @@
                       "$ref": "#/definitions/notificationFrequency",
                       "default": "always"
                     },
+                    "on_start": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "never"
+                    },
+                    "on_cancel": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_error": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
                     "skip_join": {
                       "type": "boolean"
                     },
                     "use_notice": {
                       "type": "boolean"
+                    }
+                  }
+                }
+              ]
+            },
+            "pushover": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "api_key": {
+                      "$ref": "#/definitions/nonEmptyString"
+                    },
+                    "users": {
+                      "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
+                    },
+                    "template": {
+                      "$ref": "#/definitions/notRequiredNonEmptyStringOrArrayOfNonEmptyStrings"
+                    },
+                    "on_success": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_failure": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_start": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "never"
+                    },
+                    "on_cancel": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_error": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    }
+                  }
+                }
+              ]
+            },
+            "campfire": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "rooms": {
+                      "$ref": "#/definitions/arrayOfNonEmptyStrings"
+                    },
+                    "template": {
+                      "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
+                    },
+                    "on_success": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_failure": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_start": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "never"
+                    },
+                    "on_cancel": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_error": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    }
+                  }
+                }
+              ]
+            },
+            "flowdock": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/nonEmptyString"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "api_token": {
+                      "$ref": "#/definitions/nonEmptyString"
+                    },
+                    "on_success": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_failure": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_start": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "never"
+                    },
+                    "on_cancel": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_error": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    }
+                  }
+                }
+              ]
+            },
+            "hipchat": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/arrayOfNonEmptyStrings"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "rooms": {
+                      "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
+                    },
+                    "format": {
+                      "enum": [ "html", "text" ]
+                    },
+                    "template": {
+                      "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings"
+                    },
+                    "on_success": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_failure": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_start": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "never"
+                    },
+                    "on_cancel": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
+                    },
+                    "on_error": {
+                      "$ref": "#/definitions/notificationFrequency",
+                      "default": "always"
                     }
                   }
                 }
@@ -1653,8 +1917,7 @@
             },
             "fast_finish": {
               "type": "boolean",
-              "description":
-                "If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed. To mark the build as finished as soon as possible, add fast_finish: true"
+              "description": "If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed. To mark the build as finished as soon as possible, add fast_finish: true"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
There are more notification options on Travis-CI that covered by the current
.travis-ci schema. The missed are:
- Campfire
- HipChat
- flowdock
- Pushover
Also some notification events are missed as well on the present notification
providers. Namely on_cancel, on_error, on_start.
I've added all of this. There is a lack of documentation, so I do my best.

Issue: SchemaStore#647