### PR TITLE
Fix fabric.mod.json not being locatable

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -491,7 +491,7 @@
       "name": "fabric.mod.json",
       "description": "Metadata file used by the Fabric mod loader",
       "fileMatch": ["fabric.mod.json"],
-      "url": "http://json.schemastore.org/fabric-mod-json"
+      "url": "http://json.schemastore.org/fabric.mod.json"
     },
     {
       "name": "Fantomas",


### PR DESCRIPTION
Probably closes #805. 

Seems like the url parser looks for the name in the config instead of the specified url?!