### PR TITLE
feat: Added Ray autocluster schema reference to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1919,6 +1919,14 @@
         "jsdoc.js*"
       ],
       "url": "http://json.schemastore.org/jsdoc-1.0.0"
+    },
+    {
+      "name": "Ray",
+      "description": "Ray autocluster configuration file",
+      "fileMatch": [
+        "ray-*-cluster.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/ray-project/ray/master/python/ray/autoscaler/ray-schema.json"
     }
   ]
 }


### PR DESCRIPTION
Schema for [autocluster](https://ray.readthedocs.io/en/latest/autoscaling.html) configuration of a [Ray](https://github.com/ray-project/ray) cluster

FYI @richardliaw
