### PR TITLE
Added lwc parser to prettierrc

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -108,7 +108,8 @@
             { "enum": ["vue"], "description": "Vue" },
             { "enum": ["yaml"], "description": "YAML" },
             { "enum": ["html"], "description": "HTML" },
-            { "enum": ["angular"], "description": "Angular" }
+            { "enum": ["angular"], "description": "Angular" },
+            { "enum": ["lwc"], "description": "Lightning Web Components" }
           ]
         },
         "pluginSearchDirs": {


### PR DESCRIPTION
Prettier 1.17 added support for a new parser `lwc`. See: https://prettier.io/blog/2019/04/12/1.17.0.html#add-support-for-lightning-web-components-5800-by-ntotten