### PR TITLE
Fix aws_credentials in Cirrus CI schema

### DIFF
--- a/src/schemas/json/cirrus.json
+++ b/src/schemas/json/cirrus.json
@@ -766,7 +766,7 @@
       "type": "string"
     },
     "aws_credentials": {
-      "pattern": "ENCRYPTED[.*]",
+      "pattern": "ENCRYPTED\\[.*]",
       "type": "string"
     },
     "azure_container_instance": {


### PR DESCRIPTION
The brackets should be literals.