### PR TITLE
Cron support for '0 */6 * * *' in GitHub Workflows

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -724,7 +724,7 @@
                   "cron": {
                     "$comment": "https://stackoverflow.com/a/57639657/4044345",
                     "type": "string",
-                    "pattern": "^(((\\d+,)+\\d+|(\\d+(/|-)\\d+)|\\d+|\\*) ?){5,7}$"
+                    "pattern": "^(((\\d+,)+\\d+|((\\d+|\\*)\\/\\d+)|(\\d+-\\d+)|\\d+|\\*) ?){5,7}$"
                   }
                 },
                 "additionalProperties": false


### PR DESCRIPTION
The cron patten in GitHub Workflows doesn't match rules on the form `0 */6 * * *` (the "wildcard slash digit" part).