### PR TITLE
Fix URL for .nodehawkrc store

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -768,7 +768,7 @@
     {
       "name": ".nodehawkrc",
       "description": "JSON schema for .nodehawkrc configuration files.",
-      "url": "http://json.schemastore.org/nodehawk",
+      "url": "http://json.schemastore.org/nodehawkrc",
       "fileMatch": [".nodehawkrc"]
     },
     {


### PR DESCRIPTION
As per #965, here is a PR to fix the URL of the `.nodehawkrc` configuration file.