### PR TITLE
JSDoc config file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1,19 +1,24 @@
 {
   "$schema": "http://json.schemastore.org/schema-catalog",
-
   "version": 1.0,
   "schemas": [
     {
       "name": ".angular-cli.json",
       "description": "Angular CLI configuration file",
-      "fileMatch": [".angular-cli.json", "angular-cli.json"],
+      "fileMatch": [
+        ".angular-cli.json",
+        "angular-cli.json"
+      ],
       "url": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/schema.json"
     },
     {
       "name": "Ansible",
       "description": "Ansible task files",
       "url": "http://json.schemastore.org/ansible-stable-2.9",
-      "fileMatch": ["tasks/*.yml", "tasks/*.yaml"],
+      "fileMatch": [
+        "tasks/*.yml",
+        "tasks/*.yaml"
+      ],
       "versions": {
         "2.0": "http://json.schemastore.org/ansible-stable-2.0",
         "2.1": "http://json.schemastore.org/ansible-stable-2.1",
@@ -29,37 +34,52 @@
     {
       "name": "apple-app-site-association",
       "description": "Apple Universal Link, App Site Association",
-      "fileMatch": ["apple-app-site-association"],
+      "fileMatch": [
+        "apple-app-site-association"
+      ],
       "url": "http://json.schemastore.org/apple-app-site-association"
     },
     {
       "name": "appsscript.json",
       "description": "Google Apps Script manifest file",
-      "fileMatch": ["appsscript.json"],
+      "fileMatch": [
+        "appsscript.json"
+      ],
       "url": "http://json.schemastore.org/appsscript"
     },
     {
       "name": "appsettings.json",
       "description": "ASP.NET Core's configuration file",
-      "fileMatch": ["appsettings.json", "appsettings.*.json"],
+      "fileMatch": [
+        "appsettings.json",
+        "appsettings.*.json"
+      ],
       "url": "http://json.schemastore.org/appsettings"
     },
     {
       "name": "appveyor.yml",
       "description": "AppVeyor CI configuration file",
-      "fileMatch": ["appveyor.yml"],
+      "fileMatch": [
+        "appveyor.yml"
+      ],
       "url": "http://json.schemastore.org/appveyor"
     },
     {
       "name": "arc.json",
       "description": "A JSON schema for OpenJS Architect",
-      "fileMatch": ["arc.json", "arc.yml", "arc.yaml"],
+      "fileMatch": [
+        "arc.json",
+        "arc.yml",
+        "arc.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/architect/parser/master/schema.json"
     },
     {
       "name": "Avro Avsc",
       "description": "Avro Schema Avsc file",
-      "fileMatch": [".avsc"],
+      "fileMatch": [
+        ".avsc"
+      ],
       "url": "http://json.schemastore.org/avro-avsc"
     },
     {
@@ -74,7 +94,10 @@
     {
       "name": "Azure IoT Edge deployment template",
       "description": "Azure IoT Edge deployment template schema",
-      "fileMatch": ["deployment.template.json", "deployment.*.template.json"],
+      "fileMatch": [
+        "deployment.template.json",
+        "deployment.*.template.json"
+      ],
       "url": "http://json.schemastore.org/azure-iot-edge-deployment-template-2.0",
       "versions": {
         "1.0": "http://json.schemastore.org/azure-iot-edge-deployment-template-1.0",
@@ -84,73 +107,101 @@
     {
       "name": "Foxx Manifest",
       "description": "ArangoDB Foxx service manifest file",
-      "fileMatch": ["manifest.json"],
+      "fileMatch": [
+        "manifest.json"
+      ],
       "url": "http://json.schemastore.org/foxx-manifest"
     },
     {
       "name": ".asmdef",
       "description": "Unity 3D assembly definition file",
-      "fileMatch": ["*.asmdef"],
+      "fileMatch": [
+        "*.asmdef"
+      ],
       "url": "http://json.schemastore.org/asmdef"
     },
     {
       "name": "babelrc.json",
       "description": "Babel configuration file",
-      "fileMatch": [".babelrc", "babel.config.json"],
+      "fileMatch": [
+        ".babelrc",
+        "babel.config.json"
+      ],
       "url": "http://json.schemastore.org/babelrc"
     },
     {
       "name": ".backportrc.json",
       "description": "Backport configuration file",
-      "fileMatch": [".backportrc.json"],
+      "fileMatch": [
+        ".backportrc.json"
+      ],
       "url": "http://json.schemastore.org/backportrc"
     },
     {
       "name": "batect.yml",
       "description": "batect configuration file",
-      "fileMatch": ["batect.yml"],
+      "fileMatch": [
+        "batect.yml"
+      ],
       "url": "https://batect.dev/configSchema.json"
     },
     {
       "name": ".bootstraprc",
       "description": "Webpack bootstrap-loader configuration file",
-      "fileMatch": [".bootstraprc"],
+      "fileMatch": [
+        ".bootstraprc"
+      ],
       "url": "http://json.schemastore.org/bootstraprc"
     },
     {
       "name": "bower.json",
       "description": "Bower package description file",
-      "fileMatch": ["bower.json", ".bower.json"],
+      "fileMatch": [
+        "bower.json",
+        ".bower.json"
+      ],
       "url": "http://json.schemastore.org/bower"
     },
     {
       "name": ".bowerrc",
       "description": "Bower configuration file",
-      "fileMatch": [".bowerrc"],
+      "fileMatch": [
+        ".bowerrc"
+      ],
       "url": "http://json.schemastore.org/bowerrc"
     },
     {
       "name": "behat.yml",
       "description": "Behat configuration file",
-      "fileMatch": ["behat.yml", "*.behat.yml"],
+      "fileMatch": [
+        "behat.yml",
+        "*.behat.yml"
+      ],
       "url": "http://json.schemastore.org/behat"
     },
     {
       "name": "bozr.suite.json",
       "description": "Bozr test suite file",
-      "fileMatch": [".suite.json", ".xsuite.json"],
+      "fileMatch": [
+        ".suite.json",
+        ".xsuite.json"
+      ],
       "url": "http://json.schemastore.org/bozr"
     },
     {
       "name": "bucklescript",
       "description": "BuckleScript configuration file",
-      "fileMatch": ["bsconfig.json"],
+      "fileMatch": [
+        "bsconfig.json"
+      ],
       "url": "https://bucklescript.github.io/bucklescript/docson/build-schema.json"
     },
     {
       "name": "Bukkit plugin.yml",
       "description": "Schema for Minecraft Bukkit plugin description files",
-      "fileMatch": ["plugin.yml"],
+      "fileMatch": [
+        "plugin.yml"
+      ],
       "url": "http://json.schemastore.org/bukkit-plugin"
     },
     {
@@ -175,19 +226,26 @@
     {
       "name": ".build.yml",
       "description": "Sourcehut Build Manifest",
-      "fileMatch": [".build.yml"],
+      "fileMatch": [
+        ".build.yml"
+      ],
       "url": "http://json.schemastore.org/sourcehut-build"
     },
     {
       "name": "bundleconfig.json",
       "description": "Schema for bundleconfig.json files",
-      "fileMatch": ["bundleconfig.json"],
+      "fileMatch": [
+        "bundleconfig.json"
+      ],
       "url": "http://json.schemastore.org/bundleconfig"
     },
     {
       "name": "BungeeCord plugin.yml",
       "description": "Schema for BungeeCord plugin description files",
-      "fileMatch": ["plugin.yml", "bungee.yml"],
+      "fileMatch": [
+        "plugin.yml",
+        "bungee.yml"
+      ],
       "url": "http://json.schemastore.org/bungee-plugin"
     },
     {
@@ -201,49 +259,66 @@
     {
       "name": "circleciconfig.json",
       "description": "Schema for CircleCI 2.0 config files",
-      "fileMatch": [".circleci/config.yml"],
+      "fileMatch": [
+        ".circleci/config.yml"
+      ],
       "url": "http://json.schemastore.org/circleciconfig"
     },
     {
       "name": ".cirrus.yml",
       "description": "Cirrus CI configuration files",
-      "fileMatch": [".cirrus.yml"],
+      "fileMatch": [
+        ".cirrus.yml"
+      ],
       "url": "http://json.schemastore.org/cirrus"
     },
     {
       "name": ".clasp.json",
       "description": "Google Apps Script CLI project file",
-      "fileMatch": [".clasp.json"],
+      "fileMatch": [
+        ".clasp.json"
+      ],
       "url": "http://json.schemastore.org/clasp"
     },
     {
       "name": "JSON schema for Codecov configuration files",
       "description": "Schema for codecov.yml files.",
-      "fileMatch": [".codecov.yml", "codecov.yml"],
+      "fileMatch": [
+        ".codecov.yml",
+        "codecov.yml"
+      ],
       "url": "http://json.schemastore.org/codecov"
     },
     {
       "name": "compilerconfig.json",
       "description": "Schema for compilerconfig.json files",
-      "fileMatch": ["compilerconfig.json"],
+      "fileMatch": [
+        "compilerconfig.json"
+      ],
       "url": "http://json.schemastore.org/compilerconfig"
     },
     {
       "name": "compile_commands.json",
       "description": "LLVM compilation database",
-      "fileMatch": ["compile_commands.json"],
+      "fileMatch": [
+        "compile_commands.json"
+      ],
       "url": "http://json.schemastore.org/compile-commands"
     },
     {
       "name": "commands.json",
       "description": "Config file for Command Task Runner",
-      "fileMatch": ["commands.json"],
+      "fileMatch": [
+        "commands.json"
+      ],
       "url": "http://json.schemastore.org/commands"
     },
     {
       "name": "cosmos.config.json",
       "description": "React Cosmos configuration file",
-      "fileMatch": ["cosmos.config.json"],
+      "fileMatch": [
+        "cosmos.config.json"
+      ],
       "url": "http://json.schemastore.org/cosmos-config"
     },
     {
@@ -254,19 +329,25 @@
     {
       "name": "chutzpah.json",
       "description": "Chutzpah configuration file",
-      "fileMatch": ["chutzpah.json"],
+      "fileMatch": [
+        "chutzpah.json"
+      ],
       "url": "http://json.schemastore.org/chutzpah"
     },
     {
       "name": "contentmanifest.json",
       "description": "Visual Studio manifest injection file",
-      "fileMatch": ["contentmanifest.json"],
+      "fileMatch": [
+        "contentmanifest.json"
+      ],
       "url": "http://json.schemastore.org/vsix-manifestinjection"
     },
     {
       "name": "cloud-sdk-pipeline-config-schema",
       "description": "SAP Cloud SDK Pipeline configuration",
-      "fileMatch": ["pipeline_config.yml"],
+      "fileMatch": [
+        "pipeline_config.yml"
+      ],
       "url": "http://json.schemastore.org/cloud-sdk-pipeline-config-schema.json"
     },
     {
@@ -311,91 +392,123 @@
     {
       "name": "coffeelint.json",
       "description": "CoffeeLint configuration file",
-      "fileMatch": ["coffeelint.json"],
+      "fileMatch": [
+        "coffeelint.json"
+      ],
       "url": "http://json.schemastore.org/coffeelint"
     },
     {
       "name": "composer.json",
       "description": "PHP Composer configuration file",
-      "fileMatch": ["composer.json"],
+      "fileMatch": [
+        "composer.json"
+      ],
       "url": "http://json.schemastore.org/composer"
     },
     {
       "name": "component.json",
       "description": "Web component file",
-      "fileMatch": ["component.json"],
+      "fileMatch": [
+        "component.json"
+      ],
       "url": "http://json.schemastore.org/component"
     },
     {
       "name": "config.json",
       "description": "ASP.NET project config file",
-      "fileMatch": ["config.json"],
+      "fileMatch": [
+        "config.json"
+      ],
       "url": "http://json.schemastore.org/config"
     },
     {
       "name": "contribute.json",
       "description": "A JSON schema for open-source project contribution data by Mozilla",
-      "fileMatch": ["contribute.json"],
+      "fileMatch": [
+        "contribute.json"
+      ],
       "url": "http://json.schemastore.org/contribute"
     },
     {
       "name": "cypress.json",
       "description": "Cypress.io test runner configuration file",
-      "fileMatch": ["cypress.json"],
+      "fileMatch": [
+        "cypress.json"
+      ],
       "url": "https://raw.githubusercontent.com/cypress-io/cypress/develop/cli/schema/cypress.schema.json"
     },
     {
       "name": ".creatomic",
       "description": "A config for Atomic Design 4 React generator",
-      "fileMatch": [".creatomic"],
+      "fileMatch": [
+        ".creatomic"
+      ],
       "url": "http://json.schemastore.org/creatomic"
     },
     {
       "name": "cspell",
       "description": "JSON schema for cspell configuration file",
-      "fileMatch": [".cspell.json", "cspell.json", "cSpell.json"],
+      "fileMatch": [
+        ".cspell.json",
+        "cspell.json",
+        "cSpell.json"
+      ],
       "url": "https://raw.githubusercontent.com/streetsidesoftware/cspell/master/cspell.schema.json"
     },
     {
       "name": ".csscomb.json",
       "description": "A JSON schema CSS Comb's configuration file",
-      "fileMatch": [".csscomb.json"],
+      "fileMatch": [
+        ".csscomb.json"
+      ],
       "url": "http://json.schemastore.org/csscomb"
     },
     {
       "name": ".csslintrc",
       "description": "A JSON schema CSS Lint's configuration file",
-      "fileMatch": [".csslintrc"],
+      "fileMatch": [
+        ".csslintrc"
+      ],
       "url": "http://json.schemastore.org/csslintrc"
     },
     {
       "name": "datalogic-scan2deploy-android",
       "description": "Datalogic Scan2Deploy Android file",
-      "fileMatch": [".dla.json"],
+      "fileMatch": [
+        ".dla.json"
+      ],
       "url": "http://json.schemastore.org/datalogic-scan2deploy-android"
     },
     {
       "name": "datalogic-scan2deploy-ce",
       "description": "Datalogic Scan2Deploy CE file",
-      "fileMatch": [".dlc.json"],
+      "fileMatch": [
+        ".dlc.json"
+      ],
       "url": "http://json.schemastore.org/datalogic-scan2deploy-ce"
     },
     {
       "name": "debugsettings.json",
       "description": "A JSON schema for the ASP.NET DebugSettings.json files",
-      "fileMatch": ["debugsettings.json"],
+      "fileMatch": [
+        "debugsettings.json"
+      ],
       "url": "http://json.schemastore.org/debugsettings"
     },
     {
       "name": "dependabot.json",
       "description": "A JSON schema for the Dependabot config.yml files",
-      "fileMatch": [".dependabot/config.yml"],
+      "fileMatch": [
+        ".dependabot/config.yml"
+      ],
       "url": "http://json.schemastore.org/dependabot"
     },
     {
       "name": "docfx.json",
       "description": "A JSON schema for DocFx configuraton files",
-      "fileMatch": ["docfx.json"],
+      "fileMatch": [
+        "docfx.json"
+      ],
       "url": "http://json.schemastore.org/docfx",
       "versions": {
         "2.8.0": "http://json.schemastore.org/docfx-2.8.0"
@@ -404,67 +517,89 @@
     {
       "name": "Dolittle Artifacts",
       "description": "A JSON schema for a Dolittle bounded context's artifacts",
-      "fileMatch": [".dolittle/artifacts.json"],
+      "fileMatch": [
+        ".dolittle/artifacts.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/master/Schemas/Artifacts.Configuration/artifacts.json"
     },
     {
       "name": "Dolittle Bounded Context Configuration",
       "description": "A JSON schema for Dolittle application's bounded context configuration",
-      "fileMatch": ["bounded-context.json"],
+      "fileMatch": [
+        "bounded-context.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Applications.Configuration/bounded-context.json"
     },
     {
       "name": "Dolittle Event Horizons Configuration",
       "description": "A JSON schema for a Dolittle bounded context's event horizon configurations",
-      "fileMatch": [".dolittle/event-horizons.json"],
+      "fileMatch": [
+        ".dolittle/event-horizons.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Events/event-horizons.json"
     },
     {
       "name": "Dolittle Resources Configuration",
       "description": "A JSON schema for a Dolittle bounded context's resource configurations",
-      "fileMatch": [".dolittle/resources.json"],
+      "fileMatch": [
+        ".dolittle/resources.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.Fundamentals/master/Schemas/ResourceTypes.Configuration/resources.json"
     },
     {
       "name": "Dolittle Server Configuration",
       "description": "A JSON schema for a Dolittle bounded context's event horizon's interaction server configuration",
-      "fileMatch": [".dolittle/server.json"],
+      "fileMatch": [
+        ".dolittle/server.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Server/server.json"
     },
     {
       "name": "Dolittle Tenants Configuration",
       "description": "A JSON schema for a Dolittle bounded context's tenant configuration",
-      "fileMatch": [".dolittle/tenants.json"],
+      "fileMatch": [
+        ".dolittle/tenants.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Tenancy/tenants.json"
     },
     {
       "name": "Dolittle Tenant Map Configuration",
       "description": "A JSON schema for a Dolittle bounded context's tenant mapping configurations",
-      "fileMatch": [".dolittle/tenant-map.json"],
+      "fileMatch": [
+        ".dolittle/tenant-map.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.Fundamentals/master/Schemas/Tenancy.Configuration/tenant-map.json"
     },
     {
       "name": "Dolittle Topology",
       "description": "A JSON schema for a Dolittle bounded context's topology",
-      "fileMatch": [".dolittle/topology.json"],
+      "fileMatch": [
+        ".dolittle/topology.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/master/Schemas/Applications.Configuration/topology.json"
     },
     {
       "name": "dotnetcli.host.json",
       "description": "JSON schema for .NET CLI template host files",
-      "fileMatch": ["dotnetcli.host.json"],
+      "fileMatch": [
+        "dotnetcli.host.json"
+      ],
       "url": "http://json.schemastore.org/dotnetcli.host"
     },
     {
       "name": "drone.json",
       "description": "Drone CI configuration file",
-      "fileMatch": [ ".drone.yml" ],
+      "fileMatch": [
+        ".drone.yml"
+      ],
       "url": "http://json.schemastore.org/drone"
     },
     {
       "name": "Drush site aliases",
       "description": "JSON Schema for Drush 9 site aliases file",
-      "fileMatch": ["sites/*.site.yml"],
+      "fileMatch": [
+        "sites/*.site.yml"
+      ],
       "url": "http://json.schemastore.org/drush.site.yml"
     },
     {
@@ -480,13 +615,17 @@
     {
       "name": "epr-manifest.json",
       "description": "Entry Point Regulation manifest file",
-      "fileMatch": ["epr-manifest.json"],
+      "fileMatch": [
+        "epr-manifest.json"
+      ],
       "url": "http://json.schemastore.org/epr-manifest"
     },
     {
       "name": "electron-builder configuration file.",
       "description": "JSON schema for electron-build configuration file.",
-      "fileMatch": ["electron-builder.json"],
+      "fileMatch": [
+        "electron-builder.json"
+      ],
       "url": "http://json.schemastore.org/electron-builder"
     },
     {
@@ -503,19 +642,25 @@
     {
       "name": "fabric.mod.json",
       "description": "Metadata file used by the Fabric mod loader",
-      "fileMatch": ["fabric.mod.json"],
+      "fileMatch": [
+        "fabric.mod.json"
+      ],
       "url": "http://json.schemastore.org/fabric-mod-json"
     },
     {
       "name": "Fantomas",
       "description": "Fantomas configuration file",
-      "fileMatch": ["fantomas-config.json"],
+      "fileMatch": [
+        "fantomas-config.json"
+      ],
       "url": "http://json.schemastore.org/fantomas"
     },
     {
       "name": "function.json",
       "description": "JSON schema for Azure Functions function.json files",
-      "fileMatch": ["function.json"],
+      "fileMatch": [
+        "function.json"
+      ],
       "url": "http://json.schemastore.org/function"
     },
     {
@@ -526,151 +671,204 @@
     {
       "name": "GitHub Action",
       "description": "YAML schema for GitHub Actions",
-      "fileMatch": ["action.yml"],
+      "fileMatch": [
+        "action.yml"
+      ],
       "url": "http://json.schemastore.org/github-action"
     },
     {
       "name": "GitHub Workflow",
       "description": "YAML schema for GitHub Workflow",
-      "fileMatch": [".github/workflows/**.yml", ".github/workflows/**.yaml"],
+      "fileMatch": [
+        ".github/workflows/**.yml",
+        ".github/workflows/**.yaml"
+      ],
       "url": "http://json.schemastore.org/github-workflow"
     },
     {
       "name": "gitlab-ci",
       "description": "JSON schema for configuring Gitlab CI",
-      "fileMatch": [".gitlab-ci.yml"],
+      "fileMatch": [
+        ".gitlab-ci.yml"
+      ],
       "url": "http://json.schemastore.org/gitlab-ci"
     },
     {
       "name": "Gitpod Configuration",
       "description": "JSON schema for configuring Gitpod.io",
-      "fileMatch": [".gitpod.yml"],
+      "fileMatch": [
+        ".gitpod.yml"
+      ],
       "url": "https://gitpod.io/schemas/gitpod-schema.json"
     },
     {
       "name": "global.json",
       "description": "ASP.NET global configuration file",
-      "fileMatch": ["global.json"],
+      "fileMatch": [
+        "global.json"
+      ],
       "url": "http://json.schemastore.org/global"
     },
     {
       "name": "Grunt copy task",
       "description": "Grunt copy task configuration file",
-      "fileMatch": ["copy.json"],
+      "fileMatch": [
+        "copy.json"
+      ],
       "url": "http://json.schemastore.org/grunt-copy-task"
     },
     {
       "name": "Grunt clean task",
       "description": "Grunt clean task configuration file",
-      "fileMatch": ["clean.json"],
+      "fileMatch": [
+        "clean.json"
+      ],
       "url": "http://json.schemastore.org/grunt-clean-task"
     },
     {
       "name": "Grunt cssmin task",
       "description": "Grunt cssmin task configuration file",
-      "fileMatch": ["cssmin.json"],
+      "fileMatch": [
+        "cssmin.json"
+      ],
       "url": "http://json.schemastore.org/grunt-cssmin-task"
     },
     {
       "name": "Grunt JSHint task",
       "description": "Grunt JSHint task configuration file",
-      "fileMatch": ["jshint.json"],
+      "fileMatch": [
+        "jshint.json"
+      ],
       "url": "http://json.schemastore.org/grunt-jshint-task"
     },
     {
       "name": "Grunt Watch task",
       "description": "Grunt Watch task configuration file",
-      "fileMatch": ["watch.json"],
+      "fileMatch": [
+        "watch.json"
+      ],
       "url": "http://json.schemastore.org/grunt-watch-task"
     },
     {
       "name": "Grunt base task",
       "description": "Schema for standard Grunt tasks",
-      "fileMatch": ["grunt/*.json", "*-tasks.json"],
+      "fileMatch": [
+        "grunt/*.json",
+        "*-tasks.json"
+      ],
       "url": "http://json.schemastore.org/grunt-task"
     },
     {
       "name": "haxelib.json",
       "description": "Haxelib manifest",
-      "fileMatch": ["haxelib.json"],
+      "fileMatch": [
+        "haxelib.json"
+      ],
       "url": "http://json.schemastore.org/haxelib"
     },
     {
       "name": "host.json",
       "description": "JSON schema for Azure Functions host.json files",
-      "fileMatch": ["host.json"],
+      "fileMatch": [
+        "host.json"
+      ],
       "url": "http://json.schemastore.org/host"
     },
     {
       "name": "host-meta.json",
       "description": "Schema for host-meta JDR files",
-      "fileMatch": ["host-meta.json"],
+      "fileMatch": [
+        "host-meta.json"
+      ],
       "url": "http://json.schemastore.org/host-meta"
     },
     {
       "name": ".htmlhintrc",
       "description": "HTML Hint configuration file",
-      "fileMatch": [".htmlhintrc"],
+      "fileMatch": [
+        ".htmlhintrc"
+      ],
       "url": "http://json.schemastore.org/htmlhint"
     },
     {
       "name": "imageoptimizer.json",
       "description": "Schema for imageoptimizer.json files",
-      "fileMatch": ["imageoptimizer.json"],
+      "fileMatch": [
+        "imageoptimizer.json"
+      ],
       "url": "http://json.schemastore.org/imageoptimizer"
     },
     {
       "name": "Jekyll configuration",
       "description": "Schema for Jekyll _config.yml",
-      "fileMatch": ["_config.yml"],
+      "fileMatch": [
+        "_config.yml"
+      ],
       "url": "http://json.schemastore.org/jekyll"
     },
     {
       "name": "Jenkins X Pipelines",
       "description": "Jenkins X Pipeline YAML configuration files",
-      "fileMatch": ["jenkins-x*.yml"],
+      "fileMatch": [
+        "jenkins-x*.yml"
+      ],
       "url": "https://jenkins-x.io/schemas/jx-schema.json"
     },
     {
       "name": "Jenkins X Requirements",
       "description": "Jenkins X Requirements YAML configuration file",
-      "fileMatch": ["jx-requirements.yml"],
+      "fileMatch": [
+        "jx-requirements.yml"
+      ],
       "url": "https://jenkins-x.io/schemas/jx-requirements.json"
     },
     {
       "name": ".jsbeautifyrc",
       "description": "js-beautify configuration file",
-      "fileMatch": [".jsbeautifyrc"],
+      "fileMatch": [
+        ".jsbeautifyrc"
+      ],
       "url": "http://json.schemastore.org/jsbeautifyrc"
     },
     {
       "name": ".jsbeautifyrc-nested",
       "description": "js-beautify configuration file allowing nested `js`, `css`, and `html` attributes",
-      "fileMatch": [".jsbeautifyrc"],
+      "fileMatch": [
+        ".jsbeautifyrc"
+      ],
       "url": "http://json.schemastore.org/jsbeautifyrc-nested"
     },
     {
       "name": ".jscsrc",
       "description": "JSCS configuration file",
-      "fileMatch": [".jscsrc", "jscsrc.json"],
+      "fileMatch": [
+        ".jscsrc",
+        "jscsrc.json"
+      ],
       "url": "http://json.schemastore.org/jscsrc"
     },
     {
       "name": ".jshintrc",
       "description": "JSHint configuration file",
-      "fileMatch": [".jshintrc"],
+      "fileMatch": [
+        ".jshintrc"
+      ],
       "url": "http://json.schemastore.org/jshintrc"
     },
     {
       "name": ".jsinspectrc",
       "description": "JSInspect configuration file",
-      "fileMatch": [".jsinspectrc"],
+      "fileMatch": [
+        ".jsinspectrc"
+      ],
       "url": "http://json.schemastore.org/jsinspectrc"
     },
     {
       "name": "JSON-API",
       "description": "JSON API document",
-      "fileMatch": ["*.schema.json"],
+      "fileMatch": [
+        "*.schema.json"
+      ],
       "url": "http://jsonapi.org/schema"
     },
     {
@@ -681,55 +879,75 @@
     {
       "name": "JSON Feed",
       "description": "JSON schema for the JSON Feed format",
-      "fileMatch": ["feed.json"],
+      "fileMatch": [
+        "feed.json"
+      ],
       "url": "http://json.schemastore.org/feed"
     },
     {
       "name": "*.jsonld",
       "description": "JSON Linked Data files",
-      "fileMatch": ["*.jsonld"],
+      "fileMatch": [
+        "*.jsonld"
+      ],
       "url": "http://json.schemastore.org/jsonld"
     },
     {
       "name": "JSONPatch",
       "description": "JSONPatch files",
-      "fileMatch": ["*.patch"],
+      "fileMatch": [
+        "*.patch"
+      ],
       "url": "http://json.schemastore.org/json-patch"
     },
     {
       "name": "jsconfig.json",
       "description": "JavaScript project configuration file",
-      "fileMatch": ["jsconfig.json"],
+      "fileMatch": [
+        "jsconfig.json"
+      ],
       "url": "http://json.schemastore.org/jsconfig"
     },
     {
       "name": "kustomization.yaml",
       "description": "Kubernetes native configuration management",
-      "fileMatch": ["kustomization.yaml", "kustomization.yml"],
+      "fileMatch": [
+        "kustomization.yaml",
+        "kustomization.yml"
+      ],
       "url": "http://json.schemastore.org/kustomization"
     },
     {
       "name": "launchsettings.json",
       "description": "A JSON schema for the ASP.NET LaunchSettings.json files",
-      "fileMatch": ["launchsettings.json"],
+      "fileMatch": [
+        "launchsettings.json"
+      ],
       "url": "http://json.schemastore.org/launchsettings"
     },
     {
       "name": "lerna.json",
       "description": "A JSON schema for lerna.json files",
-      "fileMatch": ["lerna.json"],
+      "fileMatch": [
+        "lerna.json"
+      ],
       "url": "http://json.schemastore.org/lerna"
     },
     {
       "name": "libman.json",
       "description": "JSON schema for client-side library config files",
-      "fileMatch": ["libman.json"],
+      "fileMatch": [
+        "libman.json"
+      ],
       "url": "http://json.schemastore.org/libman"
     },
     {
       "name": "lsdlschema.json",
       "description": "JSON schema for Linguistic Schema Definition Language files",
-      "fileMatch": ["*.lsdl.yaml", "*.lsdl.json"],
+      "fileMatch": [
+        "*.lsdl.yaml",
+        "*.lsdl.json"
+      ],
       "url": "http://json.schemastore.org/lsdlschema"
     },
     {
@@ -740,19 +958,25 @@
     {
       "name": "mimetypes.json",
       "description": "JSON Schema for mime type collections",
-      "fileMatch": ["mimetypes.json"],
+      "fileMatch": [
+        "mimetypes.json"
+      ],
       "url": "http://json.schemastore.org/mimetypes"
     },
     {
       "name": ".modernizrrc",
       "description": "Webpack modernizr-loader configuration file",
-      "fileMatch": [".modernizrrc"],
+      "fileMatch": [
+        ".modernizrrc"
+      ],
       "url": "http://json.schemastore.org/modernizrrc"
     },
     {
       "name": "mycode.json",
       "description": "JSON schema for mycode.js files",
-      "fileMatch": ["mycode.json"],
+      "fileMatch": [
+        "mycode.json"
+      ],
       "url": "http://json.schemastore.org/mycode"
     },
     {
@@ -769,13 +993,17 @@
       "name": ".nodehawkrc",
       "description": "JSON schema for .nodehawkrc configuration files.",
       "url": "http://json.schemastore.org/nodehawkrc",
-      "fileMatch": [".nodehawkrc"]
+      "fileMatch": [
+        ".nodehawkrc"
+      ]
     },
     {
       "name": "nodemon.json",
       "description": "JSON schema for nodemon.json configuration files.",
       "url": "http://json.schemastore.org/nodemon",
-      "fileMatch": ["nodemon.json"]
+      "fileMatch": [
+        "nodemon.json"
+      ]
     },
     {
       "name": ".npmpackagejsonlintrc",
@@ -799,24 +1027,34 @@
       "name": "nswag.json",
       "description": "JSON schema for nswag configuration",
       "url": "http://json.schemastore.org/nswag",
-      "fileMatch": ["nswag.json"]
+      "fileMatch": [
+        "nswag.json"
+      ]
     },
     {
       "name": "ocelot.json",
       "description": "JSON schema for the Ocelot Api Gateway.",
-      "fileMatch": ["ocelot.json"],
+      "fileMatch": [
+        "ocelot.json"
+      ],
       "url": "http://json.schemastore.org/ocelot"
     },
     {
       "name": "omnisharp.json",
       "description": "Omnisharp Configuration file",
-      "fileMatch": ["omnisharp.json"],
+      "fileMatch": [
+        "omnisharp.json"
+      ],
       "url": "http://json.schemastore.org/omnisharp"
     },
     {
       "name": "openapi.json",
       "description": "A JSON schema for Open API documentation files",
-      "fileMatch": ["openapi.json", "openapi.yml", "openapi.yaml"],
+      "fileMatch": [
+        "openapi.json",
+        "openapi.yml",
+        "openapi.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v3.0/schema.json"
     },
     {
@@ -827,13 +1065,17 @@
     {
       "name": "package.json",
       "description": "NPM configuration file",
-      "fileMatch": ["package.json"],
+      "fileMatch": [
+        "package.json"
+      ],
       "url": "http://json.schemastore.org/package"
     },
     {
       "name": "package.manifest",
       "description": "Umbraco package configuration file",
-      "fileMatch": ["package.manifest"],
+      "fileMatch": [
+        "package.manifest"
+      ],
       "url": "http://json.schemastore.org/package.manifest",
       "versions": {
         "8.0.0": "http://json.schemastore.org/package.manifest-8.0.0",
@@ -843,25 +1085,36 @@
     {
       "name": "pattern.json",
       "description": "Patternplate pattern manifest file",
-      "fileMatch": ["pattern.json"],
+      "fileMatch": [
+        "pattern.json"
+      ],
       "url": "http://json.schemastore.org/pattern"
     },
     {
       "name": "PocketMine plugin.yml",
       "description": "PocketMine plugin manifest file",
-      "fileMatch": ["plugin.yml"],
+      "fileMatch": [
+        "plugin.yml"
+      ],
       "url": "http://json.schemastore.org/pocketmine-plugin"
     },
     {
       "name": ".phraseapp.yml",
       "description": "PhraseApp configuration file",
-      "fileMatch": [".phraseapp.yml"],
+      "fileMatch": [
+        ".phraseapp.yml"
+      ],
       "url": "http://json.schemastore.org/phraseapp"
     },
     {
       "name": "prettierrc.json",
       "description": ".prettierrc configuration file",
-      "fileMatch": [".prettierrc", ".prettierrc.json"],
+      "fileMatch": [
+        ".prettierrc",
+        ".prettierrc.json",
+        ".prettierrc.yml",
+        ".prettierrc.yaml"
+      ],
       "url": "http://json.schemastore.org/prettierrc",
       "versions": {
         "1.8.2": "http://json.schemastore.org/prettierrc-1.8.2"
@@ -870,13 +1123,17 @@
     {
       "name": "prisma.yml",
       "description": "prisma.yml service definition file",
-      "fileMatch": ["prisma.yml"],
+      "fileMatch": [
+        "prisma.yml"
+      ],
       "url": "http://json.schemastore.org/prisma"
     },
     {
       "name": "project.json",
       "description": "ASP.NET vNext project configuration file",
-      "fileMatch": ["project.json"],
+      "fileMatch": [
+        "project.json"
+      ],
       "url": "http://json.schemastore.org/project",
       "versions": {
         "1.0.0-beta3": "http://json.schemastore.org/project-1.0.0-beta3",
@@ -927,43 +1184,57 @@
     {
       "name": "prometheus.json",
       "description": "Prometheus configuration file",
-      "fileMatch": ["prometheus.yml"],
+      "fileMatch": [
+        "prometheus.yml"
+      ],
       "url": "http://json.schemastore.org/prometheus"
     },
     {
       "name": "prometheus.rules.json",
       "description": "Prometheus rules file",
-      "fileMatch": ["*.rules"],
+      "fileMatch": [
+        "*.rules"
+      ],
       "url": "http://json.schemastore.org/prometheus.rules"
     },
     {
       "name": "proxies.json",
       "description": "JSON schema for Azure Function Proxies proxies.json files",
-      "fileMatch": ["proxies.json"],
+      "fileMatch": [
+        "proxies.json"
+      ],
       "url": "http://json.schemastore.org/proxies"
     },
     {
       "name": "pubspec.yaml",
       "description": "Schema for pubspecs, the format used by Dart's dependency manager",
-      "fileMatch": ["pubspec.yaml"],
+      "fileMatch": [
+        "pubspec.yaml"
+      ],
       "url": "http://json.schemastore.org/pubspec"
     },
     {
       "name": "pyrseas-0.8.json",
       "description": "Pyrseas database schema versioning for Postgres databases, v0.8",
-      "fileMatch": ["pyrseas-0.8.json"],
+      "fileMatch": [
+        "pyrseas-0.8.json"
+      ],
       "url": "http://json.schemastore.org/pyrseas-0.8"
     },
     {
       "name": "*.resjson",
       "description": "Windows App localization file",
-      "fileMatch": ["*.resjson"],
+      "fileMatch": [
+        "*.resjson"
+      ],
       "url": "http://json.schemastore.org/resjson"
     },
     {
       "name": "JSON Resume",
       "description": "A JSON format to describe resumes",
-      "fileMatch": ["resume.json"],
+      "fileMatch": [
+        "resume.json"
+      ],
       "url": "http://json.schemastore.org/resume"
     },
     {
@@ -1062,235 +1333,326 @@
     {
       "name": "settings.job",
       "description": "Azure Webjob settings file",
-      "fileMatch": ["settings.job"],
+      "fileMatch": [
+        "settings.job"
+      ],
       "url": "http://json.schemastore.org/settings.job"
     },
     {
       "name": "skyuxconfig.json",
       "description": "SKY UX CLI configuration file",
-      "fileMatch": ["skyuxconfig.json", "skyuxconfig.*.json"],
+      "fileMatch": [
+        "skyuxconfig.json",
+        "skyuxconfig.*.json"
+      ],
       "url": "https://raw.githubusercontent.com/blackbaud/skyux-builder/master/skyuxconfig-schema.json"
     },
     {
       "name": "snapcraft",
       "description": "snapcraft project  (https://snapcraft.io)",
-      "fileMatch": [".snapcraft.yaml", "snapcraft.yaml"],
+      "fileMatch": [
+        ".snapcraft.yaml",
+        "snapcraft.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/snapcore/snapcraft/master/schema/snapcraft.json"
     },
     {
       "name": "Solidarity",
       "description": "CLI config for enforcing environment settings",
-      "fileMatch": [".solidarity", ".solidarity.json"],
+      "fileMatch": [
+        ".solidarity",
+        ".solidarity.json"
+      ],
       "url": "http://json.schemastore.org/solidaritySchema"
     },
     {
       "name": "Source Maps v3",
       "description": "Source Map files version 3",
-      "fileMatch": ["*.map"],
+      "fileMatch": [
+        "*.map"
+      ],
       "url": "http://json.schemastore.org/sourcemap-v3"
     },
     {
       "name": ".sprite files",
       "description": "Schema for image sprite generation files",
-      "fileMatch": ["*.sprite"],
+      "fileMatch": [
+        "*.sprite"
+      ],
       "url": "http://json.schemastore.org/sprite"
     },
     {
       "name": "Stryker Mutator",
       "description": "Configuration file for Stryker Mutator, the mutation testing framework for JavaScript and friends. See https://stryker-mutator.io.",
-      "fileMatch": ["stryker.conf.json", "stryker-*.conf.json"],
+      "fileMatch": [
+        "stryker.conf.json",
+        "stryker-*.conf.json"
+      ],
       "url": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/api/schema/stryker-core.json"
     },
     {
       "name": "StyleCop Analyzers Configuration",
       "description": "Configuration file for StyleCop Analyzers",
-      "fileMatch": ["stylecop.json"],
+      "fileMatch": [
+        "stylecop.json"
+      ],
       "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
     },
     {
       "name": ".stylelintrc",
       "description": "Configuration file for stylelint",
-      "fileMatch": [".stylelintrc", "stylelintrc.json", ".stylelintrc.json"],
+      "fileMatch": [
+        ".stylelintrc",
+        "stylelintrc.json",
+        ".stylelintrc.json"
+      ],
       "url": "http://json.schemastore.org/stylelintrc"
     },
     {
       "name": "Swagger API 2.0",
       "description": "Swagger API 2.0 schema",
-      "fileMatch": ["swagger.json"],
+      "fileMatch": [
+        "swagger.json"
+      ],
       "url": "http://json.schemastore.org/swagger-2.0"
     },
     {
       "name": "template.json",
       "description": "JSON schema .NET template files",
-      "fileMatch": [".template.config/template.json"],
+      "fileMatch": [
+        ".template.config/template.json"
+      ],
       "url": "http://json.schemastore.org/template"
     },
     {
       "name": "templatsources.json",
       "description": "SideWaffle template source schema",
-      "fileMatch": ["templatesources.json"],
+      "fileMatch": [
+        "templatesources.json"
+      ],
       "url": "http://json.schemastore.org/templatesources"
     },
     {
       "name": "tmLanguage",
       "description": "Language grammar description files in Textmate and compatible editors",
-      "fileMatch": ["*.tmLanguage.json"],
+      "fileMatch": [
+        "*.tmLanguage.json"
+      ],
       "url": "https://raw.githubusercontent.com/Septh/tmlanguage/master/tmLanguage.schema.json"
     },
     {
       "name": ".travis.yml",
       "description": "Travis CI configuration file",
-      "fileMatch": [".travis.yml"],
+      "fileMatch": [
+        ".travis.yml"
+      ],
       "url": "http://json.schemastore.org/travis"
     },
     {
       "name": "tsconfig.json",
       "description": "TypeScript compiler configuration file",
-      "fileMatch": ["tsconfig.json"],
+      "fileMatch": [
+        "tsconfig.json"
+      ],
       "url": "http://json.schemastore.org/tsconfig"
     },
     {
       "name": "tsd.json",
       "description": "JSON schema for DefinatelyTyped description manager (TSD)",
-      "fileMatch": ["tsd.json"],
+      "fileMatch": [
+        "tsd.json"
+      ],
       "url": "http://json.schemastore.org/tsd"
     },
     {
       "name": "tsdrc.json",
       "description": "TypeScript Definition manager (tsd) global settings file",
-      "fileMatch": [".tsdrc"],
+      "fileMatch": [
+        ".tsdrc"
+      ],
       "url": "http://json.schemastore.org/tsdrc"
     },
     {
       "name": "ts-force-config.json",
       "description": "Generated Typescript classes for Salesforce",
-      "fileMatch": ["ts-force-config.json"],
+      "fileMatch": [
+        "ts-force-config.json"
+      ],
       "url": "http://json.schemastore.org/ts-force-config"
     },
     {
       "name": "tslint.json",
       "description": "TypeScript Lint configuration file",
-      "fileMatch": ["tslint.json", "tslint.yaml", "tslint.yml"],
+      "fileMatch": [
+        "tslint.json",
+        "tslint.yaml",
+        "tslint.yml"
+      ],
       "url": "http://json.schemastore.org/tslint"
     },
     {
       "name": "typewiz.json",
       "description": "Typewiz configuration file",
-      "fileMatch": ["typewiz.json"],
+      "fileMatch": [
+        "typewiz.json"
+      ],
       "url": "http://json.schemastore.org/typewiz"
     },
     {
       "name": "typings.json",
       "description": "Typings TypeScript definitions manager definition file",
-      "fileMatch": ["typings.json"],
+      "fileMatch": [
+        "typings.json"
+      ],
       "url": "http://json.schemastore.org/typings"
     },
     {
       "name": "typingsrc.json",
       "description": "Typings TypeScript definitions manager configuration file",
-      "fileMatch": [".typingsrc"],
+      "fileMatch": [
+        ".typingsrc"
+      ],
       "url": "http://json.schemastore.org/typingsrc"
     },
     {
       "name": "up.json",
       "description": "Up configuration file",
-      "fileMatch": ["up.json"],
+      "fileMatch": [
+        "up.json"
+      ],
       "url": "http://json.schemastore.org/up.json"
     },
     {
       "name": "ui5-manifest",
       "description": "UI5/OPENUI5 descriptor file",
-      "fileMatch": [".manifest"],
+      "fileMatch": [
+        ".manifest"
+      ],
       "url": "http://json.schemastore.org/ui5-manifest"
     },
     {
       "name": "vega.json",
       "description": "Vega visualization specification file",
-      "fileMatch": ["*.vg", "*.vg.json"],
+      "fileMatch": [
+        "*.vg",
+        "*.vg.json"
+      ],
       "url": "http://json.schemastore.org/vega"
     },
     {
       "name": "vega-lite.json",
       "description": "Vega-Lite visualization specification file",
-      "fileMatch": ["*.vl", "*.vl.json"],
+      "fileMatch": [
+        "*.vl",
+        "*.vl.json"
+      ],
       "url": "http://json.schemastore.org/vega-lite"
     },
     {
       "name": "version.json",
       "description": "A project version descriptor file used by Nerdbank.GitVersioning",
-      "fileMatch": ["version.json"],
+      "fileMatch": [
+        "version.json"
+      ],
       "url": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
       "name": "vsls.json",
       "description": "Visual Studio Live Share configuration file",
-      "fileMatch": [".vsls.json"],
+      "fileMatch": [
+        ".vsls.json"
+      ],
       "url": "http://json.schemastore.org/vsls"
     },
     {
       "name": "vs-2017.3.host.json",
       "description": "JSON schema for Visual Studio template host file",
-      "fileMatch": ["vs-2017.3.host.json"],
+      "fileMatch": [
+        "vs-2017.3.host.json"
+      ],
       "url": "http://json.schemastore.org/vs-2017.3.host"
     },
     {
       "name": "vs-nesting.json",
       "description": "JSON schema for Visual Studio's file nesting feature",
-      "fileMatch": ["*.filenesting.json", ".filenesting.json"],
+      "fileMatch": [
+        "*.filenesting.json",
+        ".filenesting.json"
+      ],
       "url": "http://json.schemastore.org/vs-nesting"
     },
     {
       "name": ".vsconfig",
       "description": "JSON schema for Visual Studio component configuration files",
-      "fileMatch": ["*.vsconfig"],
+      "fileMatch": [
+        "*.vsconfig"
+      ],
       "url": "http://json.schemastore.org/vsconfig"
     },
     {
       "name": ".vsext",
       "description": "JSON schema for Visual Studio extension pack manifests",
-      "fileMatch": ["*.vsext"],
+      "fileMatch": [
+        "*.vsext"
+      ],
       "url": "http://json.schemastore.org/vsext"
     },
     {
       "name": "VSIX CLI publishing",
       "description": "JSON schema for Visual Studio extension publishing",
-      "fileMatch": ["vs-publish.json"],
+      "fileMatch": [
+        "vs-publish.json"
+      ],
       "url": "http://json.schemastore.org/vsix-publish"
     },
     {
       "name": "vss-extension.json",
       "description": "JSON Schema for Azure DevOps Extensions",
-      "fileMatch": ["vss-extension.json"],
+      "fileMatch": [
+        "vss-extension.json"
+      ],
       "url": "http://json.schemastore.org/vss-extension"
     },
     {
       "name": "WebExtensions",
       "description": "JSON schema for WebExtension manifest files",
-      "fileMatch": ["manifest.json"],
+      "fileMatch": [
+        "manifest.json"
+      ],
       "url": "http://json.schemastore.org/webextension"
     },
     {
       "name": "Web Manifest",
       "description": "Web Application manifest file",
-      "fileMatch": ["manifest.json", "*.webmanifest"],
+      "fileMatch": [
+        "manifest.json",
+        "*.webmanifest"
+      ],
       "url": "http://json.schemastore.org/web-manifest"
     },
     {
       "name": "webjobs-list.json",
       "description": "Azure Webjob list file",
-      "fileMatch": ["webjobs-list.json"],
+      "fileMatch": [
+        "webjobs-list.json"
+      ],
       "url": "http://json.schemastore.org/webjobs-list"
     },
     {
       "name": "webjobpublishsettings.json",
       "description": "Azure Webjobs publish settings file",
-      "fileMatch": ["webjobpublishsettings.json"],
+      "fileMatch": [
+        "webjobpublishsettings.json"
+      ],
       "url": "http://json.schemastore.org/webjob-publish-settings"
     },
     {
       "name": "Web types",
       "description": "JSON standard for web component libraries metadata",
-      "fileMatch": ["web-types.json", "*.web-types.json"],
+      "fileMatch": [
+        "web-types.json",
+        "*.web-types.json"
+      ],
       "url": "http://json.schemastore.org/web-types"
     },
     {
@@ -1301,7 +1663,9 @@
     {
       "name": "KSP-CKAN 1.26.4",
       "description": "Metadata spec v1.26.4 for KSP-CKAN",
-      "fileMatch": ["*.ckan"],
+      "fileMatch": [
+        "*.ckan"
+      ],
       "url": "http://json.schemastore.org/ksp-ckan"
     },
     {
@@ -1312,92 +1676,128 @@
     {
       "name": "xunit.runner.json",
       "description": "xUnit.net runner configuration file",
-      "fileMatch": ["xunit.runner.json"],
+      "fileMatch": [
+        "xunit.runner.json"
+      ],
       "url": "http://json.schemastore.org/xunit.runner.schema"
     },
     {
       "name": ".cryproj engine-5.2",
       "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
+      "fileMatch": [
+        "*.cryproj"
+      ],
       "url": "http://json.schemastore.org/cryproj.52.schema"
     },
     {
       "name": ".cryproj engine-5.3",
       "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
+      "fileMatch": [
+        "*.cryproj"
+      ],
       "url": "http://json.schemastore.org/cryproj.53.schema"
     },
     {
       "name": ".cryproj engine-5.4",
       "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
+      "fileMatch": [
+        "*.cryproj"
+      ],
       "url": "http://json.schemastore.org/cryproj.54.schema"
     },
     {
       "name": ".cryproj engine-5.5",
       "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
+      "fileMatch": [
+        "*.cryproj"
+      ],
       "url": "http://json.schemastore.org/cryproj.55.schema"
     },
     {
       "name": ".cryproj engine-dev",
       "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
+      "fileMatch": [
+        "*.cryproj"
+      ],
       "url": "http://json.schemastore.org/cryproj.dev.schema"
     },
     {
       "name": ".cryproj (generic)",
       "description": "A JSON schema for CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
+      "fileMatch": [
+        "*.cryproj"
+      ],
       "url": "http://json.schemastore.org/cryproj"
     },
     {
       "name": "typedoc.json",
       "description": "A JSON schema for the Typedoc configuration file",
-      "fileMatch": ["typedoc.json"],
+      "fileMatch": [
+        "typedoc.json"
+      ],
       "url": "http://json.schemastore.org/typedoc"
     },
     {
       "name": "huskyrc",
       "description": "Husky can prevent bad `git commit`, `git push` and more 🐶 woof!",
-      "fileMatch": [".huskyrc", ".huskyrc.json"],
+      "fileMatch": [
+        ".huskyrc",
+        ".huskyrc.json"
+      ],
       "url": "http://json.schemastore.org/huskyrc"
     },
     {
       "name": ".lintstagedrc",
       "description": "JSON schema for lint-staged config",
-      "fileMatch": [".lintstagedrc", ".lintstagedrc.json"],
+      "fileMatch": [
+        ".lintstagedrc",
+        ".lintstagedrc.json"
+      ],
       "url": "http://json.schemastore.org/lintstagedrc.schema"
     },
     {
       "name": "mta.yaml",
       "description": "A JSON schema for MTA projects v3.3",
-      "fileMatch": [ "mta.yaml", "mta.yml" ],
+      "fileMatch": [
+        "mta.yaml",
+        "mta.yml"
+      ],
       "url": "http://json.schemastore.org/mta"
     },
     {
       "name": "mtad.yaml",
       "description": "A JSON schema for MTA deployment descriptors v3.3",
-      "fileMatch": ["mtad.yaml", "mtad.yml"],
+      "fileMatch": [
+        "mtad.yaml",
+        "mtad.yml"
+      ],
       "url": "http://json.schemastore.org/mtad"
     },
     {
       "name": ".mtaext",
       "description": "A JSON schema for MTA extension descriptors v3.3",
-      "fileMatch": ["*.mtaext"],
+      "fileMatch": [
+        "*.mtaext"
+      ],
       "url": "http://json.schemastore.org/mtaext"
     },
     {
       "name": "Opctl",
       "description": "Opctl schema for describing an op",
       "url": "http://json.schemastore.org/opspec-io-0.1.7",
-      "fileMatch": [".opspec/*/*.yml", ".opspec/*/*.yaml"]
+      "fileMatch": [
+        ".opspec/*/*.yml",
+        ".opspec/*/*.yaml"
+      ]
     },
     {
       "name": "HEMTT",
       "description": "HEMTT Project File",
       "url": "http://json.schemastore.org/hemtt-0.6.2",
-      "fileMatch": ["hemtt.json", "hemtt.toml"],
+      "fileMatch": [
+        "hemtt.json",
+        "hemtt.toml"
+      ],
       "versions": {
         "0.6.2": "http://json.schemastore.org/hemtt-0.6.2"
       }
@@ -1405,56 +1805,90 @@
     {
       "name": "now",
       "description": "ZEIT Now project configuration file",
-      "fileMatch": ["now.json"],
+      "fileMatch": [
+        "now.json"
+      ],
       "url": "http://json.schemastore.org/now"
     },
     {
       "name": "taskcat",
       "description": "taskcat",
-      "fileMatch": [".taskcat.yml"],
+      "fileMatch": [
+        ".taskcat.yml"
+      ],
       "url": "https://raw.githubusercontent.com/aws-quickstart/taskcat/master/taskcat/cfg/config_schema.json"
     },
     {
       "name": "BizTalkServerApplicationSchema",
       "description": "BizTalk server application inventory json file.",
-      "fileMatch": ["BizTalkServerInventory.json"],
+      "fileMatch": [
+        "BizTalkServerInventory.json"
+      ],
       "url": "http://json.schemastore.org/BizTalkServerApplicationSchema"
     },
     {
       "name": "httpmockrc",
       "description": "Http-mocker is a tool for mock local requests or proxy remote requests.",
-      "fileMatch": [".httpmockrc", ".httpmock.json"],
+      "fileMatch": [
+        ".httpmockrc",
+        ".httpmock.json"
+      ],
       "url": "http://json.schemastore.org/httpmockrc"
     },
     {
       "name": "neoload",
       "description": "Neotys as-code load test specification, more at: https://github.com/Neotys-Labs/neoload-cli",
-      "fileMatch": [".nl.yaml", ".nl.yml", ".nl.json", ".neoload.yaml", ".neoload.yml", ".neoload.json"],
+      "fileMatch": [
+        ".nl.yaml",
+        ".nl.yml",
+        ".nl.json",
+        ".neoload.yaml",
+        ".neoload.yml",
+        ".neoload.json"
+      ],
       "url": "https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/master/resources/as-code.latest.schema.json"
     },
     {
       "name": "release drafter",
       "description": "Release Drafter configuration file",
-      "fileMatch": ["release-drafter.yml"],
+      "fileMatch": [
+        "release-drafter.yml"
+      ],
       "url": "https://raw.githubusercontent.com/release-drafter/release-drafter/master/schema.json"
     },
     {
       "name": "zuul",
       "description": "Zuul CI configuration file",
-      "fileMatch": ["*zuul.d/*.yaml", "*/.zuul.yaml"],
+      "fileMatch": [
+        "*zuul.d/*.yaml",
+        "*/.zuul.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/pycontribs/zuul-lint/master/zuul_lint/zuul-schema.json"
     },
     {
       "name": "Briefcase",
       "description": "Microsoft Briefcase configuration file",
-      "fileMatch": ["briefcase.yaml"],
+      "fileMatch": [
+        "briefcase.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/Briefcase/master/mlbriefcase/briefcase-schema.json"
     },
     {
       "name": "httparchive",
       "description": "HTTP Archive",
-      "fileMatch": ["*.har"],
+      "fileMatch": [
+        "*.har"
+      ],
       "url": "https://raw.githubusercontent.com/ahmadnassri/har-schema/master/lib/har.json"
+    },
+    {
+      "name": "jsdoc",
+      "description": "JSDoc configuration file",
+      "fileMatch": [
+        "conf.js*",
+        "jsdoc.js*"
+      ],
+      "url": "http://json.schemastore.org/jsdoc"
     }
   ]
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -704,15 +704,15 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
     "grunt": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
-      "integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.1.0.tgz",
+      "integrity": "sha512-+NGod0grmviZ7Nzdi9am7vuRS/h76PcWDsV635mEXF0PEQMUV6Kb+OjTdsVxbi0PZmfQOjCMKb3w8CVZcqsn1g==",
       "dev": true,
       "requires": {
         "coffeescript": "~1.10.0",
@@ -726,9 +726,9 @@
         "grunt-legacy-log": "~2.0.0",
         "grunt-legacy-util": "~1.1.1",
         "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.13.0",
+        "js-yaml": "~3.13.1",
         "minimatch": "~3.0.2",
-        "mkdirp": "~0.5.1",
+        "mkdirp": "~1.0.3",
         "nopt": "~3.0.6",
         "path-is-absolute": "~1.0.0",
         "rimraf": "~2.6.2"
@@ -948,9 +948,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
     "http-errors": {
@@ -1037,13 +1037,10 @@
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-number-like": {
       "version": "1.0.8",
@@ -1238,9 +1235,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "ministyle": {
@@ -1267,21 +1264,10 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
-      }
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
+      "dev": true
     },
     "morgan": {
       "version": "1.9.1",
@@ -1361,12 +1347,6 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -1680,9 +1660,9 @@
       }
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -1698,9 +1678,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1732,9 +1712,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "send": {
@@ -1904,9 +1884,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {

--- a/src/package.json
+++ b/src/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/schemastore/SchemaStore"
   },
   "devDependencies": {
-    "grunt": "^1.0.4",
+    "grunt": "^1.1.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-http": "^2.3.1",
     "grunt-tv4": "^2.1.0"

--- a/src/schemas/json/jsdoc-1.0.0.json
+++ b/src/schemas/json/jsdoc-1.0.0.json
@@ -1,0 +1,245 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "title": "JSON Schema for JSDoc configuration files",
+    "properties": {
+        "plugins": {
+            "type": "array",
+            "title": "Configuring plugins",
+            "description": "Enables plugins for JSDoc",
+            "default": [],
+            "examples": [
+                [
+                    "plugins/markdown",
+                    "plugins/summarize"
+                ]
+            ]
+        },
+        "recurseDepth": {
+            "type": "integer",
+            "title": "Specifying recursion depth",
+            "default": 10,
+            "$comment": "Is used only if `jsdoc` command is invoked with `-r` flag",
+            "description": "Controls recursion depth for source files and tutorials"
+        },
+        "source": {
+            "type": "object",
+            "title": "Specifying input files",
+            "description": "Determines the set of input files",
+            "properties": {
+                "include": {
+                    "examples": [
+                        [
+                            "myProject/a.js",
+                            "myProject/lib",
+                            "myProject/_private"
+                        ]
+                    ],
+                    "type": "array",
+                    "title": "Input files paths",
+                    "description": "An array of paths to input files",
+                    "$comment": "`-r` flag for `jsdoc` command will recurse in subdirectories of paths listed"
+                },
+                "exclude": {
+                    "examples": [
+                        [
+                            "myProject/lib/ignore.js"
+                        ]
+                    ],
+                    "type": "array",
+                    "title": "Input files exclusion paths",
+                    "description": "An array of paths to exclude from input",
+                    "$comment": "With JSDoc ^3.3.0 may include subdirectories of include"
+                },
+                "includePattern": {
+                    "type": "string",
+                    "title": "Inclusion RegExp",
+                    "default": ".+\\.js(doc|x)?$",
+                    "$comment": "By default, .js, .jsx, .jsdoc files are included",
+                    "description": "Forces input filenames to match regular expression"
+                },
+                "excludePattern": {
+                    "type": "string",
+                    "title": "Exclusion RegExp",
+                    "default": "(^|\\/|\\\\)_",
+                    "$comment": "By default, underscored files and folders are excluded",
+                    "description": "Forces input filenames to match regular expression"
+                }
+            },
+            "additionalProperties": false
+        },
+        "sourceType": {
+            "type": "string",
+            "enum": [
+                "module",
+                "script"
+            ],
+            "default": "module",
+            "title": "Specifying source type",
+            "description": "Determines how input files are parsed"
+        },
+        "opts": {
+            "type": "object",
+            "title": "Incorporating CLI options",
+            "description": "Determines flags that `jsdoc` command will be invoked with",
+            "additionalProperties": false,
+            "properties": {
+                "template": {
+                    "$comment": "Equivalent to `-t` flag",
+                    "default": "templates/default",
+                    "description": "The path to the template to use for generating output",
+                    "title": "Output template",
+                    "type": "string"
+                },
+                "encoding": {
+                    "$comment": "Equivalent to `-e` flag",
+                    "default": "utf8",
+                    "description": "Assume this encoding when reading all source files",
+                    "title": "Input files encoding",
+                    "type": "string"
+                },
+                "destination": {
+                    "$comment": "Equivalent to `-d` flag",
+                    "default": "./out/",
+                    "description": "The path to the output folder for the generated documentation",
+                    "title": "Output folder",
+                    "type": "string"
+                },
+                "recurse": {
+                    "$comment": "Equivalent to `-r` flag",
+                    "default": false,
+                    "description": "Recurses to subdirectories when searching input files",
+                    "title": "Recurse to subdirectories",
+                    "type": "boolean"
+                },
+                "tutorials": {
+                    "$comment": "Equivalent to `-u` flag",
+                    "description": "Directory in which JSDoc should search for tutorials",
+                    "examples": [
+                        "path/to/tutorials",
+                        "./docs/tutorials"
+                    ],
+                    "title": "Tutorials path",
+                    "type": "string"
+                }
+            }
+        },
+        "tags": {
+            "additionalProperties": false,
+            "description": "Controls allowed JSDoc tags and their interpretation",
+            "properties": {
+                "allowUnknownTags": {
+                    "$comment": "If set to `false`, emits a warning. If set to an array, whitelists tags",
+                    "default": true,
+                    "description": "Determines how to handle unrecognized tags",
+                    "items": {
+                        "title": "JSDoc tag",
+                        "type": "string"
+                    },
+                    "title": "Unknown tags",
+                    "type": [
+                        "boolean",
+                        "array"
+                    ],
+                    "uniqueItems": true
+                },
+                "dictionaries": {
+                    "additionalItems": false,
+                    "description": "Controls which tags JSDoc recognizes and how they are interpreted",
+                    "items": {
+                        "$comment": "^3.3.0 two dictionaries: JSDoc and Closure Compiler",
+                        "default": [
+                            "jsdoc",
+                            "closure"
+                        ],
+                        "enum": [
+                            "jsdoc",
+                            "closure"
+                        ],
+                        "title": "Dictionary",
+                        "type": "string"
+                    },
+                    "title": "JSDoc dictionaries",
+                    "type": "array"
+                }
+            },
+            "title": "Configuring tags and tag dictionaries",
+            "type": "object"
+        },
+        "templates": {
+            "description": "Affect the appearance and content of generated documentation",
+            "properties": {
+                "cleverLinks": {
+                    "$comment": "If `true`, text of @link tag that is a URL will be rendered in normal font, else in monospace",
+                    "default": false,
+                    "description": "Controls @link tag text rendering",
+                    "title": "@link URL",
+                    "type": "boolean"
+                },
+                "default": {
+                    "properties": {
+                        "includeDate": {
+                            "$comment": "^3.3.0 can be set to `false` to omit current date",
+                            "default": true,
+                            "description": "Controls if current date is displayed in the footer of documentation",
+                            "title": "Showing the current date",
+                            "type": "boolean"
+                        },
+                        "layoutFile": {
+                            "$comment": "^3.4.0 can be set to custom layout file",
+                            "default": "layout.tmpl",
+                            "description": "Path to layout file to use for documentation template",
+                            "title": "Overriding layout file",
+                            "type": "string"
+                        },
+                        "staticFiles": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "exclude": {
+                                    "description": "An array of paths that should not be copied to the output directory",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "excludePattern": {
+                                    "description": "A regular expression indicating which files to skip.",
+                                    "type": "string"
+                                },
+                                "include": {
+                                    "description": "An array of paths whose contents should be copied to the output directory",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "includePattern": {
+                                    "description": "A regular expression indicating which files to copy",
+                                    "type": "string"
+                                }
+                            },
+                            "title": "Copying static files",
+                            "type": "object"
+                        },
+                        "useLongnameInNav": {
+                            "$comment": "^3.4.0 can be set to `true` to use longhands",
+                            "default": false,
+                            "description": "Controls if shortened or longhand version of a symbol will be shown in documentation",
+                            "title": "Showing longnames",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "monospaceLinks": {
+                    "$comment": "If `true`, all link text of inline @link tag will be rendered in monospace font",
+                    "default": false,
+                    "description": "Controls @link tag text rendering",
+                    "title": "@link text",
+                    "type": "boolean"
+                }
+            },
+            "title": "Configuring templates",
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
### Reasoning

**Commit 1** - Automated `npm audit` fix for project dependencies security issues.
**Commit 2** - Surprisingly I could not find a schema for JSDoc config files. [JSDoc](https://jsdoc.app/about-configuring-jsdoc.html ) is well-documented, but being able to use intellisense for such files (especially since JSDoc does not support package.json tool keys config yet as far as I am aware) justifies adding the schema to the roster. 

The schema is intended to be expanded with different versions of JSDoc schema changes, additional examples, etc if included.