### PR TITLE
Bump ansible version to 2.7

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -12,7 +12,7 @@
     {
       "name": "Ansible",
       "description": "Ansible task files",
-      "url": "http://json.schemastore.org/ansible-stable-2.5",
+      "url": "http://json.schemastore.org/ansible-stable-2.7",
       "fileMatch": ["tasks/*.yml", "tasks/*.yaml"],
       "versions": {
         "2.0": "http://json.schemastore.org/ansible-stable-2.0",


### PR DESCRIPTION
If I understand correctly - default URL to Ansible schema must be to version 2.7 as latest.