### PR TITLE
Update eslintrc.json to accept string for `ignorePatterns`

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -529,7 +529,7 @@
     },
     "ignorePatterns": {
       "description": "Tell ESLint to ignore specific files and directories. Each value uses the same pattern as the `.eslintignore` file.",
-      "type": "array",
+      "type": [ "string", "array" ],
       "items": {
         "type": "string"
       }


### PR DESCRIPTION
Like the `extends` member, the `ignorePatterns` can also take a string.