### PR TITLE
Fix incorrect "Incomatible types" warning for tslint import-blacklist

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -876,7 +876,30 @@
             "options": {
               "type": "array",
               "items": {
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minLength": 1
+                  }
+                ]
               },
               "minItems": 1,
               "uniqueItems": true


### PR DESCRIPTION
Updated the schema according to the doc in https://palantir.github.io/tslint/rules/import-blacklist/

See also https://youtrack.jetbrains.com/issue/WEB-44193