### PR TITLE
Add schema for NeoLoad as-code v3 spec

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1383,6 +1383,12 @@
       "description": "Http-mocker is a tool for mock local requests or proxy remote requests.",
       "fileMatch": [".httpmockrc", ".httpmock.json"],
       "url": "http://json.schemastore.org/httpmockrc"
+    },
+    {
+      "name": "neoload",
+      "description": "Neotys as-code load test specification, more at: https://github.com/Neotys-Labs/neoload-cli",
+      "fileMatch": [".nl.yaml", ".nl.yml", ".nl.json", ".neoload.yaml", ".neoload.yml", ".neoload.json"],
+      "url": "https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/master/resources/as-code.latest.schema.json"
     }
   ]
 }

--- a/src/schemas/json/neoload.json
+++ b/src/schemas/json/neoload.json
@@ -1,0 +1,675 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://neotys.com/schemas/as-code/v3",
+	"title": "JSON Schema for NeoLoad as-code files",
+	"fileMatch": [
+		"*.nl.yaml", "*.neoload.yaml", "neoload*.yaml",
+		"*.nl.yml", "*.neoload.yml", "neoload*.yml",
+		"*.nl.json", "*.neoload.json", "neoload*.json"
+	],
+	"type": "object",
+	"additionalProperties": false,
+	"minProperties": 1,
+	"xrequired": ["name","because neoload files can be partial"],
+	"properties": {
+	  "$schema": { "$ref": "#/definitions/common/full_url" },
+	  "name": { "$ref": "#/definitions/common/name" },
+	  "includes": {
+		"$id":"#root/includes",
+		"title":"Includes",
+		"type":"array",
+		"minItems":1,
+		"additionalProperties":false,
+		"items": { "$ref": "#/definitions/common/text" }
+	  },
+	  "variables": {
+		"$id":"#root/variables",
+		"title":"Variables",
+		"type":"array",
+		"additionalItems": false,
+		"minItems":1,
+		"additionalProperties":false,
+		"items": {
+			"anyOf": [
+				{ "$ref": "#/definitions/variables/constant" },
+				{ "$ref": "#/definitions/variables/file" },
+				{ "$ref": "#/definitions/variables/counter" },
+				{ "$ref": "#/definitions/variables/random_number" },
+				{ "$ref": "#/definitions/variables/javascript" }
+			]
+		}
+	  },
+	  "servers": {
+		"$id":"#root/servers",
+		"title":"Servers",
+		"type":"array",
+		"minItems": 1,
+		"items": { "$ref":  "#/definitions/server" }
+	  },
+	  "sla_profiles":{
+		"$id":"#root/sla_profiles",
+		"title":"SLA Profiles",
+		"type":"array",
+		"minItems": 1,
+		"items": { "$ref":  "#/definitions/sla" }
+	  },
+	  "populations":{
+		"$id":"#root/populations",
+		"title":"Populations",
+		"type":"array",
+		"minItems": 1,
+		"items": { "$ref": "#/definitions/populations/population" }
+	  },
+	  "scenarios":{
+		"$id":"#root/scenarios",
+		"title":"Scenarios",
+		"type":"array",
+		"minItems": 1,
+		"items": { "$ref": "#/definitions/scenario" }
+	  },
+	  "user_paths":{
+		"$id":"#root/user_paths",
+		"title":"User_paths",
+		"type":"array",
+		"minItems": 1,
+		"items": { "$ref": "#/definitions/user_paths/user_path" }
+	  }
+	},
+	"definitions":{
+		"common": {
+			"name":{
+				"title":"Name",
+				"type":"string",
+				"pattern":"^.*$"
+			  },
+			  "text":{
+				"title":"Value",
+				"type":"string",
+				"pattern":"^.*$"
+			  },
+			  "full_url": {
+				  "title":"Url",
+				  "type":"string",
+				  "pattern": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)"
+			  },
+			  "var_change_policy": {
+				"type":"string",
+				"default": "each_iteration",
+				"enum": ["each_use", "each_request", "each_page", "each_iteration", "each_user"]
+			  },
+			  "var_scope": {
+				"type":"string",
+				"default": "global",
+				"enum": ["local", "global", "unique"]
+			  },
+			  "var_order": {
+				"type":"string",
+				"default": "global",
+				"enum": ["sequential", "random", "any"]
+			  },
+			  "var_out_of_value": {
+				"type":"string",
+				"default": "global",
+				"enum": ["cycle", "stop_test", "no_value_code"]
+			  }
+		},
+		"variables": {
+			"generic": {
+				"$id":"#/definitions/variables/generic",
+				"type":"object",
+				"xrequired": ["name"],
+				"properties":{
+					"name": { "$ref": "#/definitions/common/name" },
+					"descrption": { "$ref": "#/definitions/common/text" },
+					"change_policy": { "$ref": "#/definitions/common/var_change_policy" }
+				}
+			},
+			"constant":{
+				"$id":"#/definitions/variables/constant",
+				"title":"Constant",
+				"type":"object",
+				"xrequired": ["value"],
+				"allOf": [
+					{ "$ref": "#/definitions/variables/generic" },
+					{
+						"properties":{
+							"value": { "$ref": "#/definitions/common/text" }
+						  }
+					}
+				],
+				"x-d7nosupport-additionalProperties": false
+			},
+			"file":{
+				"$id":"#/definitions/variables/file",
+				"title":"File",
+				"type":"object",
+				"xrequired": ["path"],
+				"allOf": [
+					{ "$ref": "#/definitions/variables/generic" },
+					{
+						"properties":{
+							"column_names": {
+							  "type": "array",
+							  "items": [ { "type": "string" } ]
+							},
+							"is_first_line_column_names": {
+							  "type": "boolean",
+							  "default": false
+							},
+							"start_from_line": {
+								"type": "integer",
+								"default": 1
+							},
+							"delimiter": {
+								"$ref": "#/definitions/common/text",
+								"default": ","
+							},
+							"path": { "$ref": "#/definitions/common/text" },
+							"scope": { "$ref": "#/definitions/common/var_scope" },
+							"order": { "$ref": "#/definitions/common/var_order" },
+							"out_of_value": { "$ref": "#/definitions/common/var_out_of_value" }
+						}
+					}
+				],
+				"x-d7nosupport-additionalProperties": false
+			},
+			"counter":{
+				"$id":"#/definitions/variables/counter",
+				"title":"Counter",
+				"type":"object",
+				"xrequired": ["start", "end", "increment"],
+				"allOf": [
+					{ "$ref": "#/definitions/variables/generic" },
+					{
+						"properties":{
+							"start": {
+								"type": "number"
+							},
+							"end": {
+								"type": "number"
+							},
+							"increment": {
+								"type": "number"
+							},
+							"scope": { "$ref": "#/definitions/common/var_scope" },
+							"out_of_value": { "$ref": "#/definitions/common/var_out_of_value" }
+						}
+					}
+				],
+				"x-d7nosupport-additionalProperties": false
+			},
+			"random_number":{
+				"$id":"#/definitions/variables/random_number",
+				"title":"Random Number",
+				"type":"object",
+				"xrequired": ["min", "max"],
+				"allOf": [
+					{ "$ref": "#/definitions/variables/generic" },
+					{
+						"properties":{
+							"min": {
+								"type": "number"
+							},
+							"max": {
+								"type": "number"
+							},
+							"predictable": {
+								"type": "boolean"
+							}
+						}
+					}
+				],
+				"x-d7nosupport-additionalProperties": false
+			},
+			"javascript":{
+				"$id":"#/definitions/variables/javascript",
+				"title":"Javascript",
+				"type":"object",
+				"xrequired": ["script"],
+				"allOf": [
+					{ "$ref": "#/definitions/variables/generic" },
+					{
+						"properties":{
+							"script": { "$ref": "#/definitions/common/text" }
+						}
+					}
+				],
+				"x-d7nosupport-additionalProperties": false
+			}
+		},
+		"server": {
+			"$id":"#/definitions/server",
+			"title":"Server",
+			"type":"object",
+			"xrequired": ["name","host"],
+			"additionalProperties": false,
+			"properties":{
+				"name":{ "$ref": "#/definitions/common/text" },
+				"host":{ "$ref": "#/definitions/common/text" },
+				"scheme":{
+					"$id":"#root/servers/items/scheme",
+					"type":"string",
+					"enum": ["http", "https"]
+				},
+				"port": {
+					"type": "integer"
+				},
+				"basic_authentication": { "$ref": "#/definitions/authentication/basic" },
+				"ntlm_authentication": { "$ref": "#/definitions/authentication/ntlm" },
+				"negotiate_authentication": { "$ref": "#/definitions/authentication/basic" }
+			}
+		},
+		"authentication": {
+			"auth-generic": {
+				"$id":"#/definitions/authentication/auth-generic",
+				"type":"object",
+				"xrequired": ["login","password"],
+				"properties":{
+					"login":{ "$ref": "#/definitions/common/text" },
+					"password":{ "$ref": "#/definitions/common/text" }
+				}
+			},
+			"auth-generic-domain": {
+				"$id":"#/definitions/authentication/auth-generic-domain",
+				"type":"object",
+				"allOf": [
+					{ "$ref": "#/definitions/authentication/auth-generic" },
+					{
+						"properties":{
+							"domain": { "$ref": "#/definitions/common/text" }
+						  }
+					}
+				]
+			},
+			"basic": {
+				"$id":"#/definitions/authentication/basic",
+				"title":"Basic Authentication",
+				"type":"object",
+				"allOf": [
+					{ "$ref": "#/definitions/authentication/auth-generic" },
+					{
+						"properties":{
+							"realm": { "$ref": "#/definitions/common/text" }
+						  }
+					}
+				]
+			},
+			"ntlm": {
+				"$id":"#/definitions/authentication/ntlm",
+				"title":"NTLM Authentication",
+				"type":"object",
+				"allOf": [
+					{ "$ref": "#/definitions/authentication/auth-generic-domain" }
+				]
+			},
+			"negotiate": {
+				"$id":"#/definitions/authentication/negotiate",
+				"title":"Negotiate Authentication",
+				"type":"object",
+				"allOf": [
+					{ "$ref": "#/definitions/authentication/auth-generic-domain" }
+				]
+			}
+		},
+		"sla": {
+			"$id":"#/definitions/sla",
+			"title":"SLA Profile",
+			"type": "object",
+			"xrequired": ["name","thresholds"],
+			"properties": {
+				"name": { "$ref": "#/definitions/common/text" },
+				"description": { "$ref": "#/definitions/common/text" },
+				"thresholds": {
+					"$id":"#/definitions/sla/thresholds",
+					"title":"Thresholds",
+					"type":"array",
+					"minItems":1,
+					"additionalProperties":false,
+					"items": { "$ref": "#/definitions/sla/threshold" }
+				  }
+			},
+			"threshold":{
+				"$id":"#/definitions/sla/threshold",
+				"title":"Threshold",
+				"type":"string",
+				"pattern":"^(.*?)\\s(warn\\s(>=|==|<=|>|<))(?=\\s)(.*?)per\\s(test|interval)$"
+			  }
+		},
+		"populations": {
+			"population":{
+				"$id":"#/definitions/population",
+				"title":"Population",
+				"type":"object",
+				"properties":{
+					"name":{ "$ref": "#/definitions/common/text" },
+					"description":{ "$ref": "#/definitions/common/text" },
+					"xcomments": {
+						"value": "why do we need the substructure 'name' to denote a string list?"
+					},
+					"user_paths":{
+						"type":"array",
+						"minItems":1,
+						"additionalProperties":false,
+						"additionalItems": false,
+						"items": {
+							"type": "object",
+							"properties": {
+								"name": { "$ref": "#/definitions/common/text" }
+							}
+						}
+					}
+				}
+			},
+			"variation_commons": {
+				"$id":"#/definitions/populations/variation_commons",
+				"type":"object",
+				"xrequired": ["duration","start_after","stop_after"],
+				"properties":{
+					"duration":{
+						"title":"Duration",
+						"type":"string",
+						"pattern":"^.*$"
+					},
+					"start_after":{
+						"title":"Start after",
+						"type":"string",
+						"pattern":"^.*$"
+					},
+					"stop_after":{
+						"title":"Stop after",
+						"type":"string",
+						"pattern":"^.*$"
+					}
+				  }
+			},
+			"constant_load":{
+				"$id":"#/definitions/populations/constant_load",
+				"title":"Constant Load",
+				"type":"object",
+				"xrequired": ["users"],
+				"allOf": [
+					{ "$ref": "#/definitions/populations/variation_commons" },
+					{
+						"properties":{
+							"users":{
+								"type":"integer",
+								"default":1
+							},
+							"rampup": { "$ref": "#/definitions/common/text" }
+						}
+					}
+				]
+			},
+			"rampup_load":{
+				"$id":"#/definitions/populations/rampup_load",
+				"title":"Ramp-up Load",
+				"type":"object",
+				"xrequired": ["min_users","increment_users","increment_every"],
+				"allOf": [
+					{ "$ref": "#/definitions/populations/variation_commons" },
+					{
+						"properties":{
+							"min_users":{
+								"type":"integer",
+								"default":1
+							},
+							"max_users":{
+								"type":"integer",
+								"default":1
+							},
+							"increment_users":{
+								"type":"integer",
+								"default":1
+							},
+							"increment_every": { "$ref": "#/definitions/common/text" },
+							"increment_rampup": { "$ref": "#/definitions/common/text" }
+						}
+					}
+				]
+			},
+			"peaks_phase": {
+				"$id":"#/definitions/populations/peaks_phase",
+				"title":"Peaks Load",
+				"type":"object",
+				"xrequired": ["users","duration"],
+				"properties": {
+					"users": {
+						"type": "integer",
+						"default": 1
+					},
+					"duration": { "$ref": "#/definitions/common/text" }
+				}
+			},
+			"peaks_load":{
+				"$id":"#/definitions/populations/peaks_load",
+				"title":"Peaks Load",
+				"type":"object",
+				"xrequired": ["minimum","maximum","start"],
+				"allOf": [
+					{ "$ref": "#/definitions/populations/variation_commons" },
+					{
+						"properties":{
+							"minimum":{ "$ref": "#/definitions/populations/peaks_phase" },
+							"maximum":{ "$ref": "#/definitions/populations/peaks_phase" },
+							"start": {
+								"type": "string",
+								"enum": ["minimum","maximum"]
+							},
+							"step_rampup": { "$ref": "#/definitions/common/text" }
+						}
+					}
+				]
+			}
+		},
+		"scenario":{
+			"$id":"#/definitions/scenario",
+			"title":"Scenario",
+			"type":"object",
+			"properties":{
+			  "name":{ "$ref": "#/definitions/common/text" },
+			  "description":{ "$ref": "#/definitions/common/text" },
+			  "populations":{
+				"$id":"#/definitions/scenario/populations",
+				"title":"Scenario Populations",
+				"type":"array",
+				"minItems": 1,
+				"additionalItems": false,
+				"additionalProperties": false,
+				"items":{
+				  "$id":"#/definitions/scenario/populations/items",
+				  "type":"object",
+				  "xrequired": ["name"],
+				  "anyOf": [
+					{ "$ref": "#/definitions/populations/constant_load" },
+					{ "$ref": "#/definitions/populations/rampup_load" },
+					{ "$ref": "#/definitions/populations/peaks_load" },
+					{
+						"properties":{
+							"name":{ "$ref": "#/definitions/common/text" }
+						}
+					}
+				  ]
+				}
+			  }
+			}
+		},
+		"user_paths": {
+			"user_path":{
+				"$id":"#/definitions/user_paths/user_path",
+				"title":"User Path",
+				"type":"object",
+				"xrequired": ["name","actions"],
+				"properties":{
+				  "name":{ "$ref": "#/definitions/common/text" },
+				  "description":{ "$ref": "#/definitions/common/text" },
+				  "user_session": {
+					  "type": "string",
+					  "enum": ["reset_on","reset_off","reset_auto"]
+				  },
+				  "init": { "$ref": "#/definitions/user_paths/container" },
+				  "actions": { "$ref": "#/definitions/user_paths/container" },
+				  "end": { "$ref": "#/definitions/user_paths/container" }
+				}
+			},
+			"container":{
+				"$id":"#/definitions/user_paths/container",
+				"title":"Containers",
+				"type":"object",
+				"xrequired": ["steps"],
+				"properties":{
+					"sla_profile": {
+						"type": "string"
+					},
+					"steps":{
+						"title":"Steps",
+						"type":"array",
+						"minItems": 1,
+						"items": {
+							"anyOf": [
+								{ "$ref": "#/definitions/user_paths/actions/transaction" },
+								{ "$ref": "#/definitions/user_paths/actions/request" },
+								{ "$ref": "#/definitions/user_paths/actions/delay" },
+								{ "$ref": "#/definitions/user_paths/actions/think_time" },
+								{ "$ref": "#/definitions/user_paths/actions/javascript" },
+								{ "$ref": "#/definitions/user_paths/actions/if" }
+							]
+						}
+					}
+				}
+			},
+			"actions": {
+				"transaction":{
+					"$id":"#/definitions/user_paths/actions/transaction",
+					"title":"Action: Transaction",
+					"type":"object",
+					"xrequired": ["name"],
+					"allOf": [
+						{ "$ref": "#/definitions/user_paths/container" },
+						{
+							"properties":{
+								"name": { "$ref": "#/definitions/common/text" },
+								"description": { "$ref": "#/definitions/common/text" }
+							}
+						}
+					]
+				},
+				"request": {
+					"$id":"#/definitions/user_paths/actions/request",
+					"title":"Action: HTTP/s Request",
+					"type":"object",
+					"xrequired": ["url"],
+					"properties":{
+						"url":{ "$ref": "#/definitions/common/text" },
+						"server": { "$ref": "#/definitions/common/text" },
+						"method": {
+							"type": "string",
+							"enum": [
+								"GET","POST","HEAD","PUT","DELETE","OPTIONS","TRACE"
+							]
+						},
+						"headers": {
+							"type": "array",
+							"items": { "$ref": "#/definitions/common/text" }
+						},
+						"sla_profile": { "$ref": "#/definitions/common/text" },
+						"body": { "$ref": "#/definitions/common/text" },
+						"extractors": {
+							"type": "array",
+							"items": { "$ref": "#/definitions/user_paths/extractor" }
+						}
+					}
+				},
+				"delay": {
+					"$id":"#/definitions/user_paths/actions/delay",
+					"title":"Action: Delay",
+					"type":"string",
+					"allOf": [
+						{ "$ref": "#/definitions/common/text" }
+					]
+				},
+				"think_time": {
+					"$id":"#/definitions/user_paths/actions/think_time",
+					"title":"Action: Think Time",
+					"type":"string",
+					"allOf": [
+						{ "$ref": "#/definitions/common/text" }
+					]
+				},
+				"javascript": {
+					"$id":"#/definitions/user_paths/actions/javascript",
+					"title":"Action: Javascript",
+					"type": "object",
+					"xrequired": ["name","script"],
+					"properties": {
+						"name": { "$ref": "#/definitions/common/text" },
+						"description": { "$ref": "#/definitions/common/text" },
+						"script": { "$ref": "#/definitions/common/text" }
+					}
+				},
+				"if": {
+					"$id":"#/definitions/user_paths/actions/if",
+					"title":"Action: If",
+					"type": "object",
+					"xrequired": ["conditions","then"],
+					"properties": {
+						"name": { "$ref": "#/definitions/common/text" },
+						"description": { "$ref": "#/definitions/common/text" },
+						"conditions": {
+							"type": "array",
+							"xcomments": "like GWBSR said: 'aint gonna do it', at least not this commit",
+							"items": { "$ref": "#/definitions/common/text" }
+						},
+						"match": {
+							"type": "string",
+							"enum": ["any","all"],
+							"default": "any"
+						},
+						"then": { "$ref": "#/definitions/user_paths/container" },
+						"else": { "$ref": "#/definitions/user_paths/container" }
+					}
+				}
+
+			},
+			"extractor": {
+				"type": "object",
+				"xrequired": ["name"],
+				"properties": {
+					"name":{ "$ref": "#/definitions/common/text" },
+					"from": {
+						"type": "string",
+						"default": "body",
+						"enum": [
+							"header","body","both"
+						]
+					},
+					"xpath":{ "$ref": "#/definitions/common/text" },
+					"jsonpath":{ "$ref": "#/definitions/common/text" },
+					"regexp":{ "$ref": "#/definitions/common/text" },
+					"match_number": {
+						"type": "integer",
+						"default": 1
+					},
+					"template":{ "$ref": "#/definitions/common/text" },
+					"decode": {
+						"type": "string",
+						"enum": [
+							"html","url"
+						]
+					},
+					"extract_once": {
+						"type": "boolean",
+						"default": false
+					},
+					"default": {
+						"type": "string",
+						"default": ""
+					},
+					"throw_assertion_error": {
+						"type": "boolean",
+						"default": true
+					}
+				}
+			}
+		}
+	}
+  }

--- a/src/test/neoload/neoload-allthethings.json
+++ b/src/test/neoload/neoload-allthethings.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "https://neotys.com/as-code-v3.json",
+  "name": "NeoLoad-CLI-example-2_0",
+  "includes": [
+    "paths/geosearch_get.yaml"
+  ],
+  "variables": [
+    {
+      "constant": {
+        "name": "constant_variable",
+        "value": "12345abcd"
+      }
+    },
+    {
+      "file": {
+        "name": "cities",
+        "column_names": [
+          "City"
+        ],
+        "is_first_line_column_names": false,
+        "start_from_line": 1,
+        "delimiter": ",",
+        "path": "data/cities.csv",
+        "change_policy": "each_iteration",
+        "scope": "global",
+        "order": "any",
+        "out_of_value": "cycle"
+      }
+    },
+    {
+      "counter": {
+        "name": "counter_variable",
+        "start": 0,
+        "end": 100,
+        "increment": 2,
+        "change_policy": "each_iteration",
+        "scope": "local",
+        "out_of_value": "cycle"
+      }
+    },
+    {
+      "random_number": {
+        "name": "random_number_variable",
+        "min": 0,
+        "max": 999,
+        "predictable": false,
+        "change_policy": "each_request"
+      }
+    },
+    {
+      "javascript": {
+        "name": "My JSVar",
+        "description": "This is a js var",
+        "script": "function evaluate() {\n\tlogger.debug(\"Computing value of js variable\");\n\treturn\nnew function() {\n\t\tthis.firstField = \"a value\";\n\t\tthis.secondField =\nmyLibraryFunction();\n\t};\n}",
+        "change_policy": "each_iteration"
+      }
+    }
+  ],
+  "servers": [
+    {
+      "name": "geolookup_host",
+      "host": "nominatim.openstreetmap.org",
+      "scheme": "https"
+    },
+    {
+      "name": "nonstandard_port",
+      "host": "nominatim.openstreetmap.org",
+      "port": 81,
+      "scheme": "http"
+    },
+    {
+      "name": "basic_auth",
+      "host": "nominatim.openstreetmap.org",
+      "basic_authentication": {
+        "login": "${auth_login}",
+        "password": "${auth_password}",
+        "realm": "realm-value"
+      }
+    },
+    {
+      "name": "basic_auth",
+      "host": "nominatim.openstreetmap.org",
+      "ntlm_authentication": {
+        "login": "${auth_login}",
+        "password": "${auth_password}",
+        "domain": "domain-value"
+      }
+    },
+    {
+      "name": "negotiate_auth",
+      "host": "nominatim.openstreetmap.org",
+      "negotiate_authentication": {
+        "login": "${auth_login}",
+        "password": "${auth_password}"
+      }
+    }
+  ],
+  "sla_profiles": [
+    {
+      "name": "per_test_slas",
+      "description": "SLAs calculated at the end of the test",
+      "thresholds": [
+        "avg-request-resp-time warn >= 1000ms fail >= 25000ms per test",
+        "avg-page-resp-time warn >= 1000ms fail >= 25000ms per test",
+        "avg-transaction-resp-time warn >= 1000ms fail >= 25000ms per test",
+        "perc-transaction-resp-time (p95) warn >= 1s per test",
+        "avg-request-per-sec warn == 0/s fail >= 250/s per test",
+        "avg-throughput-per-sec warn <= 0Mbps fail >= 250Mbps per test",
+        "errors-count warn >= 50 fail >= 100 per test",
+        "count warn < 10 fail == 0 per test",
+        "throughput warn < 1MB fail == 0MB per test",
+        "error-rate warn >= 2% fail >= 25% per test"
+      ]
+    },
+    {
+      "name": "per_interval_slas",
+      "description": "SLAs calculated during the test",
+      "thresholds": [
+        "avg-resp-time warn >= 1000ms fail >= 25000ms per interval",
+        "avg-elt-per-sec warn < 1/s fail == 0/s per interval",
+        "avg-throughput-per-sec warn < 1Mbps fail >= 250Mbps per interval",
+        "errors-per-sec warn > 1/s fail > 5/s per interval",
+        "error-rate warn >= 2% fail >= 25% per interval"
+      ]
+    }
+  ],
+  "populations": [
+    {
+      "name": "popGets",
+      "description": "a simple population (distribution of user paths)",
+      "user_paths": [
+        {
+          "name": "ex_2_0_geosearch_get"
+        }
+      ]
+    },
+    {
+      "name": "popMix",
+      "description": "a mixed population",
+      "user_paths": [
+        {
+          "name": "ex_2_0_geosearch_get",
+          "distribution": "33.3%"
+        },
+        {
+          "name": "ex_2_0_geosearch_get",
+          "distribution": "66.7%"
+        }
+      ]
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "sanityScenario",
+      "description": "a scenario to run as a sanity check on environment and test assets",
+      "populations": [
+        {
+          "name": "popGets",
+          "rampup_load": {
+            "min_users": 1,
+            "max_users": 2,
+            "increment_users": 1,
+            "increment_every": "2s",
+            "duration": "10s"
+          }
+        }
+      ]
+    },
+    {
+      "name": "rampScenario",
+      "description": "a scenario to run as a sanity check on environment and test assets",
+      "populations": [
+        {
+          "name": "popOne",
+          "rampup_load": {
+            "min_users": 1,
+            "max_users": 2,
+            "increment_users": 1,
+            "increment_every": "2s",
+            "duration": "10s"
+          }
+        },
+        {
+          "name": "popTwo",
+          "rampup_load": {
+            "min_users": 1,
+            "max_users": 2,
+            "increment_users": 1,
+            "increment_every": "2s",
+            "increment_rampup": "2s",
+            "start_after": "popOne",
+            "stop_after": "2m30s"
+          }
+        }
+      ]
+    },
+    {
+      "name": "slaScenario",
+      "description": "a scenario that uses an SLA and constant population",
+      "sla_profile": "per_test_slas",
+      "populations": [
+        {
+          "name": "constantPopUnlimited",
+          "constant_load": {
+            "users": 5,
+            "duration": "unlimited",
+            "start_after": "15 iterations",
+            "stop_after": "25 iterations"
+          }
+        },
+        {
+          "name": "constantPop",
+          "constant_load": {
+            "users": 5,
+            "duration": "10m30s",
+            "start_after": "constantPopUnlimited",
+            "rampup": "30s"
+          }
+        }
+      ]
+    },
+    {
+      "name": "peakScenario",
+      "description": "a scenario to test peak schema",
+      "populations": [
+        {
+          "name": "MyPopulation1",
+          "peaks_load": {
+            "minimum": {
+              "users": 100,
+              "duration": "5m"
+            },
+            "maximum": {
+              "users": 500,
+              "duration": "3m"
+            },
+            "start": "minimum"
+          }
+        },
+        {
+          "name": "MyPopulation2",
+          "peaks_load": {
+            "minimum": {
+              "users": 100,
+              "duration": "5 iterations"
+            },
+            "maximum": {
+              "users": 500,
+              "duration": "3 iterations"
+            },
+            "start": "minimum",
+            "duration": "80 iterations",
+            "start_after": "MyPopulation1",
+            "step_rampup": "15s",
+            "stop_after": "current_iteration"
+          }
+        }
+      ]
+    }
+  ],
+  "user_paths": [
+    {
+      "name": "ex_2_0_geosearch_get",
+      "actions": {
+        "steps": [
+          {
+            "transaction": {
+              "name": "External Geo-lookup",
+              "description": "Call Open Street Maps to translate city names to lat/lon",
+              "steps": [
+                {
+                  "request": {
+                    "url": "/search?format=json&q=${cities.City}",
+                    "server": "geolookup_host",
+                    "sla_profile": "geo_3rdparty_sla"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "delay": "1s"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Initial push of JSON Schema spec for NeoLoad as-code specification. Describes payloads and semantics for executing reliable load tests.