### PR TITLE
Bump resumejson schema to v1.0.0

### DIFF
--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function (grunt) {
         dest: "schemas/json/swagger-2.0.json"
       },
       resume: {
-        options: { url: "https://raw.githubusercontent.com/jsonresume/resume-schema/master/schema.json" },
+        options: { url: "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json" },
         dest: "schemas/json/resume.json"
       },
       jsonld: {

--- a/src/schemas/json/resume.json
+++ b/src/schemas/json/resume.json
@@ -4,377 +4,467 @@
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {
-		"basics": {
+	  "basics": {
+		"type": "object",
+		"additionalProperties": true,
+		"properties": {
+		  "name": {
+			"type": "string"
+		  },
+		  "label": {
+			"type": "string",
+			"description": "e.g. Web Developer"
+		  },
+		  "image": {
+			"type": "string",
+			"description": "URL (as per RFC 3986) to a image in JPEG or PNG format"
+		  },
+		  "email": {
+			"type": "string",
+			"description": "e.g. thomas@gmail.com",
+			"format": "email"
+		  },
+		  "phone": {
+			"type": "string",
+			"description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+		  },
+		  "url": {
+			"type": "string",
+			"description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
+			"format": "uri"
+		  },
+		  "summary": {
+			"type": "string",
+			"description": "Write a short 2-3 sentence biography about yourself"
+		  },
+		  "location": {
 			"type": "object",
 			"additionalProperties": true,
 			"properties": {
-				"name": {
-					"type": "string"
+			  "address": {
+				"type": "string",
+				"description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
+			  },
+			  "postalCode": {
+				"type": "string"
+			  },
+			  "city": {
+				"type": "string"
+			  },
+			  "countryCode": {
+				"type": "string",
+				"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+			  },
+			  "region": {
+				"type": "string",
+				"description": "The general region where you live. Can be a US state, or a province, for instance."
+			  }
+			}
+		  },
+		  "profiles": {
+			"type": "array",
+			"description": "Specify any number of social networks that you participate in",
+			"additionalItems": false,
+			"items": {
+			  "type": "object",
+			  "additionalProperties": true,
+			  "properties": {
+				"network": {
+				  "type": "string",
+				  "description": "e.g. Facebook or Twitter"
 				},
-				"label": {
-					"type": "string",
-					"description": "e.g. Web Developer"
-				},
-				"picture": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to a picture in JPEG or PNG format"
-				},
-				"email": {
-					"type": "string",
-					"description": "e.g. thomas@gmail.com",
-					"format": "email"
-				},
-				"phone": {
-					"type": "string",
-					"description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+				"username": {
+				  "type": "string",
+				  "description": "e.g. neutralthoughts"
 				},
 				"url": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
-					"format": "uri"
-				},
-				"summary": {
-					"type": "string",
-					"description": "Write a short 2-3 sentence biography about yourself"
-				},
-				"location": {
-					"type": "object",
-					"additionalProperties": true,
-					"properties": {
-						"address": {
-							"type": "string",
-							"description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
-						},
-						"postalCode": {
-							"type": "string"
-						},
-						"city": {
-							"type": "string"
-						},
-						"countryCode": {
-							"type": "string",
-							"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
-						},
-						"region": {
-							"type": "string",
-							"description": "The general region where you live. Can be a US state, or a province, for instance."
-						}
-					}
-				},
-				"profiles": {
-					"type": "array",
-					"description": "Specify any number of social networks that you participate in",
-					"additionalItems": false,
-					"items": {
-						"type": "object",
-						"additionalProperties": true,
-						"properties": {
-							"network": {
-								"type": "string",
-								"description": "e.g. Facebook or Twitter"
-							},
-							"username": {
-								"type": "string",
-								"description": "e.g. neutralthoughts"
-							},
-							"url": {
-								"type": "string",
-								"description": "e.g. http://twitter.com/neutralthoughts"
-							}
-						}
-					}
+				  "type": "string",
+				  "description": "e.g. http://twitter.example.com/neutralthoughts"
 				}
-			}
-		},
-		"work": {
-			"type": "array",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"company": {
-			  		"type": "string",
-			  		"description": "e.g. Facebook"
-			  	},
-			  	"position": {
-			  		"type": "string",
-			  		"description": "e.g. Software Engineer"
-			  	},
-			  	"url": {
-			  		"type": "string",
-			  		"description": "e.g. http://facebook.com",
-			  		"format": "uri"
-			  	},
-			  	"startDate": {
-			  		"type": "string",
-			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
-			  		"format": "date"
-			  	},
-			  	"endDate": {
-			  		"type": "string",
-			  		"description": "e.g. 2012-06-29",
-			  		"format": "date"
-			  	},
-			  	"summary": {
-			  		"type": "string",
-			  		"description": "Give an overview of your responsibilities at the company"
-			  	},
-			  	"highlights": {
-			  		"type": "array",
-			  		"description": "Specify multiple accomplishments",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
-			  		}
-			  	}
 			  }
-
 			}
-		},
-		"volunteer": {
-			"type": "array",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"organization": {
-			  		"type": "string",
-			  		"description": "e.g. Facebook"
-			  	},
-			  	"position": {
-			  		"type": "string",
-			  		"description": "e.g. Software Engineer"
-			  	},
-			  	"url": {
-			  		"type": "string",
-			  		"description": "e.g. http://facebook.com",
-			  		"format": "uri"
-			  	},
-			  	"startDate": {
-			  		"type": "string",
-			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
-			  		"format": "date"
-			  	},
-			  	"endDate": {
-			  		"type": "string",
-			  		"description": "e.g. 2012-06-29",
-			  		"format": "date"
-			  	},
-			  	"summary": {
-			  		"type": "string",
-			  		"description": "Give an overview of your responsibilities at the company"
-			  	},
-			  	"highlights": {
-			  		"type": "array",
-			  		"description": "Specify multiple accomplishments",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
-			  		}
-			  	}
-			  }
-
-			}
-		},
-		"education": {
-			"type": "array",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-				  	"institution": {
-				  		"type": "string",
-				  		"description": "e.g. Massachusetts Institute of Technology"
-				  	},
-				  	"area": {
-				  		"type": "string",
-				  		"description": "e.g. Arts"
-				  	},
-				  	"studyType": {
-				  		"type": "string",
-				  		"description": "e.g. Bachelor"
-				  	},
-				  	"startDate": {
-				  		"type": "string",
-			  			"description": "e.g. 2014-06-29",
-			  			"format": "date"
-				  	},
-				  	"endDate": {
-				  		"type": "string",
-			  			"description": "e.g. 2012-06-29",
-			  			"format": "date"
-				  	},
-				  	"gpa": {
-				  		"type": "string",
-				  		"description": "grade point average, e.g. 3.67/4.0"
-				  	},
-				  	"courses": {
-				  		"type": "array",
-				  		"description": "List notable courses/subjects",
-				  		"additionalItems": false,
-				  		"items": {
-				  			"type": "string",
-				  			"description": "e.g. H1302 - Introduction to American history"
-				  		}
-				  	}
-			  	}
-
-
-			}
-		},
-		"awards": {
-			"type": "array",
-			"description": "Specify any awards you have received throughout your professional career",
-			"additionalItems": false,
-			"items": {
-			  	"type": "object",
-			  	"additionalProperties": true,
-				"properties": {
-				  	"title": {
-				  		"type": "string",
-				  		"description": "e.g. One of the 100 greatest minds of the century"
-				  	},
-				  	"date": {
-				  		"type": "string",
-				  		"description": "e.g. 1989-06-12",
-				  		"format": "date"
-				  	},
-				  	"awarder": {
-				  		"type": "string",
-				  		"description": "e.g. Time Magazine"
-				  	},
-				  	"summary": {
-				  		"type": "string",
-				  		"description": "e.g. Received for my work with Quantum Physics"
-				  	}
-				}
-			}
-		},
-		"publications": {
-			"type": "array",
-			"description": "Specify your publications through your career",
-			"additionalItems": false,
-			"items": {
-		  		"type": "object",
-		  		"additionalProperties": true,
-				"properties": {
-				  	"name": {
-				  		"type": "string",
-				  		"description": "e.g. The World Wide Web"
-				  	},
-				  	"publisher": {
-				  		"type": "string",
-				  		"description": "e.g. IEEE, Computer Magazine"
-				  	},
-				  	"releaseDate": {
-				  		"type": "string",
-				  		"description": "e.g. 1990-08-01"
-				  	},
-				  	"url": {
-				  		"type": "string",
-				  		"description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
-				  	},
-				  	"summary": {
-				  		"type": "string",
-				  		"description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
-				  	}
-			  	}
-			}
-		},
-		"skills": {
-			"type": "array",
-			"description": "List out your professional skill-set",
-			"additionalItems": false,
-			"items": {
-			  	"type": "object",
-			  	"additionalProperties": true,
-				"properties": {
-				  	"name": {
-				  		"type": "string",
-				  		"description": "e.g. Web Development"
-				  	},
-				  	"level": {
-				  		"type": "string",
-				  		"description": "e.g. Master"
-				  	},
-				  	"keywords": {
-				  		"type": "array",
-				  		"description": "List some keywords pertaining to this skill",
-				  		"additionalItems": false,
-				  		"items": {
-				  			"type": "string",
-				  			"description": "e.g. HTML"
-				  		}
-				  	}
-				}
-			}
-		},
-		"languages": {
-			"type": "array",
-			"description": "List any other languages you speak",
-			"additionalItems": false,
-			"items": {
-				"type": "object",
-				"additionalProperties": true,
-				"properties": {
-					"name": {
-						"type": "string",
-						"description": "e.g. English, Spanish"
-					},
-					"level": {
-						"type": "string",
-						"description": "e.g. Fluent, Beginner"
-					}
-				}
-			}
-		},
-		"interests": {
-			"type": "array",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"name": {
-			  		"type": "string",
-			  		"description": "e.g. Philosophy"
-			  	},
-			  	"keywords": {
-			  		"type": "array",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Friedrich Nietzsche"
-			  		}
-			  	}
-			  }
-
-			}
-		},
-		"references": {
-			"type": "array",
-			"description": "List references you have received",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"name": {
-			  		"type": "string",
-			  		"description": "e.g. Timothy Cook"
-			  	},
-			  	"reference": {
-			  		"type": "string",
-			  		"description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
-			  	}
-			  }
-
-			}
+		  }
 		}
+	  },
+	  "work": {
+		"type": "array",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"name": {
+			  "type": "string",
+			  "description": "e.g. Facebook"
+			},
+			"location": {
+			  "type": "string",
+			  "description": "e.g. Menlo Park, CA"
+			},
+			"description": {
+			  "type": "string",
+			  "description": "e.g. Social Media Company"
+			},
+			"position": {
+			  "type": "string",
+			  "description": "e.g. Software Engineer"
+			},
+			"url": {
+			  "type": "string",
+			  "description": "e.g. http://facebook.example.com",
+			  "format": "uri"
+			},
+			"startDate": {
+			  "type": "string",
+			  "description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
+			  "format": "date"
+			},
+			"endDate": {
+			  "type": "string",
+			  "description": "e.g. 2012-06-29",
+			  "format": "date"
+			},
+			"summary": {
+			  "type": "string",
+			  "description": "Give an overview of your responsibilities at the company"
+			},
+			"highlights": {
+			  "type": "array",
+			  "description": "Specify multiple accomplishments",
+			  "additionalItems": false,
+			  "items": {
+				"type": "string",
+				"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+			  }
+			}
+		  }
+		}
+	  },
+	  "volunteer": {
+		"type": "array",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"organization": {
+			  "type": "string",
+			  "description": "e.g. Facebook"
+			},
+			"position": {
+			  "type": "string",
+			  "description": "e.g. Software Engineer"
+			},
+			"url": {
+			  "type": "string",
+			  "description": "e.g. http://facebook.example.com",
+			  "format": "uri"
+			},
+			"startDate": {
+			  "type": "string",
+			  "description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
+			  "format": "date"
+			},
+			"endDate": {
+			  "type": "string",
+			  "description": "e.g. 2012-06-29",
+			  "format": "date"
+			},
+			"summary": {
+			  "type": "string",
+			  "description": "Give an overview of your responsibilities at the company"
+			},
+			"highlights": {
+			  "type": "array",
+			  "description": "Specify accomplishments and achievements",
+			  "additionalItems": false,
+			  "items": {
+				"type": "string",
+				"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+			  }
+			}
+		  }
+		}
+	  },
+	  "education": {
+		"type": "array",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"institution": {
+			  "type": "string",
+			  "description": "e.g. Massachusetts Institute of Technology"
+			},
+			"area": {
+			  "type": "string",
+			  "description": "e.g. Arts"
+			},
+			"studyType": {
+			  "type": "string",
+			  "description": "e.g. Bachelor"
+			},
+			"startDate": {
+			  "type": "string",
+			  "description": "e.g. 2014-06-29",
+			  "format": "date"
+			},
+			"endDate": {
+			  "type": "string",
+			  "description": "e.g. 2012-06-29",
+			  "format": "date"
+			},
+			"gpa": {
+			  "type": "string",
+			  "description": "grade point average, e.g. 3.67/4.0"
+			},
+			"courses": {
+			  "type": "array",
+			  "description": "List notable courses/subjects",
+			  "additionalItems": false,
+			  "items": {
+				"type": "string",
+				"description": "e.g. H1302 - Introduction to American history"
+			  }
+			}
+		  }
+		}
+	  },
+	  "awards": {
+		"type": "array",
+		"description": "Specify any awards you have received throughout your professional career",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"title": {
+			  "type": "string",
+			  "description": "e.g. One of the 100 greatest minds of the century"
+			},
+			"date": {
+			  "type": "string",
+			  "description": "e.g. 1989-06-12",
+			  "format": "date"
+			},
+			"awarder": {
+			  "type": "string",
+			  "description": "e.g. Time Magazine"
+			},
+			"summary": {
+			  "type": "string",
+			  "description": "e.g. Received for my work with Quantum Physics"
+			}
+		  }
+		}
+	  },
+	  "publications": {
+		"type": "array",
+		"description": "Specify your publications through your career",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"name": {
+			  "type": "string",
+			  "description": "e.g. The World Wide Web"
+			},
+			"publisher": {
+			  "type": "string",
+			  "description": "e.g. IEEE, Computer Magazine"
+			},
+			"releaseDate": {
+			  "type": "string",
+			  "description": "e.g. 1990-08-01"
+			},
+			"url": {
+			  "type": "string",
+			  "description": "e.g. http://www.computer.org.example.com/csdl/mags/co/1996/10/rx069-abs.html"
+			},
+			"summary": {
+			  "type": "string",
+			  "description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
+			}
+		  }
+		}
+	  },
+	  "skills": {
+		"type": "array",
+		"description": "List out your professional skill-set",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"name": {
+			  "type": "string",
+			  "description": "e.g. Web Development"
+			},
+			"level": {
+			  "type": "string",
+			  "description": "e.g. Master"
+			},
+			"keywords": {
+			  "type": "array",
+			  "description": "List some keywords pertaining to this skill",
+			  "additionalItems": false,
+			  "items": {
+				"type": "string",
+				"description": "e.g. HTML"
+			  }
+			}
+		  }
+		}
+	  },
+	  "languages": {
+		"type": "array",
+		"description": "List any other languages you speak",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"language": {
+			  "type": "string",
+			  "description": "e.g. English, Spanish"
+			},
+			"fluency": {
+			  "type": "string",
+			  "description": "e.g. Fluent, Beginner"
+			}
+		  }
+		}
+	  },
+	  "interests": {
+		"type": "array",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"name": {
+			  "type": "string",
+			  "description": "e.g. Philosophy"
+			},
+			"keywords": {
+			  "type": "array",
+			  "additionalItems": false,
+			  "items": {
+				"type": "string",
+				"description": "e.g. Friedrich Nietzsche"
+			  }
+			}
+		  }
+		}
+	  },
+	  "references": {
+		"type": "array",
+		"description": "List references you have received",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"name": {
+			  "type": "string",
+			  "description": "e.g. Timothy Cook"
+			},
+			"reference": {
+			  "type": "string",
+			  "description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+			}
+		  }
+		}
+	  },
+	  "projects": {
+		"type": "array",
+		"description": "Specify career projects",
+		"additionalItems": false,
+		"items": {
+		  "type": "object",
+		  "additionalProperties": true,
+		  "properties": {
+			"name": {
+			  "type": "string",
+			  "description": "e.g. The World Wide Web"
+			},
+			 "description": {
+			  "type": "string",
+			  "description": "Short summary of project. e.g. Collated works of 2017."
+			},
+			"highlights": {
+			  "type": "array",
+			  "description": "Specify multiple features",
+			  "additionalItems": false,
+			  "items": {
+				"type": "string",
+				"description": "e.g. Directs you close but not quite there"
+			  }
+			},
+			"keywords": {
+			  "type": "array",
+			  "description": "Specify special elements involved",
+			  "additionalItems": false,
+			  "items": {
+				"type": "string",
+				"description": "e.g. AngularJS"
+			  }
+			},
+			"startDate": {
+			  "type": "string",
+			  "description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
+			  "format": "date"
+			},
+			"endDate": {
+			  "type": "string",
+			  "description": "e.g. 2012-06-29",
+			  "format": "date"
+			},
+			"url": {
+			  "type": "string",
+			  "format":"uri",
+			  "description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
+			},
+			"roles":{
+			  "type":"array",
+			  "description": "Specify your role on this project or in company",
+			  "additionalItems": false,
+			  "items": {
+				"type":"string",
+				"description": "e.g. Team Lead, Speaker, Writer"
+			  }
+			},
+			"entity":{
+			  "type": "string",
+			  "description": "Specify the relevant company/entity affiliations e.g. 'greenpeace', 'corporationXYZ'"
+			},
+			"type":{
+			  "type":"string",
+			  "description": " e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
+			}
+		  }
+		}
+	  },
+	  "meta": {
+		"type": "object",
+		"description": "The schema version and any other tooling configuration lives here",
+		"additionalProperties": true,
+		"properties": {
+		  "canonical": {
+			"type": "string",
+			"description": "URL (as per RFC 3986) to latest version of this document"
+		  },
+		  "version": {
+			"type": "string",
+			"description": "A version field which follows semver - e.g. v1.0.0"
+		  },
+		  "lastModified": {
+			"type": "string",
+			"description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
+		  }
+		}
+	  }
 	}
-}
+  }


### PR DESCRIPTION
[resumejson](https://github.com/SchemaStore/schemastore/blob/9602a79be26cc6f0fcd739fd870546443cdfee33/src/schemas/json/resume.json) schema was updated to [v1.0.0](https://github.com/jsonresume/resume-schema/blob/v1.0.0/schema.json) in #792 and killed in #802 by the automatic build.
Changes were re-introduced in #878 and killed in #906 again.

This PR re-introduces the changes and change automatic build URL to the proper one.

/cc @michaltalaga: these are the changes one needs to introduce to prevent overwriting of your commits.

/cc @madskristensen: you are in a good position of saving collaborators from making these kinds of mistakes by spotting such errors. Thank you for your work!

_upd_: little clarification, no sarcasm intended in the last sentence, that project is really amazing and I am happy to be able to use it.