### PR TITLE
Fix typo in CSS Grid schema

### DIFF
--- a/src/schemas/css/css-module-grid-layout.xml
+++ b/src/schemas/css/css-module-grid-layout.xml
@@ -46,7 +46,7 @@
 
   <CssProperty name="grid-row-gap" version="3.0" browsers="none" restriction="length" syntax="#item1 { $(name): 2em; }" description="Specifies the gutters between grid rows." standard-reference="http://www.w3.org/TR/css-grid-1/#propdef-grid-row-gap" />
 
-  <CssProperty name="grid-template" restriction="identifier, legnth, percentage, string, enum" version="3.0" browsers="none" syntax="#item1 { $(name): auto 1fr auto / auto 1fr; }" description="Shorthand for setting grid-template-columns, grid-template-rows, and grid-template-areas in a single declaration." standard-reference="http://www.w3.org/TR/css-grid-1/#propdef-grid-template">
+  <CssProperty name="grid-template" restriction="identifier, length, percentage, string, enum" version="3.0" browsers="none" syntax="#item1 { $(name): auto 1fr auto / auto 1fr; }" description="Shorthand for setting grid-template-columns, grid-template-rows, and grid-template-areas in a single declaration." standard-reference="http://www.w3.org/TR/css-grid-1/#propdef-grid-template">
     <entry value="none" />
     <entry value="min-content" />
     <entry value="max-content" />
@@ -60,7 +60,7 @@
     <entry value="none" />
   </CssProperty>
 
-  <CssProperty name="grid-template-columns" restriction="identifier, legnth, percentage, enum" version="3.0" browsers="none" syntax="#item1 { $(name): 100px 1fr max-content minmax(min-content, 1fr); }" description="Specifies, as a space-separated track list, the line names and track sizing functions of the grid." standard-reference="http://www.w3.org/TR/css-grid-1/#propdef-grid-template-columns">
+  <CssProperty name="grid-template-columns" restriction="identifier, length, percentage, enum" version="3.0" browsers="none" syntax="#item1 { $(name): 100px 1fr max-content minmax(min-content, 1fr); }" description="Specifies, as a space-separated track list, the line names and track sizing functions of the grid." standard-reference="http://www.w3.org/TR/css-grid-1/#propdef-grid-template-columns">
     <entry value="none" />
     <entry value="min-content" />
     <entry value="max-content" />
@@ -70,7 +70,7 @@
     <entry value="repeat()" />
   </CssProperty>
 
-  <CssProperty name="grid-template-rows" restriction="identifier, legnth, string, percentage, enum" version="3.0" browsers="none" syntax="#item1 { $(name): 100px 1fr max-content minmax(min-content, 1fr); }" description="Specifies, as a space-separated track list, the line names and track sizing functions of the grid" standard-reference="http://www.w3.org/TR/css-grid-1/#propdef-grid-template-rows">
+  <CssProperty name="grid-template-rows" restriction="identifier, length, string, percentage, enum" version="3.0" browsers="none" syntax="#item1 { $(name): 100px 1fr max-content minmax(min-content, 1fr); }" description="Specifies, as a space-separated track list, the line names and track sizing functions of the grid" standard-reference="http://www.w3.org/TR/css-grid-1/#propdef-grid-template-rows">
     <entry value="none" />
     <entry value="min-content" />
     <entry value="max-content" />


### PR DESCRIPTION
The schema for CSS Grid contained a typo in the definition for grid-template, grid-template-columns and grid-template-rows: **legnth** instead of **length**.