### PR TITLE
[gitlab-ci.yml] Add top-level workflow property

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -52,6 +52,23 @@
     "pages": {
       "$ref": "#/definitions/job",
       "description": "A special job used to upload static sites to Gitlab pages. Requires a `public/` directory with `artifacts.path` pointing to it."
+    },
+    "workflow": {
+      "type": "object",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "items": {
+            "if": {
+              "type": "string"
+            },
+            "when": {
+              "type": "string",
+              "enum": ["always", "never"]
+            }
+          }
+        }
+      }
     }
   },
   "patternProperties": {

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -209,5 +209,20 @@
   },
   "performance-b": {
     "extends": ".performance-tmpl"
+  },
+  "workflow": {
+    "rules": [
+      {
+        "if": "$CI_COMMIT_REF_NAME =~ /-wip$/",
+        "when": "never"
+      },
+      {
+        "if": "$CI_COMMIT_TAG",
+        "when": "never"
+      },
+      {
+        "when": "always"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Closes #1007

Adds a new top-level property `workflow` which is documented [here](https://docs.gitlab.com/ee/ci/yaml/README.html#workflowrules). 