### PR TITLE
Add cosmos.config.json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -203,6 +203,12 @@
       "url": "http://json.schemastore.org/commands"
     },
     {
+      "name": "cosmos.config.json",
+      "description": "React Cosmos configuration file",
+      "fileMatch": [ "cosmos.config.json" ],
+      "url": "http://json.schemastore.org/cosmos-config"
+    },
+    {
       "name": "Chrome Extension",
       "description": "Google Chrome extension manifest file",
       "url": "http://json.schemastore.org/chrome-manifest"

--- a/src/schemas/json/cosmos-config.json
+++ b/src/schemas/json/cosmos-config.json
@@ -1,9 +1,8 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-04/schema",
   "title": "JSON schema for React Cosmos configs",
   "type": "object",
   "additionalProperties": false,
-  "required": [],
   "properties": {
     "rootDir": {
       "description": "The root directory that all others paths in this config are relative to. Usually the root of your repo. If omitted, rootDir is equal to the directory containing your Cosmos config. When you don't use a Cosmos config, rootDir defaults to the current working directory.",

--- a/src/schemas/json/cosmos-config.json
+++ b/src/schemas/json/cosmos-config.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "JSON schema for React Cosmos configs",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [],
+  "properties": {
+    "rootDir": {
+      "description": "The root directory that all others paths in this config are relative to. Usually the root of your repo. If omitted, rootDir is equal to the directory containing your Cosmos config. When you don't use a Cosmos config, rootDir defaults to the current working directory.",
+      "type": "string",
+      "minLength": 1
+    },
+    "exportPath": {
+      "description": "Where to generate static exports on disk. [default: \"cosmos-export\"]",
+      "type": "string",
+      "minLength": 1
+    },
+    "staticPath": {
+      "description": "Dir path to serve static assets from.",
+      "type": "string",
+      "minLength": 1
+    },
+    "publicUrl": {
+      "description": "Base URL for static assets. [default: \"/\"]",
+      "type": "string"
+    },
+    "fixturesDir": {
+      "description": "Name for directories that contain fixtures (eg. __fixtures__/example.jsx). [default: \"__fixtures__\"]",
+      "type": "string",
+      "minLength": 1
+    },
+    "fixtureFileSuffix": {
+      "description": "Suffix for fixture files (eg. example.fixture.jsx). [default: \"fixture\"]",
+      "type": "string",
+      "minLength": 1
+    },
+    "watchDirs": {
+      "description": "Directories where the Cosmos server watches for fixture files changes while running. [default: [\".\"]]",
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "userDepsFilePath": {
+      "description": "Where to generate a file that contains a map to all fixtures and other Cosmos-related user modules. Only used in setups where Cosmos can't piggyback on the user's build (eg. React Native setups). [default: \"cosmos.userdeps.js\"]",
+      "type": "string",
+      "minLength": 1
+    },
+    "hostname": {
+      "description": "Dev server hostname. Set to null to accept connections with any hostname. [default: null]",
+      "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+    },
+    "port": {
+      "description": "Dev server port. [default: 5000]",
+      "type": ["number"]
+    },
+    "globalImports": {
+      "description": "Modules to be imported before loading components. Stuff like reset.css, polyfills, etc.",
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "dom": {
+      "description": "DOM-related options",
+      "type": "object",
+      "properties": {
+        "containerQuerySelector": {
+          "description": "Document selector for existing element to use as component parent (eg. #root). A blank container element is created from scratch if no selector is provided. [default: null]",
+          "type": ["string", "null"],
+          "minLength": 1
+        }
+      }
+    },
+    "webpack": {
+      "description": "Webpack-related options",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "configPath": {
+          "description": "Path to an existing webpack config, which Cosmos will reuse to build your code. Set to null to disable this behavior. [default \"webpack.config.js\"]",
+          "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+        },
+        "overridePath": {
+          "description": "Path to a user module that customizes the webpack config used by Cosmos. Set to null to disable this behavior. [default \"webpack.override.js\"]",
+          "anyOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }]
+        },
+        "hotReload": {
+          "description": "Enable webpack's Hot Module Replacement. [default: true]",
+          "type": "boolean"
+        }
+      }
+    },
+    "ui": {
+      "description": "UI plugin options",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "responsivePreview": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "devices": {
+              "description": "List of device viewports",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["label", "width", "height"],
+                "properties": {
+                  "label": { "type": "string", "minLength": 1 },
+                  "width": { "type": "number", "minimum": 1 },
+                  "height": { "type": "number", "minimum": 1 }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Thanks for managing this awesome schema collection! 🙌

---

Add a schema for cosmos.config.json files. These files are used to configure a project using [React Cosmos](https://github.com/react-cosmos/react-cosmos).