### PR TITLE
CircleCI: support names for all builtin steps

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -503,6 +503,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "name": {
+              "description": "Title of the step to be shown in the CircleCI UI",
+              "type": "string"
+            },
             "path": {
               "description": "Checkout directory (default: job’s `working_directory`)",
               "type": "string"
@@ -518,6 +522,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "name": {
+              "description": "Title of the step to be shown in the CircleCI UI",
+              "type": "string"
+            },
             "docker_layer_caching": {
               "description": "When `docker_layer_caching` is set to `true`, CircleCI will try to reuse Docker Images (layers) built during a previous job or workflow (Paid feature)",
               "type": "boolean",
@@ -607,6 +615,10 @@
               "additionalProperties": false,
               "required": ["keys"],
               "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Title of the step to be shown in the CircleCI UI (default: 'Restoring Cache')"
+                },
                 "keys": {
                   "description": "List of cache keys to lookup for a cache to restore. Only first existing key will be restored.",
                   "type": "array",
@@ -638,6 +650,10 @@
           "additionalProperties": false,
           "required": ["path"],
           "properties": {
+            "name": {
+              "description": "Title of the step to be shown in the CircleCI UI",
+              "type": "string"
+            },
             "path": {
               "description": "Directory in the primary container to save as job artifacts",
               "type": "string"
@@ -658,6 +674,10 @@
           "additionalProperties": false,
           "required": ["path"],
           "properties": {
+            "name": {
+              "description": "Title of the step to be shown in the CircleCI UI",
+              "type": "string"
+            },
             "path": {
               "description": "Path (absolute, or relative to your `working_directory`) to directory containing subdirectories of JUnit XML or Cucumber JSON test metadata files",
               "type": "string"
@@ -674,6 +694,10 @@
           "additionalProperties": false,
           "required": ["root", "paths"],
           "properties": {
+            "name": {
+              "description": "Title of the step to be shown in the CircleCI UI",
+              "type": "string"
+            },
             "root": {
               "description": "Either an absolute path or a path relative to `working_directory`",
               "type": "string"
@@ -697,6 +721,10 @@
           "additionalProperties": false,
           "required": ["at"],
           "properties": {
+            "name": {
+              "description": "Title of the step to be shown in the CircleCI UI",
+              "type": "string"
+            },
             "at": {
               "description": "Directory to attach the workspace to",
               "type": "string"
@@ -712,6 +740,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "name": {
+              "description": "Title of the step to be shown in the CircleCI UI",
+              "type": "string"
+            },
             "fingerprints": {
               "description": "Directory to attach the workspace to",
               "type": "array",

--- a/src/test/circleciconfig/chromeless.json
+++ b/src/test/circleciconfig/chromeless.json
@@ -159,16 +159,19 @@
         },
         {
           "checkout": {
+            "name": "Check out repository",
             "path": "~/chromeless/test"
           }
         },
         {
           "setup_remote_docker": {
+            "name": "Setup docker",
             "version": "17.11.0-ce"
           }
         },
         {
           "restore_cache": {
+            "name": "Restore npm cache",
             "keys": ["npm-cache-{{ checksum \"package-lock.json\" }}"]
           }
         },
@@ -177,6 +180,7 @@
         },
         {
           "save_cache": {
+            "name": "Save npm cache",
             "key": "npm-cache-{{ checksum \"package-lock.json\" }}",
             "paths": ["~/.npm"]
           }


### PR DESCRIPTION
Missed a spot in #719 - it's valid for builtin steps to have a `name` property