### PR TITLE
Add schema for web-types

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1147,6 +1147,12 @@
       "url": "http://json.schemastore.org/webjob-publish-settings"
     },
     {
+      "name": "Web types",
+      "description": "JSON standard for web component libraries metadata",
+      "fileMatch": ["web-types.json", "*.web-types.json"],
+      "url": "http://json.schemastore.org/web-types"
+    },
+    {
       "name": "JSON-stat 2.0",
       "description": "JSON-stat 2.0 Schema",
       "url": "https://json-stat.org/format/schema/2.0/"

--- a/src/schemas/json/web-types.json
+++ b/src/schemas/json/web-types.json
@@ -1,0 +1,562 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON schema for web-types",
+  "type": "object",
+  "properties": {
+    "framework": {
+      "description": "Framework, for which the components are provided by the library",
+      "type": "string",
+      "enum": [
+        "vue"
+      ]
+    },
+    "name": {
+      "description": "Name of the library",
+      "type": "string"
+    },
+    "version": {
+      "description": "Version of the library, for which web-types are provided",
+      "type": "string"
+    },
+    "contributions": {
+      "type": "object",
+      "properties": {
+        "html": {
+          "$ref": "#/definitions/html"
+        }
+      }
+    }
+  },
+  "required": [
+    "framework",
+    "name",
+    "version",
+    "contributions"
+  ],
+  "definitions": {
+    "html": {
+      "type": "object",
+      "properties": {
+        "types-syntax": {
+          "description": "Language in which types as specified.",
+          "type": "string",
+          "enum": [
+            "typescript"
+          ]
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/html-tag"
+          }
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/html-attribute"
+          }
+        },
+        "vue-filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/html-vue-filter"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "html-tag": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/html-tag-attribute"
+          }
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        },
+        "events": {
+          "description": "",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/html-tag-event"
+          }
+        },
+        "slots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/html-tag-slot"
+          }
+        },
+        "vue-scoped-slots": {
+          "description": "Deprecated. Use regular 'slot' property instead and specify 'vue-properties' to provide slot scope information.",
+          "type": "null",
+          "additionalProperties": false
+        },
+        "vue-model": {
+          "$ref": "#/definitions/html-tag-vue-model"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "html-tag-attribute": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        },
+        "default": {
+          "$ref": "#/definitions/html-attribute-default"
+        },
+        "required": {
+          "$ref": "#/definitions/html-attribute-required"
+        },
+        "value": {
+          "$ref": "#/definitions/html-attribute-value"
+        },
+        "type": {
+          "description": "Deprecated. Use 'value' property instead. Specify only if type is 'boolean' for compatibility with WebStorm 2019.2.",
+          "const": "boolean"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "html-attribute": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        },
+        "default": {
+          "$ref": "#/definitions/html-attribute-default"
+        },
+        "required": {
+          "$ref": "#/definitions/html-attribute-required"
+        },
+        "value": {
+          "$ref": "#/definitions/html-attribute-value"
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        },
+        "vue-argument": {
+          "$ref": "#/definitions/html-attribute-vue-argument"
+        },
+        "vue-modifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/html-attribute-vue-modifier"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "html-vue-filter-argument": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        },
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "optional": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "html-vue-filter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        },
+        "accepts": {
+          "description": "Type of expression on the left hand-side of the pipe of operator",
+          "$ref": "#/definitions/type"
+        },
+        "returns": {
+          "description": "Type of the result",
+          "$ref": "#/definitions/type"
+        },
+        "arguments": {
+          "description": "List of arguments accepted by the filter. All arguments are non-optional by default.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/html-vue-filter-argument"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "html-tag-event": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/typed-entity"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "html-tag-slot": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        },
+        "vue-properties": {
+          "description": "Specify properties of the slot scope",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/typed-entity"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "html-tag-vue-model": {
+      "type": "object",
+      "properties": {
+        "prop": {
+          "default": "value",
+          "type": "string"
+        },
+        "event": {
+          "default": "input",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "html-attribute-value": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "number"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "boolean"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "enum"
+            },
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "expression"
+            },
+            "type": {
+              "$ref": "#/definitions/type"
+            }
+          },
+          "required": [
+            "kind",
+            "type"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "html-attribute-default": {
+      "type": "string"
+    },
+    "html-attribute-required": {
+      "type": "boolean"
+    },
+    "html-attribute-vue-argument": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        }
+      },
+      "additionalProperties": false
+    },
+    "html-attribute-vue-modifier": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "typed-entity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "doc-url": {
+          "$ref": "#/definitions/doc-url"
+        },
+        "type": {
+          "$ref": "#/definitions/type"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "type": {
+      "description": "Specify type according to selected language for type syntax. The type can be specified by a string expression, an object with list of imports and an expression, or an array of possible types.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/complex-type"
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/complex-type"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "complex-type": {
+      "type": "object",
+      "properties": {
+        "imports": {
+          "description": "List of import statements required to resolve symbol in the type expression.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "expression": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "imports",
+        "expression"
+      ],
+      "additionalProperties": false
+    },
+    "source": {
+      "description": "Allows to specify the source of the entity. For Vue.js component this may be for instance a class.",
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "file": {
+              "description": "Path to the file, relative to the web-types JSON.",
+              "type": "string"
+            },
+            "offset": {
+              "description": "Offset in the file under which the source symbol, like class name, is located.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "file",
+            "offset"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "module": {
+              "description": "Name of module, which exports the symbol. May be omitted, in which case it's assumed to be the name of the library.",
+              "type": "string"
+            },
+            "symbol": {
+              "description": "Name of the exported symbol.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "symbol"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "description": "Short description to be rendered in documentation popup. May contain HTML tags.",
+      "type": "string"
+    },
+    "doc-url": {
+      "description": "Link to online documentation.",
+      "type": "string"
+    },
+    "pattern": {
+      "description": "A RegEx pattern to match whole content. Syntax should work with at least ECMA, Java and Python implementations.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "regex": {
+              "type": "string"
+            },
+            "case-sensitive": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/web-types/web-types.json
+++ b/src/test/web-types/web-types.json
@@ -1,0 +1,204 @@
+{
+  "framework": "vue",
+  "name": "example",
+  "version": "1.0.0",
+  "contributions": {
+    "html": {
+      "types-syntax": "typescript",
+      "tags": [
+        {
+          "name": "ex-component",
+          "source": {
+            "module": "example",
+            "symbol": "ExComponent"
+          },
+          "description": "An example component to showcase web-types capabilities",
+          "doc-url": "http://example.com/docs/components/ex-component",
+          "attributes": [
+            {
+              "name": "color",
+              "value": {
+                "kind": "expression",
+                "type": [
+                  "string",
+                  {
+                    "imports": [
+                      "import Color from 'example'"
+                    ],
+                    "expression": "Color"
+                  }
+                ]
+              },
+              "default": "\"red\""
+            },
+            {
+              "name": "position",
+              "value": {
+                "kind": "expression",
+                "type": "'top' | 'bottom' | 'left' | 'right'"
+              },
+              "default": "\"top\""
+            },
+            {
+              "name": "active",
+              "value": {
+                "kind": "expression",
+                "type": "boolean"
+              },
+              "type": "boolean"
+            },
+            {
+              "name": "reverse",
+              "description": "A regular attribute not bound to a component prop",
+              "value": {
+                "kind": "boolean"
+              }
+            }
+          ],
+          "events": [
+            {
+              "name": "init",
+              "description": "An event fired when component is initialized",
+              "arguments": [
+                {
+                  "name": "component",
+                  "type": {
+                    "imports": [
+                      "import VComponent from 'example'"
+                    ],
+                    "expression": "VComponent"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "colorChanged"
+            }
+          ],
+          "slots": [
+            {
+              "name": "example",
+              "description": "Use this slot in the component if you want to render an example text",
+              "doc-url": "http://example.com/docs/components/ex-component#slot.example"
+            },
+            {
+              "name": "cell({key})",
+              "pattern": "cell\\([A-Za-z0-9_$]+\\)"
+            },
+            {
+              "name": "scoped-example",
+              "description": "This slot allows you to access component's scope",
+              "doc-url": "http://example.com/docs/components/ex-component#scoped-slot.scoped-example",
+              "vue-properties": [
+                {
+                  "name": "color",
+                  "type": [
+                    "string",
+                    {
+                      "imports": [
+                        "import Color from 'example'"
+                      ],
+                      "expression": "Color"
+                    }
+                  ]
+                },
+                {
+                  "name": "isActive",
+                  "type": "boolean"
+                }
+              ]
+            },
+            {
+              "name": "scoped-pattern",
+              "description": "This slot depends on some dynamic information",
+              "pattern": {
+                "regex": "col-[a-z0-9]",
+                "case-sensitive": false
+              },
+              "vue-properties": [
+                {
+                  "name": "content",
+                  "type": "string"
+                }
+              ]
+            }
+          ],
+          "vue-model": {
+            "event": "colorChanged",
+            "prop": "color"
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "v-example-directive",
+          "description": "An example directive located by an offset in the file relative to web-types.json.",
+          "source": {
+            "file": "./src/directives/example.js",
+            "offset": 213
+          },
+          "value": {
+            "kind": "expression",
+            "type": "string"
+          },
+          "vue-argument": {
+            "pattern": "[0-9]{3}-[0-9]{3}-[0-9]{3}",
+            "description": "Provide phone number"
+          },
+          "vue-modifiers": [
+            {
+              "name": "immediate",
+              "description": "Don't waste time, do the thing immediately"
+            },
+            {
+              "name": "convert"
+            },
+            {
+              "name": "delay",
+              "pattern": {
+                "regex": "d[0-9]+",
+                "case-sensitive": false
+              }
+            }
+          ]
+        },
+        {
+          "name": "example-attr",
+          "description": "An example regular attribute applicable to any tag.",
+          "value": {
+            "kind": "enum",
+            "items": [
+              "foo",
+              "bar"
+            ]
+          }
+        }
+      ],
+      "vue-filters": [
+        {
+          "name": "capitalize",
+          "description": "Capitalize",
+          "doc-url": "https://www.example.com/docs/filters/capitalize",
+          "source": {
+            "file": "./src/directives/example.js",
+            "offset": 213
+          },
+          "accepts": "string",
+          "returns": "string",
+          "arguments": [
+            {
+              "name": "all-words",
+              "type": "boolean"
+            }
+          ]
+        },
+        {
+          "name": "async",
+          "description": "Resolves promise",
+          "accepts": "Promise<T>",
+          "returns": "T"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I would like to add a schema for web-types. The schema is sourced in repository https://github.com/JetBrains/web-types . Web-types is aimed to be a standard for metadata specification of HTML elements provided by libraries for usage within an IDEs. Library vendors are encouraged to ship web-types with their packages and to ease them with development it would be best to have a publicly available schema to refer to.