### PR TITLE
Fix types in Ansible 2.9 apt module schema

### DIFF
--- a/src/test/ansible-stable-2.9/apt.json
+++ b/src/test/ansible-stable-2.9/apt.json
@@ -1,0 +1,123 @@
+[
+  {
+    "name": "Install apache httpd  (state=present is optional)",
+    "apt": {
+      "name": "apache2",
+      "state": "present"
+    }
+  },
+  {
+    "name": "Update repositories cache and install \"foo\" package",
+    "apt": {
+      "name": "foo",
+      "update_cache": true
+    }
+  },
+  {
+    "name": "Remove \"foo\" package",
+    "apt": {
+      "name": "foo",
+      "state": "absent"
+    }
+  },
+  {
+    "name": "Install the package \"foo\"",
+    "apt": {
+      "name": "foo"
+    }
+  },
+  {
+    "name": "Install a list of packages",
+    "apt": {
+      "pkg": ["foo", "foo-tools"]
+    }
+  },
+  {
+    "name": "Install the version '1.00' of package \"foo\"",
+    "apt": {
+      "name": "foo=1.00"
+    }
+  },
+  {
+    "name": "Update the repository cache and update package \"nginx\" to latest version using default release squeeze-backport",
+    "apt": {
+      "name": "nginx",
+      "state": "latest",
+      "default_release": "squeeze-backports",
+      "update_cache": true
+    }
+  },
+  {
+    "name": "Install latest version of \"openjdk-6-jdk\" ignoring \"install-recommends\"",
+    "apt": {
+      "name": "openjdk-6-jdk",
+      "state": "latest",
+      "install_recommends": false
+    }
+  },
+  {
+    "name": "Upgrade all packages to the latest version",
+    "apt": {
+      "name": "*",
+      "state": "latest"
+    }
+  },
+  {
+    "name": "Update all packages to the latest version",
+    "apt": {
+      "upgrade": "dist"
+    }
+  },
+  {
+    "name": "Run the equivalent of \"apt-get update\" as a separate step",
+    "apt": {
+      "update_cache": true
+    }
+  },
+  {
+    "name": "Only run \"update_cache=yes\" if the last one is more than 3600 seconds ago",
+    "apt": {
+      "update_cache": true,
+      "cache_valid_time": 3600
+    }
+  },
+  {
+    "name": "Pass options to dpkg on run",
+    "apt": {
+      "upgrade": "dist",
+      "update_cache": true,
+      "dpkg_options": "force-confold,force-confdef"
+    }
+  },
+  {
+    "name": "Install a .deb package",
+    "apt": {
+      "deb": "/tmp/mypackage.deb"
+    }
+  },
+  {
+    "name": "Install the build dependencies for package \"foo\"",
+    "apt": {
+      "pkg": "foo",
+      "state": "build-dep"
+    }
+  },
+  {
+    "name": "Install a .deb package from the internet.",
+    "apt": {
+      "deb": "https://example.com/python-ppq_0.1-1_all.deb"
+    }
+  },
+  {
+    "name": "Remove useless packages from the cache",
+    "apt": {
+      "autoclean": true
+    }
+  },
+  {
+    "name": "Remove dependencies that are no longer required",
+    "apt": {
+      "autoremove": true
+    }
+  }
+]


### PR DESCRIPTION
Two parameters of Ansible 2.9 apt module had incorrect types:

* name/package/pkg parameter had its type set to "string", but according
  to Ansible documentation [[1]], it should be "ansible_array".

* cache_valid_time parameter also had its type set to "string", but
  according to Ansible documentation [[2]], it should be "ansible_number".

This commit fixes both parameters to use proper definition references
instead of the invalid types.

[1]: https://docs.ansible.com/ansible/2.9/modules/apt_module.html#parameter-name
[2]: https://docs.ansible.com/ansible/2.9/modules/apt_module.html#parameter-cache_valid_time


This bug currently breaks the YAML extension for Visual Studio Code:
<img width="471" alt="image" src="https://user-images.githubusercontent.com/7155728/83313216-9077ba80-a215-11ea-8bf9-259b220faee1.png">