### PR TITLE
Add support for the 'needs' keyword for GitLab-CI

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -464,6 +464,14 @@
             }
           ]
         },
+        "needs": {
+          "description": "The list of jobs in previous stages whose sole completion is needed to start the current job.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
         "except": {
           "$ref": "#/definitions/filter",
           "description": "Job will run *except* for when these filtering options match."


### PR DESCRIPTION
This PR addresses the modifications mentioned in #783.

For now, the array **must** contain at least one element, [per GitLab's recommendations](https://docs.gitlab.com/ee/ci/yaml/README.html#requirements-and-limitations). This will not be the case anymore once [this issue](https://gitlab.com/gitlab-org/gitlab-ce/issues/65504) will be resolved, but I think it's best to wait until then before getting rid of the `"minItems": 1` rule.

Closes #783