### PR TITLE
fix json-patch-schema

### DIFF
--- a/src/schemas/json/json-patch.json
+++ b/src/schemas/json/json-patch.json
@@ -1,64 +1,59 @@
 {
-	"title": "JSON schema for JSONPatch files",
-	"$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON schema for JSONPatch files",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
 
-	"type": "array",
-
-	"items": {
-		"$ref": "#/definitions/operation"
-	},
-
-	"definitions": {
-		"operation": {
-			"type": "object",
-			"required": [ "op", "path" ],
-			"allOf": [ { "$ref": "#/definitions/path" } ],
-			"oneOf": [
-				{
-					"required": [ "value" ],
-					"properties": {
-						"op": {
-							"description": "The operation to perform.",
-							"type": "string",
-							"enum": [ "add", "replace", "test" ]
-						},
-						"value": {
-							"description": "The value to add, replace or test."
-						}
-					}
-				},
-				{
-					"properties": {
-						"op": {
-							"description": "The operation to perform.",
-							"type": "string",
-							"enum": [ "remove" ]
-						}
-					}
-				},
-				{
-					"required": [ "from" ],
-					"properties": {
-						"op": {
-							"description": "The operation to perform.",
-							"type": "string",
-							"enum": [ "move", "copy" ]
-						},
-						"from": {
-							"description": "A JSON Pointer path pointing to the location to move/copy from.",
-							"type": "string"
-						}
-					}
-				}
-			]
-		},
-		"path": {
-			"properties": {
-				"path": {
-					"description": "A JSON Pointer path.",
-					"type": "string"
-				}
-			}
-		}
-	}
+    "items": {
+        "oneOf": [
+            {
+                "additionalProperties": false,
+                "required": [ "value", "op", "path"],
+                "properties": {
+                    "path" : { "$ref": "#/definitions/path" },
+                    "op": {
+                        "description": "The operation to perform.",
+                        "type": "string",
+                        "enum": [ "add", "replace", "test" ]
+                    },
+                    "value": {
+                        "description": "The value to add, replace or test."
+                    }
+                }
+            },
+            {
+                "additionalProperties": false,
+                "required": [ "op", "path"],
+                "properties": {
+                    "path" : { "$ref": "#/definitions/path" },
+                    "op": {
+                        "description": "The operation to perform.",
+                        "type": "string",
+                        "enum": [ "remove" ]
+                    }
+                }
+            },
+            {
+                "additionalProperties": false,
+                "required": [ "from", "op", "path" ],
+                "properties": {
+                    "path" : { "$ref": "#/definitions/path" },
+                    "op": {
+                        "description": "The operation to perform.",
+                        "type": "string",
+                        "enum": [ "move", "copy" ]
+                    },
+                    "from": {
+                        "$ref": "#/definitions/path",
+                        "description": "A JSON Pointer path pointing to the location to move/copy from."
+                    }
+                }
+            }
+        ]
+    },
+    "definitions": {
+        "path": {
+            "description": "A JSON Pointer path.",
+            "type": "string"
+        }
+    }
 }


### PR DESCRIPTION
Many things weren't OK within the schema:

- "allOf", "oneOf" can't be combined within a (sub)-schema
- logical-combinations (allOf, oneOf) do not inherit
  information from it's parent
- tabs were used ... ;-)