### PR TITLE
allow numbers for julia and python for travis

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -480,20 +480,7 @@
           "description": "By default, Travis CI will assume that your Podfile is in the root of the repository. If this is not the case, you can specify where the Podfile is"
         },
         "python": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "number"
-            }
-          ]
+          "$ref": "#/definitions/stringOrNumberOrAcceptBothTypeAsArrayUnique"
         },
         "elixir": {
           "oneOf": [
@@ -538,17 +525,7 @@
           ]
         },
         "julia": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/stringOrNumberOrAcceptBothTypeAsArrayUnique"
         },
         "opt_release": {
           "oneOf": [

--- a/src/test/travis/language-julia.json
+++ b/src/test/travis/language-julia.json
@@ -1,0 +1,19 @@
+{
+    "julia": [
+       "nightly",
+       1.1,
+       "1.0.3"
+   ],
+    "jobs": {
+        "include": [
+           {
+              "stage": "lint",
+              "julia": 1.1
+           },
+           {
+              "stage": "install",
+              "julia": "1.0.3"
+           }
+        ]
+    }
+}

--- a/src/test/travis/language-python.json
+++ b/src/test/travis/language-python.json
@@ -1,10 +1,20 @@
 {
+   "python": [
+      2.7,
+      "3.5",
+      "nightly"
+  ],
     "jobs": {
        "include": [
           {
              "stage": "lint",
              "script": "python -m tox",
              "python": 2.7
+          },
+          {
+             "stage": "install",
+             "script": "python setup.py install",
+             "python": "3.5"
           }
        ]
     }


### PR DESCRIPTION
The docs for Travis for:
* [python](https://docs.travis-ci.com/user/languages/python/)
* [julia](https://docs.travis-ci.com/user/languages/julia/)

use a combination of strings and numbers in both list and singular form, and that it's very common for python projects to only use floating point numbers in their Travis configuration. This updates the schema to not throw an error on either of those, as well as adds a test for both to validate the behavior.