### PR TITLE
Update batect configuration file URL.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -108,7 +108,7 @@
       "name": "batect.yml",
       "description": "batect configuration file",
       "fileMatch": ["batect.yml"],
-      "url": "https://batect.charleskorn.com/configSchema.json"
+      "url": "https://batect.dev/configSchema.json"
     },
     {
       "name": ".bootstraprc",


### PR DESCRIPTION
batect has moved to a new domain (batect.dev).