### PR TITLE
support custom named cloudbuild yaml config files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -228,7 +228,7 @@
     {
       "name": "cloudbuild.json",
       "description": "Google Cloud Build configuration file",
-      "fileMatch": ["cloudbuild.json","cloudbuild.yaml","cloudbuild.yml", "*.cloudbuild.json"],
+      "fileMatch": ["cloudbuild.json","cloudbuild.yaml","cloudbuild.yml", "*.cloudbuild.json", "*.cloudbuild.yaml", "*.cloudbuild.yml"],
       "url": "http://json.schemastore.org/cloudbuild"
     },
     {


### PR DESCRIPTION
I came here to add CloudBuild support but found it already here 🎉 I just needed support for custom named `yaml` files as with `json`

This existed:
* `*.cloudbuild.json`

These did not:
* `*.cloudbuild.yaml`
* `*.cloudbuild.yml`