### PR TITLE
Update Gitlab schema with reports:cobertura keyword

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -689,6 +689,23 @@
                     }
                   ]
                 },
+                "cobertura": {
+                  "description": "Path for file(s) that should be parsed as Cobertura XML coverage report",
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "Path to a single XML file"
+                    },
+                    {
+                      "type": "array",
+                      "description": "A list of paths to XML files that will automatically be merged into one report",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minLength": 1
+                    }
+                  ]
+                },
                 "codequality": {
                   "$ref": "#/definitions/string_file_list",
                   "description": "Path to file or list of files with code quality report(s) (such as Code Climate)."

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -85,6 +85,7 @@
       "expire_in": "1 week",
       "reports": {
         "junit": "result.xml",
+        "cobertura": "cobertura-coverage.xml",
         "codequality": "codequality.json",
         "sast": "sast.json",
         "dependency_scanning": "scan.json",
@@ -146,6 +147,7 @@
     "artifacts": {
       "reports": {
         "junit": ["result.xml"],
+        "cobertura": ["cobertura-coverage.xml"],
         "codequality": ["codequality.json"],
         "sast": ["sast.json"],
         "dependency_scanning": ["scan.json"],


### PR DESCRIPTION
Starting with GitLab 12.9, support for Cobertura XML based coverage reports were added,
see https://docs.gitlab.com/ee/user/project/merge_requests/test_coverage_visualization.html.
It works analogue to jUnit reports and supports coverage report merging as well.