### PR TITLE
Add schema for Drush site aliases

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -367,6 +367,12 @@
       "url": "http://json.schemastore.org/dotnetcli.host"
     },
     {
+      "name": "Drush site aliases",
+      "description": "JSON Schema for Drush 9 site aliases file",
+      "fileMatch": [ "sites/*.site.yml" ],
+      "url": "http://json.schemastore.org/drush.site.yml"
+    },
+    {
       "name": "dss-2.0.0.json",
       "description": "Digital Signature Service Core Protocols, Elements, and Bindings Version 2.0",
       "url": "http://json.schemastore.org/dss-2.0.0.json"

--- a/src/schemas/json/drush.site.yml.json
+++ b/src/schemas/json/drush.site.yml.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON Schema for Drush site aliases",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "root": {
+        "title": "The Drupal root for this site",
+        "default": "/path/to/drupal/root",
+        "type": "string"
+      },
+      "host": {
+        "title": "The fully-qualified domain name of the remote system hosting the Drupal instance",
+        "default": "my-server.com",
+        "type": "string"
+      },
+      "uri": {
+        "title": "Site URI",
+        "description": "The value of uri should always be the same as when the site is being accessed from a web browser",
+        "default": "https://example.com",
+        "type": "string"
+      },
+      "user": {
+        "title": "The username to log in as when using ssh or rsync",
+        "type": "string"
+      },
+      "os": {
+        "title": "The operating system of the remote server",
+        "type": "string",
+        "enum": ["Windows", "Linux"]
+      },
+      "ssh": {
+        "title": "Contains settings used to control how ssh commands are generated when running remote commands",
+        "type": "object",
+        "properties": {
+          "options": {
+            "title": "Additional commandline options for the ssh command itself",
+            "type": "string"
+          },
+          "tty": {
+            "title": "A flag to force Drush to always or never create a tty",
+            "type": "boolean"
+          }
+        }
+      },
+      "paths": {
+        "title": "Aliases for common rsync targets",
+        "type": "object",
+        "properties": {
+          "drush-script": {
+            "title": "Path to the remote Drush command",
+            "default": "/path/to/drush",
+            "type": "string"
+          },
+          "alias-path": {
+            "title": "A list of paths where Drush will search for alias files",
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "files": {
+            "titles": "Path to 'files' directory",
+            "type": "string"
+          }
+        },
+        "additionalProperties": {"type": "string"}
+      },
+      "command": {
+        "title": "Contains options for specific commands",
+        "type": "object",
+        "additionalProperties": {"type": "object"}
+      },
+      "docker": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "title": "The name of the container to run on",
+            "type": "string"
+          },
+          "exec": {
+            "type": "object",
+            "options": {
+              "title": "Options for exec command",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/drush.site.yml.json
+++ b/src/schemas/json/drush.site.yml.json
@@ -85,6 +85,10 @@
             }
           }
         }
+      },
+      "vagrant": {
+        "title": "Vagrant transport",
+        "type": "null"
       }
     }
   }


### PR DESCRIPTION
This adds a JSON schema for [Drush](https://www.drush.org) site aliases.

The annotated file used as a reference.
https://github.com/drush-ops/drush/blob/master/examples/example.site.yml