### PR TITLE
Fix unterminated regex group for Github Workflow

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -883,7 +883,7 @@
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun",
                     "description": "Using the working-directory keyword, you can specify the working directory of where to run the command.",
                     "type": "string",
-                    "pattern": "^(\\.[^\\\\?%*:|\"<>\\n]+$"
+                    "pattern": "^(\\.[^\\\\?%*:|\"<>\\n]+)$"
                   },
                   "shell": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell",


### PR DESCRIPTION
The regex group is missing a closing bracket.