### PR TITLE
[gitlab-ci] add terraform as valid key for artifacts:reports

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -789,6 +789,10 @@
                 "metrics": {
                   "$ref": "#/definitions/string_file_list",
                   "description": "Path to file or list of files with custom metrics report(s)."
+                },
+                "terraform": {
+                  "$ref": "#/definitions/string_file_list",
+                  "description": "Path to file or list of files with terraform plan(s)."
                 }
               }
             }

--- a/src/test/gitlab-ci/terraform_report.json
+++ b/src/test/gitlab-ci/terraform_report.json
@@ -1,0 +1,67 @@
+{
+  "image": {
+    "name": "registry.gitlab.com/gitlab-org/gitlab-build-images:terraform",
+    "entrypoint": [
+      "/usr/bin/env",
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ]
+  },
+  "variables": {
+    "PLAN": "plan.tfplan",
+    "JSON_PLAN_FILE": "tfplan.json"
+  },
+  "cache": {
+    "paths": [
+      ".terraform"
+    ]
+  },
+  "before_script": [
+    "alias convert_report=\"jq -r '([.resource_changes[]?.change.actions?]|flatten)|{\"create\":(map(select(.==\"create\"))|length),\"update\":(map(select(.==\"update\"))|length),\"delete\":(map(select(.==\"delete\"))|length)}'\"",
+    "terraform --version",
+    "terraform init"
+  ],
+  "stages": [
+    "validate",
+    "build",
+    "test",
+    "deploy"
+  ],
+  "validate": {
+    "stage": "validate",
+    "script": [
+      "terraform validate"
+    ]
+  },
+  "plan": {
+    "stage": "build",
+    "script": [
+      "terraform plan -out=$PLAN",
+      "terraform show --json $PLAN | convert_report > $JSON_PLAN_FILE"
+    ],
+    "artifacts": {
+      "name": "plan",
+      "paths": [
+        "$PLAN"
+      ],
+      "reports": {
+        "terraform": "$JSON_PLAN_FILE"
+      }
+    }
+  },
+  "apply": {
+    "stage": "deploy",
+    "environment": {
+      "name": "production"
+    },
+    "script": [
+      "terraform apply -input=false $PLAN"
+    ],
+    "dependencies": [
+      "plan"
+    ],
+    "when": "manual",
+    "only": [
+      "master"
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #1057 

Adds a new entry to `artifacts:reports` for [`terraform`](https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html#artifactsreportsterraform). While the documentation implies you would probably only pass in a single string here, it uses the same underlying loader as the other reports making it allowed to use a list of strings.

The included test is Gitlab's sample Terraform pipeline: https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Terraform.gitlab-ci.yml.