### PR TITLE
Allow asterisk in package.json name field

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -84,7 +84,7 @@
           "type": "string",
           "maxLength": 214,
           "minLength": 1,
-          "pattern": "^(?:@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*$"
+          "pattern": "^(?:@[a-z0-9-*~][a-z0-9-*._~]*/)?[a-z0-9-~][a-z0-9-._~]*$"
         },
         "version": {
           "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency.",


### PR DESCRIPTION
Example: [https://www.npmjs.com/org/**](https://www.npmjs.com/org/**)