### PR TITLE
Updated Travis to use Redis not Redis-Server

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -176,7 +176,7 @@
         "neo4j",
         "postgresql",
         "rabbitmq",
-        "redis-server",
+        "redis",
         "rethinkdb",
         "riak",
         "xvfb"


### PR DESCRIPTION
Redis-Server is a depreciated alias, the new schema validation feature alerts to use of redis-server and expects redis as resolution.