### PR TITLE
ocelot: rename ReRoutes -> Routes

### DIFF
--- a/src/schemas/json/ocelot.json
+++ b/src/schemas/json/ocelot.json
@@ -2,35 +2,35 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "JSON Schema for Ocelot.json",
   "type": "object",
-  "required": [ "ReRoutes" ],
+  "required": [ "Routes" ],
   "properties": {
-    "ReRoutes": {
-      "$id": "#/properties/ReRoutes",
+    "Routes": {
+      "$id": "#/properties/Routes",
       "type": "array",
-      "title": "The Reroutes Schema",
+      "title": "The Routes Schema",
       "items": {
-        "$id": "#/properties/ReRoutes/items",
+        "$id": "#/properties/Routes/items",
         "type": "object",
         "title": "The Items Schema",
         "properties": {
           "DownstreamPathTemplate": {
-            "$id": "#/properties/ReRoutes/items/properties/DownstreamPathTemplate",
+            "$id": "#/properties/Routes/items/properties/DownstreamPathTemplate",
             "type": "string",
             "title": "The Downstreampathtemplate Schema",
             "pattern": "^(.*)$"
           },
           "UpstreamPathTemplate": {
-            "$id": "#/properties/ReRoutes/items/properties/UpstreamPathTemplate",
+            "$id": "#/properties/Routes/items/properties/UpstreamPathTemplate",
             "type": "string",
             "title": "The Upstreampathtemplate Schema",
             "pattern": "^(.*)$"
           },
           "UpstreamHttpMethod": {
-            "$id": "#/properties/ReRoutes/items/properties/UpstreamHttpMethod",
+            "$id": "#/properties/Routes/items/properties/UpstreamHttpMethod",
             "type": "array",
             "title": "The Upstreamhttpmethod Schema",
             "items": {
-              "$id": "#/properties/ReRoutes/items/properties/UpstreamHttpMethod/items",
+              "$id": "#/properties/Routes/items/properties/UpstreamHttpMethod/items",
               "type": "string",
               "title": "The Items Schema",
               "examples": [
@@ -40,77 +40,77 @@
             }
           },
           "AddHeadersToRequest": {
-            "$id": "#/properties/ReRoutes/items/properties/AddHeadersToRequest",
+            "$id": "#/properties/Routes/items/properties/AddHeadersToRequest",
             "type": "object",
             "title": "The Addheaderstorequest Schema"
           },
           "AddClaimsToRequest": {
-            "$id": "#/properties/ReRoutes/items/properties/AddClaimsToRequest",
+            "$id": "#/properties/Routes/items/properties/AddClaimsToRequest",
             "type": "object",
             "title": "The Addclaimstorequest Schema"
           },
           "RouteClaimsRequirement": {
-            "$id": "#/properties/ReRoutes/items/properties/RouteClaimsRequirement",
+            "$id": "#/properties/Routes/items/properties/RouteClaimsRequirement",
             "type": "object",
             "title": "The Routeclaimsrequirement Schema"
           },
           "AddQueriesToRequest": {
-            "$id": "#/properties/ReRoutes/items/properties/AddQueriesToRequest",
+            "$id": "#/properties/Routes/items/properties/AddQueriesToRequest",
             "type": "object",
             "title": "The Addqueriestorequest Schema"
           },
           "RequestIdKey": {
-            "$id": "#/properties/ReRoutes/items/properties/RequestIdKey",
+            "$id": "#/properties/Routes/items/properties/RequestIdKey",
             "type": "string",
             "title": "The Requestidkey Schema",
             "pattern": "^(.*)$"
           },
           "FileCacheOptions": {
-            "$id": "#/properties/ReRoutes/items/properties/FileCacheOptions",
+            "$id": "#/properties/Routes/items/properties/FileCacheOptions",
             "type": "object",
             "title": "The Filecacheoptions Schema",
             "properties": {
               "TtlSeconds": {
-                "$id": "#/properties/ReRoutes/items/properties/FileCacheOptions/properties/TtlSeconds",
+                "$id": "#/properties/Routes/items/properties/FileCacheOptions/properties/TtlSeconds",
                 "type": "integer",
                 "title": "The Ttlseconds Schema"
               },
               "Region": {
-                "$id": "#/properties/ReRoutes/items/properties/FileCacheOptions/properties/Region",
+                "$id": "#/properties/Routes/items/properties/FileCacheOptions/properties/Region",
                 "type": "string",
                 "title": "The Region Schema",
                 "pattern": "^(.*)$"
               }
             }
           },
-          "ReRouteIsCaseSensitive": {
-            "$id": "#/properties/ReRoutes/items/properties/ReRouteIsCaseSensitive",
+          "RouteIsCaseSensitive": {
+            "$id": "#/properties/Routes/items/properties/RouteIsCaseSensitive",
             "type": "boolean",
             "title": "The Rerouteiscasesensitive Schema"
           },
           "ServiceName": {
-            "$id": "#/properties/ReRoutes/items/properties/ServiceName",
+            "$id": "#/properties/Routes/items/properties/ServiceName",
             "type": "string",
             "title": "The Servicename Schema",
             "pattern": "^(.*)$"
           },
           "DownstreamScheme": {
-            "$id": "#/properties/ReRoutes/items/properties/DownstreamScheme",
+            "$id": "#/properties/Routes/items/properties/DownstreamScheme",
             "type": "string",
             "title": "The Downstreamscheme Schema",
             "pattern": "^(.*)$"
           },
           "DownstreamHostAndPorts": {
-            "$id": "#/properties/ReRoutes/items/properties/DownstreamHostAndPorts",
+            "$id": "#/properties/Routes/items/properties/DownstreamHostAndPorts",
             "type": "array",
             "title": "The Downstreamhostandports Schema",
             "items": {
-              "$id": "#/properties/ReRoutes/items/properties/DownstreamHostAndPorts/items",
+              "$id": "#/properties/Routes/items/properties/DownstreamHostAndPorts/items",
               "type": "object",
               "title": "The Items Schema",
               "properties": {
                 "Host": {
-                  "$id": "#/properties/ReRoutes/items/properties/DownstreamHostAndPorts/items/properties/Host",
+                  "$id": "#/properties/Routes/items/properties/DownstreamHostAndPorts/items/properties/Host",
                   "type": "string",
                   "title": "The Host Schema",
                   "default": "",
@@ -120,7 +120,7 @@
                   "pattern": "^(.*)$"
                 },
                 "Port": {
-                  "$id": "#/properties/ReRoutes/items/properties/DownstreamHostAndPorts/items/properties/Port",
+                  "$id": "#/properties/Routes/items/properties/DownstreamHostAndPorts/items/properties/Port",
                   "type": "integer",
                   "title": "The Port Schema"
                 }
@@ -128,108 +128,108 @@
             }
           },
           "QoSOptions": {
-            "$id": "#/properties/ReRoutes/items/properties/QoSOptions",
+            "$id": "#/properties/Routes/items/properties/QoSOptions",
             "type": "object",
             "title": "The Qosoptions Schema",
             "properties": {
               "ExceptionsAllowedBeforeBreaking": {
-                "$id": "#/properties/ReRoutes/items/properties/QoSOptions/properties/ExceptionsAllowedBeforeBreaking",
+                "$id": "#/properties/Routes/items/properties/QoSOptions/properties/ExceptionsAllowedBeforeBreaking",
                 "type": "integer",
                 "title": "The Exceptionsallowedbeforebreaking Schema"
               },
               "DurationOfBreak": {
-                "$id": "#/properties/ReRoutes/items/properties/QoSOptions/properties/DurationOfBreak",
+                "$id": "#/properties/Routes/items/properties/QoSOptions/properties/DurationOfBreak",
                 "type": "integer",
                 "title": "The Durationofbreak Schema"
               },
               "TimeoutValue": {
-                "$id": "#/properties/ReRoutes/items/properties/QoSOptions/properties/TimeoutValue",
+                "$id": "#/properties/Routes/items/properties/QoSOptions/properties/TimeoutValue",
                 "type": "integer",
                 "title": "The Timeoutvalue Schema"
               }
             }
           },
           "LoadBalancer": {
-            "$id": "#/properties/ReRoutes/items/properties/LoadBalancer",
+            "$id": "#/properties/Routes/items/properties/LoadBalancer",
             "type": "string",
             "title": "The Loadbalancer Schema",
             "pattern": "^(.*)$"
           },
           "RateLimitOptions": {
-            "$id": "#/properties/ReRoutes/items/properties/RateLimitOptions",
+            "$id": "#/properties/Routes/items/properties/RateLimitOptions",
             "type": "object",
             "title": "The Ratelimitoptions Schema",
             "properties": {
               "ClientWhitelist": {
-                "$id": "#/properties/ReRoutes/items/properties/RateLimitOptions/properties/ClientWhitelist",
+                "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/ClientWhitelist",
                 "type": "array",
                 "title": "The Clientwhitelist Schema"
               },
               "EnableRateLimiting": {
-                "$id": "#/properties/ReRoutes/items/properties/RateLimitOptions/properties/EnableRateLimiting",
+                "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/EnableRateLimiting",
                 "type": "boolean",
                 "title": "The Enableratelimiting Schema"
               },
               "Period": {
-                "$id": "#/properties/ReRoutes/items/properties/RateLimitOptions/properties/Period",
+                "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/Period",
                 "type": "string",
                 "title": "The Period Schema",
                 "pattern": "^(.*)$"
               },
               "PeriodTimespan": {
-                "$id": "#/properties/ReRoutes/items/properties/RateLimitOptions/properties/PeriodTimespan",
+                "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/PeriodTimespan",
                 "type": "integer",
                 "title": "The Periodtimespan Schema"
               },
               "Limit": {
-                "$id": "#/properties/ReRoutes/items/properties/RateLimitOptions/properties/Limit",
+                "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/Limit",
                 "type": "integer",
                 "title": "The Limit Schema"
               }
             }
           },
           "AuthenticationOptions": {
-            "$id": "#/properties/ReRoutes/items/properties/AuthenticationOptions",
+            "$id": "#/properties/Routes/items/properties/AuthenticationOptions",
             "type": "object",
             "title": "The Authenticationoptions Schema",
             "properties": {
               "AuthenticationProviderKey": {
-                "$id": "#/properties/ReRoutes/items/properties/AuthenticationOptions/properties/AuthenticationProviderKey",
+                "$id": "#/properties/Routes/items/properties/AuthenticationOptions/properties/AuthenticationProviderKey",
                 "type": "string",
                 "title": "The Authenticationproviderkey Schema",
                 "pattern": "^(.*)$"
               },
               "AllowedScopes": {
-                "$id": "#/properties/ReRoutes/items/properties/AuthenticationOptions/properties/AllowedScopes",
+                "$id": "#/properties/Routes/items/properties/AuthenticationOptions/properties/AllowedScopes",
                 "type": "array",
                 "title": "The Allowedscopes Schema"
               }
             }
           },
           "HttpHandlerOptions": {
-            "$id": "#/properties/ReRoutes/items/properties/HttpHandlerOptions",
+            "$id": "#/properties/Routes/items/properties/HttpHandlerOptions",
             "type": "object",
             "title": "The Httphandleroptions Schema",
             "properties": {
               "AllowAutoRedirect": {
-                "$id": "#/properties/ReRoutes/items/properties/HttpHandlerOptions/properties/AllowAutoRedirect",
+                "$id": "#/properties/Routes/items/properties/HttpHandlerOptions/properties/AllowAutoRedirect",
                 "type": "boolean",
                 "title": "The Allowautoredirect Schema"
               },
               "UseCookieContainer": {
-                "$id": "#/properties/ReRoutes/items/properties/HttpHandlerOptions/properties/UseCookieContainer",
+                "$id": "#/properties/Routes/items/properties/HttpHandlerOptions/properties/UseCookieContainer",
                 "type": "boolean",
                 "title": "The Usecookiecontainer Schema"
               },
               "UseTracing": {
-                "$id": "#/properties/ReRoutes/items/properties/HttpHandlerOptions/properties/UseTracing",
+                "$id": "#/properties/Routes/items/properties/HttpHandlerOptions/properties/UseTracing",
                 "type": "boolean",
                 "title": "The Usetracing Schema"
               }
             }
           },
           "DangerousAcceptAnyServerCertificateValidator": {
-            "$id": "#/properties/ReRoutes/items/properties/DangerousAcceptAnyServerCertificateValidator",
+            "$id": "#/properties/Routes/items/properties/DangerousAcceptAnyServerCertificateValidator",
             "type": "boolean",
             "title": "The Dangerousacceptanyservercertificatevalidator Schema"
           }

--- a/src/test/ocelot/ocelot.json
+++ b/src/test/ocelot/ocelot.json
@@ -1,5 +1,5 @@
 {
-  "ReRoutes": [
+  "Routes": [
     {
       "DownstreamPathTemplate": "/",
       "UpstreamPathTemplate": "/",
@@ -15,7 +15,7 @@
         "TtlSeconds": 0,
         "Region": ""
       },
-      "ReRouteIsCaseSensitive": false,
+      "RouteIsCaseSensitive": false,
       "ServiceName": "",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [


### PR DESCRIPTION
Update two properties:
ReRoutes -> Routes
ReRouteIsCaseSensitive -> RouteIsCaseSensitive

Rename all $id: ReRoutes -> Routes

See:
doc https://ocelot.readthedocs.io/en/latest/features/routing.html

git: https://github.com/ThreeMammals/Ocelot/commit/3439be89271bb37b170429d69ca74978c941432e
All ReRoutes are rename to Routes

closes #1071
