### PR TITLE
[travis] add focal ubuntu distribution

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -690,7 +690,7 @@
         },
         "dist": {
           "description": "The Ubuntu distribution to use",
-          "enum": [ "precise", "trusty", "xenial", "bionic" ]
+          "enum": [ "precise", "trusty", "xenial", "bionic", "focal" ]
         },
         "sudo": {
           "enum": [ true, false, "", "required", "enabled" ],


### PR DESCRIPTION
Closes #1054 

Support for `focal` as a value for the `dist` key was added in travis-ci/travis-yml#170 and is now supported within Travis (example build using focal dist: https://travis-ci.org/github/dreibh/netperfmeter).