### PR TITLE
Ansible: Add 2.9 schema to catalog API and update default url

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -12,7 +12,7 @@
     {
       "name": "Ansible",
       "description": "Ansible task files",
-      "url": "http://json.schemastore.org/ansible-stable-2.7",
+      "url": "http://json.schemastore.org/ansible-stable-2.9",
       "fileMatch": ["tasks/*.yml", "tasks/*.yaml"],
       "versions": {
         "2.0": "http://json.schemastore.org/ansible-stable-2.0",
@@ -22,7 +22,8 @@
         "2.4": "http://json.schemastore.org/ansible-stable-2.4",
         "2.5": "http://json.schemastore.org/ansible-stable-2.5",
         "2.6": "http://json.schemastore.org/ansible-stable-2.6",
-        "2.7": "http://json.schemastore.org/ansible-stable-2.7"
+        "2.7": "http://json.schemastore.org/ansible-stable-2.7",
+        "2.9": "http://json.schemastore.org/ansible-stable-2.9"
       }
     },
     {


### PR DESCRIPTION
The 2.9 schema was added in #943, but is still missing from catalog.json. This PR adds version 2.9 and updates the default URL so that the 2.9 schema will be exposed [here](http://schemastore.org/api/json/catalog.json).