### PR TITLE
Add vim-addon-info schema for vim plugin addon-info.json files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1579,6 +1579,14 @@
       "url": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
+      "name": "vim-addon-info",
+      "description": "JSON schema for vim plugin addon-info.json metadata files",
+      "fileMatch": [
+        "*vim*/addon-info.json"
+      ],
+      "url": "http://json.schemastore.org/vim-addon-info"
+    },
+    {
       "name": "vsls.json",
       "description": "Visual Studio Live Share configuration file",
       "fileMatch": [

--- a/src/schemas/json/vim-addon-info.json
+++ b/src/schemas/json/vim-addon-info.json
@@ -1,0 +1,118 @@
+{
+  "title": "JSON schema for vim plugin addon-info.json metadata files",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://json.schemastore.org/vim-addon-info",
+
+  "type": "object",
+
+  "properties": {
+    "name": {
+      "description": "The name of the plugin. Used by plugin managers and some introspection tools. Generally corresponds to the name of the repository but without \"vim\" prefix/suffix.",
+      "type": "string",
+      "examples": ["surround.vim", "nerdtree", "maktaba"]
+    },
+    "version": {
+      "description": "Dotted version number of the plugin, generally in semantic versioning scheme.",
+      "type": "string",
+      "examples": ["0.0.1", "2.0"],
+      "default": "0.0.1"
+    },
+    "description": {
+      "description": "Short description of the plugin and what it does (a sentence or two)",
+      "type": "string"
+    },
+    "homepage": {
+      "description": "Primary homepage of the plugin.",
+      "type": "string",
+      "format": "uri"
+    },
+    "author": {
+      "description": "Name of the person or organization that created the plugin",
+      "type": "string",
+      "examples": ["Priya Exampleton", "Example Industries"]
+    },
+    "maintainer": {
+      "description": "Name of the person who maintains the plugin",
+      "type": "string",
+      "examples": ["Priya Exampleton"]
+    },
+    "repository": { "$ref": "#/definitions/selfRepository" },
+    "dependencies": {
+      "description": "Plugins that are strictly required for the plugin to work, where keys are plugin names and values may describe where plugins can be fetched from.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/otherRepository"
+      }
+    }
+  },
+  "definitions": {
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "examples": ["git://github.com/tpope/vim-surround"]
+    },
+    "repoType": {
+      "enum": ["hg", "git", "svn", "bzr"]
+    },
+    "selfRepository": {
+      "description": "Info for the plugin itself. Describes where the canonical copy of the plugin can be fetched from.",
+      "type": "object",
+      "properties": {
+        "type": { "$ref": "#/definitions/repoType" },
+        "url": { "$ref": "#/definitions/url" },
+        "deprecated": {
+          "description": "For a deprecated plugin, a deprecation message to be shown to any user who installs the plugin.",
+          "type": "string"
+        }
+      },
+      "dependencies": {
+        "url": ["type"],
+        "type": ["url"]
+      }
+    },
+    "otherRepository": {
+      "description": "Info about a plugin/repository outside this one.",
+      "type": "object",
+      "anyOf": [
+        {
+          "$comment": "Empty repository info. Used to declare plugin with the given name is required without specifying any explicit details about how to fetch it (e.g., if name can be looked up in a predefined package index).",
+          "additionalProperties": false
+        },
+        {
+          "$comment": "Repository with empty type and url pointing to local path.",
+          "properties": {
+            "type": { "enum": ["", "archive"] },
+            "url": { "$ref": "#/definitions/url" },
+            "vim_script_nr": {
+              "description": "Script ID number of the target plugin on www.vim.org, if any.",
+              "type": "number",
+              "examples": [31, 1075]
+            },
+            "script-type": {
+              "enum": ["color scheme", "ftplugin", "game", "indent", "syntax", "utility", "patch"]
+            }
+          }
+        },
+        {
+          "$comment": "Explicit remote repository.",
+          "properties": {
+            "type": { "$ref": "#/definitions/repoType" },
+            "url": { "$ref": "#/definitions/url" }
+          },
+          "required": ["type", "url"]
+        }
+      ],
+      "properties": {
+        "homepage": {
+          "description": "Primary homepage of the plugin.",
+          "type": "string",
+          "format": "uri"
+        },
+        "addon-info": {
+          "$comment": "Addon information for the other plugin in case it does not supply its own addon-info file.",
+          "$ref": "#"
+        }
+      }
+    }
+  }
+}

--- a/src/test/vim-addon-info/basic-example.json
+++ b/src/test/vim-addon-info/basic-example.json
@@ -1,0 +1,4 @@
+{
+  "name": "myplugin",
+  "description": "A plugin that does a thing"
+}

--- a/src/test/vim-addon-info/with-dependencies.json
+++ b/src/test/vim-addon-info/with-dependencies.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "somelib": {},
+    "a": {
+      "archive_name": "a.vim",
+      "script-type": "utility",
+      "type": "archive",
+      "url": "http://www.vim.org/scripts/download_script.php?src_id=7218",
+      "version": "2.18",
+      "vim_script_nr": 31
+    },
+    "dispatch.vim": {
+      "type": "git",
+      "url": "git://github.com/tpope/vim-dispatch"
+    }
+  }
+}


### PR DESCRIPTION
Defines a JSON schema for a subset of the addon-info.json format for vim plugins described at http://vimpluginloader.sourceforge.net/doc/vim-addon-manager-additional-documentation.txt.html#addon-info.2ejson.

For now, to keep things simpler, this sticks with a subset of properties and doesn't include some of the more VAM-specific ones like `post-install-hook`, but those could be added later and this schema is kept open to allow arbitrary additional properties.