### PR TITLE
Add missing api-version examples to bukkit-plugin.json

### DIFF
--- a/src/schemas/json/bukkit-plugin.json
+++ b/src/schemas/json/bukkit-plugin.json
@@ -172,7 +172,7 @@
     "api-version": {
       "description": "Gives the API version which this plugin is designed to support.",
       "type": "string",
-      "examples": [ "1.13" ]
+      "examples": [ "1.13", "1.14", "1.15", "1.16" ]
     }
   }
 }


### PR DESCRIPTION
This adds "1.14", "1.15" and "1.16" to the `api-version` examples which *should* work (I'm unsure about 1.15 and 1.16 but I know for a fact that 1.14 is used and works.)