### PR TITLE
Behat contexts array 

### DIFF
--- a/src/schemas/json/behat.json
+++ b/src/schemas/json/behat.json
@@ -73,7 +73,7 @@
         "contexts": {
           "title": "Suite contexts",
           "type": "array",
-          "items": {"type": "string"},
+          "items": {"type": ["string", "object"]},
           "uniqueItems": true
         },
         "filters": {


### PR DESCRIPTION
Behat contexts array can either be filled with items containing a str…ing (class name) or an object (class + parameters).
Behaviour is described in latest version of behat documentation:
http://behat.org/en/latest/user_guide/context.html#context-parameters
