### PR TITLE
pubspec.yaml: Allow null version constraint

### DIFF
--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -43,6 +43,10 @@
             "oneOf": [
                 {"$ref": "#/definitions/versionConstraint"},
                 {
+                    "description": "Default dependency, matches any version of the package",
+                    "type": "null"
+                },
+                {
                     "title": "SDK dependency",
                     "type": "object",
                     "properties": {

--- a/src/test/pubspec/pubspec.json
+++ b/src/test/pubspec/pubspec.json
@@ -14,7 +14,8 @@
             "version": ">=1.7.0"
         },
         "analyzer": "any",
-        "bar": ""
+        "bar": "",
+        "another": null
     },
     "dev_dependencies": {
         "build_runner": {


### PR DESCRIPTION
This PR fixes the mistake pointed out in https://github.com/SchemaStore/schemastore/pull/830#issuecomment-547564135. A null version constraint is allowed by pub.