### PR TITLE
[github-workflow] allow expression syntax for step.continue-on-error

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -183,6 +183,10 @@
       ],
       "additionalProperties": true
     },
+    "expressionSyntax": {
+      "type": "string",
+      "pattern": "^\\${{.*}}$"
+    },
     "globs": {
       "type": "array",
       "items": {
@@ -1026,7 +1030,14 @@
                   "continue-on-error": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error",
                     "description": "Prevents a job from failing when a step fails. Set to true to allow a job to pass when this step fails.",
-                    "type": "boolean",
+                    "oneOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "$ref": "#/definitions/expressionSyntax"
+                      }
+                    ],
                     "default": false
                   },
                   "timeout-minutes": {
@@ -1112,7 +1123,7 @@
                   "type": "boolean"
                 },
                 {
-                  "type": "string"
+                  "$ref": "#/definitions/expressionSyntax"
                 }
               ]
             },

--- a/src/test/github-workflow/continue-on-error.json
+++ b/src/test/github-workflow/continue-on-error.json
@@ -1,0 +1,28 @@
+{
+  "name": "Test continue-on-error",
+  "on": [
+    "push"
+  ],
+  "jobs": {
+    "build": {
+      "runs-on": "ubuntu-latest",
+      "continue-on-error": true,
+      "steps": [
+        {
+          "run": "exit 1",
+          "continue-on-error": true
+        }
+      ]
+    },
+    "test": {
+      "runs-on": "ubuntu-latest",
+      "continue-on-error": "${{ startsWith(github.ref, 'refs/heads/feature/') }}",
+      "steps": [
+        {
+          "run": "echo 'Test'",
+          "continue-on-error": "${{ env.CI == 'true' }}"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds pattern regex for GitHub Actions [expression syntax](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#about-contexts-and-expressions). Also adds consistency between `job.continue-on-error` and `step.continue-on-error`.