### PR TITLE
Update eslintrc schema witch changes made in ESLint 6.2.0

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -193,6 +193,7 @@
         "func-name-matching": { "$ref": "#/definitions/rule", "description": "Require function names to match the name of the variable or property to which they are assigned" },
         "func-names": { "$ref": "#/definitions/rule", "description": "Require or disallow named function expressions" },
         "func-style": { "$ref": "#/definitions/rule", "description": "Enforce the consistent use of either function declarations or expressions" },
+        "function-call-argument-newline": { "$ref": "#/definitions/rule", "description": "Enforce line breaks between arguments of a function call" },
         "function-paren-newline": { "$ref": "#/definitions/rule", "description": "Enforce consistent line breaks inside function parentheses" },
         "id-blacklist": { "$ref": "#/definitions/rule", "description": "Disallow specified identifiers" },
         "id-length": { "$ref": "#/definitions/rule", "description": "Enforce minimum and maximum identifier lengths" },
@@ -489,6 +490,10 @@
         ]
       }
     },
+    "noInlineConfig": {
+      "description": "Prevent comments from changing config or rules",
+      "type": "boolean"
+    },
     "parser": {
       "type": "string"
     },
@@ -500,9 +505,9 @@
           "$ref": "#/properties/ecmaFeatures"
         },
         "ecmaVersion": {
-          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018, 10, 2019 ],
+          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018, 10, 2019, 11, 2020 ],
           "default": 5,
-          "description": "Set to 3, 5 (default), 6, 7, 8, 9, or 10 to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), or 2019 (same as 10) to use the year-based naming."
+          "description": "Set to 3, 5 (default), 6, 7, 8, 9, 10 or 11 to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10) or 2020 (same as 11) to use the year-based naming."
         },
         "sourceType": {
           "enum": [ "script", "module" ],


### PR DESCRIPTION
Current [eslintrc schema](https://github.com/SchemaStore/schemastore/blob/fc584d92456e7d8863729bdb67db0f1cc374120e/src/schemas/json/eslintrc.json) doesn't support new options introduced in [ESLint v6.2.0](https://eslint.org/blog/2019/08/eslint-v6.2.0-released) and this pull request should update schema with these changes:
 - `11` and `2020` are valid values for `ecmaVersion` (required for `BigInt` and Dynamic Imports). Description copied from official [ESLint documentation](https://eslint.org/docs/user-guide/configuring#specifying-parser-options).
 - New rule [`function-call-argument-newline`](https://eslint.org/docs/rules/function-call-argument-newline). [Rule Details](https://eslint.org/docs/rules/function-call-argument-newline#rule-details) were used as a description (with a small modification to match style of other descriptions).
 - New `noInlineConfig` setting documented in [this ESLint RFC](https://github.com/eslint/rfcs/tree/master/designs/2019-core-options#-noinlineconfig) and introduced in eslint/eslint#12091. Description was copied from [ESLint CLI options](https://eslint.org/docs/user-guide/command-line-interface#options): `--no-inline-config`.