### PR TITLE
Add commitlint config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2054,6 +2054,15 @@
       "fileMatch": [
         "manifests/*/*/*.yaml"
       ]
+    },
+    {
+      "name": ".commitlintrc",
+      "description": "JSON schema for commitlint configuration files",
+      "fileMatch": [
+        ".commitlintrc",
+        ".commitlintrc.json"
+      ],
+      "url": "https://json.schemastore.org/commitlintrc"
     }
   ]
 }

--- a/src/schemas/json/commitlintrc.json
+++ b/src/schemas/json/commitlintrc.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "definitions": {
+    "rule": {
+      "oneOf": [
+        {
+          "description": "A rule",
+          "type": "array",
+          "items": [
+            {
+              "description": "Level: 0 disables the rule. For 1 it will be considered a warning, for 2 an error",
+              "type": "number",
+              "enum": [0, 1, 2]
+            },
+            {
+              "description": "Applicable: always|never: never inverts the rule",
+              "type": "string",
+              "enum": ["always", "never"]
+            },
+            {
+              "description": "Value: the value for this rule"
+            }
+          ],
+          "minItems": 3,
+          "additionalItems": false
+        }
+      ]
+    }
+  },
+  "properties": {
+    "extends": {
+      "description": "Resolveable ids to commitlint configurations to extend",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "parserPreset": {
+      "description": "Resolveable id to conventional-changelog parser preset to import and use",
+      "type": "string"
+    },
+    "formatter": {
+      "description": "Resolveable id to package, from node_modules, which formats the output",
+      "type": "string"
+    },
+    "rules": {
+      "description": "Rules to check against",
+      "type": "object",
+      "propertyNames": { "type": "string" },
+      "additionalProperties": { "$ref": "#/definitions/rule" }
+    },
+    "defaultIgnores": {
+      "description": "Whether commitlint uses the default ignore rules",
+      "type": "boolean"
+    }
+  }
+}

--- a/src/test/commitlintrc/commitlintrc-test.json
+++ b/src/test/commitlintrc/commitlintrc-test.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/src/test/commitlintrc/commitlintrc-test2.json
+++ b/src/test/commitlintrc/commitlintrc-test2.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "scope-case": [2, "always", ["lower-case"]]
+  }
+}

--- a/src/test/commitlintrc/commitlintrc-test3.json
+++ b/src/test/commitlintrc/commitlintrc-test3.json
@@ -1,0 +1,3 @@
+{
+  "defaultIgnores": false
+}

--- a/src/test/commitlintrc/commitlintrc-test4.json
+++ b/src/test/commitlintrc/commitlintrc-test4.json
@@ -1,0 +1,3 @@
+{
+  "parserPreset": "conventional-changelog-atom"
+}


### PR DESCRIPTION
Adds a [commitlint](https://github.com/conventional-changelog/commitlint) config schema.

Added according to:
 - [Guide: Local setup](https://commitlint.js.org/#/guides-local-setup)
 - [Reference: Configuration](https://commitlint.js.org/#/reference-configuration)

- [x] Schema added
 - [x] Added to catalog
 - [x] Tests
 - - [x] Tests added
 - - [x] Tests ran
