### PR TITLE
Add missing .travis.yml "jobs" properties

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -2121,11 +2121,35 @@
                 ]
               }
             },
+            "exclude": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/job"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "stage": {
+                        "type": "string",
+                        "description": "The name of the build stage",
+                        "default": "test"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
             "allow_failures": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/job"
               }
+            },
+            "fast_finish": {
+              "type": "boolean",
+              "description": "If some rows in the build matrix are allowed to fail, the build won’t be marked as finished until they have completed. To mark the build as finished as soon as possible, add fast_finish: true"
             }
           }
         },


### PR DESCRIPTION
The schema should support the additional keys "fast_finish" and "exclude" on the jobs root key: https://config.travis-ci.com/ref/jobs#keys