### PR TITLE
Fixes Drone CI steps on kind "pipeline"

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -271,8 +271,9 @@
           }
         },
         "steps": {
-          "type": "array",
-          "minLength": 1
+          "items": {
+            "$ref": "#/definitions/step"
+          }
         },
         "trigger": {
           "$ref": "#/definitions/allConditions"


### PR DESCRIPTION
The steps object was not using the step definition, yielding errors when using attributes `name` and `commands` for instance. 

EDIT: PR 1000!!!  🥳 