### PR TITLE
Update build flow + fix HEMTT schema + automate README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+### JSON Schema
+You can contribute in a variety of ways. For a detailed tutorial, read [Scott Addie](https://twitter.com/Scott_Addie)'s [**Community-Driven JSON Schemas in Visual Studio 2015**](https://scottaddie.com/2016/08/02/community-driven-json-schemas-in-visual-studio-2015/) blog post.
+
+1. Submit new JSON schema files
+2. Add a JSON schema file to the [schema catalog](src/api/json/catalog.json)
+3. Modify/update existing schema files
+
+Versioning of schema files are handled by modifying the file name to include
+the version number: *myschema-1.2.json*
+
+When uploading a new schema file, make sure it targets a file that is commonly
+used or has potential for broad uptake.
+
+If you don't have Visual Studio (using macOS or Linux?), you can check your modifications are fine by running:
+```Shell
+make
+```
+
+### CSS spec
+The CSS specification is divided into multple XML documents
+- one for each CSS module as specified by the W3C.
+
+Each XML document can contain properies, @-directives and
+pseudo elements/classes with descriptions, example usage
+and allowed values.
+
+Here are some ways to contribute:
+
+1. Add missing descriptions
+2. Add missing properties and values
+3. Update the supported browsers attribute
+4. Add new CSS modules by creating a new file
+
+The easiest way to contribute is to use Visual Studio 2012
+or newer, since it has native support for this XML format.
+
+After cloning this project to your local machine, copy
+the 
+[XML schema files](/src/schemas/css) to this folder:
+
+**C:\Users\[username]\AppData\Roaming\Microsoft\VisualStudio\14.0\schemas\css** where
+_14.0_ refers to the version of Visual Studio.
+
+If the last part of the path (_schemas\css_) doesn't exist, 
+you should create it manually. 
+
+Visual Studio will now use these schema files instead of
+the ones it ships with.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 build:
 	cd src && \
 	npm install && \
-	./node_modules/.bin/grunt
+	npm run build
 	git diff-index --quiet HEAD -- || { \
 		echo "ERROR: Dirty repository found"; \
 		git status --porcelain; \

--- a/README.md
+++ b/README.md
@@ -1,65 +1,39 @@
 # JSON Schema Store
 
+
+
  A collection of JSON schemas
+
+
 
 [![Build status](https://ci.appveyor.com/api/projects/status/ab34h2jsrjfiw2xq?svg=true)](https://ci.appveyor.com/project/madskristensen/schemastore-371)
 
+
+
 The repository is meant as a universal JSON schema store,
+
 where schemas for popular JSON documents can be found.
 
-Website: [schemastore.org](http://schemastore.org)
 
-For HTTP/TLS use: [schemastore.azurewebsites.net](https://schemastore.azurewebsites.net)
+
+Website: [schemastore.org](https://schemastore.azurewebsites.net)
+
+
+
+## How to use
+
+
+
+Schemas are available at (just append schema file name to the path):
+
+
+
+| HTTP | HTTP/TLS |
+| --- | --- |
+| <a href="http://schemastore.org/css/" referrerpolicy="no-referrer">CSS</a> \| <a href="http://schemastore.org/json/" referrerpolicy="no-referrer">JSON</a> \| <a href="http://schemastore.org/javascript/" referrerpolicy="no-referrer">JS</a> | <a href="https://schemastore.azurewebsites.net/schemas/css/" referrerpolicy="no-referrer">CSS</a> \| <a href="https://schemastore.azurewebsites.net/schemas/json/" referrerpolicy="no-referrer">JSON</a> \| <a href="https://schemastore.azurewebsites.net/schemas/javascript/" referrerpolicy="no-referrer">JS</a> |
+
+
 
 ## Contribute
-Contributions are more than welcome. Both to the website
-itself or to the various schema files.
 
-### JSON Schema
-You can contribute in a variety of ways. For a detailed tutorial, read [Scott Addie](https://twitter.com/Scott_Addie)'s [**Community-Driven JSON Schemas in Visual Studio 2015**](https://scottaddie.com/2016/08/02/community-driven-json-schemas-in-visual-studio-2015/) blog post.
-
-1. Submit new JSON schema files
-2. Add a JSON schema file to the [schema catalog](src/api/json/catalog.json)
-3. Modify/update existing schema files
-
-Versioning of schema files are handled by modifying the file name to include
-the version number: *myschema-1.2.json*
-
-When uploading a new schema file, make sure it targets a file that is commonly
-used or has potential for broad uptake.
-
-If you don't have Visual Studio (using macOS or Linux?), you can check your modifications are fine by running:
-```Shell
-make
-```
-
-### CSS spec
-The CSS specification is divided into multple XML documents
-- one for each CSS module as specified by the W3C.
-
-Each XML document can contain properies, @-directives and
-pseudo elements/classes with descriptions, example usage
-and allowed values.
-
-Here are some ways to contribute:
-
-1. Add missing descriptions
-2. Add missing properties and values
-3. Update the supported browsers attribute
-4. Add new CSS modules by creating a new file
-
-The easiest way to contribute is to use Visual Studio 2012
-or newer, since it has native support for this XML format.
-
-After cloning this project to your local machine, copy
-the 
-[XML schema files](/src/schemas/css) to this folder:
-
-**C:\Users\[username]\AppData\Roaming\Microsoft\VisualStudio\14.0\schemas\css** where
-_14.0_ refers to the version of Visual Studio.
-
-If the last part of the path (_schemas\css_) doesn't exist, 
-you should create it manually. 
-
-Visual Studio will now use these schema files instead of
-the ones it ships with.
+Contributions are more than welcome. Both to the website itself or to the various schema files. Before contributing, please carefully read the [guidelines](./CONTRIBUTING.md).

--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -54,19 +54,19 @@ module.exports = function (grunt) {
         dest: "schemas/json/jsonld.json"
       },
       ninjs_v12: {
-        options: { url: "http://www.iptc.org/std/ninjs/ninjs-schema_1.2.json" },
+        options: { url: "https://www.iptc.org/std/ninjs/ninjs-schema_1.2.json" },
         dest: "schemas/json/ninjs-1.2.json"
       },
       ninjs_v11: {
-        options: { url: "http://www.iptc.org/std/ninjs/ninjs-schema_1.1.json" },
+        options: { url: "https://www.iptc.org/std/ninjs/ninjs-schema_1.1.json" },
         dest: "schemas/json/ninjs-1.1.json"
       },
       ninjs_v10: {
-        options: { url: "http://www.iptc.org/std/ninjs/ninjs-schema_1.0.json" },
+        options: { url: "https://www.iptc.org/std/ninjs/ninjs-schema_1.0.json" },
         dest: "schemas/json/ninjs-1.0.json"
       },
       xunit_v23: {
-        options: { url: "http://xunit.github.io/schema/v2.3/xunit.runner.schema.json" },
+        options: { url: "https://xunit.github.io/schema/v2.3/xunit.runner.schema.json" },
         dest: "schemas/json/xunit.runner.schema.json"
       }
     },
@@ -88,10 +88,12 @@ module.exports = function (grunt) {
 
   grunt.registerTask("setup", "Dynamically load schema validation based on the files and folders in /test/", function () {
     var fs = require('fs');
-    var dir = "test";
+    var pt = require("path");
+
+    var testDir = "test";
     var schemas = fs.readdirSync("schemas/json");
 
-    var folders = fs.readdirSync(dir);
+    var folders = fs.readdirSync(testDir);
     var tv4 = {};
 
     schemas.forEach(function (schema) {
@@ -103,14 +105,19 @@ module.exports = function (grunt) {
     folders.forEach(function (folder) {
 
       // If it's a file, ignore and continue. We only care about folders.
-      if (folder.indexOf('.') > -1)
+      if (/.+(?=\.[a-zA-Z]+$)/.test(folder)) {
         return;
+      }
+
+      const toPath = (file) => pt.join(testDir, folder, file);
 
       var name = folder.replace("_", ".");
-      var schema = grunt.file.readJSON("schemas/json/" + name + ".json");
-      var files = fs.readdirSync(dir + "/" + folder).map(function (file) { return dir + "/" + folder + "/" + file; });
+      var schema = grunt.file.readJSON(`schemas/json/${name}.json`);
+      var files = fs.readdirSync(pt.join(testDir, folder)).map(toPath);
 
-      grunt.config.set("tv4." + folder, {
+      const valid = folder.replace(/\./g, "\\.");
+
+      grunt.config.set("tv4." + valid, {
         options: {
           root: schema,
           banUnknown: false

--- a/src/package.json
+++ b/src/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "https://github.com/schemastore/SchemaStore"
   },
+  "scripts": {
+    "build": "grunt"
+  },
   "devDependencies": {
     "grunt": "^1.1.0",
     "grunt-contrib-watch": "^1.1.0",

--- a/src/schemas/json/hemtt-0.6.2.json
+++ b/src/schemas/json/hemtt-0.6.2.json
@@ -3,7 +3,11 @@
   "type": "object",
   "title": "The Root Schema",
   "description": "The hemtt.json or hemtt.toml file is used to configure your HEMTT Project. All examples are done using JSON, but both files support every feature of HEMTT. hemtt.toml will be used if both files are present.",
-  "required": [ "name", "prefix", "author" ],
+  "required": [
+    "name",
+    "prefix",
+    "author"
+  ],
   "properties": {
     "name": {
       "$id": "#/properties/name",
@@ -11,7 +15,9 @@
       "title": "The Name Schema",
       "default": "",
       "description": "Long name of your project.",
-      "examples": [ "Advanced Banana Environment" ],
+      "examples": [
+        "Advanced Banana Environment"
+      ],
       "pattern": "^(.*)$"
     },
     "prefix": {
@@ -20,7 +26,9 @@
       "title": "The Prefix Schema",
       "default": "",
       "description": "Prefix used for CBA macros and the release directory name.",
-      "examples": [ "ABE3" ],
+      "examples": [
+        "ABE3"
+      ],
       "pattern": "^(.*)$"
     },
     "author": {
@@ -29,7 +37,9 @@
       "title": "The Author Schema",
       "default": "",
       "description": "Author of the project.",
-      "examples": [ "ACE Mod Team" ],
+      "examples": [
+        "ACE Mod Team"
+      ],
       "pattern": "^(.*)$"
     },
     "version": {
@@ -38,7 +48,9 @@
       "title": "The Version Schema",
       "default": "",
       "description": "HEMTT will look for ```addons/main/script_version.hpp``` and use it for the version number. If you are not using the CBA project structure or do not have that file you can add a version number in the HEMTT project file.",
-      "examples": [ "1.0.0.0" ],
+      "examples": [
+        "1.0.0.0"
+      ],
       "pattern": "^(.*)$"
     },
     "files": {
@@ -52,7 +64,11 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "mod.cpp", "logo.paa", "*.dll" ],
+        "examples": [
+          "mod.cpp",
+          "logo.paa",
+          "*.dll"
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -67,7 +83,9 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "./include" ],
+        "examples": [
+          "./include"
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -82,7 +100,11 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "*.psd", "*.png", "*.tga" ],
+        "examples": [
+          "*.psd",
+          "*.png",
+          "*.tga"
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -97,7 +119,10 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "tracers", "particles" ],
+        "examples": [
+          "tracers",
+          "particles"
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -107,7 +132,9 @@
       "title": "The Folder_optionals Schema",
       "description": "HEMTT will by default build optionals into their own mod folders, which can be directly launched by the user. This can be turned off to build optional PBOs directly into optionals folder.",
       "default": false,
-      "examples": [ false ]
+      "examples": [
+        false
+      ]
     },
     "skip": {
       "$id": "#/properties/skip",
@@ -120,7 +147,10 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "hearing", "zeus" ],
+        "examples": [
+          "hearing",
+          "zeus"
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -135,7 +165,9 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "author=me" ],
+        "examples": [
+          "author=me"
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -145,7 +177,9 @@
       "title": "The Modname Schema",
       "description": "HEMTT will use the specified mod name (without @) to form @mod folder. Supports templating.",
       "default": "",
-      "examples": [ "my_mod" ],
+      "examples": [
+        "my_mod"
+      ],
       "pattern": "^(.*)$"
     },
     "keyname": {
@@ -154,7 +188,9 @@
       "title": "The Keyname Schema",
       "description": "HEMTT will use the specified key name for .bikey and .biprivatekey names. Supports templating.",
       "default": "",
-      "examples": [ "my_key" ],
+      "examples": [
+        "my_key"
+      ],
       "pattern": "^(.*)$"
     },
     "signame": {
@@ -163,7 +199,9 @@
       "title": "The Signame Schema",
       "description": "HEMTT will use the specified signature name as part of the full signature (.bisign) name. Supports templating.",
       "default": "",
-      "examples": [ "my_custom_name" ],
+      "examples": [
+        "my_custom_name"
+      ],
       "pattern": "^(.*)$"
     },
     "sigversion": {
@@ -172,7 +210,9 @@
       "title": "The Sigversion Schema",
       "description": "HEMTT will use the specified signature version. Currently Supported: V2, V3 (Experiemental).",
       "default": 2,
-      "examples": [ 3 ]
+      "examples": [
+        3
+      ]
     },
     "reuse_private_key": {
       "$id": "#/properties/reuse_private_key",
@@ -180,7 +220,9 @@
       "title": "The Reuse_private_key Schema",
       "description": "If set to true, HEMTT will use (and re-use) releases/keys/{keyname}.biprivatekey. It will be generated if it doesn't exist. The default behaviour is to generate a new private key each time and discard it immediately. HEMTT strongly recommends that you only re-use the key if you are making a client-side mod where it will not matter if clients are running different versions of the mod.",
       "default": false,
-      "examples": [ false ]
+      "examples": [
+        false
+      ]
     },
     "postbuild": {
       "$id": "#/properties/postbuild",
@@ -192,7 +234,9 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "" ],
+        "examples": [
+          ""
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -206,7 +250,9 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "" ],
+        "examples": [
+          ""
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -220,7 +266,9 @@
         "type": "string",
         "title": "The Items Schema",
         "default": "",
-        "examples": [ "" ],
+        "examples": [
+          ""
+        ],
         "pattern": "^(.*)$"
       }
     },
@@ -229,102 +277,129 @@
       "type": "object",
       "title": "The Scripts Schema",
       "default": null,
-      "properties": {
-        "": {
-          "$id": "#/properties/scripts/properties/",
-          "type": "object",
-          "title": "The  Schema",
-          "default": null,
-          "properties": {
-            "steps": {
-              "$id": "#/properties/scripts/properties//properties/steps",
-              "type": "array",
-              "title": "The Steps Schema",
-              "default": null,
-              "items": {
-                "$id": "#/properties/scripts/properties//properties/steps/items",
-                "type": "string",
-                "title": "The Items Schema",
-                "default": "",
-                "examples": [
-                  "echo {{addon}} took {{time}} ms to build."
-                ],
-                "pattern": "^(.*)$"
-              }
-            },
-            "steps_linux": {
-              "$id": "#/properties/scripts/properties//properties/steps_linux",
-              "type": "array",
-              "title": "The Steps_linux Schema",
-              "default": null,
-              "description": "steps_windows and steps_linux can be used to run different steps on the respective platforms.",
-              "items": {
-                "$id": "#/properties/scripts/properties//properties/steps_linux/items",
-                "type": "string",
-                "title": "The Items Schema",
-                "default": "",
-                "examples": [ "" ],
-                "pattern": "^(.*)$"
-              }
-            },
-            "steps_windows": {
-              "$id": "#/properties/scripts/properties//properties/steps_windows",
-              "type": "array",
-              "title": "The Steps_windows Schema",
-              "default": null,
-              "description": "steps_windows and steps_linux can be used to run different steps on the respective platforms.",
-              "items": {
-                "$id": "#/properties/scripts/properties//properties/steps_windows/items",
-                "type": "string",
-                "title": "The Items Schema",
-                "default": "",
-                "examples": [ "" ],
-                "pattern": "^(.*)$"
-              }
-            },
-            "show_output": {
-              "$id": "#/properties/scripts/properties//properties/show_output",
-              "type": "boolean",
-              "title": "The Show_output Schema",
-              "description": "All output is hidden by default. Setting show_output will display the command being executed and its output.",
-              "default": false,
-              "examples": [ true ]
-            },
-            "foreach": {
-              "$id": "#/properties/scripts/properties//properties/foreach",
-              "type": "boolean",
-              "title": "The Foreach Schema",
-              "default": false,
-              "description": "Scripts can be ran for each addons. Inside prebuild the script will be ran for each addon that HEMTT will build, including addons that will be skipped if they are already built. Inside postbuild and releasebuild only addons that were successfully built with be used, excluding addons that were skipped for being up to date.",
-              "examples": [ true ]
-            },
-            "parallel": {
-              "$id": "#/properties/scripts/properties//properties/parallel",
-              "type": "boolean",
-              "title": "The Parallel Schema",
-              "description": "Requires foreach to be true. If a script is thread safe parallel can be used to process multiple addons at a time.",
-              "default": false,
-              "examples": [ true ]
+      "additionalProperties": {
+        "$id": "#/properties/scripts/properties/",
+        "type": "object",
+        "title": "The  Schema",
+        "default": null,
+        "properties": {
+          "steps": {
+            "$id": "#/properties/scripts/properties//properties/steps",
+            "type": "array",
+            "title": "The Steps Schema",
+            "default": null,
+            "items": {
+              "$id": "#/properties/scripts/properties//properties/steps/items",
+              "type": "string",
+              "title": "The Items Schema",
+              "default": "",
+              "examples": [
+                "echo {{addon}} took {{time}} ms to build."
+              ],
+              "pattern": "^(.*)$"
             }
+          },
+          "steps_linux": {
+            "$id": "#/properties/scripts/properties//properties/steps_linux",
+            "type": "array",
+            "title": "The Steps_linux Schema",
+            "default": null,
+            "description": "steps_windows and steps_linux can be used to run different steps on the respective platforms.",
+            "items": {
+              "$id": "#/properties/scripts/properties//properties/steps_linux/items",
+              "type": "string",
+              "title": "The Items Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            }
+          },
+          "steps_windows": {
+            "$id": "#/properties/scripts/properties//properties/steps_windows",
+            "type": "array",
+            "title": "The Steps_windows Schema",
+            "default": null,
+            "description": "steps_windows and steps_linux can be used to run different steps on the respective platforms.",
+            "items": {
+              "$id": "#/properties/scripts/properties//properties/steps_windows/items",
+              "type": "string",
+              "title": "The Items Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            }
+          },
+          "show_output": {
+            "$id": "#/properties/scripts/properties//properties/show_output",
+            "type": "boolean",
+            "title": "The Show_output Schema",
+            "description": "All output is hidden by default. Setting show_output will display the command being executed and its output.",
+            "default": false,
+            "examples": [
+              true
+            ]
+          },
+          "foreach": {
+            "$id": "#/properties/scripts/properties//properties/foreach",
+            "type": "boolean",
+            "title": "The Foreach Schema",
+            "default": false,
+            "description": "Scripts can be ran for each addons. Inside prebuild the script will be ran for each addon that HEMTT will build, including addons that will be skipped if they are already built. Inside postbuild and releasebuild only addons that were successfully built with be used, excluding addons that were skipped for being up to date.",
+            "examples": [
+              true
+            ]
+          },
+          "parallel": {
+            "$id": "#/properties/scripts/properties//properties/parallel",
+            "type": "boolean",
+            "title": "The Parallel Schema",
+            "description": "Requires foreach to be true. If a script is thread safe parallel can be used to process multiple addons at a time.",
+            "default": false,
+            "examples": [
+              true
+            ]
           }
-        }
+        },
+        "allOf": [
+          {
+            "$ref": "#/definitions/parallel-requires-foreach-to-be-true"
+          }
+        ]
       }
     }
   },
-  "allOf": [
-    { "$ref": "#/definitions/parallel-requires-foreach-to-be-true" }
-  ],
   "definitions": {
     "parallel-requires-foreach-to-be-true": {
       "anyOf": [
-        { "not": { "$ref": "#/definitions/is-foreach-false" } },
-        { "required": [ "foreach" ] }
+        {
+          "not": {
+            "$ref": "#/definitions/is-parallel-true"
+          }
+        },
+        {
+          "properties": {
+            "foreach": {
+              "enum": [
+                true
+              ]
+            }
+          },
+          "required": [
+            "foreach"
+          ]
+        }
       ]
     },
-    "is-foreach-false": {
+    "is-parallel-true": {
       "properties": {
-        "foreach": {
-          "boolean": false
+        "parallel": {
+          "enum": [
+            true
+          ]
         }
       }
     }

--- a/src/utility/README_template.md
+++ b/src/utility/README_template.md
@@ -1,0 +1,19 @@
+# JSON Schema Store
+
+ A collection of JSON schemas
+
+[![Build status](https://ci.appveyor.com/api/projects/status/ab34h2jsrjfiw2xq?svg=true)](https://ci.appveyor.com/project/madskristensen/schemastore-371)
+
+The repository is meant as a universal JSON schema store,
+where schemas for popular JSON documents can be found.
+
+Website: [${domain}](${https})
+
+## How to use
+
+Schemas are available at (just append schema file name to the path):
+
+${schemas}
+
+## Contribute
+Contributions are more than welcome. Both to the website itself or to the various schema files. Before contributing, please carefully read the [guidelines](./CONTRIBUTING.md).

--- a/src/utility/fixtures.json
+++ b/src/utility/fixtures.json
@@ -1,0 +1,4 @@
+{
+    "README_PATH": "../../README.md",
+    "TLS_URL": "https://schemastore.azurewebsites.net"
+}

--- a/src/utility/readme.js
+++ b/src/utility/readme.js
@@ -1,0 +1,85 @@
+const fs = require("fs");
+const { homepage } = require("../package.json");
+const { README_PATH, TLS_URL } = require("./fixtures.json");
+
+const template = fs.readFileSync("./README_template.md", { encoding: "utf8" });
+
+/**
+ * @param {string} link 
+ * @param {string} [text] 
+ * @returns {string}
+ */
+function anchor(link, text = link) {
+    return `<a href="${link}" referrerpolicy="no-referrer">${text}</a>`;
+}
+
+/**
+ * @param  {...string} cells
+ * @returns {string}
+ */
+const mdRow = (...cells) => {
+    return `| ${cells.join(" | ")} |`;
+};
+
+/**
+ * @param {string} content 
+ * @param {function} callback
+ * @param {string[]} acc
+ * @returns {string[]}
+ */
+function readLines(content, callback, acc = []) {
+    const lines = content.split(/\r|\n/);
+    for (const line of lines) {
+        callback(line, acc);
+    }
+    return acc;
+}
+
+const placeholderMap = new Map()
+    .set("domain", () => {
+        return homepage.replace(/http(?:s)*:\/\/(?:www\.)*/, "");
+    })
+    .set("homepage", () => homepage)
+    .set("https", () => TLS_URL)
+    .set("schemas", () => {
+
+        const jsonHTTP = anchor(`${homepage}/json/`, "JSON");
+        const cssHTTP = anchor(`${homepage}/css/`, "CSS");
+        const jsHTTP = anchor(`${homepage}/javascript/`, "JS");
+
+        const jsonTLS = anchor(`${TLS_URL}/schemas/json/`, "JSON");
+        const cssTLS = anchor(`${TLS_URL}/schemas/css/`, "CSS");
+        const jsTLS = anchor(`${TLS_URL}/schemas/javascript/`, "JS");
+
+        return [
+            mdRow("HTTP", "HTTP/TLS"),
+            mdRow("---", "---"),
+            mdRow(
+                [cssHTTP, jsonHTTP, jsHTTP].join(" \\| "),
+                [cssTLS, jsonTLS, jsTLS].join(" \\| ")
+            )
+        ].join("\n");
+    });
+
+/**
+ * @param {string} line 
+ * @param {string[]} acc
+ * @returns {void}
+ */
+function parsePlaceholders(line, acc) {
+
+    const updated = line.replace(/\$\{(\w+)\}/g, (full, name) => {
+        const handler = placeholderMap.get(name);
+        return handler ? handler() : "";
+    });
+
+    acc.push(updated);
+}
+
+function run() {
+    const parsed = readLines(template, parsePlaceholders);
+    const output = fs.createWriteStream(README_PATH);
+    output.write(parsed.join("\n"));
+}
+
+run();


### PR DESCRIPTION
This PR proposes several updates in bundle:

**I. Update build and fix HEMTT schema**
I've been tinkering with `Gruntfile.js` to improve upon it a tiny bit and noticed that switching from `folder.indexOf('.') > -1` to `isDirectory()` for checking if entry is a folder awakens some "sleeping" tests that were (apparently not intentionally) skipped for folders such as "hetmtt-0.6.2" (or "azure-iot-edge-deployment-1.0").

**Issue**
Validation of JSON schemas for the abovementioned tests passes, but there is one schema that does not - `hemtt-0.6.2`, relevant grunt report as follows:

````
>> failed test/hemtt-0.6.2/hemtt-test.json
!= The Root Schema
   data does not match any schemas from "anyOf"
      /allOf/0/anyOf
       > object -> {"name":"Advanced Banana Environment","prefix":"ABE3","author":"ACE Mod Team","version":"1.0.0.0"...
      data matches schema from "not"
         /allOf/0/anyOf/0/anyOf/0/not
      missing required property: foreach
         /allOf/0/anyOf/1/anyOf/1/required/0
````
This PR fixes the schema without changing authors intention (by switching to `additionalProperties` and fixing property interdependence constraint). Additionally, switched NinJS and xUnit links to HTTPS and added npm `build` script.

**II. Automate README**
In continuation to #1009 discussion, I've added reference to correct paths for both HTTP and HTTP/TLS protocols and thought that it would be easier to be able to update these values via templates (which can be expanded as needed).

**III. Add CONTRIBUTING.md**
Moved contributing guidelines to dedicated CONTRIBUTING.md (no content change).

Hope you'll find the PR useful 

[Apologies for build fails, seems like AppVeyor CI uses older Node.js than I locally do - backtracked the change a little to make it pass],
