### PR TITLE
Add option 'require-const-for-all-caps' to tslint's variable-name rule

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -4173,6 +4173,7 @@
                 "type": "string",
                 "enum": [
                   "check-format",
+                  "require-const-for-all-caps",
                   "allow-leading-underscore",
                   "allow-trailing-underscore",
                   "allow-pascal-case",
@@ -4181,7 +4182,7 @@
                 ]
               },
               "minItems": 1,
-              "maxItems": 6,
+              "maxItems": 7,
               "uniqueItems": true
             }
           },


### PR DESCRIPTION
This PR add the option `require-const-for-all-caps` for TSLint's `variable-name` rule. That option is currently missing from the schema.

See the documentation here: https://palantir.github.io/tslint/rules/variable-name/