### PR TITLE
Apache Avro: Primitive types with metadata

### DIFF
--- a/src/schemas/json/avro-avsc.json
+++ b/src/schemas/json/avro-avsc.json
@@ -45,7 +45,7 @@
             "description": "A primitive type with metadata attached.",
             "type": "object",
             "properties": {
-                "type": { "$ref": "#/definitions/primitiveType" },
+                "type": { "$ref": "#/definitions/primitiveType" }
             },
             "required": ["type"]
         },

--- a/src/schemas/json/avro-avsc.json
+++ b/src/schemas/json/avro-avsc.json
@@ -15,6 +15,7 @@
             "description": "Allowed Avro types",
             "oneOf": [
                 { "$ref": "#/definitions/primitiveType" },
+                { "$ref": "#/definitions/primitiveTypeWithMetadata" },
                 { "$ref": "#/definitions/customTypeReference" },
                 { "$ref": "#/definitions/avroRecord" },
                 { "$ref": "#/definitions/avroEnum" },
@@ -38,6 +39,15 @@
                 "bytes",
                 "string"
             ]
+        },
+        "primitiveTypeWithMetadata": {
+            "title": "Primitive Type With Metadata",
+            "description": "A primitive type with metadata attached.",
+            "type": "object",
+            "properties": {
+                "type": { "$ref": "#/definitions/primitiveType" },
+            },
+            "required": ["type"]
         },
         "customTypeReference": {
             "title": "Custom Type",


### PR DESCRIPTION
It's valid in Avro specification to add metadata to primitive types encapsulating them into objects. This is how logical types are created or how   metadata for code generation are attached in official libraries created by Apache.