### PR TITLE
GitLab CI: Support cache.key.files

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -324,8 +324,26 @@
           }
         },
         "key": {
-          "type": "string",
-          "description": "Unique cache ID, to allow e.g. specific branch or job cache. Environment variables can be used to set up unique keys (e.g. \"$CI_COMMIT_REF_SLUG\" for per branch cache)."
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Unique cache ID, to allow e.g. specific branch or job cache. Environment variables can be used to set up unique keys (e.g. \"$CI_COMMIT_REF_SLUG\" for per branch cache)."
+            },
+            {
+              "type": "object",
+              "description": "When you include cache:key:files, you must also list the project files that will be used to generate the key, up to a maximum of two files. The cache key will be a SHA checksum computed from the most recent commits (up to two, if two files are listed) that changed the given files.",
+              "properties": {
+                "files": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "maxItems": 2
+                }
+              }
+            }
+          ]
         },
         "untracked": {
           "type": "boolean",


### PR DESCRIPTION
Add support for the new `cache.key.files` keyword from GitLab 12.5

Reference: https://docs.gitlab.com/ee/ci/yaml/#cachekeyfiles