### PR TITLE
Add "cache/apt" value in travis schema

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -184,6 +184,7 @@
     },
     "cache": {
       "enum": [
+        "apt" ,
         "bundler",
         "cargo",
         "ccache",
@@ -1058,6 +1059,9 @@
                   "type": "number",
                   "description": "Upload timeout in seconds",
                   "default": 1800
+                },
+                "apt": {
+                  "type": "boolean"
                 },
                 "bundler": {
                   "type": "boolean"


### PR DESCRIPTION
According to the [Travis references](https://config.travis-ci.com/ref/job/cache), "cache" has "apt" Key.
- https://config.travis-ci.com/ref/job/cache
- https://github.com/travis-ci/travis-yml/blob/master/schema.json#L362