### PR TITLE
Fail execution on dirty repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,7 @@ build:
 	cd src && \
 	npm install && \
 	./node_modules/.bin/grunt
+	git diff-index --quiet HEAD -- || { \
+		echo "ERROR: Dirty repository found"; \
+		git status --porcelain; \
+		exit 1; }


### PR DESCRIPTION
This will prevent accidents where running tests produce untracked or modify tracked files.

@madskristensen Ideally this command should run on schedule on CI but I have no way to control that with a PR. Anyway that code is valid, it will fail if files are modified after running tests.

I supposed the easiest way to enable this on CI is to also enable github workflows and to run `make` there.

Partial: #903