### PR TITLE
Fix GitHub Workflow schema not accepting expressions

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -899,7 +899,7 @@
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun",
                     "description": "Using the working-directory keyword, you can specify the working directory of where to run the command.",
                     "type": "string",
-                    "pattern": "^(\\.[^\\\\?%*:|\"<>\\n]+)$"
+                    "pattern": "^(\\.[^\\\\?%*:|\"<>\\n]+|\\${{.*}})$"
                   },
                   "shell": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell",

--- a/src/test/github-workflow/919.json
+++ b/src/test/github-workflow/919.json
@@ -1,0 +1,34 @@
+{
+  "name": "Test on Pull",
+  "on": [
+    "push"
+  ],
+  "jobs": {
+    "build": {
+      "runs-on": "ubuntu-latest",
+      "env": {
+        "build-suite-dir": "./build-suite"
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v1"
+        },
+        {
+          "uses": "actions/setup-node@v1",
+          "with": {
+            "node-version": "10.x"
+          }
+        },
+        {
+          "name": "starting directory",
+          "run": "ls"
+        },
+        {
+          "name": "build directory",
+          "run": "ls",
+          "working-directory": "${{env.build-suite-dir}}"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #919.

- The regexp pattern should now also allow said "expressions" (environment variables).
- Added a test case for this scenario.

Thanks @amezick and @madskristensen.