### PR TITLE
Allow empty needs array for Gitlab 12.8

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -584,8 +584,7 @@
                 "required": ["job"]
               }
             ]
-          },
-          "minItems": 1
+          }
         },
         "except": {
           "$ref": "#/definitions/filter",


### PR DESCRIPTION
See https://docs.gitlab.com/ee/ci/yaml/#needs and https://about.gitlab.com/releases/2020/02/22/gitlab-12-8-released/#jobs-in-directed-acyclic-graph-dag-pipelines-can-be-set-up-with-no-predecessors