### PR TITLE
Allow package.json private field as string

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -401,8 +401,18 @@
           "description": "DEPRECATED: This option used to trigger an npm warning, but it will no longer warn. It is purely there for informational purposes. It is now recommended that you install any binaries as local devDependencies wherever possible."
         },
         "private": {
-          "type": "boolean",
-          "description": "If set to true, then npm will refuse to publish it."
+          "description": "If set to true, then npm will refuse to publish it.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "enum": [
+                "false",
+                "true"
+              ]
+            }
+          ]
         },
         "publishConfig": {
           "type": "object",

--- a/src/test/package/private-string-test1.json
+++ b/src/test/package/private-string-test1.json
@@ -1,0 +1,3 @@
+{
+    "private": "true"
+}

--- a/src/test/package/private-string-test2.json
+++ b/src/test/package/private-string-test2.json
@@ -1,0 +1,3 @@
+{
+    "private": "false"
+}


### PR DESCRIPTION
npm allows to use "true" or "false" strings for the private field.