### PR TITLE
[github-workflow] Add registry_package eventObject

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -717,6 +717,27 @@
               },
               "additionalProperties": false
             },
+            "registry_package": {
+              "$comment": "https://help.github.com/en/actions/reference/events-that-trigger-workflows#registry-package-event-registry_package",
+              "$ref": "#/definitions/eventObject",
+              "description": "Runs your workflow anytime a package is published or updated. For more information, see https://help.github.com/en/github/managing-packages-with-github-packages.",
+              "properties": {
+                "types": {
+                  "$ref": "#/definitions/types",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "published",
+                      "updated"
+                    ]
+                  },
+                  "default": [
+                    "published",
+                    "updated"
+                  ]
+                }
+              }
+            },
             "release": {
               "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows#release-event-release",
               "$ref": "#/definitions/eventObject",


### PR DESCRIPTION
Combined with #1012 closes #928

Adds `registry_package` as an eventObject (```on: {registry_package: {types: ['published']}}``` as you can specify the types of actions that will trigger it. Previously it was just defined in as an event enum value (```on: ['registry_package']```)