### PR TITLE
Update prettierrc.json for 1.19.0

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Schema for .prettierrc",
-  "type": ["object", "string"],
+  "type": "object",
   "definitions": {
     "optionsDefinition": {
       "type": "object",
@@ -145,9 +145,18 @@
           "description": "Change when properties in objects are quoted.",
           "default": "as-needed",
           "oneOf": [
-            { "enum": ["as-needed"], "description": "Only add quotes around object properties where required." },
-            { "enum": ["consistent"], "description": "If at least one property in an object requires quotes, quote all properties." },
-            { "enum": ["preserve"], "description": "Respect the input use of quotes in object properties." }
+            {
+              "enum": ["as-needed"],
+              "description": "Only add quotes around object properties where required."
+            },
+            {
+              "enum": ["consistent"],
+              "description": "If at least one property in an object requires quotes, quote all properties."
+            },
+            {
+              "enum": ["preserve"],
+              "description": "Respect the input use of quotes in object properties."
+            }
           ]
         },
         "rangeEnd": {
@@ -199,6 +208,11 @@
           "description": "Indent with tabs instead of spaces.",
           "default": false,
           "type": "boolean"
+        },
+        "vueIndentScriptAndStyle": {
+          "description": "Indent script and style tags in Vue files.",
+          "default": false,
+          "type": "boolean"
         }
       }
     },
@@ -238,14 +252,9 @@
       }
     }
   },
-  "oneOf": [
-    { "type": "string" },
-    {
-      "type": "object",
-      "allOf": [
-        { "$ref": "#/definitions/optionsDefinition" },
-        { "$ref": "#/definitions/overridesDefinition" }
-      ]
-    }
+  "allOf": [
+    { "$ref": "#/definitions/optionsDefinition" },
+    { "$ref": "#/definitions/overridesDefinition" }
   ]
 }
+


### PR DESCRIPTION
This is the output from running `node scripts/generate-schema.js` in the Prettier repo. I made the 1.19.0 release and it’s part of the release process to make a PR here if the schema has changed.