### PR TITLE
jekyll: scope.type can also be any string

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -26,11 +26,19 @@
           "title": "File path for this scope"
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "pages",
-            "posts",
-            "drafts"
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "pages",
+                "posts",
+                "drafts"
+              ]
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
           ]
         }
       }


### PR DESCRIPTION
Keep enum for code completion

close #1063 