### PR TITLE
[tsconfig.json] [jsconfig.json] Update module and lib with es2020 values

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -110,14 +110,14 @@
               "type": "string"
             },
             "module": {
-              "description": "When down-level compiling, specify module code generation: 'none', 'commonJS', 'amd', 'system', 'umd', 'es2015' or 'esnext'.",
+              "description": "When down-level compiling, specify module code generation: 'none', 'commonJS', 'amd', 'system', 'umd', 'es2015', 'es2020' or 'esnext'.",
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [ "commonJS", "amd", "umd", "system", "es6", "es2015", "esnext", "none" ]
+                  "enum": [ "commonJS", "amd", "umd", "system", "es6", "es2015", "es2020", "esnext", "none" ]
                 },
                 {
-                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|(201[567])|[Nn][Ee][Xx][Tt])|[Nn][Oo][Nn][Ee])$"
+                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|201[567]|2020|[Nn][Ee][Xx][Tt])|[Nn][Oo][Nn][Ee])$"
                 }
               ]
             },
@@ -381,6 +381,8 @@
                       "es2019.symbol",
 
                       "es2020",
+                      "es2020.bigint",
+                      "es2020.promise",
                       "es2020.string",
                       "es2020.symbol.wellknown",
 
@@ -419,7 +421,7 @@
                     "pattern": "^[Ee][Ss]2019(\\.([Aa][Rr][Rr][Aa][Yy]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll]))?$"
                   },
                   {
-                    "pattern": "^[Ee][Ss]2020(\\.([Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll].[Ww][Ee][Ll][Ll][Kk][Nn][Oo][Ww][Nn]))?$"
+                    "pattern": "^[Ee][Ss]2020(\\.([Bb][Ii][Gg][Ii][Nn][Tt]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll].[Ww][Ee][Ll][Ll][Kk][Nn][Oo][Ww][Nn]))?$"
                   },
                   {
                     "pattern": "^[Ee][Ss][Nn][Ee][Xx][Tt](\\.([Aa][Rr][Rr][Aa][Yy]|[Aa][Ss][Yy][Nn][Cc][Ii][Tt][Ee][Rr][Aa][Bb][Ll][Ee]|[Bb][Ii][Gg][Ii][Nn][Tt]|[Ii][Nn][Tt][Ll]|[Ss][Yy][Mm][Bb][Oo][Ll]))?$"
@@ -505,7 +507,7 @@
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it.",
               "type": "boolean"
-            }   
+            }
           },
           "additionalProperties": false
         }

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -120,14 +120,14 @@
               "type": "string"
             },
             "module": {
-              "description": "Specify module code generation: 'None', 'CommonJS', 'AMD', 'System', 'UMD', 'ES6', 'ES2015' or 'ESNext'. Only 'AMD' and 'System' can be used in conjunction with --outFile. 'ES6' and 'ES2015' values may be used when targeting 'ES5' or lower.",
+              "description": "Specify module code generation: 'None', 'CommonJS', 'AMD', 'System', 'UMD', 'ES6', 'ES2015', 'ES2020' or 'ESNext'. Only 'AMD' and 'System' can be used in conjunction with --outFile.",
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [ "CommonJS", "AMD", "System", "UMD", "ES6", "ES2015", "ESNext", "None" ]
+                  "enum": [ "CommonJS", "AMD", "System", "UMD", "ES6", "ES2015", "ES2020", "ESNext", "None" ]
                 },
                 {
-                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|(201[567])|[Nn][Ee][Xx][Tt])|[Nn][Oo][Nn][Ee])$"
+                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|201[567]|2020|[Nn][Ee][Xx][Tt])|[Nn][Oo][Nn][Ee])$"
                 }
               ]
             },
@@ -445,6 +445,8 @@
                       "ES2019.Symbol",
 
                       "ES2020",
+                      "ES2020.BigInt",
+                      "ES2020.Promise",
                       "ES2020.String",
                       "ES2020.Symbol.WellKnown",
 
@@ -483,7 +485,7 @@
                     "pattern": "^[Ee][Ss]2019(\\.([Aa][Rr][Rr][Aa][Yy]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll]))?$"
                   },
                   {
-                    "pattern": "^[Ee][Ss]2020(\\.([Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll].[Ww][Ee][Ll][Ll][Kk][Nn][Oo][Ww][Nn]))?$"
+                    "pattern": "^[Ee][Ss]2020(\\.([Bb][Ii][Gg][Ii][Nn][Tt]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll].[Ww][Ee][Ll][Ll][Kk][Nn][Oo][Ww][Nn]))?$"
                   },
                   {
                     "pattern": "^[Ee][Ss][Nn][Ee][Xx][Tt](\\.([Aa][Rr][Rr][Aa][Yy]|[Aa][Ss][Yy][Nn][Cc][Ii][Tt][Ee][Rr][Aa][Bb][Ll][Ee]|[Bb][Ii][Gg][Ii][Nn][Tt]|[Ii][Nn][Tt][Ll]|[Ss][Yy][Mm][Bb][Oo][Ll]))?$"
@@ -583,7 +585,7 @@
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it.",
               "type": "boolean"
-            }              
+            }
           }
         }
       }


### PR DESCRIPTION
I also am opting to remove the message

> 'ES6' and 'ES2015' values may be used when targeting 'ES5' or lower.

because

1. That list will grow by one element a year and become unwieldy.
2. It makes it sound as if ES6+ values can _only_ be used when targeting ES5 or lower, which isn’t true. The message seems to be just a reassurance that a particular combination _is_ valid, when that should be the default assumption in the absence of any errors.