### PR TITLE
Add schema for pubspec files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -873,6 +873,12 @@
       "url": "http://json.schemastore.org/proxies"
     },
     {
+      "name": "pubspec.yaml",
+      "description": "Schema for pubspecs, the format used by Dart's dependency manager",
+      "fileMatch": ["pubspec.yaml"],
+      "url": "http://json.schemastore.org/pubspec"
+    },
+    {
       "name": "pyrseas-0.8.json",
       "description": "Pyrseas database schema versioning for Postgres databases, v0.8",
       "fileMatch": ["pyrseas-0.8.json"],

--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -1,0 +1,193 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "http://json.schemastore.org/pubspec",
+    "title": "Pubspec",
+    "description": "Dart Pubspec file",
+    "definitions": {
+        "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+(?:[+-]\\S+)?$"
+        },
+        "versionConstraint": {
+            "description": "Version range of the package or SDK to use",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "Allows any version of the package. This is not recommended for performance reasons",
+                    "enum": [
+                        "any",
+                        ""
+                    ]
+                },
+                {
+                    "$ref": "#/definitions/version"
+                },
+                {
+                    "type": "string",
+                    "examples": [
+                        ">1.0.0 <2.3.0-beta",
+                        ">=1.0.0-pre.1 <=3.0.0"
+                    ],
+                    "pattern": "^(?:(?:>=|>|<=|<)\\d+\\.\\d+\\.\\d+(?:[+-]\\S+)?\\s*)+$"
+                },
+                {
+                    "type": "string",
+                    "examples": [
+                        "^1.0.0"
+                    ],
+                    "pattern": "^\\^\\d+\\.\\d+\\.\\d+(?:[+-]\\S+)?$"
+                }
+            ]
+        },
+        "dependency": {
+            "oneOf": [
+                {"$ref": "#/definitions/versionConstraint"},
+                {
+                    "title": "SDK dependency",
+                    "type": "object",
+                    "properties": {
+                        "sdk": {
+                            "description": "The SDK which contains this package",
+                            "type": "string"
+                        },
+                        "version": {"$ref": "#/definitions/versionConstraint"}
+                    },
+                    "required": ["sdk"],
+                    "additionalProperties": false
+                },
+                {
+                    "title": "Hosted dependency",
+                    "type": "object",
+                    "properties": {
+                        "hosted": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "url": {
+                                    "description": "The package server hosting this package",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "version": {"$ref": "#/definitions/versionConstraint"}
+                    },
+                    "required": ["hosted"],
+                    "additionalProperties": false
+                },
+                {
+                    "description": "Git dependency",
+                    "type": "object",
+                    "properties": {
+                        "git": {
+                            "$comment": "Can either be a string (uri) or an object with ref etc.",
+                            "oneOf": [
+                                {
+                                    "description": "URI of the repository hosting this package",
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "type": "string",
+                                            "description": "URI of the repository hosting this package"
+                                        },
+                                        "path": {
+                                            "type": "string",
+                                            "description": "Path of this package relative to the Git repo's root"
+                                        },
+                                        "ref": {
+                                            "type": "string",
+                                            "description": "The branch, tag, or anything else Git allows to identify a commit."
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "required": ["git"],
+                    "additionalProperties": false
+                },
+                {
+                    "desciption": "Path dependency",
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/dependency"
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "name": {
+            "description": "The name of this package. The name is how other packages refer to yours, should you publish it.",
+            "type": "string"
+        },
+        "version": {
+            "$ref": "#/definitions/version"
+        },
+        "description": {
+            "type": "string"
+        },
+        "authors": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "homepage": {
+            "type": "string",
+            "format": "uri"
+        },
+        "repository": {
+            "type": "string",
+            "format": "uri"
+        },
+        "issue_tracker": {
+            "type": "string",
+            "format": "uri"
+        },
+        "documentation": {
+            "type": "string",
+            "format": "uri"
+        },
+        "executables": {
+            "type": "object"
+        },
+        "publish_to": {
+            "type": "string"
+        },
+        "environment": {
+            "type": "object",
+            "examples": [
+                {
+                    "sdk": ">=1.19.0 <3.0.0",
+                    "flutter": "^0.1.2"
+                }
+            ],
+            "additionalProperties": {
+                "$ref": "#/definitions/versionConstraint"
+            }
+        },
+        "dependencies": {
+            "$ref": "#/definitions/dependencies"
+        },
+        "dev_dependencies": {
+            "$ref": "#/definitions/dependencies"
+        },
+        "dependency_overrides": {
+            "$ref": "#/definitions/dependencies"
+        }
+    },
+    "required": [
+        "name"
+    ]
+}

--- a/src/test/pubspec/pubspec.json
+++ b/src/test/pubspec/pubspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "foo",
+    "description": "My package description",
+    "version": "0.3.1-foobar.2.0",
+    "homepage": "https://pub.dev",
+    "environment": {
+        "sdk": ">=2.2.2 <3.0.0",
+        "flutter": "^1.0.0"
+    },
+    "dependencies": {
+        "meta": "^1.1.0",
+        "flutter": {
+            "sdk": "flutter",
+            "version": ">=1.7.0"
+        },
+        "analyzer": "any",
+        "bar": ""
+    },
+    "dev_dependencies": {
+        "build_runner": {
+            "hosted": {
+                "name": "another_build_runner",
+                "url": "https://pub.example.org"
+            }
+        }
+    },
+    "dependency_overrides": {
+        "analyzer": {
+            "git": "https://example.com/repo.git"
+        },
+        "meta": {
+            "git": {
+                "url": "https://example.com/another.git",
+                "path": "packages/analyzer",
+                "ref": "stable"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a schema definition for `pubspec.yaml` files, which are used by the [package manager](https://dart.dev/guides/packages) of the [Dart programming language](https://dart.dev/).

As a reference, I've used the [pubspec file format](https://dart.dev/tools/pub/pubspec) documentation. The regular expressions for version constraints are based on [this section](https://dart.dev/tools/pub/dependencies#version-constraints).