### PR TITLE
[stylelintrc.json] Updated max-nesting-depth ignore enum

### DIFF
--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -2372,7 +2372,8 @@
 												"items": {
 													"type": "string",
 													"enum": [
-														"at-rules-without-declaration-blocks"
+														"blockless-at-rules",
+														"pseudo-classes"
 													]
 												}
 											},


### PR DESCRIPTION
Updated to reflect the current documentation: 
https://stylelint.io/user-guide/rules/max-nesting-depth