### PR TITLE
Web App Manifest update

### DIFF
--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -116,7 +116,7 @@
         },
         "purpose": {
           "type": "string",
-          "enum": [ "badge", "maskable", "any" ],
+          "enum": [ "monochrome", "maskable", "any" ],
           "default": "any"
         },
         "platform": {

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -79,6 +79,13 @@
       "description": "A string that represents a short version of the name of the web application.",
       "type": "string"
     },
+    "shortcuts": {
+      "description": "Array of shortcut items that provide access to key tasks within a web application.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/shortcut_item"
+      }
+    },
     "start_url": {
       "description": "Represents the URL that the developer would prefer the user agent load when the user launches the web application.",
       "type": "string"
@@ -163,6 +170,37 @@
     "platform": {
       "description": "The platform it is associated to.",
       "enum": [ "play", "itunes", "windows" ]
+    },
+    "shortcut_item": {
+      "type": "object",
+      "description": "A shortcut item represents a link to a key task or page within a web app. A user agent can use these values to assemble a context menu to be displayed by the operating system when a user engages with the web app's icon.",
+      "properties": {
+        "name": {
+          "description": "The name member of a shortcut item is a string that represents the name of the shortcut as it is usually displayed to the user in a context menu.",
+          "type": "string"
+        },
+        "short_name": {
+          "description": "The short_name member of a shortcut item is a string that represents a short version of the name of the shortcut. It is intended to be used where there is insufficient space to display the full name of the shortcut.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The description member of a shortcut item is a string that allows the developer to describe the purpose of the shortcut.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The url member of a shortcut item is a URL within scope of a processed manifest that opens when the associated shortcut is activated.",
+          "type": "string",
+          "format": "uri"
+        },
+        "icons": {
+          "description": "The icons member of a shortcut item serves as iconic representations of the shortcut in various contexts.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/manifest_image_resource"
+          }
+        }
+      },
+      "required": ["name", "url"]
     }
   }
 }

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -129,7 +129,8 @@
         "platform": {
           "$ref": "#/definitions/platform"
         }
-      }
+      },
+      "required": ["src"]
     },
     "related_application": {
       "type": "object",
@@ -165,7 +166,8 @@
             }
           }
         }
-      }
+      },
+      "required": ["platform"]
     },
     "platform": {
       "description": "The platform it is associated to.",

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -95,7 +95,6 @@
       "type": "string"
     }
   },
-  "required": [ "name", "icons" ],
   "definitions": {
     "manifest_image_resource": {
       "type": "object",

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -75,28 +75,6 @@
         "$ref": "#/definitions/image"
       }
     },
-    "serviceworker": {
-      "description": "The service worker of the web application.",
-      "type": "object",
-      "properties": {
-        "src": {
-          "description": "URL representing a service worker.",
-          "type": "string"
-        },
-        "scope": {
-          "description": "The service worker's associated scope URL.",
-          "type": "string"
-        },
-        "type": {
-          "description": "The service worker's worker type.",
-          "type": "string"
-        },
-        "use_cache": {
-          "description": "Determines whether the user agent cache should be used when fetching the service worker.",
-          "type": "boolean"
-        }
-      }
-    },
     "short_name": {
       "description": "A string that represents a short version of the name of the web application.",
       "type": "string"

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -38,7 +38,7 @@
       "description": "The icons member is an array of icon objects that can serve as iconic representations of the web application in various contexts.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/image"
+        "$ref": "#/definitions/manifest_image_resource"
       }
     },
     "lang": {
@@ -72,7 +72,7 @@
       "description": "The screenshots member is an array of image objects represent the web application in common usage scenarios.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/image"
+        "$ref": "#/definitions/manifest_image_resource"
       }
     },
     "short_name": {
@@ -90,7 +90,7 @@
   },
   "required": [ "name", "icons" ],
   "definitions": {
-    "image": {
+    "manifest_image_resource": {
       "type": "object",
       "properties": {
         "sizes": {

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -61,7 +61,7 @@
       "description": "Array of application accessible to the underlying application platform that has a relationship with the web application.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/related_application"
+        "$ref": "#/definitions/external_application_resource"
       }
     },
     "scope": {
@@ -131,7 +131,7 @@
       },
       "required": ["src"]
     },
-    "related_application": {
+    "external_application_resource": {
       "type": "object",
       "properties": {
         "platform": {


### PR DESCRIPTION
Updates the Web App Manifest JSON schema to match the [latest version of the spec](https://www.w3.org/TR/appmanifest/):
* drops the `serviceworker` member
* adds the `shortcuts` member
* replaces the `badge` purpose by `monochrome`
* renames the `image` type to `manifest_image_resource` to match spec
* renames the `related_application` type to `external_application_resource` to match spec
* adds required properties that were missing before

Additionally, the `name` and `icons` properties are no longer required. Although they are very important and most applications may want to set them, the specification does not require them.