### PR TITLE
Add docker-compose to JSON schema catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -401,6 +401,29 @@
       }
     },
     {
+      "name": "docker-compose.yaml",
+      "description": "A JSON schema for Docker Compose configuration files",
+      "fileMatch": ["docker-compose.yaml", "docker-compose.yml", "docker-compose.override.yaml", "docker-compose.override.yml"],
+      "url": "http://json.schemastore.org/docker-compose",
+      "versions": {
+        "1": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v1.json",
+        "2.0": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v2.0.json",
+        "2.1": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v2.1.json",
+        "2.2": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v2.2.json",
+        "2.3": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v2.3.json",
+        "2.4": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v2.4.json",
+        "3.0": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.0.json",
+        "3.1": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.1.json",
+        "3.2": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.2.json",
+        "3.3": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.3.json",
+        "3.4": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.4.json",
+        "3.5": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.5.json",
+        "3.6": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.6.json",
+        "3.7": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.7.json",
+        "3.8": "https://raw.githubusercontent.com/docker/compose/master/compose/config/config_schema_v3.8.json"
+      }
+    },
+    {
       "name": "Dolittle Artifacts",
       "description": "A JSON schema for a Dolittle bounded context's artifacts",
       "fileMatch": [".dolittle/artifacts.json"],


### PR DESCRIPTION
This PR adds the docker-compose JSON schema files.

A few notes:

  * I made it match to [the official file names](https://github.com/docker/compose/blob/80ba1f07f38aa38c19fa561fcf6c710cddeaafcf/compose/config/config.py#L154) but I know that it's common to also have patterns like these for such files: `*-compose.*.ya?ml`

  * It's usually only YAML files, not JSON. I don't know if they're handled differently in this repo.

  * I am not sure what should be used for the `url` key. The version is identified by the `$.version` value inside the YAML document, so maybe there's a way (in the schema itself or in the metadata here) to identify which version to use based on that?
