### PR TITLE
Add artifacts:expose_as parameter to gitlab-ci schema

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -614,6 +614,10 @@
               },
               "minLength": 1
             },
+            "expose_as": {
+              "type": "string",
+              "description": "Can be used to expose job artifacts in the merge request UI. GitLab will add a link <expose_as> to the relevant merge request that points to the artifact."
+            },
             "name": {
               "type": "string",
               "description": "Name for the archive created on job success. Can use variables in the name, e.g. '$CI_JOB_NAME'"

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -79,6 +79,7 @@
       "paths": [
         "dist/"
       ],
+      "expose_as": "link_name_in_merge_request",
       "name": "bundles",
       "when": "on_success",
       "expire_in": "1 week",


### PR DESCRIPTION
GitLab 12.5 introduced `artifacts:expose_as` to the .gitlab-ci.yml schema.
see https://docs.gitlab.com/ee/ci/yaml/#artifactsexpose_as