### PR TITLE
Fix suggestions for depend & softdepend

### DIFF
--- a/src/schemas/json/bungee-plugin.json
+++ b/src/schemas/json/bungee-plugin.json
@@ -29,14 +29,14 @@
       "description": "Plugin author.",
       "type": "string"
     },
-    "depend": {
+    "depends": {
       "description": "Plugin hard dependencies.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/plugin-name"
       }
     },
-    "softdepend": {
+    "softdepends": {
       "description": "Plugin soft dependencies.",
       "type": "array",
       "items": {


### PR DESCRIPTION
https://github.com/SpigotMC/BungeeCord/blob/master/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java#L35-L42

The names for `depend` and `softdepend` should be `depends` and `softdepends`.
`depend` and `softdepend` are correct for Bukkit, but not BungeeCord.