### PR TITLE
Add top-level default property to gitlab schema

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -15,6 +15,14 @@
     "after_script": { "$ref": "#/definitions/after_script" },
     "variables": { "$ref": "#/definitions/variables" },
     "cache": { "$ref": "#/definitions/cache" },
+    "default": {
+      "type": "object",
+      "image": { "$ref": "#/definitions/image" },
+      "services": { "$ref": "#/definitions/services" },
+      "before_script": { "$ref": "#/definitions/before_script" },
+      "after_script": { "$ref": "#/definitions/after_script" },
+      "cache": { "$ref": "#/definitions/cache" }
+    },
     "stages": {
       "type": "array",
       "description": "Groups jobs into stages. All jobs in one stage must complete before next stage is executed. Defaults to ['build', 'test', 'deploy'].",

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -1,4 +1,19 @@
 {
+  "default": {
+    "image": "ruby:2.5",
+    "services": [
+      "docker:dind"
+    ],
+    "cache": {
+      "paths": ["vendor/"]
+    },
+    "before_script": [
+      "bundle install --path vendor/"
+    ],
+    "after_script": [
+      "rm -rf tmp/"
+    ]
+  },
   "stages": [
     "build",
     "test",


### PR DESCRIPTION
Closes #749

Adds a `default` property to the gitlab-ci json-schema following the details at https://docs.gitlab.com/ee/ci/yaml/#setting-default-parameters and https://docs.gitlab.com/ee/ci/yaml/#globally-defined-image-services-cache-before_script-after_script where it could contain `image`, `services`, `before_script`, `after_script`, and/or `cache`.