### PR TITLE
Add Expo SDK 37 schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -630,6 +630,14 @@
       "url": "http://json.schemastore.org/electron-builder"
     },
     {
+      "name": "Expo SDK",
+      "description": "JSON schema for Expo SDK app manifest",
+      "fileMatch": [
+        "app.json"
+      ],
+      "url": "http://json.schemastore.org/expo-37.0.0.json"
+    },
+    {
       "name": ".eslintrc",
       "description": "JSON schema for ESLint configuration files",
       "fileMatch": [

--- a/src/schemas/json/expo-37.0.0.json
+++ b/src/schemas/json/expo-37.0.0.json
@@ -1,0 +1,1383 @@
+{
+  "title": "JSON schema for Expo SDK 37 app manifest",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "expo"
+  ],
+  "properties": {
+    "expo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of your app as it appears both within Expo and on your home screen as a standalone app.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A short description of what your app is and why it is great.",
+          "type": "string"
+        },
+        "slug": {
+          "description": "The friendly url name for publishing. eg: `expo.io/@your-username/slug`.",
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_\\-]+$"
+        },
+        "owner": {
+          "description": "The username of the account under which this app is published. If not specified, the app is published as the currently signed-in user.",
+          "type": "string"
+        },
+        "privacy": {
+          "description": "Either `public` or `unlisted`. If not provided, defaults to `unlisted`. In the future `private` will be supported. `unlisted` hides the experience from search results.",
+          "enum": [
+            "public",
+            "unlisted"
+          ],
+          "type": [
+            "array",
+            "boolean",
+            "number",
+            "object",
+            "string",
+            "null"
+          ]
+        },
+        "sdkVersion": {
+          "description": "The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.",
+          "type": "string",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+)|(UNVERSIONED)$"
+        },
+        "version": {
+          "description": "Your app version, use whatever versioning scheme that you like.",
+          "type": "string"
+        },
+        "platforms": {
+          "description": "Platforms that your project explicitly supports. If not specified, it defaults to `[\"ios\", \"android\"]`.",
+          "example": [
+            "ios",
+            "android",
+            "web"
+          ],
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "android",
+              "ios",
+              "web"
+            ]
+          }
+        },
+        "githubUrl": {
+          "description": "If you would like to share the source code of your app on Github, enter the URL for the repository here and it will be linked to from your Expo project page.",
+          "pattern": "^https://github\\.com/",
+          "example": "https://github.com/expo/expo",
+          "type": [
+            "string"
+          ]
+        },
+        "orientation": {
+          "description": "Lock your app to a specific orientation with `portrait` or `landscape`. Defaults to no lock.",
+          "enum": [
+            "default",
+            "portrait",
+            "landscape"
+          ],
+          "type": [
+            "array",
+            "boolean",
+            "number",
+            "object",
+            "string",
+            "null"
+          ]
+        },
+        "userInterfaceStyle": {
+          "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+          "type": "string",
+          "fallback": "light",
+          "enum": [
+            "light",
+            "dark",
+            "automatic"
+          ]
+        },
+        "backgroundColor": {
+          "description": "The background color for your app, behind any of your React views.",
+          "type": "string",
+          "pattern": "^#|(&#x23;)\\d{6}$",
+          "meta": {
+            "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+          }
+        },
+        "primaryColor": {
+          "description": "On Android, this will determine the color of your app in the multitasker. Currently this is not used on iOS, but it may be used for other purposes in the future.",
+          "type": "string",
+          "pattern": "^#|(&#x23;)\\d{6}$",
+          "meta": {
+            "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+          }
+        },
+        "icon": {
+          "description": "Local path or remote url to an image to use for your app's icon. We recommend that you use a 1024x1024 png file. This icon will appear on the home screen and within the Expo app.",
+          "type": "string",
+          "meta": {
+            "asset": true,
+            "contentTypePattern": "^image/png$",
+            "contentTypeHuman": ".png image",
+            "square": true
+          }
+        },
+        "notification": {
+          "description": "Configuration for remote (push) notifications.",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "description": "Local path or remote url to an image to use as the icon for push notifications. 96x96 png grayscale with transparency.",
+              "type": "string",
+              "meta": {
+                "asset": true,
+                "contentTypePattern": "^image/png$",
+                "contentTypeHuman": ".png image",
+                "square": true
+              }
+            },
+            "color": {
+              "description": "Tint color for the push notification image when it appears in the notification tray.",
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            },
+            "iosDisplayInForeground": {
+              "description": "Display the notification when the app is in foreground on iOS.",
+              "type": "boolean"
+            },
+            "androidMode": {
+              "description": "Show each push notification individually (`default`) or collapse into one (`collapse`).",
+              "enum": [
+                "default",
+                "collapse"
+              ],
+              "type": [
+                "array",
+                "boolean",
+                "number",
+                "object",
+                "string",
+                "null"
+              ]
+            },
+            "androidCollapsedTitle": {
+              "description": "If `androidMode` is set to `collapse`, this title is used for the collapsed notification message. eg: `'#{unread_notifications} new interactions'`.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "loading": {
+          "description": "DEPREACTED: Use `splash` instead. Configuration for the loading screen that users see when opening your app, while fetching & caching bundle and assets.",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "description": "Local path or remote url to an image to display while starting up the app. Image size and aspect ratio are up to you. Must be a .png.",
+              "type": "string",
+              "meta": {
+                "asset": true,
+                "contentTypePattern": "^image/png$",
+                "contentTypeHuman": ".png image"
+              }
+            },
+            "exponentIconColor": {
+              "description": "If no icon is provided, we will show the Expo logo. You can choose between `white` and `blue`.",
+              "enum": [
+                "white",
+                "blue"
+              ],
+              "type": [
+                "array",
+                "boolean",
+                "number",
+                "object",
+                "string",
+                "null"
+              ]
+            },
+            "exponentIconGrayscale": {
+              "description": "Similar to `exponentIconColor` but instead indicate if it should be grayscale (`1`) or not (`0`).",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "backgroundImage": {
+              "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+              "type": "string",
+              "meta": {
+                "asset": true,
+                "contentTypePattern": "^image/png$",
+                "contentTypeHuman": ".png image"
+              }
+            },
+            "backgroundColor": {
+              "description": "Color to fill the loading screen background",
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            },
+            "hideExponentText": {
+              "description": "By default, Expo shows some text at the bottom of the loading screen. Set this to `true` to disable.",
+              "type": "boolean"
+            },
+            "loadingIndicatorStyleExperimental": {
+              "description": "DEPRECATED: was used in the past for changing the style of the iOS loading indicator.",
+              "type": "string",
+              "pattern": "^light$",
+              "meta": {
+                "autogenerated": true
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "appKey": {
+          "description": "By default, Expo looks for the application registered with the AppRegistry as `main`. If you would like to change this, you can specify the name in this property.",
+          "type": "string"
+        },
+        "androidStatusBarColor": {
+          "description": "DEPRECATED. Use `androidStatusBar` instead.",
+          "type": "string",
+          "pattern": "^#|(&#x23;)\\d{6}$",
+          "meta": {
+            "deprecated": true,
+            "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+          }
+        },
+        "androidStatusBar": {
+          "description": "Configuration for the status bar on Android.",
+          "type": "object",
+          "properties": {
+            "barStyle": {
+              "description": "Configures the status bar icons to have a light or dark color.",
+              "type": "string",
+              "enum": [
+                "light-content",
+                "dark-content"
+              ]
+            },
+            "backgroundColor": {
+              "description": "Specifies the background color of the status bar.",
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            }
+          }
+        },
+        "androidNavigationBar": {
+          "description": "Configuration for the bottom navigation bar on Android.",
+          "type": "object",
+          "properties": {
+            "visible": {
+              "description": "Determines how and when the navigation bar is shown.",
+              "type": "string",
+              "enum": [
+                "leanback",
+                "immersive",
+                "sticky-immersive"
+              ]
+            },
+            "barStyle": {
+              "description": "Configure the navigation bar icons to have a light or dark color. Supported on Android Oreo and newer.",
+              "type": "string",
+              "enum": [
+                "light-content",
+                "dark-content"
+              ]
+            },
+            "backgroundColor": {
+              "description": "Specifies the background color of the navigation bar.",
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            }
+          }
+        },
+        "androidShowExponentNotificationInShellApp": {
+          "description": "Adds a notification to your standalone app with refresh button and debug info.",
+          "type": "boolean"
+        },
+        "scheme": {
+          "description": "URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped.",
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9+.-]*$",
+          "meta": {
+            "regexHuman": "String beginning with a lowercase letter followed by any combination of lowercase letters, digits, \"+\", \".\" or \"-\"",
+            "standaloneOnly": true
+          }
+        },
+        "entryPoint": {
+          "description": "The relative path to your main JavaScript file.",
+          "type": "string"
+        },
+        "extra": {
+          "description": "Any extra fields you want to pass to your experience. Values are accessible via `Expo.Constants.manifest.extra` ([read more](../sdk/constants.html#expoconstantsmanifest))",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "rnCliPath": {
+          "type": "string"
+        },
+        "packagerOpts": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "ignoreNodeModulesValidation": {
+          "type": "boolean"
+        },
+        "nodeModulesPath": {
+          "type": "string"
+        },
+        "updates": {
+          "description": "Configuration for how and when the app should request OTA JavaScript updates",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "If set to false, your standalone app will never download any code, and will only use code bundled locally on the device. In that case, all updates to your app must be submitted through Apple review. Defaults to true. (Note that this will not work out of the box with ExpoKit projects)",
+              "type": "boolean"
+            },
+            "checkAutomatically": {
+              "description": "By default, Expo will check for updates every time the app is loaded. Set this to `'ON_ERROR_RECOVERY'` to disable automatic checking unless recovering from an error.",
+              "enum": [
+                "ON_ERROR_RECOVERY",
+                "ON_LOAD"
+              ],
+              "type": [
+                "array",
+                "boolean",
+                "number",
+                "object",
+                "string",
+                "null"
+              ]
+            },
+            "fallbackToCacheTimeout": {
+              "description": "How long (in ms) to allow for fetching OTA updates before falling back to a cached version of the app. Defaults to 30000 (30 sec).",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 300000
+            }
+          },
+          "additionalProperties": false
+        },
+        "locales": {
+          "description": "Provide overrides by locale for System Dialog prompts like Permissions Boxes",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "ios": {
+          "description": "iOS standalone app specific configuration",
+          "type": "object",
+          "meta": {
+            "standaloneOnly": true
+          },
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the Android version of your app will be written to this path during publish.",
+              "type": "string",
+              "meta": {
+                "autogenerated": true
+              }
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the Android version of your app will be written to this path during publish.",
+              "type": "string",
+              "meta": {
+                "autogenerated": true
+              }
+            },
+            "bundleIdentifier": {
+              "description": "The bundle identifier for your iOS standalone app. You make it up, but it needs to be unique on the App Store. See [this StackOverflow question](http://stackoverflow.com/questions/11347470/what-does-bundle-identifier-mean-in-the-ios-project).",
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9\\-\\.]+$",
+              "meta": {
+                "regexHuman": "iOS bundle identifier notation unique name for your app. For example, host.exp.expo, where exp.host is our domain and expo is our app name."
+              }
+            },
+            "buildNumber": {
+              "description": "Build number for your iOS standalone app. Must be a string that matches Apple's [format for CFBundleVersion](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).",
+              "type": "string",
+              "pattern": "^[A-Za-z0-9\\.]+$"
+            },
+            "backgroundColor": {
+              "description": "The background color for your iOS app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on iOS. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency. Expo will generate the other required sizes. This icon will appear on the home screen and within the Expo app.",
+              "type": "string",
+              "meta": {
+                "asset": true,
+                "contentTypePattern": "^image/png$",
+                "contentTypeHuman": ".png image",
+                "square": true
+              }
+            },
+            "merchantId": {
+              "description": "Merchant ID for use with Apple Pay in your standalone app.",
+              "type": "string"
+            },
+            "appStoreUrl": {
+              "description": "URL to your app on the Apple App Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://(itunes|apps)\\.apple\\.com/.*?\\d+",
+              "example": "https://apps.apple.com/us/app/expo-client/id982107779",
+              "type": [
+                "string"
+              ]
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "usesNonExemptEncryption": {
+                  "description": "Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.",
+                  "type": "boolean"
+                },
+                "googleMapsApiKey": {
+                  "description": "[Google Maps iOS SDK](https://developers.google.com/maps/documentation/ios-sdk/start) key for your standalone app.",
+                  "type": "string"
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`.",
+                  "type": "boolean",
+                  "fallback": false
+                },
+                "googleSignIn": {
+                  "description": "[Google Sign-In iOS SDK](https://developers.google.com/identity/sign-in/ios/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "reservedClientId": {
+                      "description": "The reserved client ID URL scheme. Can be found in `GoogeService-Info.plist`.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "isRemoteJSEnabled": {
+              "description": "DEPRECATED: use `updates.enabled` instead.",
+              "type": "boolean",
+              "deprecated": true
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) GoogleService-Info.plist file for configuring Firebase.",
+              "type": "string"
+            },
+            "loadJSInBackgroundExperimental": {
+              "description": "DEPRECATED: use `updates` key with `fallbackToCacheTimeout: 0` instead.",
+              "type": "boolean",
+              "deprecated": true
+            },
+            "supportsTablet": {
+              "description": "Whether your standalone iOS app supports tablet screen sizes. Defaults to `false`.",
+              "type": "boolean"
+            },
+            "isTabletOnly": {
+              "description": "If true, indicates that your standalone iOS app does not support handsets, and only supports tablets.",
+              "type": "boolean"
+            },
+            "requireFullScreen": {
+              "description": "If true, indicates that your standalone iOS app does not support Slide Over and Split View on iPad. Defaults to `true` currently, but will change to `false` in a future SDK version.",
+              "type": "boolean"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "fallback": "light",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "infoPlist": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "associatedDomains": {
+              "description": "An array that contains Associated Domains for the standalone app.",
+              "type": "array"
+            },
+            "usesIcloudStorage": {
+              "description": "A boolean indicating if the app uses iCloud Storage for DocumentPicker. See DocumentPicker docs for details.",
+              "type": "boolean"
+            },
+            "usesAppleSignIn": {
+              "description": "A boolean indicating if the app uses Apple Sign-In. See AppleAuthentication docs for details.",
+              "type": "boolean",
+              "fallback": false
+            },
+            "accessesContactNotes": {
+              "description": "A Boolean value that indicates whether the app may access the notes stored in contacts. You must receive permission from Apple before you can submit your app for review with this capability: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes.",
+              "type": "boolean",
+              "fallback": false
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for standalone iOS apps.",
+              "type": "object",
+              "properties": {
+                "xib": {
+                  "description": "Local path to a XIB file as the loading screen. It overrides other loading screen options.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^text/xml$",
+                    "contentTypeHuman": ".xib interface builder document"
+                  }
+                },
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^#|(&#x23;)\\d{6}$",
+                  "meta": {
+                    "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+                  }
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": [
+                    "array",
+                    "boolean",
+                    "number",
+                    "object",
+                    "string",
+                    "null"
+                  ]
+                },
+                "image": {
+                  "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image"
+                  }
+                },
+                "tabletImage": {
+                  "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "android": {
+          "description": "Android standalone app specific configuration",
+          "type": "object",
+          "meta": {
+            "standaloneOnly": true
+          },
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the Android version of your app will be written to this path during publish.",
+              "type": "string",
+              "meta": {
+                "autogenerated": true
+              }
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the Android version of your app will be written to this path during publish.",
+              "type": "string",
+              "meta": {
+                "autogenerated": true
+              }
+            },
+            "package": {
+              "description": "The package name for your Android standalone app. You make it up, but it needs to be unique on the Play Store. See [this StackOverflow question](http://stackoverflow.com/questions/6273892/android-package-name-convention).",
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9\\_]*(\\.[a-zA-Z][a-zA-Z0-9\\_]*)+$",
+              "meta": {
+                "regexHuman": "Valid Android Application ID. For example, host.exp.exponent, where exp.host is our domain and Expo is our app. The name may only contain lowercase and uppercase letters (a-z, A-Z), numbers (0-9) and underscores (_), separated by periods (.). Each component of the name should start with a lowercase letter."
+              }
+            },
+            "versionCode": {
+              "description": "Version number required by Google Play. Increment by one for each release. Must be an integer. https://developer.android.com/studio/publish/versioning.html",
+              "type": "integer"
+            },
+            "backgroundColor": {
+              "description": "The background color for your Android app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "fallback": "light",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "icon": {
+              "description": "Local path or remote url to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` key. We recommend that you use a 1024x1024 png file (transparency is recommended for the Google Play Store). This icon will appear on the home screen and within the Expo app.",
+              "type": "string",
+              "meta": {
+                "asset": true,
+                "contentTypePattern": "^image/png$",
+                "contentTypeHuman": ".png image",
+                "square": true
+              }
+            },
+            "adaptiveIcon": {
+              "type": "object",
+              "properties": {
+                "foregroundImage": {
+                  "description": "Local path or remote url to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` and the `android.icon` keys. Should follow the guidelines specified at https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive. This icon will appear on the home screen.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image",
+                    "square": true
+                  }
+                },
+                "backgroundImage": {
+                  "description": "Local path or remote url to a background image for your app's Adaptive Icon on Android. If specified, this overrides the `backgroundColor` key. Should follow the guidelines specified at https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image",
+                    "square": true
+                  }
+                },
+                "backgroundColor": {
+                  "description": "Color to use as the background for your app's Adaptive Icon on Android.",
+                  "type": "string",
+                  "pattern": "^#|(&#x23;)\\d{6}$",
+                  "meta": {
+                    "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "playStoreUrl": {
+              "description": "URL to your app on the Google Play Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://play\\.google\\.com/",
+              "example": "https://play.google.com/store/apps/details?id=host.exp.exponent",
+              "type": [
+                "string"
+              ]
+            },
+            "permissions": {
+              "description": "List of permissions used by the standalone app. Remove the field to use the default list of permissions.\n\n  Example: `[ \"CAMERA\", \"ACCESS_FINE_LOCATION\" ]`.\n\n  You can specify the following permissions depending on what you need:\n\n- `ACCESS_COARSE_LOCATION`\n- `ACCESS_FINE_LOCATION`\n- `CAMERA`\n- `MANAGE_DOCUMENTS`\n- `READ_CONTACTS`\n- `READ_EXTERNAL_STORAGE`\n- `READ_INTERNAL_STORAGE`\n- `READ_PHONE_STATE`\n- `RECORD_AUDIO`\n- `USE_FINGERPRINT`\n- `VIBRATE`\n- `WAKE_LOCK`\n- `WRITE_EXTERNAL_STORAGE`\n- `com.anddoes.launcher.permission.UPDATE_COUNT`\n- `com.android.launcher.permission.INSTALL_SHORTCUT`\n- `com.google.android.c2dm.permission.RECEIVE`\n- `com.google.android.gms.permission.ACTIVITY_RECOGNITION`\n- `com.google.android.providers.gsf.permission.READ_GSERVICES`\n- `com.htc.launcher.permission.READ_SETTINGS`\n- `com.htc.launcher.permission.UPDATE_SHORTCUT`\n- `com.majeur.launcher.permission.UPDATE_BADGE`\n- `com.sec.android.provider.badge.permission.READ`\n- `com.sec.android.provider.badge.permission.WRITE`\n- `com.sonyericsson.home.permission.BROADCAST_BADGE`",
+              "type": "array"
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) google-services.json file for configuring Firebase.",
+              "type": "string"
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "fabric": {
+                  "description": "[Google Developers Fabric](https://get.fabric.io/) keys to hook up Crashlytics and other services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Fabric API key",
+                      "type": "string"
+                    },
+                    "buildSecret": {
+                      "description": "Your Fabric build secret",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMaps": {
+                  "description": "[Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) key for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Google Maps Android SDK API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`.",
+                  "type": "boolean",
+                  "fallback": false
+                },
+                "googleSignIn": {
+                  "description": "[Google Sign-In Android SDK](https://developers.google.com/identity/sign-in/android/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "The Android API key. Can be found in the credentials section of the developer console or in `google-services.json`.",
+                      "type": "string"
+                    },
+                    "certificateHash": {
+                      "description": "The SHA-1 hash of the signing certificate used to build the apk without any separator `:`. Can be found in `google-services.json`. https://developers.google.com/android/guides/client-auth",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for standalone Android apps.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^#|(&#x23;)\\d{6}$",
+                  "meta": {
+                    "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+                  }
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain",
+                    "native"
+                  ],
+                  "type": [
+                    "array",
+                    "boolean",
+                    "number",
+                    "object",
+                    "string",
+                    "null"
+                  ]
+                },
+                "mdpi": {
+                  "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image"
+                  }
+                },
+                "hdpi": {
+                  "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image"
+                  }
+                },
+                "xhdpi": {
+                  "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image"
+                  }
+                },
+                "xxhdpi": {
+                  "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image"
+                  }
+                },
+                "xxxhdpi": {
+                  "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image"
+                  }
+                }
+              }
+            },
+            "intentFilters": {
+              "description": "An array of intent filters.",
+              "example": [
+                {
+                  "autoVerify": true,
+                  "action": "VIEW",
+                  "data": {
+                    "scheme": "https",
+                    "host": "*.expo.io"
+                  },
+                  "category": [
+                    "BROWSABLE",
+                    "DEFAULT"
+                  ]
+                }
+              ],
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "autoVerify": {
+                    "type": "boolean"
+                  },
+                  "action": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": [
+                      "array",
+                      "object"
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "scheme": {
+                          "type": "string"
+                        },
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "pathPattern": {
+                          "type": "string"
+                        },
+                        "pathPrefix": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "properties": {
+                      "scheme": {
+                        "type": "string"
+                      },
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "pathPattern": {
+                        "type": "string"
+                      },
+                      "pathPrefix": {
+                        "type": "string"
+                      },
+                      "mimeType": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "category": {
+                    "type": [
+                      "array",
+                      "string"
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "action"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "web": {
+          "description": "Web platform specific configuration",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "favicon": {
+              "description": "Relative path of an image to use for your app's favicon.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Defines the title of the document, defaults to the outer level name",
+              "PWA": "name",
+              "metatag": "title",
+              "type": "string"
+            },
+            "shortName": {
+              "description": "A short version of the app's name, 12 characters or fewer. Used in app launcher and new tab pages. Maps to `short_name` in the PWA manifest.json. Defaults to the `name` property.",
+              "PWA": "short_name",
+              "type": "string",
+              "meta": {
+                "regexHuman": "Maximum 12 characters long"
+              }
+            },
+            "lang": {
+              "description": "Specifies the primary language for the values in the name and short_name members. This value is a string containing a single language tag.",
+              "fallback": "'en'",
+              "PWA": "lang",
+              "type": "string"
+            },
+            "scope": {
+              "description": "Defines the navigation scope of this website's context. This restricts what web pages can be viewed while the manifest is applied. If the user navigates outside the scope, it returns to a normal web page inside a browser tab/window. If the scope is a relative URL, the base URL will be the URL of the manifest.",
+              "PWA": "scope",
+              "type": "string"
+            },
+            "themeColor": {
+              "description": "Defines the color of the Android tool bar, and may be reflected in the app's preview in task switchers.",
+              "PWA": "theme_color",
+              "metatag": "theme-color",
+              "fallback": [
+                "expo.primaryColor",
+                "#4630EB"
+              ],
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            },
+            "description": {
+              "description": "Provides a general description of what the pinned website does.",
+              "metatag": "description",
+              "PWA": "description",
+              "fallback": [
+                "expo.description",
+                "'A Neat Expo App'"
+              ],
+              "type": "string"
+            },
+            "dir": {
+              "description": "Specifies the primary text direction for the name, short_name, and description members. Together with the lang member, it helps the correct display of right-to-left languages.",
+              "fallback": "auto",
+              "PWA": "dir",
+              "enum": [
+                "auto",
+                "ltr",
+                "rtl"
+              ],
+              "type": "string"
+            },
+            "display": {
+              "description": "Defines the developers’ preferred display mode for the website.",
+              "fallback": "standalone",
+              "PWA": "display",
+              "enum": [
+                "fullscreen",
+                "standalone",
+                "minimal-ui",
+                "browser"
+              ],
+              "type": "string"
+            },
+            "startUrl": {
+              "description": "The URL that loads when a user launches the application (e.g. when added to home screen), typically the index. Note that this has to be a relative URL, relative to the manifest URL.",
+              "PWA": "start_url",
+              "type": "string"
+            },
+            "orientation": {
+              "description": "Defines the default orientation for all the website's top level browsing contexts.",
+              "enum": [
+                "any",
+                "natural",
+                "landscape",
+                "landscape-primary",
+                "landscape-secondary",
+                "portrait",
+                "portrait-primary",
+                "portrait-secondary"
+              ],
+              "type": "string"
+            },
+            "backgroundColor": {
+              "description": "Defines the expected “background color” for the website. This value repeats what is already available in the site’s CSS, but can be used by browsers to draw the background color of a shortcut when the manifest is available before the stylesheet has loaded. This creates a smooth transition between launching the web application and loading the site's content.",
+              "PWA": "background_color",
+              "fallback": [
+                "expo.splash.backgroundColor",
+                "#ffffff"
+              ],
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            },
+            "barStyle": {
+              "description": "If content is set to default, the status bar appears normal. If set to black, the status bar has a black background. If set to black-translucent, the status bar is black and translucent. If set to default or black, the web content is displayed below the status bar. If set to black-translucent, the web content is displayed on the entire screen, partially obscured by the status bar.",
+              "fallback": "default",
+              "metatag": "apple-mobile-web-app-status-bar-style",
+              "enum": [
+                "default",
+                "black",
+                "black-translucent"
+              ],
+              "type": "string"
+            },
+            "preferRelatedApplications": {
+              "description": "Hints for the user agent to indicate to the user that the specified native applications (defined in expo.ios and expo.android) are recommended over the website.",
+              "fallback": true,
+              "type": "boolean"
+            },
+            "use": {
+              "description": "DEPRECATED: Use the dedicated adapters like Next.js, Gatsby, Electron, etc...",
+              "fallback": "default",
+              "meta": {
+                "deprecated": true
+              },
+              "enum": [
+                "default",
+                "nextjs"
+              ],
+              "type": "string"
+            },
+            "build": {
+              "description": "Basic customization options for dangerously configuring the default webpack config. Please use `expo customize:web` to modify the versioned Webpack config directly instead.",
+              "type": "object",
+              "additionalProperties": true,
+              "meta": {
+                "deprecated": true
+              },
+              "properties": {
+                "rootId": {
+                  "description": "ID of the root DOM element in your index.html. By default this is \"root\".",
+                  "fallback": "root",
+                  "type": "string"
+                },
+                "devtool": {
+                  "description": "DEPRECATED: Modify the Webpack config directly. Choose a custom style of source mapping to enhance the debugging process. These values can affect build and rebuild speed dramatically.",
+                  "type": "string",
+                  "meta": {
+                    "deprecated": true
+                  }
+                },
+                "publicPath": {
+                  "description": "DEPRECATED: Modify the Webpack config directly. Allows you to specify the base path for all the assets within your application.",
+                  "type": "string",
+                  "meta": {
+                    "deprecated": true
+                  }
+                },
+                "minifyHTML": {
+                  "description": "DEPRECATED: Modify the Webpack config directly. Configuration for customizing webpack report. See `HtmlWebpackPlugin.Options` from `html-webpack-plugin`.",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {},
+                  "meta": {
+                    "deprecated": true
+                  }
+                },
+                "report": {
+                  "description": "DEPRECATED: Modify the Webpack config directly. Configuration for enabling webpack report and `stats.json`. See `BundleAnalyzerPlugin.Options` from `webpack-bundle-analyzer`.",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {},
+                  "meta": {
+                    "deprecated": true
+                  }
+                },
+                "serviceWorker": {
+                  "description": "DEPRECATED: Modify the Webpack config directly. Configuration for customizing the service worker. See `GenerateSWOptions` from `workbox-webpack-plugin`.",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {},
+                  "meta": {
+                    "deprecated": true
+                  }
+                }
+              }
+            },
+            "meta": {
+              "description": "DEPRECATED. Defines the meta tag elements that will be added to the head element of your index.html.",
+              "type": "object",
+              "additionalProperties": true,
+              "meta": {
+                "deprecated": true
+              },
+              "properties": {
+                "googleSiteVerification": {
+                  "description": "ID provided by the Google Site Verification API: https://developers.google.com/site-verification/",
+                  "type": "string"
+                },
+                "apple": {
+                  "description": "Apple PWA-specific meta elements. By default these values will be inferred from fields in the scope above, but you can override them here.",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "mobileWebAppCapable": {
+                      "description": "Enables PWA functionality on iOS devices.",
+                      "metatag": "apple-mobile-web-app-capable",
+                      "fallback": "yes",
+                      "type": "string"
+                    },
+                    "barStyle": {
+                      "description": "If content is set to \"default\", the status bar appears normal. If set to \"black\", the status bar has a black background. If set to \"black-translucent\", the status bar is black and translucent. If set to \"default\" or \"black\", the web content is displayed below the status bar. If set to \"black-translucent\", the web content is displayed on the entire screen, partially obscured by the status bar.",
+                      "fallback": [
+                        "expo.web.barStyle",
+                        "default"
+                      ],
+                      "metatag": "apple-mobile-web-app-status-bar-style",
+                      "enum": [
+                        "default",
+                        "black",
+                        "black-translucent"
+                      ],
+                      "type": "string"
+                    }
+                  }
+                },
+                "twitter": {
+                  "description": "Twitter card protocol: https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup.html",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {}
+                },
+                "openGraph": {
+                  "description": "The Open Graph protocol: http://ogp.me/",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {}
+                },
+                "microsoft": {
+                  "description": "X-UA protocol",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {}
+                }
+              }
+            },
+            "dangerous": {
+              "description": "Experimental features. These will break without deprecation notice.",
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "viewport": {
+                  "description": "Viewport meta tag for your index.html. By default this is optimized for mobile usage, disabling zooming, and resizing for iPhone X.",
+                  "fallback": "width=device-width,initial-scale=1,minimum-scale=1,viewport-fit=cover",
+                  "type": "string"
+                },
+                "noJavaScriptMessage": {
+                  "description": "Message that is rendered when the browser using your page doesn't have JS enabled.",
+                  "fallback": "Oh no! It looks like JavaScript is not enabled in your browser.",
+                  "type": "string"
+                }
+              }
+            },
+            "splash": {
+              "description": "Configuration for PWA splash screens.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^#|(&#x23;)\\d{6}$",
+                  "meta": {
+                    "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+                  }
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": [
+                    "array",
+                    "boolean",
+                    "number",
+                    "object",
+                    "string",
+                    "null"
+                  ]
+                },
+                "image": {
+                  "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string",
+                  "meta": {
+                    "asset": true,
+                    "contentTypePattern": "^image/png$",
+                    "contentTypeHuman": ".png image"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "facebookAppId": {
+          "description": "Used for all Facebook libraries. Set up your Facebook App ID at https://developers.facebook.com.",
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "facebookAutoInitEnabled": {
+          "description": "Whether the Facebook SDK should be initialized automatically. The default in Expo (Client and in standalone apps) is `false`.",
+          "type": "boolean"
+        },
+        "facebookAutoLogAppEventsEnabled": {
+          "description": "Whether the Facebook SDK log app events automatically. If you don't set this property, Facebook's default will be used. (Applicable only to standalone apps.)",
+          "type": "boolean"
+        },
+        "facebookAdvertiserIDCollectionEnabled": {
+          "description": "Whether the Facebook SDK should collect advertiser ID properties, like the Apple IDFA and Android Advertising ID, automatically. If you don't set this property, Facebook's default policy will be used. (Applicable only to standalone apps.)",
+          "type": "boolean"
+        },
+        "facebookDisplayName": {
+          "description": "Used for native Facebook login.",
+          "type": "string"
+        },
+        "facebookScheme": {
+          "description": "Used for Facebook native login. Starts with 'fb' and followed by a string of digits, like 'fb1234567890'. You can find your scheme at https://developers.facebook.com/docs/facebook-login/ios in the 'Configuring Your info.plist' section.",
+          "type": "string",
+          "pattern": "^fb[0-9]+[A-Za-z]*$"
+        },
+        "isDetached": {
+          "description": "Is app detached",
+          "type": "boolean",
+          "meta": {
+            "autogenerated": true
+          }
+        },
+        "detach": {
+          "description": "Extra fields needed by detached apps",
+          "type": "object",
+          "properties": {},
+          "meta": {
+            "autogenerated": true
+          },
+          "additionalProperties": true
+        },
+        "splash": {
+          "description": "Configuration for loading and splash screen for standalone apps.",
+          "type": "object",
+          "properties": {
+            "backgroundColor": {
+              "description": "Color to fill the loading screen background",
+              "type": "string",
+              "pattern": "^#|(&#x23;)\\d{6}$",
+              "meta": {
+                "regexHuman": "6 character long hex color string, eg: `'#000000'`"
+              }
+            },
+            "resizeMode": {
+              "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+              "enum": [
+                "cover",
+                "contain"
+              ],
+              "type": [
+                "array",
+                "boolean",
+                "number",
+                "object",
+                "string",
+                "null"
+              ]
+            },
+            "image": {
+              "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+              "type": "string",
+              "meta": {
+                "asset": true,
+                "contentTypePattern": "^image/png$",
+                "contentTypeHuman": ".png image"
+              }
+            }
+          }
+        },
+        "hooks": {
+          "description": "Configuration for scripts to run to hook into the publish process",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "postPublish": {
+              "type": "array"
+            }
+          }
+        },
+        "assetBundlePatterns": {
+          "description": "An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.io/versions/latest/guides/offline-support.html)",
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "slug"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds the Expo SDK schema (version `37.0.0`) [wrapped in the `expo` property](https://docs.expo.io/versions/v37.0.0/workflow/configuration/) 😄 

[Expo publishes this schema](https://expo.io/--/xdl-schema/37.0.0) for all versions from their API. Unfortunately, this is not the full schema. Instead, this is the subset of the property `expo` within the file. I'm not sure if it's possible to automate wrapping this schema in an `expo` property, if it's possible that might be a better way.

Hope it helps!