### PR TITLE
[package.json] Add common properties to publishConfig

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -392,6 +392,19 @@
         },
         "publishConfig": {
           "type": "object",
+          "properties": {
+            "access": {
+              "type": "string",
+              "enum": ["public", "restricted"]
+            },
+            "tag": {
+              "type": "string"
+            },
+            "registry": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
           "additionalProperties": true
         },
         "dist": {


### PR DESCRIPTION
This adds the three most common properties one might expect to use in the `publishConfig` key of the package.json per https://docs.npmjs.com/files/package.json#publishconfig. Could go through and add all of the values of https://docs.npmjs.com/misc/config, but I suspect that is probably overkill for the general use-case of most people.