### PR TITLE
added resumic schema

### DIFF
--- a/src/schemas/json/resumic-schema.json
+++ b/src/schemas/json/resumic-schema.json
@@ -1,0 +1,883 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "awards": {
+      "description": "list of awards have been received",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "awarder": {
+            "description": "name of the awarder",
+            "type": "string"
+          },
+          "date": {
+            "description": "date of the award",
+            "format": "date",
+            "type": "string"
+          },
+          "summary": {
+            "description": "reason of the award",
+            "type": "string"
+          },
+          "title": {
+            "description": "title of the award",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "date",
+          "awarder"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "certificate": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "description": "code of the certificate",
+            "type": "string"
+          },
+          "doesNotExpire": {
+            "type": "boolean"
+          },
+          "endDate": {
+            "description": "end date of certificate",
+            "format": "date",
+            "type": "string"
+          },
+          "grantDate": {
+            "description": "date of the grant",
+            "format": "date",
+            "type": "string"
+          },
+          "name": {
+            "description": "name of the certificate",
+            "type": "string"
+          },
+          "score": {
+            "additionalProperties": false,
+            "description": "exam score",
+            "properties": {
+              "best": {
+                "description": "best possible score",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of the score",
+                "type": "string"
+              },
+              "value": {
+                "description": "value of the score",
+                "type": "string"
+              },
+              "worst": {
+                "description": "worst possible score",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "value",
+              "best",
+              "worst"
+            ],
+            "type": "object"
+          },
+          "verification": {
+            "description": "external candidate verification URL",
+            "format": "uri",
+            "type": "string"
+          },
+          "website": {
+            "description": "link to issuing authority's description of the certificate",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "core": {
+      "additionalProperties": false,
+      "properties": {
+        "livingArea": {
+          "description": "living area which could be city or country or even continent",
+          "type": "string"
+        },
+        "title": {
+          "description": "job title",
+          "type": "string"
+        },
+        "workArea": {
+          "description": "work area which could be city or country or even remote",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "education": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "area": {
+            "description": "area of study",
+            "type": "string"
+          },
+          "courses": {
+            "description": "notable courses/subjects",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "endDate": {
+            "description": "end date",
+            "format": "date",
+            "type": "string"
+          },
+          "highlights": {
+            "description": "some of accomplishments",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "honors": {
+            "description": "some education honours",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "institution": {
+            "type": "string"
+          },
+          "location": {
+            "additionalProperties": false,
+            "description": "location of institution",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "long": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "lat",
+              "long"
+            ],
+            "type": "object"
+          },
+          "score": {
+            "additionalProperties": false,
+            "properties": {
+              "best": {
+                "description": "best possible score",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of the score",
+                "type": "string"
+              },
+              "value": {
+                "description": "value of the score",
+                "type": "string"
+              },
+              "worst": {
+                "description": "worst possible score",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "value",
+              "best",
+              "worst"
+            ],
+            "type": "object"
+          },
+          "startDate": {
+            "description": "start date",
+            "format": "date",
+            "type": "string"
+          },
+          "studyType": {
+            "description": "type of study",
+            "type": "string"
+          }
+        },
+        "required": [
+          "institution",
+          "area",
+          "studyType",
+          "startDate",
+          "endDate"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "interests": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "keywords": {
+            "description": "keywords of the interest",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "name of the interest",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "languages": {
+      "description": "list of languages",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "language": {
+            "description": "name of language",
+            "type": "string"
+          },
+          "level": {
+            "description": "proficiency level for the language",
+            "enum": [
+              "basic",
+              "conversational",
+              "fluent",
+              "native"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "language"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "legal": {
+      "description": "list of legals",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "applicationDate": {
+            "description": "date of the application",
+            "format": "date",
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "coAuthors": {
+            "type": "string"
+          },
+          "currentAssignee": {
+            "type": "string"
+          },
+          "description": {
+            "description": "a brief description about the document",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "end date",
+            "format": "date",
+            "type": "string"
+          },
+          "grantDate": {
+            "description": "date of the grant",
+            "format": "date",
+            "type": "string"
+          },
+          "idNumber": {
+            "description": "application number or Id Number",
+            "type": "string"
+          },
+          "legalType": {
+            "description": "type of the document",
+            "type": "string"
+          },
+          "name": {
+            "description": "name of the document",
+            "type": "string"
+          },
+          "previousAssignee": {
+            "type": "string"
+          },
+          "resources": {
+            "description": "multiple resources with label",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "label": {
+                  "description": "label of the resource",
+                  "type": "string"
+                },
+                "url": {
+                  "description": "url of the resource",
+                  "format": "uri",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "label"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "meta": {
+      "additionalProperties": false,
+      "description": "the schema version and any other tooling configuration",
+      "properties": {
+        "canonical": {
+          "description": "URL (as per RFC 3986) to latest version of this document",
+          "type": "string"
+        },
+        "lastModified": {
+          "description": "date-time of last modified",
+          "format": "date-time",
+          "type": "string"
+        },
+        "uuid": {
+          "description": "uuid v4 of the resume",
+          "type": "string"
+        },
+        "version": {
+          "description": "version field which follows semver",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "personal": {
+      "additionalProperties": false,
+      "description": "sensitive informations",
+      "properties": {
+        "birthPlace": {
+          "description": "place of birth",
+          "type": "string"
+        },
+        "birthday": {
+          "description": "birthday date",
+          "format": "date",
+          "type": "string"
+        },
+        "currentLocation": {
+          "additionalProperties": false,
+          "description": "living location",
+          "properties": {
+            "lat": {
+              "type": "number"
+            },
+            "long": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "lat",
+            "long"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "description": "email address",
+          "format": "idn-email",
+          "type": "string"
+        },
+        "gender": {
+          "type": "string"
+        },
+        "image": {
+          "description": "url of the personal photo",
+          "type": "string"
+        },
+        "name": {
+          "description": "full name",
+          "type": "string"
+        },
+        "permanentLocation": {
+          "additionalProperties": false,
+          "description": "permanently living location",
+          "properties": {
+            "lat": {
+              "type": "number"
+            },
+            "long": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "lat",
+            "long"
+          ],
+          "type": "object"
+        },
+        "phone": {
+          "description": "phone number",
+          "type": "string"
+        },
+        "postalAddress": {
+          "type": "string"
+        },
+        "profiles": {
+          "description": "list of social networks",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "network": {
+                "description": "name of the network",
+                "type": "string"
+              },
+              "url": {
+                "description": "url of the profile",
+                "format": "uri",
+                "type": "string"
+              },
+              "username": {
+                "description": "username in the network",
+                "type": "string"
+              }
+            },
+            "required": [
+              "network",
+              "username",
+              "url"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "relationshipStatus": {
+          "description": "civil status",
+          "type": "string"
+        },
+        "summary": {
+          "description": "a short sentence about yourself",
+          "type": "string"
+        },
+        "url": {
+          "description": "homepage url",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "projects": {
+      "description": "list of career projects",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "short summary of project",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "end date",
+            "format": "date",
+            "type": "string"
+          },
+          "entity": {
+            "description": "relevant company/entity affiliations",
+            "type": "string"
+          },
+          "highlights": {
+            "description": "specify multiple features",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "keywords": {
+            "description": "specify special elements involved",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "location": {
+            "additionalProperties": false,
+            "description": "location of the project",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "long": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "lat",
+              "long"
+            ],
+            "type": "object"
+          },
+          "name": {
+            "description": "name of the project",
+            "type": "string"
+          },
+          "resources": {
+            "description": "specify multiple resources with label",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "label": {
+                  "description": "label of the resource",
+                  "type": "string"
+                },
+                "url": {
+                  "description": "url of the resource",
+                  "format": "uri",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "label"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "roles": {
+            "description": "specify your role on this project",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "startDate": {
+            "format": "date",
+            "type": "string"
+          },
+          "type": {
+            "description": "type of the project",
+            "type": "string"
+          },
+          "url": {
+            "description": "url of the project",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "startDate"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "publications": {
+      "description": "list of publications",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "description": "name of the publication",
+            "type": "string"
+          },
+          "publisher": {
+            "description": "name of the publisher",
+            "type": "string"
+          },
+          "publicationDate": {
+            "description": "date of publication",
+            "format": "date",
+            "type": "string"
+          },
+          "resources": {
+            "description": "multiple resources with label",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "label": {
+                  "description": "label of the resource",
+                  "type": "string"
+                },
+                "url": {
+                  "description": "url of the resource",
+                  "format": "uri",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "label"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "description": "short summary of the publication",
+            "type": "string"
+          },
+          "url": {
+            "description": "url of the publication",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "publisher"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "references": {
+      "description": "list of references",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "company": {
+            "description": "company name",
+            "type": "string"
+          },
+          "name": {
+            "description": "name of the reference",
+            "type": "string"
+          },
+          "position": {
+            "description": "position of reference",
+            "type": "string"
+          },
+          "reference": {
+            "description": "reference text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "reference"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "skills": {
+      "description": "list of professional skill-sets",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "keywords": {
+            "description": "some keywords pertaining to the skill",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "name of the skill",
+            "type": "string"
+          },
+          "proficiency": {
+            "description": "proficiency level of the skill",
+            "enum": [
+              "beginner",
+              "early",
+              "competent",
+              "advanced",
+              "expert"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "proficiency"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "volunteer": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "endDate": {
+            "description": "end date",
+            "format": "date",
+            "type": "string"
+          },
+          "highlights": {
+            "description": "some of accomplishments",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "location": {
+            "additionalProperties": false,
+            "description": "location of activity",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "long": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "lat",
+              "long"
+            ],
+            "type": "object"
+          },
+          "organization": {
+            "description": "name of the organization",
+            "type": "string"
+          },
+          "position": {
+            "description": "type of the contribution",
+            "type": "string"
+          },
+          "startDate": {
+            "description": "start date",
+            "format": "date",
+            "type": "string"
+          },
+          "summary": {
+            "description": "an overview of responsibilities",
+            "type": "string"
+          },
+          "url": {
+            "description": "related link to support volunteer experience",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "organization",
+          "position",
+          "startDate"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "work": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "companies primary activity",
+            "type": "string"
+          },
+          "endDate": {
+            "description": "end date",
+            "format": "date",
+            "type": "string"
+          },
+          "highlights": {
+            "description": "some of accomplishments",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "location": {
+            "additionalProperties": false,
+            "description": "location of the company",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "long": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "lat",
+              "long"
+            ],
+            "type": "object"
+          },
+          "name": {
+            "description": "name of company",
+            "type": "string"
+          },
+          "position": {
+            "description": "position at the company",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+          },
+          "startDate": {
+            "description": "start date",
+            "format": "date",
+            "type": "string"
+          },
+          "summary": {
+            "description": "an overview of responsibilities",
+            "type": "string"
+          },
+          "url": {
+            "description": "url of the company website",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "position",
+          "startDate"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "core",
+    "personal",
+    "work",
+    "education",
+    "volunteer",
+    "publications",
+    "legal",
+    "skills",
+    "awards",
+    "projects",
+    "certificate",
+    "references",
+    "languages",
+    "interests",
+    "meta"
+  ],
+  "title": "Resumic resume Schema",
+  "type": "object"
+}


### PR DESCRIPTION
Hello!
This PR comes from [resumic](https://github.com/resumic), a CLI for creating awesome looking resumes from JSON resume files. This schema aims to standardize the JSON files used with resumic.

`./node_modules/.bin/grunt` runs cleanly. This is a draft PR until the resumic schema is a little more stable. It'll close resumic/schema#109 Thanks!