### PR TITLE
Allow string and numerics for node_js on Travis

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -417,17 +417,7 @@
           "additionalProperties": false
         },
         "node_js": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/stringOrNumberOrAcceptBothTypeAsArrayUnique"
         },
         "compiler": {
           "oneOf": [

--- a/src/test/travis/language-node.json
+++ b/src/test/travis/language-node.json
@@ -1,0 +1,21 @@
+{
+  "node_js": [
+      10,
+      "12",
+      "lts/*"
+  ],
+  "jobs": {
+     "include": [
+        {
+           "stage": "lint",
+           "script": "npm run lint",
+           "node_js": "lts/*"
+        },
+        {
+           "stage": "test",
+           "script": "npm run test",
+           "node_js": 7
+        }
+     ]
+  }
+}


### PR DESCRIPTION
From their [official page](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/), Travis-CI gives examples of values that are both strings (e.g. `"lts/*"`) and numbers (`7`). This updates the schema to allow numbers as well as strings.

Adds test case to validate behavior.