### PR TITLE
Update README to use official URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The largest collection of independant JSON schemas in the world
 
 The repository is meant as a universal JSON schema store, where schemas for popular JSON documents can be found.
 
-Website: [schemastore.org](https://schemastore.azurewebsites.net)
+Website: [schemastore.org](https://www.schemastore.org/json/)
 
 ## Contribute
 


### PR DESCRIPTION
Now that schemastore.org offers https, this updates the link to the website in the README to use that URL instead of the azure builtin route. This makes it consistent that clicking on the link in the repository description takes you to the same place as the README link.