### PR TITLE
Add 'babel.config.json' mapping for Babel schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -89,7 +89,7 @@
     {
       "name": "babelrc.json",
       "description": "Babel configuration file",
-      "fileMatch": [".babelrc"],
+      "fileMatch": [".babelrc", "babel.config.json"],
       "url": "http://json.schemastore.org/babelrc"
     },
     {


### PR DESCRIPTION
This was requested by the Babel team.

See also https://youtrack.jetbrains.com/issue/WEB-42249
See also https://github.com/babel/website/pull/2106