### PR TITLE
Improved JSDoc schema & added :lock: HTTP/TLS link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ where schemas for popular JSON documents can be found.
 
 Website: [schemastore.org](http://schemastore.org)
 
+For HTTP/TLS use: [schemastore.azurewebsites.net](https://schemastore.azurewebsites.net)
+
 ## Contribute
 Contributions are more than welcome. Both to the website
 itself or to the various schema files.

--- a/src/schemas/json/jsdoc-1.0.0.json
+++ b/src/schemas/json/jsdoc-1.0.0.json
@@ -79,16 +79,37 @@
             "description": "Determines how input files are parsed"
         },
         "opts": {
+            "$comment": "The command line options take precedence over config file",
             "type": "object",
             "title": "Incorporating CLI options",
             "description": "Determines flags that `jsdoc` command will be invoked with",
             "additionalProperties": false,
             "properties": {
-                "template": {
-                    "$comment": "Equivalent to `-t` flag",
-                    "default": "templates/default",
-                    "description": "The path to the template to use for generating output",
-                    "title": "Output template",
+                "access": {
+                    "$comment": "Equivalent to `-a` flag",
+                    "default": "all",
+                    "description": "Only display symbols with the given `access` property",
+                    "enum": [
+                        "all",
+                        "private",
+                        "protected",
+                        "public",
+                        "undefined"
+                    ],
+                    "title": "Symbol access",
+                    "type": "string"
+                },
+                "debug": {
+                    "$comment": "Equivalent to `--debug` flag",
+                    "description": "Log information that can help debug issues in JSDoc itself",
+                    "title": "Log debug info",
+                    "type": "boolean"
+                },
+                "destination": {
+                    "$comment": "Equivalent to `-d` flag",
+                    "default": "./out/",
+                    "description": "The path to the output folder for the generated documentation",
+                    "title": "Output folder",
                     "type": "string"
                 },
                 "encoding": {
@@ -96,13 +117,6 @@
                     "default": "utf8",
                     "description": "Assume this encoding when reading all source files",
                     "title": "Input files encoding",
-                    "type": "string"
-                },
-                "destination": {
-                    "$comment": "Equivalent to `-d` flag",
-                    "default": "./out/",
-                    "description": "The path to the output folder for the generated documentation",
-                    "title": "Output folder",
                     "type": "string"
                 },
                 "package": {
@@ -117,12 +131,25 @@
                     "title": "Pedantic",
                     "type": "boolean"
                 },
+                "readme": {
+                    "$comment": "Equivalent to `-R` flag",
+                    "description": "The README.md file to include in the generated documentation",
+                    "title": "README.md",
+                    "type": "string"
+                },
                 "recurse": {
                     "$comment": "Equivalent to `-r` flag",
                     "default": false,
                     "description": "Recurses to subdirectories when searching input files",
                     "title": "Recurse to subdirectories",
                     "type": "boolean"
+                },
+                "template": {
+                    "$comment": "Equivalent to `-t` flag",
+                    "default": "templates/default",
+                    "description": "The path to the template to use for generating output",
+                    "title": "Output template",
+                    "type": "string"
                 },
                 "test": {
                     "$comment": "Equivalent to `-T` flag. Won't work if installed via NPM",
@@ -186,7 +213,7 @@
             "type": "object"
         },
         "templates": {
-            "description": "Affect the appearance and content of generated documentation",
+            "description": "Affects the appearance and content of generated documentation",
             "properties": {
                 "cleverLinks": {
                     "$comment": "If `true`, text of @link tag that is a URL will be rendered in normal font, else in monospace",
@@ -212,10 +239,10 @@
                             "type": "string"
                         },
                         "outputSourceFiles": {
-                            "$comment": "^3.3.0 can be set to `false` to omit source files",
+                            "$comment": "^3.3.0 can be set to `false` to remove links to source files",
                             "default": true,
-                            "description": "Escludes pretty-printed source files from docs",
-                            "title": "Disable source",
+                            "description": "Disables pretty-printed source files",
+                            "title": "Generating pretty-printed source files",
                             "type": "boolean"
                         },
                         "staticFiles": {
@@ -229,7 +256,7 @@
                                     "type": "array"
                                 },
                                 "excludePattern": {
-                                    "description": "A regular expression indicating which files to skip.",
+                                    "description": "A regular expression indicating which files to skip",
                                     "type": "string"
                                 },
                                 "include": {


### PR DESCRIPTION
As a continuation of  #1009 discussion on HTTPS version of the store, the first part adds a link to README (feel free to discard if wording / placement seem off). The second part adds more CLI options for JSDoc configuration file schema + couple of smaller improvements.