### PR TITLE
Add type field to package.json

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -175,6 +175,10 @@
             "type": "string"
           }
         },
+        "type": {
+          "description": "The type field defines how .js and extensionless files should be treated within a particular package.json file’s package scope. Supported values: \"commonjs\" (default) or \"module\".",
+          "type": "string"
+        },
         "types": {
           "description": "Set the types property to point to your bundled declaration file",
           "type": "string"


### PR DESCRIPTION
The type field defines how .js and extensionless files should be treated within a particular package.json file’s package scope. Supported values: "commonjs" (default) or "module".

More info here:
https://nodejs.org/api/esm.html#esm_code_package_json_code_code_type_code_field