### PR TITLE
Jsdoc schema update + catalog fix

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1888,7 +1888,7 @@
         "conf.js*",
         "jsdoc.js*"
       ],
-      "url": "http://json.schemastore.org/jsdoc"
+      "url": "http://json.schemastore.org/jsdoc-1.0.0"
     }
   ]
 }

--- a/src/schemas/json/jsdoc-1.0.0.json
+++ b/src/schemas/json/jsdoc-1.0.0.json
@@ -105,6 +105,12 @@
                     "title": "Output folder",
                     "type": "string"
                 },
+                "package": {
+                    "$comment": "Equivalent to `-p` flag",
+                    "description": "The `package.json` file that contains the project name, version, and other details",
+                    "title": "Package",
+                    "type": "string"
+                },
                 "recurse": {
                     "$comment": "Equivalent to `-r` flag",
                     "default": false,


### PR DESCRIPTION
Small addition to the schema (not warranting version increment) - CLI option for specifying path to `package.json` + fixed `catalog.json` entry to display version 1.0.0 by default (led to schema not found since first version was named jsdoc-1.0.0).

**Note**: sorry about a bit of a mess with updating pull request, missed the fact that my branch diverged after merging (now commit history should be correct)