### PR TITLE
Update strict-boolean-expressions schema for tslint

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -5272,12 +5272,15 @@
                   "allow-null-union",
                   "allow-undefined-union",
                   "allow-string",
+                  "allow-enum",
                   "allow-number",
-                  "allow-boolean-or-undefined"
+                  "allow-mix",
+                  "allow-boolean-or-undefined",
+                  "ignore-rhs"
                 ]
               },
               "minItems": 1,
-              "maxItems": 5,
+              "maxItems": 8,
               "uniqueItems": true
             }
           },


### PR DESCRIPTION
Added the "allow-enum", "allow-mix" and "ignore-rhs" options, and increased maxItems from 5 to 8 correspondingly.

Source: https://palantir.github.io/tslint/rules/strict-boolean-expressions/
(note that the schema at the bottom of the page is also outdated, read the actual rules on the page to get the full list)

Benefit: I can use all of these options in my `tslint.json` file without it complaining about array length or undefined rules.