### PR TITLE
Add "xcode11.3" as valid `osx_image` value in travis schema

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -211,7 +211,8 @@
         "xcode10.3",
         "xcode11",
         "xcode11.1",
-        "xcode11.2"
+        "xcode11.2",
+        "xcode11.3"
       ]
     },
     "envVars": {


### PR DESCRIPTION
Travis CI released new Xcode 11.3 (11C29) build environment back in December 2019.

- https://changelog.travis-ci.com/xcode-11-3-image-released-131459
- https://docs.travis-ci.com/user/reference/osx/