### PR TITLE
fix(tslint.json): update ordered-imports rules definitions

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -3169,6 +3169,7 @@
                     "type": "string",
                     "enum": [
                       "case-insensitive",
+                      "case-insensitive-legacy",
                       "lowercase-first",
                       "lowercase-last",
                       "any"
@@ -3178,6 +3179,7 @@
                     "type": "string",
                     "enum": [
                       "case-insensitive",
+                      "case-insensitive-legacy",
                       "lowercase-first",
                       "lowercase-last",
                       "any"

--- a/src/test/tslint/tslint-test23.json
+++ b/src/test/tslint/tslint-test23.json
@@ -1,0 +1,9 @@
+{
+	"ordered-imports": [
+		true,
+		{
+			"import-sources-order": "case-insensitive-legacy",
+			"named-imports-order": "case-insensitive-legacy"
+		}
+	]
+}


### PR DESCRIPTION
- Added `case-insensitive-legacy` option to `import-sources-order` and `named-imports-order` sections in `ordered-imports` config, as per schema https://palantir.github.io/tslint/rules/ordered-imports/

Fixes #1079