### PR TITLE
Allow number for PHP versions for Travis

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -418,17 +418,7 @@
           ]
         },
         "php": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/stringOrNumberOrAcceptBothTypeAsArrayUnique"
         },
         "go": {
           "oneOf": [

--- a/src/test/travis/language-php.json
+++ b/src/test/travis/language-php.json
@@ -1,0 +1,21 @@
+{
+    "php": [
+        7.2,
+        "7.3",
+        "nightly"
+    ],
+    "jobs": {
+       "include": [
+          {
+             "stage": "lint",
+             "script": "vendor/bin/phpcs",
+             "php": 7.2
+          },
+          {
+             "stage": "test",
+             "script": "vendor/bin/phpunit",
+             "php": "nightly"
+          }
+       ]
+    }
+ }


### PR DESCRIPTION
PHP version can be specified as a string or number (or an array of either) and Travis-CI will work just fine. Currently, the store assumes that it's only a string or array of strings which is incorrect.

See examples in https://docs.travis-ci.com/user/languages/php/#choosing-php-versions-to-test-against where they use either type interchangeably.