### PR TITLE
Allow strings for hidden keys in .gitlab-ci.yml

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -56,7 +56,10 @@
   },
   "patternProperties": {
     "^[.]": {
-      "$ref": "#/definitions/job_template"
+      "oneOf": [
+        { "$ref": "#/definitions/job_template" },
+        { "type": "string" }
+      ]
     }
   },
   "additionalProperties": {

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -1,4 +1,8 @@
 {
+  ".build_config": {
+    "before_script": ["echo test"]
+  },
+  ".build_script": "echo build script",
   "default": {
     "image": "ruby:2.5",
     "services": [


### PR DESCRIPTION
fixes https://github.com/SchemaStore/schemastore/issues/754

IMO this is still too strict. shouldn't it be allowed to be anything?
