### PR TITLE
[gitlab-ci.yml] Scripts now support 1-layer array of strings

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -228,14 +228,34 @@
       "type": "array",
       "description": "Defines scripts that should run *before* the job. Can be set globally or per job.",
       "items": {
-        "type": "string"
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "after_script": {
       "type": "array",
       "description": "Defines scripts that should run *after* the job. Can be set globally or per job.",
       "items": {
-        "type": "string"
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "rules": {
@@ -536,7 +556,17 @@
             {
               "type": "array",
               "items": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
               },
               "minItems": 1
             }


### PR DESCRIPTION
GitLab now supports 1-layer of array of strings in `scripts` due to the recurring issue that users would like to be able to merge arrays, which is not natively possible in YAML.

This has been verified via the `gitlab ci lint tool`.

[Link to example in GitLab documentation](https://docs.gitlab.com/ce/ci/yaml/#yaml-anchors-for-before_script-and-after_script)