### PR TITLE
Update org owner of version.json schema file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1644,7 +1644,7 @@
       "fileMatch": [
         "version.json"
       ],
-      "url": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
+      "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
       "name": "vim-addon-info",


### PR DESCRIPTION
A GitHub redirect ensures the old URL was still working, but we should point at the current URL for future use.