### PR TITLE
match action.yaml for github action

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -681,7 +681,8 @@
       "name": "GitHub Action",
       "description": "YAML schema for GitHub Actions",
       "fileMatch": [
-        "action.yml"
+        "action.yml",
+        "action.yaml"
       ],
       "url": "http://json.schemastore.org/github-action"
     },


### PR DESCRIPTION
Support `action.yaml` as a file match for the GitHub Action schema.

Per https://help.github.com/en/actions/building-actions/about-actions#types-of-actions:

> The metadata filename must be either `action.yml` or `action.yaml`.

