### PR TITLE
Fix appsscript.json runtimeVersion values

### DIFF
--- a/src/schemas/json/appsscript.json
+++ b/src/schemas/json/appsscript.json
@@ -7,11 +7,11 @@
       "description": "Version of the server to use when executing this project.",
       "type": "string",
       "enum": [
-        "stable",
-        "v8",
-        "depreacted_es5"
+        "STABLE",
+        "V8",
+        "DEPRECATED_ES5"
       ],
-      "default": "stable"
+      "default": "STABLE"
     },
     "timeZone": {
       "description": "The script time zone in one of the available ZoneId values such as \"America/Denver\".",


### PR DESCRIPTION
uppercase only
https://developers.google.com/apps-script/manifest#Manifest.FIELDS.runtimeVersion