### PR TITLE
Sync jsconfig "target" field with that from tsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -218,10 +218,27 @@
               "type": "boolean"
             },
             "target": {
-              "description": "Specifies which default library (lib.d.ts) to use. When down-level compiling, specifies the code being generated. Permitted values are 'es3', 'es5', 'es2015', 'es2016', 'es2017', 'es2018' or 'esnext'.",
+              "description": "Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020' or 'esnext'.",
               "type": "string",
-              "pattern": "^([eE][sS]([356]|(201[5678])|[nN][eE][xX][tT]))$",
-              "default": "es2015"
+              "default": "es2015",
+              "anyOf": [
+                {
+                  "enum": [
+                    "es3",
+                    "es5",
+                    "es6",
+                    "es2015",
+                    "es2016",
+                    "es2017",
+                    "es2018",
+                    "es2019",
+                    "es2020",
+                    "esnext"
+                  ]
+                }, {
+                  "pattern": "^([eE][sS]([356]|(20(1[56789]|20))|[nN][eE][xX][tT]))$"
+                }
+              ]
             },
             "watch": {
               "description": "When down-level compiling, watch input files.",


### PR DESCRIPTION
Fixes #771

Copies the `target` field from the `tsconfig.json` schema in the `jsconfig.json` schema. The only exception is the `default` value which I set back to `es2015` in the jsconfig case