### PR TITLE
Add `tsType` property in `package.json`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -73,7 +73,8 @@
         "^_": {
           "description": "Any property starting with _ is valid.",
           "additionalProperties": true,
-          "additionalItems": true
+          "additionalItems": true,
+          "tsType": "any"
         }
       },
 
@@ -331,7 +332,8 @@
             }
           },
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "tsType": "string | undefined"
           }
         },
         "config": {


### PR DESCRIPTION
This fixes #715

`json-schema-to-typescript` will use `tsTypes` as an override, instead of whatever type it generates.

There's a number of schemas that generate invalid definitions in TS right now, but I'm not going to try fixing them until I've heard back about [improving support for optional properties](https://github.com/bcherny/json-schema-to-typescript/issues/235#issue-456502280)