### PR TITLE
Fix `fabric.mod.json` definition URL

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -663,7 +663,7 @@
       "fileMatch": [
         "fabric.mod.json"
       ],
-      "url": "https://json.schemastore.org/fabric-mod-json"
+      "url": "https://json.schemastore.org/fabric.mod.json"
     },
     {
       "name": "Fantomas",


### PR DESCRIPTION
This is the correct URL, the previous one doesn't exist.

Closes #805 for good.
Reverts #901.