### PR TITLE
Add sh support for Appveyor

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -85,6 +85,16 @@
               "type": "string"
             }
           }
+        },
+        {
+          "type": "object",
+          "description": "Run a Bash command",
+          "additionalProperties": false,
+          "properties": {
+            "sh": {
+              "type": "string"
+            }
+          }
         }
       ]
     },

--- a/src/test/appveyor/reference.json
+++ b/src/test/appveyor/reference.json
@@ -84,6 +84,9 @@
     },
     {
       "pwsh": "Write-Host 'This is PowerShell Core'"
+    },
+    {
+      "sh": "printf 'this is bash'"
     }
   ],
   "assembly_info": {


### PR DESCRIPTION
As described in the official documentation here : 
https://www.appveyor.com/docs/getting-started-with-appveyor-for-linux/#bash-and-powershell

