### PR TITLE
Update with 2 new schemas (json-schema.org family)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1722,12 +1722,12 @@
     },
     {
       "name": "JSON Schema Draft 7",
-      "description": "Meta-validation schema for JSON Schema Draft 4",
+      "description": "Meta-validation schema for JSON Schema Draft 7",
       "url": "http://json-schema.org/draft-07/schema"
     },
     {
       "name": "JSON Schema Draft 8",
-      "description": "Meta-validation schema for JSON Schema Draft 4",
+      "description": "Meta-validation schema for JSON Schema Draft 8",
       "url": "https://json-schema.org/draft/2019-09/schema"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1721,6 +1721,16 @@
       "url": "http://json-schema.org/draft-04/schema"
     },
     {
+      "name": "JSON Schema Draft 7",
+      "description": "Meta-validation schema for JSON Schema Draft 4",
+      "url": "http://json-schema.org/draft-07/schema"
+    },
+    {
+      "name": "JSON Schema Draft 8",
+      "description": "Meta-validation schema for JSON Schema Draft 4",
+      "url": "https://json-schema.org/draft/2019-09/schema"
+    },
+    {
       "name": "xunit.runner.json",
       "description": "xUnit.net runner configuration file",
       "fileMatch": [


### PR DESCRIPTION
I would like to update the schemas list, adding the updated versions of the json-schema.org family, that is draft 7 and draft 8.