### PR TITLE
Add schema for Http-mocker config file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1371,6 +1371,12 @@
       "description": "BizTalk server application inventory json file.",
       "fileMatch": ["BizTalkServerInventory.json"],
       "url": "http://json.schemastore.org/BizTalkServerApplicationSchema"
+    },
+    {
+      "name": "httpmockrc",
+      "description": "Http-mocker is a tool for mock local requests or proxy remote requests.",
+      "fileMatch": [".httpmockrc", ".httpmock.json"],
+      "url": "http://json.schemastore.org/httpmockrc"
     }
   ]
 }

--- a/src/schemas/json/httpmockrc.json
+++ b/src/schemas/json/httpmockrc.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Http-mocker configuration.",
+  "description": "A tool for mock local requests or proxy remote requests.",
+  "type": "object",
+  "properties": {
+    "mockFileName": {
+      "default": "mocks",
+      "type": "string",
+      "description": "Root of mock files"
+    },
+    "responseHeaders": {
+      "type": "object",
+      "description": "Custom response header"
+    },
+    "routes": {
+      "type": "object",
+      "description": "Rules for proxy and mock"
+    }
+  },
+  "required": ["mockFileName", "routes"]
+}

--- a/src/test/httpmockrc/httpmockrc-test.json
+++ b/src/test/httpmockrc/httpmockrc-test.json
@@ -1,0 +1,32 @@
+{
+    "mockFileName": "mocks",
+	"responseHeaders": {
+    	"Content-Type": "application/json"
+  	},
+    "routes": {
+        "GET /api/test.json": {
+            "path": "/get/test/api.json",
+            "ignore": false
+        },
+        "GET /api/massMessage/list": {
+            "path": "/api/massMessage/list/get.json",
+            "ignore": false
+        },
+        "GET /api/tag/list": {
+            "path": "/api/tag/list/get.json",
+            "ignore": false
+        },
+        "GET /api/message/list": {
+            "path": "/api/message/list/get.json",
+            "ignore": false
+        },
+        "GET /api/massMessage/:id": {
+            "path": "/api/massMessage/id.json",
+            "ignore": false
+        },
+        "GET /api/user/info": {
+            "path": "/api/user/info.json",
+            "ignore": false
+        }
+    }
+}


### PR DESCRIPTION
[Http-mocker](https://github.com/brizer/http-mocker) is a tool for mock local requests or proxy remote requests. Now I add  it's config file's schema.