### PR TITLE
Allow never for when attribute

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -308,6 +308,10 @@
         {
           "enum": ["delayed"],
           "description": "Execute a job after the time limit in 'start_in' expires. Read more: https://docs.gitlab.com/ee/ci/yaml/#when-delayed"
+        },
+        {
+          "enum": ["never"],
+          "description": "Never execute the job."
         }
       ]
     },


### PR DESCRIPTION
Allow the value of never for when attribute.

This is used for https://docs.gitlab.com/ee/ci/yaml/README.html#exclude-jobs-with-rules-from-certain-pipelines