### PR TITLE
Added link for bitbucket pipelines manifest

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -155,6 +155,15 @@
       "url": "https://batect.dev/configSchema.json"
     },
     {
+      "name": "bitbucket-pipelines",
+      "description": "Bitbucket Pipelines CI/CD manifest schema",
+      "url": "https://bitbucket.org/atlassianlabs/atlascode/raw/main/resources/schemas/pipelines-schema.json",
+      "fileMatch": [
+        "bitbucket-pipelines.yml",
+        "bitbucket-pipelines.yaml"
+      ]
+    },
+    {
       "name": ".bootstraprc",
       "description": "Webpack bootstrap-loader configuration file",
       "fileMatch": [


### PR DESCRIPTION
Hello,

I've added Bitbucket Pipelines URL to the catalog, pointing to the Atlassian repository schema.

Please, let me know if the additional actions required.