### PR TITLE
Added pedantic & test options + outputSourceFiles template property

### DIFF
--- a/src/schemas/json/jsdoc-1.0.0.json
+++ b/src/schemas/json/jsdoc-1.0.0.json
@@ -111,11 +111,24 @@
                     "title": "Package",
                     "type": "string"
                 },
+                "pedantic": {
+                    "default": false,
+                    "description": "Treat errors as fatal errors, and treat warnings as errors",
+                    "title": "Pedantic",
+                    "type": "boolean"
+                },
                 "recurse": {
                     "$comment": "Equivalent to `-r` flag",
                     "default": false,
                     "description": "Recurses to subdirectories when searching input files",
                     "title": "Recurse to subdirectories",
+                    "type": "boolean"
+                },
+                "test": {
+                    "$comment": "Equivalent to `-T` flag. Won't work if installed via NPM",
+                    "default": false,
+                    "description": "Run JSDoc's test suite, and print the results to the console",
+                    "title": "Run tests",
                     "type": "boolean"
                 },
                 "tutorials": {
@@ -197,6 +210,13 @@
                             "description": "Path to layout file to use for documentation template",
                             "title": "Overriding layout file",
                             "type": "string"
+                        },
+                        "outputSourceFiles": {
+                            "$comment": "^3.3.0 can be set to `false` to omit source files",
+                            "default": true,
+                            "description": "Escludes pretty-printed source files from docs",
+                            "title": "Disable source",
+                            "type": "boolean"
                         },
                         "staticFiles": {
                             "additionalProperties": false,


### PR DESCRIPTION
Included two CLI options that are tested to work with config file:
- pedantic [error escalation]
- test [running jsdoc test suite]

Included one important default template option:
- outputSourceFiles [source files exposure]