### PR TITLE
fix: `osx_image: xcode11` should be allowed

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -185,7 +185,8 @@
         "xcode9.4",
         "xcode10",
         "xcode10.1",
-        "xcode10.2"
+        "xcode10.2",
+        "xcode11"
       ]
     },
     "envVars": {


### PR DESCRIPTION
reference: https://docs.travis-ci.com/user/reference/osx/#macos-version