### PR TITLE
Add KSP-AVC

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1709,6 +1709,14 @@
       "url": "https://json-stat.org/format/schema/2.0/"
     },
     {
+      "name": "KSP-AVC 1.4.1",
+      "description": "The .version file format for KSP-AVC",
+      "fileMatch": [
+        "*.version"
+      ],
+      "url": "http://json.schemastore.org/ksp-avc"
+    },
+    {
       "name": "KSP-CKAN 1.26.4",
       "description": "Metadata spec v1.26.4 for KSP-CKAN",
       "fileMatch": [

--- a/src/schemas/json/ksp-avc.json
+++ b/src/schemas/json/ksp-avc.json
@@ -1,0 +1,172 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Add-on Version Checker file",
+    "description": "A KSP-AVC version file's content",
+    "type": "object",
+    "properties": {
+        "NAME": {
+            "description": "The display name for the add-on",
+            "type": "string"
+        },
+        "URL": {
+            "description": "Location of a remote version file for update checking",
+            "type": "string",
+            "format": "uri"
+        },
+        "DOWNLOAD": {
+            "description": "Web address where the latest version can be downloaded",
+            "type": "string",
+            "format": "uri"
+        },
+        "CHANGE_LOG": {
+            "description": "The complete or incremental change log for the add-on",
+            "type": "string"
+        },
+        "CHANGE_LOG_URL": {
+            "description": "Populates the CHANGE_LOG field using the file at this url",
+            "type": "string",
+            "format": "uri"
+        },
+        "GITHUB": {
+            "description": "Allows KSP-AVC to do release checks with GitHub including setting a download location if one is not specified. If the latest release version is not equal to the version in the file, an update notification will not appear.",
+            "type": "object",
+            "properties": {
+                "USERNAME ": {
+                    "description": "Your GitHub username",
+                    "type": "string"
+                },
+                "REPOSITORY ": {
+                    "description": "The name of the source repository",
+                    "type": "string"
+                },
+                "ALLOW_PRE_RELEASE ": {
+                    "description": "Include pre-releases in the latest release search",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "USERNAME",
+                "REPOSITORY"
+            ]
+        },
+        "KERBAL_STUFF_URL": {
+            "description": "URL to this mod's page on KerbalStuff",
+            "type": "string",
+            "format": "uri"
+        },
+        "VERSION": {
+            "description": "The version of the add-on",
+            "$ref": "#/definitions/version"
+        },
+        "KSP_VERSION": {
+            "description": "Version of KSP that the add-on was made to support",
+            "$ref": "#/definitions/version"
+        },
+        "KSP_VERSION_MIN": {
+            "description": "Minimum version of KSP that the add-on supports",
+            "$ref": "#/definitions/version"
+        },
+        "KSP_VERSION_MAX": {
+            "description": "Maximum version of KSP that the add-on supports",
+            "$ref": "#/definitions/version"
+        },
+        "DISALLOW_VERSION_OVERRIDE": {
+            "type": "boolean",
+            "description": "If true, don't trust KSP-AVC's idea of which game versions are compatible with which other game versions, based on user configuration"
+        },
+        "ASSEMBLY_NAME": {
+            "type": "string",
+            "description": "DO NOT USE, won't work with CKAN; name of a DLL to check for VERSION on the fly"
+        },
+        "KSP_VERSION_INCLUDE": {
+            "description": "DO NOT USE, won't work with CKAN; a list of versions with which this mod is compatible",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/version"
+            },
+            "uniqueItems": true
+        },
+        "KSP_VERSION_EXCLUDE": {
+            "description": "DO NOT USE, won't work with CKAN; a list of versions with which this mod is incompatible",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/version"
+            },
+            "uniqueItems": true
+        },
+        "LOCAL_HAS_PRIORITY": {
+            "type": "boolean",
+            "description": "DO NOT USE, won't work with CKAN; if true, don't override properties using the remote version file"
+        },
+        "REMOTE_HAS_PRIORITY": {
+            "type": "boolean",
+            "description": "DO NOT USE, won't work with CKAN; if false, don't override properties using the remote version file"
+        },
+        "INSTALL_LOC|INSTALL_LOC*": {
+            "description": "Stanza to define file location to check, used by MADLAD",
+            "$ref": "#/definitions/install_loc"
+        }
+    },
+    "required": [
+        "NAME",
+        "VERSION"
+    ],
+    "definitions": {
+        "version": {
+            "description": "A semantic(?) version",
+            "anyOf": [
+                {
+                    "type": "string",
+                    "pattern": "^(any|[0-9]+\\.[0-9]+(\\.[0-9]+)?)$"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "MAJOR": {
+                            "description": "Change major version when you make incompatible API changes",
+                            "type": "integer"
+                        },
+                        "MINOR": {
+                            "description": "Change minor version when you add functionality in a backwards-compatible manner",
+                            "type": "integer"
+                        },
+                        "PATCH": {
+                            "description": "Change patch version when you make backwards-compatible bug fixes",
+                            "type": "integer"
+                        },
+                        "BUILD": {
+                            "description": "Build informaion",
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "MAJOR"
+                    ]
+                }
+            ]
+        },
+        "install_loc": {
+            "description": "definition of the install_loc fields",
+            "NAME": {
+                "type": "string",
+                "description": "Name of the mod, If not specified, uses the Modname from the .version file"
+            },
+            "PATH": {
+                "type": "string",
+                "description": "Path to the directory, begins below the GameData.  Must be there, but will be empty in most cases"
+            },
+            "DIRECTORY": {
+                "type": "string",
+                "description": "Directory where file is"
+            },
+            "FILE": {
+                "type": "string",
+                "description": "filename to be checked.  If not specified, then it checks for the directory only"
+            },
+            "required": [
+                "PATH",
+                "DIRECTORY"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
KSP-AVC is a standardised system for versioning mods for Kerbal Space Program which you can find on https://github.com/linuxgurugamer/KSPAddonVersionChecker