### PR TITLE
Add Supoport for Opspec Schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1184,6 +1184,12 @@
       "description": "A JSON schema for MTA extension descriptors v3.3",
       "fileMatch": [ "*.mtaext" ],
       "url": "http://json.schemastore.org/mtaext"
+    },
+    {
+      "name": "Opctl",
+      "description": "Opctl schema for describing an op",
+      "url": "http://json.schemastore.org/opspec-io-0.1.7",
+      "fileMatch": [ ".opspec/*/*.yml", ".opspec/*/*.yaml" ]
     }
   ]
 }

--- a/src/schemas/json/opspec-io-0.1.7.json
+++ b/src/schemas/json/opspec-io-0.1.7.json
@@ -1,0 +1,994 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://opspec.io/0.1.7/op.yml.schema.json",
+  "title": "Op File",
+  "description": "Defines an op",
+  "properties": {
+    "name": {
+      "description": "Name of the op",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the op",
+      "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/dir/properties/description"
+    },
+    "inputs": {
+      "additionalProperties": false,
+      "description": "Parameter of an op",
+      "patternProperties": {
+        "[-_.a-zA-Z0-9]+": {
+          "oneOf": [
+            {
+              "required": [
+                "array"
+              ]
+            },
+            {
+              "required": [
+                "boolean"
+              ]
+            },
+            {
+              "required": [
+                "dir"
+              ]
+            },
+            {
+              "required": [
+                "file"
+              ]
+            },
+            {
+              "required": [
+                "number"
+              ]
+            },
+            {
+              "required": [
+                "object"
+              ]
+            },
+            {
+              "required": [
+                "socket"
+              ]
+            },
+            {
+              "required": [
+                "string"
+              ]
+            }
+          ],
+          "properties": {
+            "array": {
+              "additionalProperties": false,
+              "title": "arrayParam",
+              "description": "Array parameter of an op",
+              "properties": {
+                "description": {
+                  "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/dir/properties/description"
+                },
+                "default": {
+                  "type": "array"
+                },
+                "isSecret": {
+                  "description": "If the array is secret",
+                  "type": "boolean"
+                },
+                "constraints": {
+                  "title": "arrayConstraints",
+                  "type": "object",
+                  "properties": {
+                    "additionalItems": {
+                      "description": "JSON Schema [additionalItems keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.10)",
+                      "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints/properties/properties/additionalProperties"
+                    },
+                    "items": {
+                      "description": "JSON Schema [items keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.9)",
+                      "anyOf": [
+                        {
+                          "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints/properties/properties/additionalProperties"
+                        },
+                        {
+                          "items": {
+                            "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints/properties/properties/additionalProperties"
+                          }
+                        }
+                      ]
+                    },
+                    "maxItems": {
+                      "description": "JSON Schema [maxItems keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.10)",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "minItems": {
+                      "description": "JSON Schema [minItems keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.11)",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "uniqueItems": {
+                      "description": "JSON Schema [uniqueItems keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.13)",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "type": "object"
+            },
+            "boolean": {
+              "additionalProperties": false,
+              "title": "booleanParam",
+              "description": "Boolean parameter of an op",
+              "properties": {
+                "description": {
+                  "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/dir/properties/description"
+                },
+                "default": {
+                  "description": "Default value",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "dir": {
+              "additionalProperties": false,
+              "title": "dirParam",
+              "description": "Directory parameter of an op",
+              "properties": {
+                "description": {
+                  "title": "markdown",
+                  "description": "Markdown in [v0.28 CommonMark syntax](http://spec.commonmark.org/0.28/) including GFM table extension",
+                  "type": "string"
+                },
+                "default": {
+                  "description": "Default value; an absolute path rooted at dir containing op.yml or, a relative path interpreted from where the op is started",
+                  "type": "string"
+                },
+                "isSecret": {
+                  "description": "If the directory is secret",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "file": {
+              "additionalProperties": false,
+              "title": "fileParam",
+              "description": "File parameter of an op",
+              "properties": {
+                "description": {
+                  "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/dir/properties/description"
+                },
+                "default": {
+                  "description": "Default value; an absolute path rooted at dir containing op.yml or, a relative path interpreted from where the op is started",
+                  "type": "string"
+                },
+                "isSecret": {
+                  "description": "If the file is secret",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "number": {
+              "additionalProperties": false,
+              "title": "numberParam",
+              "description": "Number parameter of an op",
+              "properties": {
+                "description": {
+                  "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/dir/properties/description"
+                },
+                "default": {
+                  "type": "number"
+                },
+                "isSecret": {
+                  "description": "If the number is secret",
+                  "type": "boolean"
+                },
+                "constraints": {
+                  "title": "numberConstraints",
+                  "type": "object",
+                  "properties": {
+                    "allOf": {
+                      "description": "JSON Schema [allOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.22)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/number/properties/constraints"
+                      }
+                    },
+                    "anyOf": {
+                      "description": "JSON Schema [anyOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.23)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/number/properties/constraints"
+                      }
+                    },
+                    "enum": {
+                      "description": "JSON Schema [enum keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.20)",
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "format": {
+                      "oneOf": [
+                        {
+                          "title": "integer",
+                          "description": "Requires the number be an integer",
+                          "type": "string",
+                          "enum": [
+                            "integer"
+                          ]
+                        }
+                      ]
+                    },
+                    "maximum": {
+                      "description": "JSON Schema [maximum keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.2)",
+                      "type": "number"
+                    },
+                    "minimum": {
+                      "description": "JSON Schema [minimum keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.4)",
+                      "type": "number"
+                    },
+                    "multipleOf": {
+                      "description": "JSON Schema [multipleOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.1)",
+                      "type": "number"
+                    },
+                    "not": {
+                      "description": "JSON Schema [not keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.25)",
+                      "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/number/properties/constraints"
+                    },
+                    "oneOf": {
+                      "description": "JSON Schema [oneOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.24)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/number/properties/constraints"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "type": "object"
+            },
+            "object": {
+              "additionalProperties": false,
+              "title": "objectParam",
+              "description": "Object parameter of an op",
+              "properties": {
+                "description": {
+                  "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/dir/properties/description"
+                },
+                "default": {
+                  "type": "object"
+                },
+                "isSecret": {
+                  "description": "If the object is secret",
+                  "type": "boolean"
+                },
+                "constraints": {
+                  "title": "objectConstraints",
+                  "type": "object",
+                  "properties": {
+                    "additionalProperties": {
+                      "description": "JSON Schema [additionalProperties keyword](https://tools.ietf.org/html/draft-handrews-json-schema-validation-00#section-6.5.6)",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints/properties/properties/additionalProperties"
+                        }
+                      ]
+                    },
+                    "allOf": {
+                      "description": "JSON Schema [allOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.22)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints"
+                      }
+                    },
+                    "anyOf": {
+                      "description": "JSON Schema [anyOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.23)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints"
+                      }
+                    },
+                    "dependencies": {
+                      "description": "JSON Schema [dependencies keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.19)",
+                      "oneOf": [
+                        {
+                          "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints/properties/properties/additionalProperties"
+                        },
+                        {
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    },
+                    "enum": {
+                      "description": "JSON Schema [enum keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.20)",
+                      "type": "array",
+                      "items": {
+                        "type": [
+                          "null",
+                          "object"
+                        ]
+                      }
+                    },
+                    "maxProperties": {
+                      "description": "JSON Schema [maxProperties keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.13)",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "minProperties": {
+                      "description": "JSON Schema [minProperties keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.14)",
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "not": {
+                      "description": "JSON Schema [not keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.25)",
+                      "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints"
+                    },
+                    "oneOf": {
+                      "description": "JSON Schema [oneOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.24)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints"
+                      }
+                    },
+                    "properties": {
+                      "description": "JSON Schema [properties keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.16)",
+                      "type": "object",
+                      "additionalProperties": {
+                        "title": "typeConstraints",
+                        "description": "Parameter constraints",
+                        "anyOf": [
+                          {
+                            "properties": {
+                              "description": {
+                                "description": "JSON Schema [description](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-6.1)",
+                                "type": "string"
+                              },
+                              "title": {
+                                "description": "JSON Schema [title](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-6.1)",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "JSON Schema [type](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.21)",
+                                "type": [
+                                  "array",
+                                  "string"
+                                ]
+                              },
+                              "writeOnly": {
+                                "description": "JSON Schema [writeOnly](https://tools.ietf.org/html/draft-handrews-json-schema-validation-00#section-10.3)",
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          {
+                            "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/array/properties/constraints"
+                          },
+                          {
+                            "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/number/properties/constraints"
+                          },
+                          {
+                            "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints"
+                          },
+                          {
+                            "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/string/properties/constraints"
+                          }
+                        ]
+                      }
+                    },
+                    "patternProperties": {
+                      "description": "JSON Schema [patternProperties keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.17)",
+                      "type": "object",
+                      "additionalProperties": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/object/properties/constraints/properties/properties/additionalProperties"
+                      }
+                    },
+                    "required": {
+                      "description": "JSON Schema [required keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.15)",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "type": "object"
+            },
+            "socket": {
+              "additionalProperties": false,
+              "title": "socketParam",
+              "description": "Socket parameter of an op",
+              "properties": {
+                "description": {
+                  "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/dir/properties/description"
+                },
+                "isSecret": {
+                  "description": "If the socket is secret",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "string": {
+              "additionalProperties": false,
+              "title": "stringParam",
+              "description": "String parameter of an op",
+              "properties": {
+                "description": {
+                  "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/dir/properties/description"
+                },
+                "default": {
+                  "type": "string"
+                },
+                "isSecret": {
+                  "description": "If the string is secret",
+                  "type": "boolean"
+                },
+                "constraints": {
+                  "title": "stringConstraints",
+                  "type": "object",
+                  "properties": {
+                    "allOf": {
+                      "description": "JSON Schema [allOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.22)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/string/properties/constraints"
+                      }
+                    },
+                    "anyOf": {
+                      "description": "JSON Schema [anyOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.23)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/string/properties/constraints"
+                      }
+                    },
+                    "enum": {
+                      "description": "JSON Schema [enum keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.20)",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "format": {
+                      "description": "Superset of JSON Schema [format keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7)",
+                      "oneOf": [
+                        {
+                          "title": "date-time",
+                          "description": "JSON Schema [date-time format](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.1)",
+                          "type": "string",
+                          "enum": [
+                            "date-time"
+                          ]
+                        },
+                        {
+                          "title": "docker-image-ref",
+                          "description": "A docker image reference as defined by [github.com/docker/distribution/reference](https://github.com/docker/distribution/tree/docker/1.13/reference)",
+                          "type": "string",
+                          "enum": [
+                            "docker-image-ref"
+                          ]
+                        },
+                        {
+                          "title": "email",
+                          "description": "JSON Schema [email format](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.2)",
+                          "type": "string",
+                          "enum": [
+                            "email"
+                          ]
+                        },
+                        {
+                          "title": "hostname",
+                          "description": "JSON Schema [hostname format](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.3)",
+                          "type": "string",
+                          "enum": [
+                            "hostname"
+                          ]
+                        },
+                        {
+                          "title": "ipv4",
+                          "description": "JSON Schema [ipv4 format](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.4)",
+                          "type": "string",
+                          "enum": [
+                            "ipv4"
+                          ]
+                        },
+                        {
+                          "title": "ipv6",
+                          "description": "JSON Schema [ipv6 format](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.5)",
+                          "type": "string",
+                          "enum": [
+                            "ipv6"
+                          ]
+                        },
+                        {
+                          "title": "uri",
+                          "description": "JSON Schema [uri format](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.6)",
+                          "type": "string",
+                          "enum": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "title": "semver",
+                          "description": "A semantic version as defined by [semver.org](http://semver.org/)",
+                          "type": "string",
+                          "enum": [
+                            "semver"
+                          ]
+                        }
+                      ]
+                    },
+                    "maxLength": {
+                      "description": "JSON Schema [maxLength keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.6)",
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "minLength": {
+                      "description": "JSON Schema [minLength keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.7)",
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 0
+                    },
+                    "not": {
+                      "description": "JSON Schema [not keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.25)",
+                      "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/string/properties/constraints"
+                    },
+                    "oneOf": {
+                      "description": "JSON Schema [oneOf keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.24)",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/properties/string/properties/constraints"
+                      }
+                    },
+                    "pattern": {
+                      "description": "JSON Schema [pattern keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.8)",
+                      "type": "string",
+                      "format": "regex"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "outputs": {
+      "$ref": "#/properties/inputs"
+    },
+    "run": {
+      "additionalProperties": false,
+      "description": "A single node of the [call graph](https://en.wikipedia.org/wiki/Call_graph)",
+      "oneOf": [
+        {
+          "required": [
+            "container"
+          ]
+        },
+        {
+          "required": [
+            "op"
+          ]
+        },
+        {
+          "required": [
+            "parallel"
+          ]
+        },
+        {
+          "required": [
+            "parallelLoop"
+          ]
+        },
+        {
+          "required": [
+            "serial"
+          ]
+        },
+        {
+          "required": [
+            "serialLoop"
+          ]
+        }
+      ],
+      "properties": {
+        "container": {
+          "title": "containerCall",
+          "type": "object",
+          "properties": {
+            "cmd": {
+              "description": "Command run by a container; overrides any set at the image level",
+              "type": "array",
+              "items": {
+                "description": "Expression coercible to string value",
+                "$ref": "#/properties/run/properties/op/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/oneOf/1"
+              }
+            },
+            "dirs": {
+              "type": "object",
+              "description": "Directories in the container",
+              "patternProperties": {
+                "^([a-zA-Z]:)?[-_.\\/a-zA-Z0-9]+$": {
+                  "oneOf": [
+                    {
+                      "description": "(will be bound to same path in op)",
+                      "type": "null"
+                    },
+                    {
+                      "description": "Expression coercible to dir value &/or scope ref to set upon exit",
+                      "$ref": "#/properties/run/properties/op/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/oneOf/1"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "envVars": {
+              "oneOf": [
+                {
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^[^=]+$": {
+                      "oneOf": [
+                        {
+                          "description": "(will be bound to in scope ref w/ same name)",
+                          "type": "null"
+                        },
+                        {
+                          "description": "Expression coercible to string value",
+                          "$ref": "#/properties/run/properties/container/properties/name"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "description": "Reference to a value",
+                  "type": "string",
+                  "pattern": "^\\$\\(.+\\)$"
+                }
+              ],
+              "description": "Environment variables in the container"
+            },
+            "files": {
+              "type": "object",
+              "description": "Files in the container",
+              "patternProperties": {
+                "^([a-zA-Z]:)?[-_.\\/a-zA-Z0-9]+$": {
+                  "oneOf": [
+                    {
+                      "description": "(will be bound to same path in op)",
+                      "type": "null"
+                    },
+                    {
+                      "description": "Expression coercible to file value &/or scope ref to set upon exit",
+                      "$ref": "#/properties/run/properties/container/properties/name"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "image": {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "description": "Reference to an image",
+                  "$ref": "#/properties/run/properties/op/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/oneOf/1"
+                },
+                "pullCreds": {
+                  "$ref": "#/properties/run/properties/op/properties/pullCreds"
+                }
+              },
+              "required": [
+                "ref"
+              ],
+              "additionalProperties": false
+            },
+            "name": {
+              "description": "Name the container can be referenced by from other containers",
+              "type": [
+                "array",
+                "boolean",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "ports": {
+              "description": "Ports bound from the container to the host",
+              "type": "object",
+              "patternProperties": {
+                "[0-9]+(-[0-9]+)?(tcp|udp)?": {
+                  "description": "Host port(s) to bind to",
+                  "type": [
+                    "string",
+                    "number"
+                  ],
+                  "pattern": "[0-9]+(-[0-9]+)?"
+                }
+              },
+              "additionalProperties": false
+            },
+            "sockets": {
+              "type": "object",
+              "patternProperties": {
+                "[:a-zA-Z0-9]+": {
+                  "description": "Container socket address mapped to a socket ref",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "workDir": {
+              "description": "Working directory path (overrides any defined by image)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "image"
+          ],
+          "additionalProperties": false
+        },
+        "if": {
+          "description": "If any predicate evaluates to false, the call will be skipped.",
+          "type": "array",
+          "items": {
+            "description": "Condition which evaluates to true or false",
+            "oneOf": [
+              {
+                "required": [
+                  "eq"
+                ]
+              },
+              {
+                "required": [
+                  "exists"
+                ]
+              },
+              {
+                "required": [
+                  "ne"
+                ]
+              },
+              {
+                "required": [
+                  "notExists"
+                ]
+              }
+            ],
+            "properties": {
+              "eq": {
+                "description": "True if all items are equal",
+                "type": "array",
+                "items": {
+                  "description": "Expression coercible to string value",
+                  "$ref": "#/properties/run/properties/op/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/oneOf/1"
+                }
+              },
+              "exists": {
+                "description": "True if value exists w/ reference",
+                "type": "string",
+                "pattern": "^\\$\\(.+\\)$"
+              },
+              "ne": {
+                "description": "True if any items aren't equal",
+                "type": "array",
+                "items": {
+                  "description": "Expression coercible to string value",
+                  "$ref": "#/properties/run/properties/op/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/oneOf/1"
+                }
+              },
+              "notExists": {
+                "description": "True if no value exists w/ reference",
+                "type": "string",
+                "pattern": "^\\$\\(.+\\)$"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "op": {
+          "type": "object",
+          "properties": {
+            "inputs": {
+              "description": "Initializes INPUT_NAME from VALUE in format 'INPUT_NAME: VALUE'. If VALUE is null, it MUST be assumed VALUE == $(INPUT_NAME)",
+              "type": "object",
+              "patternProperties": {
+                "[-_.a-zA-Z0-9]+": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "description": "Expression which evaluates to a value",
+                      "type": [
+                        "array",
+                        "boolean",
+                        "number",
+                        "object",
+                        "string"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "outputs": {
+              "description": "Initializes NAME from OUTPUT_NAME in format 'NAME: OUTPUT_NAME'. If OUTPUT_NAME is null, it MUST be assumed NAME == OUTPUT_NAME",
+              "type": "object",
+              "patternProperties": {
+                "[-_.a-zA-Z0-9]+": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "pullCreds": {
+              "type": "object",
+              "description": "Credentials used during authentication with the source of an image or op",
+              "properties": {
+                "username": {
+                  "description": "Expression coercible to string value",
+                  "$ref": "#/properties/run/properties/op/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/oneOf/1"
+                },
+                "password": {
+                  "description": "Expression coercible to string value",
+                  "$ref": "#/properties/run/properties/op/properties/inputs/patternProperties/%5B-_.a-zA-Z0-9%5D%2B/oneOf/1"
+                }
+              },
+              "required": [
+                "username",
+                "password"
+              ],
+              "additionalProperties": false
+            },
+            "ref": {
+              "description": "Reference to an op",
+              "type": "string",
+              "format": "uri-reference"
+            }
+          },
+          "required": [
+            "ref"
+          ],
+          "additionalProperties": false
+        },
+        "parallel": {
+          "title": "parallelCall",
+          "type": "array",
+          "items": {
+            "$ref": "#/properties/run"
+          }
+        },
+        "parallelLoop": {
+          "additionalProperties": false,
+          "description": "Loop in which all iterations are called simultaneously.",
+          "properties": {
+            "range": {
+              "$ref": "#/properties/run/properties/serialLoop/properties/range"
+            },
+            "run": {
+              "description": "What gets run on each iteration of the loop",
+              "$ref": "#/properties/run"
+            },
+            "vars": {
+              "$ref": "#/properties/run/properties/serialLoop/properties/vars"
+            }
+          },
+          "required": [
+            "range",
+            "run"
+          ],
+          "type": "object"
+        },
+        "serial": {
+          "title": "serialCall",
+          "type": "array",
+          "items": {
+            "$ref": "#/properties/run"
+          }
+        },
+        "serialLoop": {
+          "additionalProperties": false,
+          "description": "Loop in which each iteration gets called sequentially.",
+          "oneOf": [
+            {
+              "required": [
+                "range",
+                "run"
+              ]
+            },
+            {
+              "required": [
+                "until",
+                "run"
+              ]
+            }
+          ],
+          "properties": {
+            "range": {
+              "description": "Range of the loop, i.e. the value to loop over",
+              "type": [
+                "array",
+                "object",
+                "string"
+              ]
+            },
+            "run": {
+              "description": "What gets run on each iteration of the loop",
+              "$ref": "#/properties/run"
+            },
+            "until": {
+              "description": "Exit condition of the loop; evaluated before each iteration.",
+              "type": "array",
+              "items": {
+                "$ref": "#/properties/run/properties/if/items"
+              }
+            },
+            "vars": {
+              "additionalProperties": false,
+              "description": "Variables added to scope on each iteration",
+              "properties": {
+                "index": {
+                  "description": "Variable each iterations associated index will be made available through",
+                  "$ref": "#/properties/run/properties/serialLoop/properties/vars/properties/key"
+                },
+                "key": {
+                  "description": "Variable each iterations associated key will be made available through",
+                  "type": "string",
+                  "pattern": "^[-_.a-zA-Z0-9]+$"
+                },
+                "value": {
+                  "description": "Variable each iterations associated value will be made available through",
+                  "$ref": "#/properties/run/properties/serialLoop/properties/vars/properties/key"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "title": "call"
+    },
+    "version": {
+      "description": "Version of the op",
+      "$ref": "#/properties/opspec"
+    },
+    "opspec": {
+      "description": "Version of [opspec](https://opspec.io) used by the op",
+      "title": "semVer",
+      "type": "string",
+      "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:(\\-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-\\-\\.]+)?$"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/src/schemas/json/xunit.runner.schema.json
+++ b/src/schemas/json/xunit.runner.schema.json
@@ -1,14 +1,23 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "id": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
+  "id": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "title": "xUnit.net Runner Configuration",
   "description": "Configuration file for unit test projects using xUnit.net",
   "type": "object",
   "properties": {
+    "$schema": {
+      "description": "The document schema",
+      "default": "https://xunit.net/schema/current/xunit.runner.schema.json",
+      "type": "string"
+    },
     "appDomain": {
       "description": "Determines whether the runner will use an app domain to discover and run tests. If you choose 'required', app domains will be required (only desktop tests can be run); if you choose 'denied', then tests will not use app domains; if you choose 'ifAvailable', then app domains use is left to the discretion of the runner. Defaults to 'ifAvailable'. Note that not all runners support app domains, so the 'required' value may not always be valid.",
       "default": "ifAvailable",
-      "enum": [ "required", "ifAvailable", "denied" ]
+      "enum": [
+        "required",
+        "ifAvailable",
+        "denied"
+      ]
     },
     "diagnosticMessages": {
       "description": "Enables or disables diagnostic information during test discovery and execution.",
@@ -33,7 +42,15 @@
     "methodDisplay": {
       "description": "Configures the default display name for test cases. If you choose 'method', the display name will be just the method (without the class name); if you choose 'classAndMethod', the default display name will be the fully qualified class name and method name.",
       "default": "classAndMethod",
-      "enum": [ "method", "classAndMethod" ]
+      "enum": [
+        "method",
+        "classAndMethod"
+      ]
+    },
+    "methodDisplayOptions": {
+      "description": "Configures one or more automatic transformations of test names. Flag names should be combined with a comma (i.e., flag1,flag2). Valid flags are: 'replaceUnderscoreWithSpace', 'useOperatorMonikers', 'useEscapeSequences', 'replacePeriodWithComma'. There are special flags named 'all' and 'none'.",
+      "default": "none",
+      "type": "string"
     },
     "parallelizeAssembly": {
       "description": "Instructs the test runner that this assembly is willing to run in parallel with other assemblies.",

--- a/src/schemas/json/xunit.runner.schema.json
+++ b/src/schemas/json/xunit.runner.schema.json
@@ -1,23 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "id": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "id": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
   "title": "xUnit.net Runner Configuration",
   "description": "Configuration file for unit test projects using xUnit.net",
   "type": "object",
   "properties": {
-    "$schema": {
-      "description": "The document schema",
-      "default": "https://xunit.net/schema/current/xunit.runner.schema.json",
-      "type": "string"
-    },
     "appDomain": {
       "description": "Determines whether the runner will use an app domain to discover and run tests. If you choose 'required', app domains will be required (only desktop tests can be run); if you choose 'denied', then tests will not use app domains; if you choose 'ifAvailable', then app domains use is left to the discretion of the runner. Defaults to 'ifAvailable'. Note that not all runners support app domains, so the 'required' value may not always be valid.",
       "default": "ifAvailable",
-      "enum": [
-        "required",
-        "ifAvailable",
-        "denied"
-      ]
+      "enum": [ "required", "ifAvailable", "denied" ]
     },
     "diagnosticMessages": {
       "description": "Enables or disables diagnostic information during test discovery and execution.",
@@ -42,15 +33,7 @@
     "methodDisplay": {
       "description": "Configures the default display name for test cases. If you choose 'method', the display name will be just the method (without the class name); if you choose 'classAndMethod', the default display name will be the fully qualified class name and method name.",
       "default": "classAndMethod",
-      "enum": [
-        "method",
-        "classAndMethod"
-      ]
-    },
-    "methodDisplayOptions": {
-      "description": "Configures one or more automatic transformations of test names. Flag names should be combined with a comma (i.e., flag1,flag2). Valid flags are: 'replaceUnderscoreWithSpace', 'useOperatorMonikers', 'useEscapeSequences', 'replacePeriodWithComma'. There are special flags named 'all' and 'none'.",
-      "default": "none",
-      "type": "string"
+      "enum": [ "method", "classAndMethod" ]
     },
     "parallelizeAssembly": {
       "description": "Instructs the test runner that this assembly is willing to run in parallel with other assemblies.",


### PR DESCRIPTION
Adding support for Opspec schema to suppport validation on `op.yml` files.
For more information read about us at : https://opctl.io/
