### PR TITLE
Add secretGenerator.type to kustomization schema

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -374,6 +374,10 @@
         "namespace": {
           "description": "Namespace for the configmap, optional",
           "type": "string"
+        },
+        "type": {
+          "description": "Type of Secret",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -381,24 +385,24 @@
     },
     "Target": {
       "required": [
-          "name"
+        "name"
       ],
       "properties": {
-          "apiVersion": {
-              "type": "string"
-          },
-          "group": {
-              "type": "string"
-          },
-          "kind": {
-              "type": "string"
-          },
-          "name": {
-              "type": "string"
-          },
-          "version": {
-              "type": "string"
-          }
+        "apiVersion": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
       },
       "additionalProperties": false,
       "type": "object"


### PR DESCRIPTION
As stated in https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html#secretgenerator, secretGenerator has a type field.