### PR TITLE
Add schema for fabric.mod.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -459,10 +459,10 @@
       "url": "http://json.schemastore.org/eslintrc"
     },
     {
-	  "name": "fabric.mod.json",
+      "name": "fabric.mod.json",
       "description": "Metadata file used by the Fabric mod loader",
-	  "fileMatch": ["fabric.mod.json"],
-	  "url": "http://json.schemastore.org/fabric-mod-json"
+      "fileMatch": ["fabric.mod.json"],
+      "url": "http://json.schemastore.org/fabric-mod-json"
     },
     {
       "name": "function.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -463,7 +463,7 @@
       "description": "Metadata file used by the Fabric mod loader",
 	  "fileMatch": ["fabric.mod.json"],
 	  "url": "http://json.schemastore.org/fabric-mod-json"
-	},
+    },
     {
       "name": "function.json",
       "description": "JSON schema for Azure Functions function.json files",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -459,6 +459,12 @@
       "url": "http://json.schemastore.org/eslintrc"
     },
     {
+	  "name": "fabric.mod.json",
+      "description": "Metadata file used by the Fabric mod loader",
+	  "fileMatch": ["fabric.mod.json"],
+	  "url": "http://json.schemastore.org/fabric-mod-json"
+	},
+    {
       "name": "function.json",
       "description": "JSON schema for Azure Functions function.json files",
       "fileMatch": ["function.json"],

--- a/src/schemas/json/fabric.mod.json
+++ b/src/schemas/json/fabric.mod.json
@@ -1,0 +1,288 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string",
+			"pattern": "^[a-z][a-z0-9-_]{1,63}$",
+			"description": "The mod identifier"
+		},
+		"version": {
+			"type": "string",
+			"description": "The mod version"
+		},
+		"schemaVersion": {
+			"type": "integer",
+			"description": "The version of the mod.json file",
+			"const": 1
+		},
+		"environment": {
+			"$ref": "#/definitions/environment"
+		},
+		"entrypoints": {
+			"type": "object",
+			"properties": {
+				"main": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/entrypoint"
+					},
+					"description": "The entrypoint for all environments (classes must implement ModInitializer)"
+				},
+				"client": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/entrypoint"
+					},
+					"description": "The entrypoint for the client environment (classes must implement ClientModInitializer)"
+				},
+				"server": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/entrypoint"
+					},
+					"description": "The entrypoint for the server environment (classes must implement DedicatedServerModInitializer)"
+				}
+			},
+			"description": "The entrypoints for the mod"
+		},
+		"jars": {
+			"type": "array",
+			"description": "Contains an array of nestedJar objects",
+			"items": {
+				"$ref": "#/definitions/nestedJar"
+			}
+		},
+		"languageAdapters": {
+			"type": "object",
+			"description": "A string→string dictionary, connecting namespaces to LanguageAdapter implementations",
+			"additionalProperties": {
+				"type": "string"
+			}
+		},
+		"mixins": {
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{
+						"type": "string",
+						"description": "Path to mixin file from root of the JAR"
+					},
+					{
+						"type": "object",
+						"properties": {
+							"config": {
+								"type": "string",
+								"description": "Path to mixin file from root of the JAR"
+							},
+							"environment": {
+								"$ref": "#/definitions/environment"	
+							}
+						}
+					}
+				]
+			}
+		},
+		"depends": {
+			"type": "object",
+			"description": "id→versionRange map for dependencies. Failure to meet these causes a hard failure",
+			"additionalProperties": {
+				"$ref": "#/definitions/versionRange"
+			}
+		},
+		"recommends": {
+			"type": "object",
+			"description": "id→versionRange map for dependencies. Failure to meet these causes a soft failure (warning)",
+			"additionalProperties": {
+				"$ref": "#/definitions/versionRange"
+			}
+		},
+		"suggests": {
+			"type": "object",
+			"description": "id→versionRange map for dependencies. Are not matched and are mainly used as metadata",
+			"additionalProperties": {
+				"$ref": "#/definitions/versionRange"
+			}
+		},
+		"conflicts": {
+			"type": "object",
+			"description": "id→versionRange map for dependencies. A successful match causes a soft failure (warning)",
+			"additionalProperties": {
+				"$ref": "#/definitions/versionRange"
+			}
+		},
+		"breaks": {
+			"type": "object",
+			"description": "id→versionRange map for dependencies. A successful match causes a hard failure",
+			"additionalProperties": {
+				"$ref": "#/definitions/versionRange"
+			}
+		},
+		"name": {
+			"type": "string",
+			"description": "Name of the mod"
+		},
+		"description": {
+			"type": "string",
+			"description": "Description of the mod"
+		},
+		"authors": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/person"
+			},
+			"description": "The direct authorship information"
+		},
+		"contributors": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/person"
+			},
+			"description": "Contributors to this mod"
+		}
+		"contact": {
+			"$ref": "#/definitions/contactInfo",
+			"description": "Contact infomation for the mod"
+		},
+		"license": {
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			],
+			"description": "The license the mod uses"
+		},
+		"icon": {
+			"oneOf": [
+				{
+					"type": "string",
+					"description": "The path to a single .PNG file from the root of the JAR"
+				},
+				{
+					"type": "object",
+					"description": "A string→string dictionary, where the keys conform to widths of each PNG file, and the values are said files' paths",
+					"additionalProperties": {
+						"type": "string",
+						"description": "The path to a single .PNG file from the root of the JAR"
+					}
+				}
+			]
+		},
+		"custom": {
+			"type": "object",
+			"description": "A map of namespace:id→value for custom data fields."
+		}
+
+	},
+	"required": [
+		"id",
+		"version",
+		"schemaVersion"
+	],
+	"definitions": {
+		"entrypoint": {
+			"oneOf": [
+				{
+					"type": "object",
+					"properties": {
+						"adapter": {
+							"type": "string",
+							"description": "The language adapter to use",
+							"default": "default"
+						},
+						"value": {
+							"type": "string",
+							"description": "The entrypoint function or class"
+						}
+					},
+					"required": [
+						"value"
+					]
+				},
+				{
+					"type": "string",
+					"description": "The entrypoint functions or class"
+				}
+			]
+		},
+		"contactInfo": {
+			"type": "object",
+			"properties": {
+				"email": {
+					"type": "string",
+					"description": "Contact e-mail pertaining to the mod"
+				},
+				"irc": {
+					"type": "string",
+					"description": "IRC channel pertaining to the mod. Must be of a valid URL format"
+				},
+				"homepage": {
+					"type": "string",
+					"description": "Project or user homepage. Must be a valid HTTP/HTTPS address"
+				},
+				"issues": {
+					"type": "string",
+					"description": "Project issue tracker. Must be a valid HTTP/HTTPS address"
+				},
+				"sources": {
+					"type": "string",
+					"description": "Project source code repository. Must be a valid URL"
+				}
+			}
+		},
+		"environment": {
+			"type": "string",
+			"enum": [
+				"*",
+				"client",
+				"server"
+			],
+			"description": "The environment where this is applied"
+		},
+		"nestedJar": {
+			"type": "object",
+			"properties": {
+				"file": {
+					"type": "string",
+					"description": "A string value pointing to a path from the root of the JAR to a nested JAR which should be loaded alongside the outer mod JAR"
+				}
+			},
+			"required": [
+				"file"
+			]
+		},
+		"person": {
+			"oneOf": [
+				{
+					"type": "string",
+					"description": "The name of the person"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"description": "The name of the person"
+						},
+						"contact": {
+							"description": "Contact information for the person",
+							"$ref": "#/definitions/contactInfo"
+						}
+					},
+					"required": [
+						"name"
+					]
+				}
+			]
+		},
+		"versionRange": {
+			"type": "string"
+		}
+	}
+}

--- a/src/schemas/json/fabric.mod.json
+++ b/src/schemas/json/fabric.mod.json
@@ -139,7 +139,7 @@
 				"$ref": "#/definitions/person"
 			},
 			"description": "Contributors to this mod"
-		}
+		},
 		"contact": {
 			"$ref": "#/definitions/contactInfo",
 			"description": "Contact infomation for the mod"


### PR DESCRIPTION
[`fabric.mod.json`](https://fabricmc.net/wiki/documentation:fabric_mod_json) are metadata files used for the [Fabric Loader](https://github.com/FabricMC/fabric-loader).

The Fabric Loader is mod loader for java based games and applications, mostly used for modern Minecraft modding.

Based on [this gist](https://gist.github.com/MrYurihi/4460e90099cf934b2078c7607bb0562b).