### PR TITLE
Add Zuul CI Schema Definition

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1395,6 +1395,12 @@
       "description": "Release Drafter configuration file",
       "fileMatch": ["release-drafter.yml"],
       "url": "https://raw.githubusercontent.com/release-drafter/release-drafter/master/schema.json"
+    },
+    {
+      "name": "zuul",
+      "description": "Zuul CI configuration file",
+      "fileMatch": ["*zuul.d/*.yaml", "*/.zuul.yaml"],
+      "url": "https://raw.githubusercontent.com/pycontribs/zuul-lint/master/zuul_lint/zuul-schema.json"
     }
   ]
 }


### PR DESCRIPTION
SCHEMA is taken from it current location:
https://github.com/pycontribs/zuul-lint/blob/master/zuul_lint/zuul-schema.json

Related: https://github.com/pycontribs/zuul-lint/issues/3