### PR TITLE
Add database type to prisma.yml schema

### DIFF
--- a/src/schemas/json/prisma.json
+++ b/src/schemas/json/prisma.json
@@ -101,6 +101,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "databaseType": {
+      "description": "Specifies either a relational or document database.",
+      "type": "string",
+      "enum": ["relational", "document"]
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Update the prisma json schema to include the `databaseType` field as part of the spec found here: https://www.prisma.io/docs/prisma-cli-and-configuration/prisma-yml-5cy7/#databasetype-optional