### PR TITLE
[github-workflow] Allow jobs.<job_id>.container to be a string

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -39,56 +39,65 @@
       ]
     },
     "container": {
-      "type": "object",
-      "properties": {
-        "image": {
-          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerimage",
+      "oneOf": [
+        {
+          "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer",
           "description": "The Docker image to use as the container to run the action. The value can be the Docker Hub image name or a public docker registry name.",
           "type": "string"
         },
-        "env": {
-          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerenv",
-          "$ref": "#/definitions/env",
-          "description": "Sets an array of environment variables in the container."
-        },
-        "ports": {
-          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerports",
-          "description": "Sets an array of ports to expose on the container.",
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "type": "number"
+        {
+          "type": "object",
+          "properties": {
+            "image": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerimage",
+              "description": "The Docker image to use as the container to run the action. The value can be the Docker Hub image name or a public docker registry name.",
+              "type": "string"
+            },
+            "env": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerenv",
+              "$ref": "#/definitions/env",
+              "description": "Sets an array of environment variables in the container."
+            },
+            "ports": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerports",
+              "description": "Sets an array of ports to expose on the container.",
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
-              {
-                "type": "string"
-              }
-            ]
+              "minItems": 1,
+              "additionalItems": false
+            },
+            "volumes": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainervolumes",
+              "description": "Sets an array of volumes for the container to use. You can use volumes to share data between services or other steps in a job. You can specify named Docker volumes, anonymous Docker volumes, or bind mounts on the host.\nTo specify a volume, you specify the source and destination path: <source>:<destinationPath>\nThe <source> is a volume name or an absolute path on the host machine, and <destinationPath> is an absolute path in the container.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[^:]+:[^:]+$"
+              },
+              "minItems": 1,
+              "additionalItems": false
+            },
+            "options": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontaineroptions",
+              "description": "Additional Docker container resource options. For a list of options, see https://docs.docker.com/engine/reference/commandline/create/#options.",
+              "type": "string"
+            }
           },
-          "minItems": 1,
-          "additionalItems": false
-        },
-        "volumes": {
-          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainervolumes",
-          "description": "Sets an array of volumes for the container to use. You can use volumes to share data between services or other steps in a job. You can specify named Docker volumes, anonymous Docker volumes, or bind mounts on the host.\nTo specify a volume, you specify the source and destination path: <source>:<destinationPath>\nThe <source> is a volume name or an absolute path on the host machine, and <destinationPath> is an absolute path in the container.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^[^:]+:[^:]+$"
-          },
-          "minItems": 1,
-          "additionalItems": false
-        },
-        "options": {
-          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontaineroptions",
-          "description": "Additional Docker container resource options. For a list of options, see https://docs.docker.com/engine/reference/commandline/create/#options.",
-          "type": "string"
+          "required": [
+            "image"
+          ],
+          "additionalProperties": false
         }
-      },
-      "required": [
-        "image"
-      ],
-      "additionalProperties": false
+      ]
     },
     "defaults": {
       "type": "object",


### PR DESCRIPTION
As per included $comment link, the "container" can also be a string
in which case it specified container name.