### PR TITLE
Kustomize: Fix patches property

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -238,7 +238,16 @@
         "patches": {
           "description": "Apply a patch to multiple resources",
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "$ref": "#/definitions/PatchesPatchPath"
+              },
+              {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "$ref": "#/definitions/PatchesInlinePatch"
+              }
+            ]
           },
           "type": "array"
         },
@@ -348,6 +357,63 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "PatchTargetOptional": {
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "labelSelector": {
+          "type": "string"
+        },
+        "annotationSelector": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PatchesPatchPath": {
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "target": {
+          "description": "Refers to a Kubernetes object that the patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization",
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/PatchTargetOptional"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PatchesInlinePatch": {
+      "required": [
+        "patch"
+      ],
+      "properties": {
+        "patch": {
+          "type": "string"
+        },
+        "target": {
+          "description": "Refers to a Kubernetes object that the patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization",
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/PatchTargetOptional"
+        }
+      },
+      "additionalProperties": false
     },
     "SecretArgs": {
       "description": "SecretArgs contains the metadata of how to generate a secret",

--- a/src/test/kustomization/wordpress-new-patches.json
+++ b/src/test/kustomization/wordpress-new-patches.json
@@ -1,0 +1,48 @@
+{
+  "bases": [
+     "wordpress",
+     "mysql"
+  ],
+  "patches": [
+     {
+        "target": {
+            "group": "apps",
+            "version": "v1",
+            "kind": "Deployment",
+            "name": "myDeployment"
+        },
+        "path": "deploy-patch.yaml"
+     },
+     {
+        "path": "patch.yaml"
+     },
+     {
+        "patch": "- op: add \n  path: /spec/rules/0/host\n  value: mynewhost.example.com",
+        "target": {
+          "kind": "Ingress",
+          "namespace": "test",
+          "labelSelector": "env=dev",
+          "annotationSelector": "zone=west"
+        }
+     }
+  ],
+  "namePrefix": "demo-",
+  "vars": [
+     {
+        "name": "WORDPRESS_SERVICE",
+        "objref": {
+           "kind": "Service",
+           "name": "wordpress",
+           "apiVersion": "v1"
+        }
+     },
+     {
+        "name": "MYSQL_SERVICE",
+        "objref": {
+           "kind": "Service",
+           "name": "mysql",
+           "apiVersion": "v1"
+        }
+     }
+  ]
+}


### PR DESCRIPTION
The `patches` property inside a Kubernetes `kustomization.yaml` file is currently an array of strings in the schema, which is not correct. See for example: https://kubernetes-sigs.github.io/kustomize/api-reference/kustomization/patches/
This PR fixes the part of the schema for the patches property, and also adds a new test using the patches property.