### PR TITLE
Update tsconfig/jsconfig to support TS 3.7

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -65,6 +65,14 @@
               "description": "The character set of the input files.",
               "type": "string"
             },
+            "declaration": {
+              "description": "Generates corresponding d.ts files.",
+              "type": "boolean"
+            },
+            "declarationDir": {
+              "type": "string",
+              "description": "Specify output directory for generated declaration files. Requires TypeScript version 2.0 or later."
+            },
             "diagnostics": {
               "description": "When down-level compiling, show diagnostic information.",
               "type": "boolean"
@@ -72,6 +80,10 @@
             "emitBOM": {
               "description": "When down-level compiling, emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
               "type": "boolean"
+            },
+            "emitDeclarationOnly": {
+                "description": "Only emit '.d.ts' declaration files.",
+                "type": "boolean"
             },
             "inlineSourceMap": {
               "description": "When down-level compiling, emit a single file with source maps instead of having a separate file.",
@@ -363,6 +375,10 @@
             },
             "keyofStringsOnly": {
                 "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). Requires TypeScript version 2.9 or later.",
+                "type": "boolean"
+            },
+            "useDefineForClassFields": {
+                "description": "Emit ECMAScript standard class fields. Requires TypeScript version 3.7 or later.",
                 "type": "boolean"
             },
             "resolveJsonModule": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -470,6 +470,10 @@
                 "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). Requires TypeScript version 2.9 or later.",
                 "type": "boolean"
             },
+            "useDefineForClassFields": {
+                "description": "Emit ECMAScript standard class fields. Requires TypeScript version 3.7 or later.",
+                "type": "boolean"
+            },
             "declarationMap": {
                 "description": "Generates a sourcemap for each corresponding '.d.ts' file. Requires TypeScript version 2.9 or later.",
                 "type": "boolean"


### PR DESCRIPTION
1. Adds support for "declaration" in JS files, so jsconfig now includes it as well as "declarationDir".
2. Adds a new flag "useDefineForClassFields" that emits class fields with ECMAScript standard semantics. Supported both in jsconfig and tsconfig, because it includes errors to aid upgrading.