### PR TITLE
[github-workflow] Update release event to add missing released type

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -750,7 +750,7 @@
             "release": {
               "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows#release-event-release",
               "$ref": "#/definitions/eventObject",
-              "description": "Runs your workflow anytime the release event occurs. More than one activity type triggers this event. For information about the REST API, see https://developer.github.com/v3/repos/releases/.",
+              "description": "Runs your workflow anytime the release event occurs. More than one activity type triggers this event. For information about the REST API, see https://developer.github.com/v3/repos/releases/ in the GitHub Developer documentation.",
               "properties": {
                 "types": {
                   "$ref": "#/definitions/types",
@@ -762,7 +762,8 @@
                       "created",
                       "edited",
                       "deleted",
-                      "prereleased"
+                      "prereleased",
+                      "released"
                     ]
                   },
                   "default": [
@@ -771,7 +772,8 @@
                     "created",
                     "edited",
                     "deleted",
-                    "prereleased"
+                    "prereleased",
+                    "released"
                   ]
                 }
               }


### PR DESCRIPTION
Found a missing property here whilst working with workflows today have updated as per the [Github Workflows docs](https://help.github.com/en/actions/reference/events-that-trigger-workflows#release-event-release)