### PR TITLE
[github-workflow] allow boolean values for ref/configuration

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -24,6 +24,9 @@
           "type": "number"
         },
         {
+          "type": "boolean"
+        },
+        {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/configuration"

--- a/src/test/github-workflow/matrix_include.json
+++ b/src/test/github-workflow/matrix_include.json
@@ -1,0 +1,44 @@
+{
+  "name": "Test on Pull",
+  "on": [
+    "push"
+  ],
+  "jobs": {
+    "build": {
+      "runs-on": "ubuntu-latest",
+      "continue-on-error": "${{ matrix.experimental }}",
+      "strategy": {
+        "fail-fast": true,
+        "matrix": {
+          "node": [11, 12],
+          "os": ["macos-latest", "ubuntu-18.04"],
+          "experimental": [false],
+          "include": [
+            {
+              "node": 13,
+              "os": "ubuntu-18.04",
+              "experimental": true
+            }
+          ]
+        }
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v1"
+        },
+        {
+          "uses": "actions/setup-node@v1",
+          "with": {
+            "node-version": "${{ matrix.node-version }}"
+          }
+        },
+        {
+          "run": "npm run lint"
+        },
+        {
+          "run": "npm test"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The GitHub workflow allows boolean values for a number of configuration fields. An example which uses boolean values in a couple places, and which I hit an error in VSCode following, is the example for  [continue-on-error](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error) example.