### PR TITLE
Remove additionalProperties from root of drone.json

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -1,7 +1,6 @@
 {
   "title": "Drone CI configuration file",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
   "definitions": {
     "nonEmptyString": {
       "type": "string",


### PR DESCRIPTION
According to json schema spec:
> The additionalProperties keyword is used to control the handling of extra stuff, that is, properties whose names are not listed in the properties keyword. 

Since there is no root "properties" object, validating json/yaml against the schema will always generate errors.