### PR TITLE
JSON Catalog: Fix ui5.yaml fileMatch pattern

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1583,7 +1583,8 @@
       "description": "UI5 Tooling Configuration File (ui5.yaml)",
       "fileMatch": [
         "ui5.yaml",
-        "ui5-*.yaml"
+        "*-ui5.yaml",
+        "*.ui5.yaml"
       ],
       "url": "https://sap.github.io/ui5-tooling/schema/ui5.yaml.json"
     },


### PR DESCRIPTION
A wildcard "*" within a fileMatch pattern also matches path segment
separators, which can cause unexpected matches.

In this case, every .yaml file within a folder that contained "ui5-" has
been matched.

Therefore using *.ui5.yaml and *-ui5.yaml instead to allow additional
ui5 config files within the same folder.

This is based on the current code in the vscode-json-languageservice:
https://github.com/microsoft/vscode-json-languageservice/blob/db832ca6a9dec1693f70af575003e3beb34100d0/src/utils/strings.ts#L34-L36

Other IDE integrations might behave differently.