### PR TITLE
Add support for the 'timeout' keyword for GitLab-CI

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -275,6 +275,11 @@
         "type": ["string", "integer"]
       }
     },
+    "timeout": {
+      "type": "string",
+      "description": "Allows you to configure a timeout for a specific job (e.g. `1 minute`, `1h 30m 12s`). Read more: https://docs.gitlab.com/ee/ci/yaml/README.html#timeout",
+      "minLength": 1
+    },
     "start_in": {
       "type": "string",
       "description": "Used in conjunction with 'when: delayed' to set how long to delay before starting a job.",
@@ -562,6 +567,9 @@
           "type": "boolean",
           "description": "Setting this option to true will allow the job to fail while still letting the pipeline pass.",
           "default": false
+        },
+        "timeout": {
+          "$ref": "#/definitions/timeout"
         },
         "when": {
           "$ref": "#/definitions/when"

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -162,6 +162,7 @@
     "script": "docker build -t foo:latest",
     "when": "delayed",
     "start_in": "10 min",
+    "timeout": "1h",
     "retry": 1,
     "only": {
       "changes": ["Dockerfile", "docker/scripts/*"]


### PR DESCRIPTION
See https://docs.gitlab.com/ee/ci/yaml/README.html#timeout . 