### PR TITLE
Update Gitlab CI schema with metrics report

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -630,6 +630,10 @@
                 "performance": {
                   "$ref": "#/definitions/string_file_list",
                   "description": "Path to file or list of files with performance metrics report(s)."
+                },
+                "metrics": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with custom metrics report(s)."
                 }
               }
             }

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -77,7 +77,8 @@
         "container_scanning": "scan2.json",
         "dast": "dast.json",
         "license_management": "license.json",
-        "performance": "performance.json"
+        "performance": "performance.json",
+        "metrics": "metrics.txt"
       }
     },
     "variables": {
@@ -137,7 +138,8 @@
         "container_scanning": ["scan2.json"],
         "dast": ["dast.json"],
         "license_management": ["license.json"],
-        "performance": ["performance.json"]
+        "performance": ["performance.json"],
+        "metrics": ["metrics.txt"]
       }
     },
     "coverage": "/Cycles: \\d+\\.\\d+$/",


### PR DESCRIPTION
This property was added in Gitlab 11.10
https://docs.gitlab.com/ee/ci/yaml/#artifactsreportsmetrics-premium