### PR TITLE
Allow .prettierrc.json to be defined as a string or object

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Schema for .prettierrc",
-  "type": "object",
   "definitions": {
     "optionsDefinition": {
       "type": "object",
@@ -252,9 +251,16 @@
       }
     }
   },
-  "allOf": [
-    { "$ref": "#/definitions/optionsDefinition" },
-    { "$ref": "#/definitions/overridesDefinition" }
+  "oneOf": [
+    {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/optionsDefinition" },
+        { "$ref": "#/definitions/overridesDefinition" }
+      ]
+    },
+    {
+      "type": "string"
+    }
   ]
 }
-


### PR DESCRIPTION
You can reference a sharable config via module/package name, see the docs here:
https://prettier.io/docs/en/configuration.html#sharing-configurations

@lydell 