### PR TITLE
Add "type" property to SecretArgs

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -385,7 +385,11 @@
           "type": "string"
         },
         "namespace": {
-          "description": "Namespace for the configmap, optional",
+          "description": "Namespace for the secret, optional",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of the secret, optional",
           "type": "string"
         }
       },


### PR DESCRIPTION
See kustomizes `SecretArgs` struct for reference: https://github.com/kubernetes-sigs/kustomize/blob/894e21acbfb0387c0d3afa8086d11fcd4a394d2d/api/types/secretargs.go#L18

Fixes description for "namespace" property too