### PR TITLE
Add Azure Pipelines schema into catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -105,6 +105,15 @@
       }
     },
     {
+      "name": "Azure Pipelines",
+      "description": "Azure Pipelines YAML pipelines definition",
+      "fileMatch": [
+        "azure-pipelines.yml",
+        "azure-pipelines.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json"
+    },
+    {
       "name": "Foxx Manifest",
       "description": "ArangoDB Foxx service manifest file",
       "fileMatch": [


### PR DESCRIPTION
Azure Pipelines is using [YAML file definition](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema) to define CI/CD pipelines.

This PR adds a link to their official [JSON schema](https://github.com/microsoft/azure-pipelines-vscode/blob/master/service-schema.json) into the catalog.

