### PR TITLE
Support array for 'extends' key in GitLab CI

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -450,8 +450,19 @@
           "description": "Job will run *only* when these filtering options match."
         },
         "extends": {
-          "type": "string",
-          "description": "The name of a job to inherit configuration from."
+          "description": "The name of one or more jobs to inherit configuration from.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          ]
         },
         "except": {
           "$ref": "#/definitions/filter",


### PR DESCRIPTION
GitLab has recently [added support](https://about.gitlab.com/2019/06/22/gitlab-12-0-released/#multiple-extends-support-in-gitlab-ciyml) for multiple parent jobs in the `extends` key of the GitLab CI YML, [as documented](https://docs.gitlab.com/ee/ci/yaml/#extends). This PR updates the schema to reflect this

Closes #724