### PR TITLE
Add `node-cli-arguments-options:features`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -753,6 +753,12 @@
       }
     },
     {
+      "name": "node-cli-arguments-options:features",
+      "description": "Verifiable feature description for (node) CLI option and argument parsers",
+      "url": "https://github.com/karfau/node-cli-arguments-options/raw/master/features.json",
+      "fileMatch": ["features.json"]
+    }
+    {
       "name": "nodemon.json",
       "description": "JSON schema for nodemon.json configuration files.",
       "url": "http://json.schemastore.org/nodemon",


### PR DESCRIPTION
The goal is to make the schema discoverable through this catalog.

More information about the project hosting (and testing) the schema:
https://github.com/karfau/node-cli-arguments-options

Please let me know if there is anything else I need to do.