### PR TITLE
Add mtad.yaml and *.mtaext v3.3 json schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1124,6 +1124,18 @@
       "description": "A JSON schema for MTA projects (mta.yaml files)",
       "fileMatch": [ "mta.yaml", "mta.yml" ],
       "url": "http://json.schemastore.org/mta-3.1"
+    },
+    {
+      "name": "mtad.yaml",
+      "description": "A JSON schema for MTA deployment descriptors v3.3",
+      "fileMatch": [ "mtad.yaml", "mtad.yml" ],
+      "url": "http://json.schemastore.org/mtad"
+    },
+    {
+      "name": ".mtaext",
+      "description": "A JSON schema for MTA extension descriptors v3.3",
+      "fileMatch": [ "*.mtaext" ],
+      "url": "http://json.schemastore.org/mtaext"
     }
   ]
 }

--- a/src/schemas/json/mtad.json
+++ b/src/schemas/json/mtad.json
@@ -1,0 +1,426 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/MTA/mtad.yaml",
+    "title": "mtad.yaml v3.3",
+    "description": "MTA deployment descriptor schema v3.3",
+    "type": "object",
+    "required": [
+        "_schema-version",
+        "ID",
+        "version"
+    ],
+    "properties": {
+        "_schema-version": {
+            "description": "Used to indicate to an MTA processing tool (e.g. a deployer), which schema version was taken as the base when authoring a descriptor.",
+            "type": "string",
+            "pattern": "^[1-9]\\d*(\\.\\d+){0,2}$",
+            "default": "3.3.0"
+        },
+        "ID": {
+            "description": "A globally unique ID of this MTA. Unlimited string of unicode characters.",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+        },
+        "version": {
+            "description": "Application version. Shall follow the semantic versioning standard.",
+            "type": "string",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?$"
+        },
+        "description": {
+            "description": "A non-translatable description of this MTA. This is not a text for application users.",
+            "type": "string"
+        },
+        "provider": {
+            "description": "The provider or vendor of this software.",
+            "type": "string"
+        },
+        "copyright": {
+            "description": "A copyright statement from the provider.",
+            "type": "string"
+        },
+        "parameters": {
+            "description": "Global parameters related to the MTA application.",
+            "type": "object"
+        },
+        "parameters-metadata": {
+            "description": "Additional information about the MTA's parameters.",
+            "$ref": "#/definitions/properties-metadata"
+        },
+        "hooks": {
+            "description": "A list of hooks that will be executed for the MTA.",
+            "$ref": "#/definitions/hooks"
+        },
+        "modules": {
+            "description": "A list of modules to be deployed by the MTA application.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "type"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "The module name which must be unique and cannot be the same as any provided property set or resource name.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "type": {
+                        "description": "The module type that defines the design-time tools for the module.",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "A free text describing this module.",
+                        "type": "string"
+                    },
+                    "path": {
+                        "description": "The path to a folder that contains the module artifacts.",
+                        "type": "string"
+                    },
+                    "deployed-after": {
+                        "description": "A list containing the names of the modules that must be deployed prior to this one.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "properties": {
+                        "description": "A collection of key-value pairs that are available to the module at runtime.",
+                        "type": "object"
+                    },
+                    "properties-metadata": {
+                        "description": "Additional information about the module's properties.",
+                        "$ref": "#/definitions/properties-metadata"
+                    },
+                    "parameters": {
+                        "description": "Configuration parameters that are used when deploying the module to the target runtime environment.",
+                        "type": "object"
+                    },
+                    "parameters-metadata": {
+                        "description": "Additional information about the module's parameters.",
+                        "$ref": "#/definitions/properties-metadata"
+                    },
+                    "hooks": {
+                        "description": "A list of hooks that will be executed for the module.",
+                        "$ref": "#/definitions/hooks"
+                    },
+                    "requires": {
+                        "description": "List of names either matching a resource name or a name provided by another module within the same MTA that are required by this module.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "description": "An MTA internal name which must match either a provided name, a resource name, or a module name within the same MTA.",
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                                },
+                                "list": {
+                                    "description": "All required and found configuration data sets will be assembled into a JSON array and provided to the module by the lookup name as specified by the value of 'list'.",
+                                    "type": "string"
+                                },
+                                "properties": {
+                                    "description": "Required properties can be mapped from provided properties. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                },
+                                "properties-metadata": {
+                                    "description": "Additional information about the required dependency's properties.",
+                                    "$ref": "#/definitions/properties-metadata"
+                                },
+                                "parameters": {
+                                    "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to the module at runtime. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                },
+                                "parameters-metadata": {
+                                    "description": "Additional information about the required dependency's parameters.",
+                                    "$ref": "#/definitions/properties-metadata"
+                                }
+                            }
+                        }
+                    },
+                    "provides": {
+                        "description": "List of provided names (MTA internal) to which properties can be attached",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "description": "An MTA internal name which can used by a requiring module.",
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                                },
+                                "public": {
+                                    "description": "Indicates, that the provided properties shall be made publicly available by the deployer. Default value is false.",
+                                    "type": "boolean"
+                                },
+                                "properties": {
+                                    "description": "Property names and values make up the configuration data which is to be provided to requiring modules at runtime",
+                                    "type": "object"
+                                },
+                                "properties-metadata": {
+                                    "description": "Additional information about the provided dependency's properties.",
+                                    "$ref": "#/definitions/properties-metadata"
+                                },
+                                "parameters": {
+                                    "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to the module at runtime. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                },
+                                "parameters-metadata": {
+                                    "description": "Additional information about the provided dependency's parameters.",
+                                    "$ref": "#/definitions/properties-metadata"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "resources": {
+            "description": "A list of resources to be deployed by the MTA application.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "type"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "The resource name which must be unique and cannot be the same as any provided property set or resource name.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "type": {
+                        "description": "The resource type that defines the design-time tools for the resource.",
+                        "type": "string"
+                    },
+                    "active": {
+                        "description": "If a resource is declared to be active, it is allocated and bound according to declared requirements. Default value is true.",
+                        "type": "boolean"
+                    },
+                    "optional": {
+                        "description": "A resource can be declared to be optional, if the MTA can compensate for its non-existence. Default value is false.",
+                        "type": "boolean"
+                    },
+                    "description": {
+                        "description": "A free text describing this resource.",
+                        "type": "string"
+                    },
+                    "properties": {
+                        "description": "Property names and values make up the configuration data which is to be provided to requiring modules at runtime.",
+                        "type": "object"
+                    },
+                    "properties-metadata": {
+                        "description": "Additional information about the resource's properties.",
+                        "$ref": "#/definitions/properties-metadata"
+                    },
+                    "parameters": {
+                        "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to requiring modules at runtime. Untyped resources cannot have parameters.",
+                        "type": "object"
+                    },
+                    "parameters-metadata": {
+                        "description": "Additional information about the resource's parameters.",
+                        "$ref": "#/definitions/properties-metadata"
+                    },
+                    "hooks": {
+                        "description": "A list of hooks that will be executed for the resource.",
+                        "$ref": "#/definitions/hooks"
+                    },
+                    "requires": {
+                        "description": "List of names either matching a resource name or a name provided by another resource within the same MTA that are required by this resource.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "description": "An MTA internal name which must match either a provided name, or a resource name within the same MTA.",
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                                },
+                                "properties": {
+                                    "description": "Required properties can be mapped from provided properties. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                },
+                                "properties-metadata": {
+                                    "description": "Additional information about the required dependency's properties.",
+                                    "$ref": "#/definitions/properties-metadata"
+                                },
+                                "parameters": {
+                                    "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to the resource at runtime. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                },
+                                "parameters-metadata": {
+                                    "description": "Additional information about the required dependency's parameters.",
+                                    "$ref": "#/definitions/properties-metadata"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "module-types": {
+            "description": "A list of custom module type definitions that will be used by the MTA application.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "extends"
+                ],
+                "properties": {
+                    "name": {
+                        "description": " An MTA internal name of the module type that will be specified in the 'type' element of modules consuming it.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "extends": {
+                        "description": "The name of the extended type. Can be another module type defined in this descriptor or one of the default types supported by the deployer.",
+                        "type": "string"
+                    },
+                    "properties": {
+                        "description": "A collection of key-value pairs that will be inherited by all modules of this type.",
+                        "type": "object"
+                    },
+                    "properties-metadata": {
+                        "description": "Additional information about the module type's properties.",
+                        "$ref": "#/definitions/properties-metadata"
+                    },
+                    "parameters": {
+                        "description": "Configuration parameters that will be inherited in all modules of this type.",
+                        "type": "object"
+                    },
+                    "parameters-metadata": {
+                        "description": "Additional information about the module's parameters.",
+                        "$ref": "#/definitions/properties-metadata"
+                    }
+                }
+            }
+        },
+        "resource-types": {
+            "description": "A list of custom resource type definitions that will be used by the MTA application.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "extends"
+                ],
+                "properties": {
+                    "name": {
+                        "description": " An MTA internal name of the resource type that will be specified in the 'type' element of resources consuming it.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "extends": {
+                        "description": "The name of the extended type. Can be another resource type defined in this descriptor or one of the default types supported by the deployer.",
+                        "type": "string"
+                    },
+                    "properties": {
+                        "description": "A collection of key-value pairs that will be inherited by all resources of this type.",
+                        "type": "object"
+                    },
+                    "properties-metadata": {
+                        "description": "Additional information about the resource type's properties.",
+                        "$ref": "#/definitions/properties-metadata"
+                    },
+                    "parameters": {
+                        "description": "Configuration parameters that will be inherited in all resources of this type.",
+                        "type": "object"
+                    },
+                    "parameters-metadata": {
+                        "description": "Additional information about the resource's parameters.",
+                        "$ref": "#/definitions/properties-metadata"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "properties-metadata": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "overwritable": {
+                        "description": "Default value is true.",
+                        "type": "boolean"
+                    },
+                    "optional": {
+                        "description": "Default value is false.",
+                        "type": "boolean"
+                    }
+                }
+            }
+        },
+        "hooks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "An internal name which can be used for documentation purposes and shown by the deployer.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "type": {
+                        "description": "Defines the type of action that should be executed by the deployer.",
+                        "type": "string"
+                    },
+                    "phases": {
+                        "description": "A list of strings that define the points at which the hook must be executed.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "parameters": {
+                        "description": "Configuration parameters that are used when executing the hook to the target runtime environment.",
+                        "type": "object"
+                    },
+                    "parameters-metadata": {
+                        "description": "Additional information about the hook's parameters.",
+                        "$ref": "#/definitions/properties-metadata"
+                    },
+                    "requires": {
+                        "description": "List of names either matching a resource name or a provided dependency name provided within the same MTA that are required by this hook.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "description": "An MTA internal name which must match either a provided name, or a resource name within the same MTA.",
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                                },
+                                "parameters": {
+                                    "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to the hook at runtime. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                },
+                                "parameters-metadata": {
+                                    "description": "Additional information about the hook's parameters.",
+                                    "$ref": "#/definitions/properties-metadata"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/schemas/json/mtaext.json
+++ b/src/schemas/json/mtaext.json
@@ -1,0 +1,276 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/MTA/.mtaext",
+    "title": ".mtaext v3.3",
+    "description": "MTA extension descriptor schema v3.3",
+    "type": "object",
+    "required": [
+        "_schema-version",
+        "ID",
+        "extends"
+    ],
+    "properties": {
+        "_schema-version": {
+            "description": "Used to indicate to an MTA processing tool (e.g. a deployer), which schema version was taken as the base when authoring a descriptor.",
+            "type": "string",
+            "pattern": "^[1-9]\\d*(\\.\\d+){0,2}$",
+            "default": "3.3.0"
+        },
+        "ID": {
+            "description": "A globally unique ID of this MTA extension descriptor. Unlimited string of unicode characters.",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+        },
+        "extends": {
+            "description": "A globally unique ID of the MTA or the MTA extension which shall be extended by this descriptor.",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+        },
+        "description": {
+            "description": "A non-translatable description of this MTA extension. This is not a text for application users.",
+            "type": "string"
+        },
+        "provider": {
+            "description": "The provider or vendor.",
+            "type": "string"
+        },
+        "parameters": {
+            "description": "Global parameters that will be added to the application.",
+            "type": "object"
+        },
+        "hooks": {
+            "description": "A list of the existing hooks that will be modified by the extension.",
+            "$ref": "#/definitions/hooks"
+        },
+        "modules": {
+            "description": "List of the existing modules that will be modified by the extension.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "The module name which must match an existing module defined by the deployment descriptor.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "properties": {
+                        "description": "A collection of key-value pairs that are available to the module at runtime.",
+                        "type": "object"
+                    },
+                    "parameters": {
+                        "description": "Configuration parameters that are used when deploying the module to the target runtime environment.",
+                        "type": "object"
+                    },
+                    "hooks": {
+                        "description": "A list of the existing hooks that will be modified by the extension.",
+                        "$ref": "#/definitions/hooks"
+                    },
+                    "requires": {
+                        "description": "List of the existing required dependencies that will be modified by the extension.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "description": "The dependency name which must match an existing required dependency defined by the deployment descriptor.",
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                                },
+                                "properties": {
+                                    "description": "Required properties can be mapped from provided properties. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                },
+                                "parameters": {
+                                    "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to the module at runtime. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "provides": {
+                        "description": "List of the existing provided dependencies that will be modified by the extension.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "description": "The dependency name which must match an existing provided dependency defined by the deployment descriptor.",
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                                },
+                                "properties": {
+                                    "description": "Property names and values make up the configuration data which is to be provided to requiring modules at runtime",
+                                    "type": "object"
+                                },
+                                "parameters": {
+                                    "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to the module at runtime. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "resources": {
+            "description": "List of the existing resources that will be modified by the extension.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "The resource name which must match an existing resource defined by the deployment descriptor.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "active": {
+                        "description": "If a resource is declared to be active, it is allocated and bound according to declared requirements. Default value is true.",
+                        "type": "boolean"
+                    },
+                    "properties": {
+                        "description": "Property names and values make up the configuration data which is to be provided to requiring modules at runtime.",
+                        "type": "object"
+                    },
+                    "parameters": {
+                        "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to requiring modules at runtime. Untyped resources cannot have parameters.",
+                        "type": "object"
+                    },
+                    "hooks": {
+                        "description": "List of existing hooks that will be modified by the extension.",
+                        "$ref": "#/definitions/hooks"
+                    },
+                    "requires": {
+                        "description": "List of the existing required dependencies that will be modified by the extension.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "description": "The name of the existing required dependency that will be modified.",
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                                },
+                                "properties": {
+                                    "description": "Required properties can be mapped from provided properties. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                },
+                                "parameters": {
+                                    "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to the resource at runtime. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "module-types": {
+            "description": "A list of existing module type definitions that will be modified by the extension.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "The name of the existing module type that will be modified.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "properties": {
+                        "description": "A collection of key-value pairs that will be inherited by all modules of this type.",
+                        "type": "object"
+                    },
+                    "parameters": {
+                        "description": "Configuration parameters that will be inherited in all modules of this type.",
+                        "type": "object"
+                    }
+                }
+            }
+        },
+        "resource-types": {
+            "description": "A list of existing resource type definitions that will be modified by the extension.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "The name of the existing resource type that will be modified.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "properties": {
+                        "description": "A collection of key-value pairs that will be inherited by all modules of this type.",
+                        "type": "object"
+                    },
+                    "parameters": {
+                        "description": "Configuration parameters that will be inherited in all resources of this type.",
+                        "type": "object"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "hooks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "description": "The name of the existing hook that will be modified by this extension.",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                    },
+                    "parameters": {
+                        "description": "Configuration parameters that are used when executing the hook to the target runtime environment.",
+                        "type": "object"
+                    },
+                    "requires": {
+                        "description": "List of the existing required dependencies that will be modified by this extension.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "description": "The name of the existing required dependencies that will be modified.",
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z0-9_\\-\\.]+$"
+                                },
+                                "parameters": {
+                                    "description": "Parameters can be used to influence the behavior of tools which interpret this descriptor. Parameters are not made available to the hook at runtime. Provided property values can be accessed by \"~{<provided-property-name>}\". Such expressions can be part of an arbitrary string",
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
mtad.yaml and *.mtaext are Multi-Target Application (MTA) yaml files, used to describe deployments. The schemas added with this PR include the latest version as of now which is 3.3.0 (or 3.3 for short).