### PR TITLE
Add schema for Behat configuration files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -123,6 +123,12 @@
       "url": "http://json.schemastore.org/bowerrc"
     },
     {
+      "name": "behat.yml",
+      "description": "Behat configuration file",
+      "fileMatch": [ "behat.yml", "*.behat.yml" ],
+      "url": "http://json.schemastore.org/behat"
+    },
+    {
       "name": "bozr.suite.json",
       "description": "Bozr test suite file",
       "fileMatch": [ ".suite.json", ".xsuite.json" ],

--- a/src/schemas/json/behat.json
+++ b/src/schemas/json/behat.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Behat configuration files",
+  "type": "object",
+  "properties": {
+    "default": {
+      "title": "Default profile",
+      "$ref": "#/definitions/profile"
+    },
+    "imports": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": {
+    "title": "Profile name",
+    "$ref": "#/definitions/profile"
+  },
+  "definitions": {
+    "profile": {
+      "title": "Profile",
+      "type": "object",
+      "properties": {
+        "autoload": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "formatters": {
+          "title": "How to format tests output",
+          "default": "pretty",
+          "type": "object",
+          "properties": {
+            "pretty": {
+              "title": "Prints the feature as is",
+              "type": "boolean"
+            },
+            "progress:": {
+              "title": "Prints one character per step",
+              "type": "boolean"
+            },
+            "junit:": {
+              "title": "Outputs the failures in JUnit compatible files.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "suites": {
+          "title": "Test suites",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/suite"
+          }
+        },
+        "extensions": {
+          "title": "Behat extensions",
+          "type": "object",
+          "additionalProperties": {"type": "object"}
+        }
+      }
+    },
+    "suite": {
+      "title": "Test suite",
+      "type": "object",
+      "properties": {
+        "paths": {
+          "title": "Paths to execute",
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "contexts": {
+          "title": "Suite contexts",
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "filters": {
+          "title": "Suite filters",
+          "type": "object",
+          "properties": {
+            "tags": {"type": "string"},
+            "role": {"type": "string"}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a schema for [http://behat.org/](url)

Documentation: http://behat.org/en/latest/user_guide/configuration.html