### PR TITLE
Changed maxItems from 2 to 3 for semicolon options

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -3712,7 +3712,7 @@
                 }
               ],
               "minItems": 1,
-              "maxItems": 2
+              "maxItems": 3
             }
           },
           "allOf": [


### PR DESCRIPTION
The following valid option setting is disallowed by the previous rules: 
"semicolon": [true, "always", "ignore-interfaces", "strict-bound-class-methods"]