### PR TITLE
fix fileMatch for release-drafter

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1959,7 +1959,7 @@
       "name": "release drafter",
       "description": "Release Drafter configuration file",
       "fileMatch": [
-        "release-drafter.yml"
+        ".github/release-drafter.yml"
       ],
       "url": "https://raw.githubusercontent.com/release-drafter/release-drafter/master/schema.json"
     },


### PR DESCRIPTION
a common thing is to have `.github/release-drafter.yml` and `.github/workflows/release-drafter.yml`
That way the schema for release-drafter would be prioritized over GitHub actions.