### PR TITLE
fix jekyll schema: Allow additional properties and minor fixes

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Jekyll Static Site Generator config file schema",
-  "additionalProperties": false,
   "definitions": {
     "string-array": {
       "type": "array",
@@ -39,7 +38,7 @@
     "values": {
       "type": "object",
       "title": "Front Matter Default Values",
-      "description": "Values that are set for the given scope. Can be overriden in the files front matter.",
+      "description": "Values that are set for the given scope. Can be overridden in the files front matter.",
       "properties": {
         "layout": {
           "type": "string",
@@ -198,8 +197,7 @@
     "baseurl": {
       "type": "string",
       "title": "Base URL",
-      "description": "Serve the website from the given base URL.",
-      "format": "uri"
+      "description": "Serve the website from the given base URL.\n\nFor a site designed to be mounted at URL `https://example.com/`, the recommended values are nil, '' or '/'.\nFor a site designed to be mounted at URL `https://example.com/blog/`, the recommended values are just 'blog', '/blog', or '/blog/'"
     },
     "livereload": {
       "type": "boolean",
@@ -212,7 +210,7 @@
       "title": "Detach",
       "description": "Detach the server from the terminal."
     },
-    "collections": { 
+    "collections": {
       "$ref": "#/definitions/collections"
     },
     "collections_dir": {
@@ -266,7 +264,7 @@
     },
     "excerpt_separator": {
       "type": "string",
-      "title": "Posts excerpt separater",
+      "title": "Posts excerpt separator",
       "description": "Used for liquid filter `excerpt`.",
       "default": "\n\n"
     },
@@ -289,27 +287,44 @@
       "default": false
     },
     "liquid": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "error_mode": {
-          "type": "string",
-          "enum": [ "lax", "warn", "strict" ],
-          "default": "warn"
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "error_mode"
+          ],
+          "properties": {
+            "error_mode": {
+              "type": "string",
+              "enum": [
+                "lax",
+                "warn",
+                "strict"
+              ],
+              "default": "warn"
+            }
+          }
         },
-        "strict_filters": {
-          "type": "boolean",
-          "title": "Strict Filters",
-          "description": "Catch non-existing filters.",
-          "default": false
-        },
-        "strict_variables": {
-          "type": "boolean",
-          "title": "Strict Variables",
-          "description": "Catch non-assigned variables.",
-          "default": false
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "strict_filters": {
+              "type": "boolean",
+              "title": "Strict Filters",
+              "description": "Catch non-existing filters.",
+              "default": false
+            },
+            "strict_variables": {
+              "type": "boolean",
+              "title": "Strict Variables",
+              "description": "Catch non-assigned variables.",
+              "default": false
+            }
+          }
         }
-      }
+      ]
     },
     "rdiscount": {
       "type": "object",
@@ -474,7 +489,7 @@
           "type": ["string", "null"],
           "title": "Set the syntax highlighter",
           "description": "Specifies the syntax highlighter that should be used for highlighting code blocks and spans. If this option is set to `nil`, no syntax highlighting is done.",
-          "default": "rogue"
+          "default": "rouge"
         },
         "syntax_highlighter_opts": {
           "type": "object",
@@ -500,7 +515,7 @@
           "type": "boolean",
           "default": false
         }
-      } 
+      }
     },
     "webrick": {
       "type": "object",


### PR DESCRIPTION
1. allow additional properties (ouch, what an oversight on the first version)
2. change format of baseurl to string, since it is usually not an URL but rather a "URL base" for `relative_url` liquid filters
3. fixed typo in default syntax highlighter

Thanks to @Relequestual for helping out with the liquid error options!