### PR TITLE
updated workspaces

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -425,9 +425,11 @@
           }
         },
         "workspaces": {
+          "description": "To configure your yarn workspaces, please note private should be set to true to use yarn workspaces",
           "anyof": [
             {
               "type": "array",
+              "description":"your workspace folders also takes a glob",
               "items": "string"
             },
             {
@@ -435,10 +437,12 @@
               "properties": {
                 "packages": {
                   "type": "array",
+                  "description":"your workspace folder's also takes a glob",
                   "items": "string"
                 },
                 "nohoist": {
                   "type": "array",
+                  "description":"nohoist your npm packages",
                   "items": "string"
                 }
               }

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -4,8 +4,8 @@
   "definitions": {
     "person": {
       "description": "A person who has been involved in creating or maintaining this package",
-      "type": [ "object", "string" ],
-      "required": [ "name" ],
+      "type": ["object", "string"],
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string"
@@ -104,14 +104,11 @@
         "homepage": {
           "description": "The url to the project homepage.",
           "type": "string",
-          "oneOf": [
-            {"format": "uri"},
-            {"enum": ["."]}
-          ]
+          "oneOf": [{ "format": "uri" }, { "enum": ["."] }]
         },
         "bugs": {
           "description": "The url to your project's issue tracker and / or the email address to which issues should be reported. These are helpful for people who encounter issues with your package.",
-          "type": [ "object", "string" ],
+          "type": ["object", "string"],
           "properties": {
             "url": {
               "type": "string",
@@ -174,7 +171,7 @@
           "type": "string"
         },
         "bin": {
-          "type": [ "string", "object" ],
+          "type": ["string", "object"],
           "additionalProperties": {
             "type": "string"
           }
@@ -188,7 +185,7 @@
           "type": "string"
         },
         "man": {
-          "type": [ "array", "string" ],
+          "type": ["array", "string"],
           "description": "Specify either a single file or an array of filenames to put in place for the man program to find.",
           "items": {
             "type": "string"
@@ -414,7 +411,7 @@
         },
         "esnext": {
           "description": "A module ID with untranspiled code that is the primary entry point to your program.",
-          "type": [ "string", "object" ],
+          "type": ["string", "object"],
           "properties": {
             "main": {
               "type": "string"
@@ -428,10 +425,25 @@
           }
         },
         "workspaces": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "anyof": [
+            {
+              "type": "array",
+              "items": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "packages": {
+                  "type": "array",
+                  "items": "string"
+                },
+                "nohoist": {
+                  "type": "array",
+                  "items": "string"
+                }
+              }
+            }
+          ]
         }
       }
     },
@@ -454,9 +466,9 @@
           },
           "not": {
             "properties": {
-              "bundledDependencies": { }
+              "bundledDependencies": {}
             },
-            "required": [ "bundledDependencies" ]
+            "required": ["bundledDependencies"]
           }
         },
         {
@@ -467,9 +479,9 @@
           },
           "not": {
             "properties": {
-              "bundleDependencies": { }
+              "bundleDependencies": {}
             },
-            "required": [ "bundleDependencies" ]
+            "required": ["bundleDependencies"]
           }
         }
       ]


### PR DESCRIPTION
workspaces take an array as well as an object
https://yarnpkg.com/blog/2018/02/15/nohoist/
```
"workspaces": {
  "packages": ["packages/*"],
  "nohoist": ["**/react-native", "**/react-native/**"]
}
```
```
"workspaces": [
    "packages/*"
  ]
```
I was using prettier, seems like, prettier made some additional styling changes as well.