### PR TITLE
Dependabot: Add github_actions as supported package manager

### DIFF
--- a/src/schemas/json/dependabot.json
+++ b/src/schemas/json/dependabot.json
@@ -35,7 +35,8 @@
               "docker",
               "terraform",
               "submodules",
-              "elm"
+              "elm",
+              "github_actions"
             ],
             "description": "What package manager to use",
             "examples": ["ruby:bundler"]


### PR DESCRIPTION
Dependabot also supports updating Github Actions, even if it is not mentioned on their documentation page, but it is in their repo: https://github.com/dependabot/dependabot-core/tree/master/github_actions