### PR TITLE
Fix invalid gitlab schema

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -17,11 +17,13 @@
     "cache": { "$ref": "#/definitions/cache" },
     "default": {
       "type": "object",
-      "image": { "$ref": "#/definitions/image" },
-      "services": { "$ref": "#/definitions/services" },
-      "before_script": { "$ref": "#/definitions/before_script" },
-      "after_script": { "$ref": "#/definitions/after_script" },
-      "cache": { "$ref": "#/definitions/cache" }
+      "properties": {
+        "image": { "$ref": "#/definitions/image" },
+        "services": { "$ref": "#/definitions/services" },
+        "before_script": { "$ref": "#/definitions/before_script" },
+        "after_script": { "$ref": "#/definitions/after_script" },
+        "cache": { "$ref": "#/definitions/cache" }
+      }
     },
     "stages": {
       "type": "array",


### PR DESCRIPTION
Schema for `.gitlab-ci.yml` contains top-level `default` property, which in turn has invalid property definitions. `default` is an object with properties `image`, `services`, `before_script`, `after_script`, and `cache` but these are currently being defined at the same level as `type` instead of being nested inside a `properties` property. This PR remedies the issue.