### PR TITLE
Jest Config JSON support

### DIFF
--- a/src/schemas/json/jestconfig.json
+++ b/src/schemas/json/jestconfig.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "#/definitions/JestconfigJSON",
+    "$ref": "#/definitions/jestconfigjson",
     "definitions": {
-        "JestconfigJSON": {
+        "jestconfigjson": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -10,7 +10,7 @@
                     "type": "boolean"
                 },
                 "bail": {
-                    "type": "integer"
+                    "type": "boolean"
                 },
                 "browser": {
                     "type": "boolean"
@@ -18,8 +18,14 @@
                 "cache": {
                     "type": "boolean"
                 },
+                "cacheDirectory": {
+                    "type": "string"
+                },
                 "changedFilesWithAncestor": {
                     "type": "boolean"
+                },
+                "changedSince": {
+                    "type": "string"
                 },
                 "clearMocks": {
                     "type": "boolean"
@@ -28,14 +34,22 @@
                     "type": "boolean"
                 },
                 "collectCoverageFrom": {
-                    "type": "null"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "collectCoverageOnlyFrom": {
+                    "$ref": "#/definitions/CollectCoverageOnlyFrom"
                 },
                 "coverageDirectory": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "coveragePathIgnorePatterns": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "coverageReporters": {
                     "type": "array",
@@ -44,10 +58,13 @@
                     }
                 },
                 "coverageThreshold": {
-                    "type": "null"
+                    "$ref": "#/definitions/CoverageThreshold"
                 },
                 "dependencyExtractor": {
-                    "type": "null"
+                    "type": "string"
+                },
+                "displayName": {
+                    "$ref": "#/definitions/DisplayName"
                 },
                 "errorOnDeprecated": {
                     "type": "boolean"
@@ -55,24 +72,42 @@
                 "expand": {
                     "type": "boolean"
                 },
-                "filter": {
-                    "type": "null"
-                },
-                "forceCoverageMatch": {
+                "extraGlobals": {
                     "type": "array",
                     "items": {}
                 },
+                "filter": {
+                    "type": "string"
+                },
+                "forceCoverageMatch": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "forceExit": {
+                    "type": "boolean"
+                },
                 "globalSetup": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "globalTeardown": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "globals": {
                     "$ref": "#/definitions/Globals"
                 },
                 "haste": {
                     "$ref": "#/definitions/Haste"
+                },
+                "json": {
+                    "type": "boolean"
+                },
+                "lastCommit": {
+                    "type": "boolean"
+                },
+                "logHeapUsage": {
+                    "type": "boolean"
                 },
                 "maxConcurrency": {
                     "type": "integer"
@@ -92,12 +127,26 @@
                         "type": "string"
                     }
                 },
+                "moduleLoader": {
+                    "type": "string"
+                },
                 "moduleNameMapper": {
-                    "$ref": "#/definitions/Globals"
+                    "$ref": "#/definitions/ModuleNameMapper"
                 },
                 "modulePathIgnorePatterns": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "modulePaths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string"
                 },
                 "noStackTrace": {
                     "type": "boolean"
@@ -108,14 +157,26 @@
                 "notifyMode": {
                     "type": "string"
                 },
+                "onlyChanged": {
+                    "type": "boolean"
+                },
                 "preset": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "prettierPath": {
                     "type": "string"
                 },
                 "projects": {
-                    "type": "null"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "reporters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/JestconfigJSONReporter"
+                    }
                 },
                 "resetMocks": {
                     "type": "boolean"
@@ -124,13 +185,13 @@
                     "type": "boolean"
                 },
                 "resolver": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "restoreMocks": {
                     "type": "boolean"
                 },
                 "rootDir": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "roots": {
                     "type": "array",
@@ -146,24 +207,39 @@
                 },
                 "setupFiles": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "setupFilesAfterEnv": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "silent": {
+                    "type": "boolean"
                 },
                 "skipFilter": {
                     "type": "boolean"
                 },
+                "skipNodeResolution": {
+                    "type": "boolean"
+                },
+                "snapshotResolver": {
+                    "type": "string"
+                },
                 "snapshotSerializers": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "testEnvironment": {
                     "type": "string"
                 },
                 "testEnvironmentOptions": {
-                    "$ref": "#/definitions/Globals"
+                    "$ref": "#/definitions/TestEnvironmentOptions"
                 },
                 "testFailureExitCode": {
                     "type": "integer"
@@ -177,24 +253,29 @@
                         "type": "string"
                     }
                 },
+                "testNamePattern": {
+                    "type": "string"
+                },
                 "testPathIgnorePatterns": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/IgnorePattern"
                     }
                 },
                 "testRegex": {
-                    "type": "array",
-                    "items": {}
+                    "type": "string"
                 },
                 "testResultsProcessor": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "testRunner": {
                     "type": "string"
                 },
                 "testSequencer": {
                     "type": "string"
+                },
+                "testTimeout": {
+                    "type": "integer"
                 },
                 "testURL": {
                     "type": "string",
@@ -207,26 +288,43 @@
                     "type": "string"
                 },
                 "transform": {
-                    "type": "null"
+                    "$ref": "#/definitions/Transform"
                 },
                 "transformIgnorePatterns": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/IgnorePattern"
+                    }
+                },
+                "unmockedModulePathPatterns": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
+                "updateSnapshot": {
+                    "type": "boolean"
+                },
                 "useStderr": {
                     "type": "boolean"
                 },
                 "verbose": {
-                    "type": "null"
+                    "type": "boolean"
                 },
                 "watch": {
                     "type": "boolean"
                 },
                 "watchPathIgnorePatterns": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "watchPlugins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/JestconfigJSONWatchPlugin"
+                    }
                 },
                 "watchman": {
                     "type": "boolean"
@@ -235,9 +333,71 @@
             "required": [],
             "title": "JestconfigJSON"
         },
+        "CollectCoverageOnlyFrom": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "<rootDir>/this-directory-is-covered/Covered.js": {
+                    "type": "boolean"
+                }
+            },
+            "required": [],
+            "title": "CollectCoverageOnlyFrom"
+        },
+        "CoverageThreshold": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "global": {
+                    "$ref": "#/definitions/Global"
+                }
+            },
+            "required": [],
+            "title": "CoverageThreshold"
+        },
+        "Global": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "branches": {
+                    "type": "integer"
+                },
+                "functions": {
+                    "type": "integer"
+                },
+                "lines": {
+                    "type": "integer"
+                },
+                "statements": {
+                    "type": "integer"
+                }
+            },
+            "required": [],
+            "title": "Global"
+        },
+        "DisplayName": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "color": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [],
+            "title": "DisplayName"
+        },
         "Globals": {
             "type": "object",
             "additionalProperties": false,
+            "properties": {
+                "__DEV__": {
+                    "type": "boolean"
+                }
+            },
+            "required": [],
             "title": "Globals"
         },
         "Haste": {
@@ -247,9 +407,23 @@
                 "computeSha1": {
                     "type": "boolean"
                 },
+                "defaultPlatform": {
+                    "type": "string"
+                },
+                "hasteImplModulePath": {
+                    "type": "string"
+                },
+                "platforms": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "providesModuleNodeModules": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "throwOnModuleCollision": {
                     "type": "boolean"
@@ -257,6 +431,119 @@
             },
             "required": [],
             "title": "Haste"
+        },
+        "ModuleNameMapper": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "^React$": {
+                    "type": "string"
+                }
+            },
+            "required": [],
+            "title": "ModuleNameMapper"
+        },
+        "ReporterClass": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "configValue": {
+                    "type": "boolean"
+                }
+            },
+            "required": [],
+            "title": "ReporterClass"
+        },
+        "TestEnvironmentOptions": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "userAgent": {
+                    "type": "string"
+                }
+            },
+            "required": [],
+            "title": "TestEnvironmentOptions"
+        },
+        "IgnorePattern": {
+            "type": "object",
+            "additionalProperties": false,
+            "title": "IgnorePattern"
+        },
+        "Transform": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "^.+\\.js$": {
+                    "type": "string"
+                }
+            },
+            "required": [],
+            "title": "Transform"
+        },
+        "WatchPluginClass": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "prompt": {
+                    "type": "string"
+                }
+            },
+            "required": [],
+            "title": "WatchPluginClass"
+        },
+        "JestconfigJSONReporter": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ReporterReporterUnion"
+                    }
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "title": "JestconfigJSONReporter"
+        },
+        "ReporterReporterUnion": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ReporterClass"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "title": "ReporterReporterUnion"
+        },
+        "JestconfigJSONWatchPlugin": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/WatchPluginWatchPluginUnion"
+                    }
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "title": "JestconfigJSONWatchPlugin"
+        },
+        "WatchPluginWatchPluginUnion": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/WatchPluginClass"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "title": "WatchPluginWatchPluginUnion"
         }
     }
 }

--- a/src/schemas/json/jestconfig.json
+++ b/src/schemas/json/jestconfig.json
@@ -279,10 +279,7 @@
                 },
                 "testURL": {
                     "type": "string",
-                    "format": "uri",
-                    "qt-uri-protocols": [
-                        "http"
-                    ]
+                    "format": "uri"
                 },
                 "timers": {
                     "type": "string"

--- a/src/schemas/json/jestconfig.json
+++ b/src/schemas/json/jestconfig.json
@@ -1,0 +1,262 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/JestconfigJSON",
+    "definitions": {
+        "JestconfigJSON": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "automock": {
+                    "type": "boolean"
+                },
+                "bail": {
+                    "type": "integer"
+                },
+                "browser": {
+                    "type": "boolean"
+                },
+                "cache": {
+                    "type": "boolean"
+                },
+                "changedFilesWithAncestor": {
+                    "type": "boolean"
+                },
+                "clearMocks": {
+                    "type": "boolean"
+                },
+                "collectCoverage": {
+                    "type": "boolean"
+                },
+                "collectCoverageFrom": {
+                    "type": "null"
+                },
+                "coverageDirectory": {
+                    "type": "null"
+                },
+                "coveragePathIgnorePatterns": {
+                    "type": "array",
+                    "items": {}
+                },
+                "coverageReporters": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "coverageThreshold": {
+                    "type": "null"
+                },
+                "dependencyExtractor": {
+                    "type": "null"
+                },
+                "errorOnDeprecated": {
+                    "type": "boolean"
+                },
+                "expand": {
+                    "type": "boolean"
+                },
+                "filter": {
+                    "type": "null"
+                },
+                "forceCoverageMatch": {
+                    "type": "array",
+                    "items": {}
+                },
+                "globalSetup": {
+                    "type": "null"
+                },
+                "globalTeardown": {
+                    "type": "null"
+                },
+                "globals": {
+                    "$ref": "#/definitions/Globals"
+                },
+                "haste": {
+                    "$ref": "#/definitions/Haste"
+                },
+                "maxConcurrency": {
+                    "type": "integer"
+                },
+                "maxWorkers": {
+                    "type": "string"
+                },
+                "moduleDirectories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "moduleFileExtensions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "moduleNameMapper": {
+                    "$ref": "#/definitions/Globals"
+                },
+                "modulePathIgnorePatterns": {
+                    "type": "array",
+                    "items": {}
+                },
+                "noStackTrace": {
+                    "type": "boolean"
+                },
+                "notify": {
+                    "type": "boolean"
+                },
+                "notifyMode": {
+                    "type": "string"
+                },
+                "preset": {
+                    "type": "null"
+                },
+                "prettierPath": {
+                    "type": "string"
+                },
+                "projects": {
+                    "type": "null"
+                },
+                "resetMocks": {
+                    "type": "boolean"
+                },
+                "resetModules": {
+                    "type": "boolean"
+                },
+                "resolver": {
+                    "type": "null"
+                },
+                "restoreMocks": {
+                    "type": "boolean"
+                },
+                "rootDir": {
+                    "type": "null"
+                },
+                "roots": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "runTestsByPath": {
+                    "type": "boolean"
+                },
+                "runner": {
+                    "type": "string"
+                },
+                "setupFiles": {
+                    "type": "array",
+                    "items": {}
+                },
+                "setupFilesAfterEnv": {
+                    "type": "array",
+                    "items": {}
+                },
+                "skipFilter": {
+                    "type": "boolean"
+                },
+                "snapshotSerializers": {
+                    "type": "array",
+                    "items": {}
+                },
+                "testEnvironment": {
+                    "type": "string"
+                },
+                "testEnvironmentOptions": {
+                    "$ref": "#/definitions/Globals"
+                },
+                "testFailureExitCode": {
+                    "type": "integer"
+                },
+                "testLocationInResults": {
+                    "type": "boolean"
+                },
+                "testMatch": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "testPathIgnorePatterns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "testRegex": {
+                    "type": "array",
+                    "items": {}
+                },
+                "testResultsProcessor": {
+                    "type": "null"
+                },
+                "testRunner": {
+                    "type": "string"
+                },
+                "testSequencer": {
+                    "type": "string"
+                },
+                "testURL": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "http"
+                    ]
+                },
+                "timers": {
+                    "type": "string"
+                },
+                "transform": {
+                    "type": "null"
+                },
+                "transformIgnorePatterns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "useStderr": {
+                    "type": "boolean"
+                },
+                "verbose": {
+                    "type": "null"
+                },
+                "watch": {
+                    "type": "boolean"
+                },
+                "watchPathIgnorePatterns": {
+                    "type": "array",
+                    "items": {}
+                },
+                "watchman": {
+                    "type": "boolean"
+                }
+            },
+            "required": [],
+            "title": "JestconfigJSON"
+        },
+        "Globals": {
+            "type": "object",
+            "additionalProperties": false,
+            "title": "Globals"
+        },
+        "Haste": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeSha1": {
+                    "type": "boolean"
+                },
+                "providesModuleNodeModules": {
+                    "type": "array",
+                    "items": {}
+                },
+                "throwOnModuleCollision": {
+                    "type": "boolean"
+                }
+            },
+            "required": [],
+            "title": "Haste"
+        }
+    }
+}


### PR DESCRIPTION
Jest can be configured using a JSON as described [in the Jest documentation](https://jestjs.io/docs/en/configuration).
Using the example [valid config](https://github.com/facebook/jest/blob/master/packages/jest-config/src/ValidConfig.ts) and the types as declared by [jest-types](https://github.com/facebook/jest/blob/master/packages/jest-types/src/Config.ts) I generated the following JSON schema. (I generated it initially using [quicktype.io](https://app.quicktype.io/) )

