### PR TITLE
[package] allow bundledDependencies to be false

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -22,10 +22,19 @@
     },
     "bundledDependency": {
       "description": "Array of package names that will be bundled when publishing the package.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "enum": [
+            false
+          ]
+        }
+      ]
     },
     "dependency": {
       "description": "Dependencies are specified with a simple hash of package name to version range. The version range is a string which has one or more space-separated descriptors. Dependencies can also be identified with a tarball or git URL.",

--- a/src/test/package/installed-package-v5.json
+++ b/src/test/package/installed-package-v5.json
@@ -1,0 +1,84 @@
+{
+  "_from": "stylus@^0.54.7",
+  "_id": "stylus@0.54.7",
+  "_inBundle": false,
+  "_integrity": "sha512-Yw3WMTzVwevT6ZTrLCYNHAFmanMxdylelL3hkWNgPMeTCpMwpV3nXjpOHuBXtFv7aiO2xRuQS6OoAdgkNcSNug==",
+  "_location": "/stylus",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "stylus@^0.54.7",
+    "name": "stylus",
+    "escapedName": "stylus",
+    "rawSpec": "^0.54.7",
+    "saveSpec": null,
+    "fetchSpec": "^0.54.7"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.7.tgz",
+  "_shasum": "c6ce4793965ee538bcebe50f31537bfc04d88cd2",
+  "_spec": "stylus@^0.54.7",
+  "_where": "/mnt/e/Github/test",
+  "author": {
+    "name": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca"
+  },
+  "bin": {
+    "stylus": "./bin/stylus"
+  },
+  "browserify": "./lib/browserify.js",
+  "bugs": {
+    "url": "https://github.com/stylus/stylus/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "css-parse": "~2.0.0",
+    "debug": "~3.1.0",
+    "glob": "^7.1.3",
+    "mkdirp": "~0.5.x",
+    "safer-buffer": "^2.1.2",
+    "sax": "~1.2.4",
+    "semver": "^6.0.0",
+    "source-map": "^0.7.3"
+  },
+  "deprecated": false,
+  "description": "Robust, expressive, and feature-rich CSS superset",
+  "devDependencies": {
+    "jscoverage": "~0.6.0",
+    "mocha": "^5.2.0",
+    "should": "^13.2.3"
+  },
+  "directories": {
+    "doc": "docs",
+    "example": "examples",
+    "test": "test"
+  },
+  "engines": {
+    "node": "*"
+  },
+  "homepage": "https://github.com/stylus/stylus",
+  "keywords": [
+    "css",
+    "parser",
+    "style",
+    "stylesheets",
+    "jade",
+    "language"
+  ],
+  "license": "MIT",
+  "main": "./index.js",
+  "name": "stylus",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stylus/stylus.git"
+  },
+  "scripts": {
+    "prepublish": "npm prune",
+    "test": "mocha test/ test/middleware/ --require should --bail --check-leaks --reporter dot",
+    "test-cov": "mocha test/ test/middleware/ --require should --bail --reporter html-cov > coverage.html"
+  },
+  "version": "0.54.7"
+}


### PR DESCRIPTION
Closes #876 

Allows `bundledDependencies` / `bundleDependencies` to be boolean `false` in addition to an array of strings. This value is present on packages installed by `npm` and has been since at least v5.0.0 (about 3 years ago). Technically, one could set the value of this to any false-y string without anything breaking, in practice, this should only be seen as an array of strings (in a top-level package.json) or as false (in an installed package.json).

The testcase here is me taking the generated package.json from installing the `stylus` package (as it was mentioned in the issue) when using npm v5.