### PR TITLE
Add ts-node configuration options to tsconfig schema

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -620,6 +620,100 @@
           }
         }
       }
+    },
+    "tsNodeDefinition": {
+      "properties": {
+        "ts-node": {
+          "description": "ts-node options.  See also: https://github.com/TypeStrong/ts-node#configuration-options\n\nts-node offers TypeScript execution and REPL for node.js, with source map support.",
+          "properties": {
+            "compiler": {
+              "default": "typescript",
+              "description": "Specify a custom TypeScript compiler.",
+              "type": "string"
+            },
+            "compilerHost": {
+              "default": false,
+              "description": "Use TypeScript's compiler host API.",
+              "type": "boolean"
+            },
+            "compilerOptions": {
+              "additionalProperties": true,
+              "allOf": [
+                {
+                  "$ref": "#/definitions/compilerOptionsDefinition/properties/compilerOptions"
+                }
+              ],
+              "description": "JSON object to merge with compiler options.",
+              "properties": {},
+              "type": "object"
+            },
+            "emit": {
+              "default": false,
+              "description": "Emit output files into `.ts-node` directory.",
+              "type": "boolean"
+            },
+            "files": {
+              "default": false,
+              "description": "Load files from `tsconfig.json` on startup.",
+              "type": "boolean"
+            },
+            "ignore": {
+              "default": "/node_modules/",
+              "description": "Override the path patterns to skip compilation.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "ignoreDiagnostics": {
+              "description": "Ignore TypeScript warnings by diagnostic code.",
+              "items": {
+                "type": [
+                  "string",
+                  "number"
+                ]
+              },
+              "type": "array"
+            },
+            "logError": {
+              "default": false,
+              "description": "Logs TypeScript errors to stderr instead of throwing exceptions.",
+              "type": "boolean"
+            },
+            "preferTsExts": {
+              "default": false,
+              "description": "Re-order file extensions so that TypeScript imports are preferred.",
+              "type": "boolean"
+            },
+            "pretty": {
+              "default": false,
+              "description": "Use pretty diagnostic formatter.",
+              "type": "boolean"
+            },
+            "scope": {
+              "default": false,
+              "description": "Scope compiler to files within `cwd`.",
+              "type": "boolean"
+            },
+            "skipIgnore": {
+              "default": false,
+              "description": "Skip ignore check.",
+              "type": "boolean"
+            },
+            "transpileOnly": {
+              "default": false,
+              "description": "Use TypeScript's faster `transpileModule`.",
+              "type": "boolean"
+            },
+            "typeCheck": {
+              "default": true,
+              "description": "**DEPRECATED** Specify type-check is enabled (e.g. `transpileOnly == false`).",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      }
     }
   },
   "type": "object",
@@ -628,6 +722,7 @@
     { "$ref": "#/definitions/compileOnSaveDefinition" },
     { "$ref": "#/definitions/typeAcquisitionDefinition" },
     { "$ref": "#/definitions/extendsDefinition" },
+    { "$ref": "#/definitions/tsNodeDefinition" },
     {
       "anyOf": [
         { "$ref": "#/definitions/filesDefinition" },


### PR DESCRIPTION
Recently we added a feature to ts-node where it can pull its configuration from your tsconfig.json.  This patch adds ts-node's configuration object to the tsconfig schema.

We already ship 2 copies of the schema inside of ts-node: https://unpkg.com/browse/ts-node@8.6.2/
One references and extends the schema from schemastore.  The other is created by merging our changes into the schema from schemastore.  This PR is essentially submitting the latter.

The benefit of merging into schemastore is that users get tooling for ts-node's config object automatically.  Otherwise, they need to add a custom `"$schema"` property to their tsconfig files.

Is it sensible to merge this?  Or are there good reasons to avoid putting ts-node-specific flags into the schema?