### PR TITLE
[web-manifest] Drop `platform` from `manifest_image_resource`

### DIFF
--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -124,9 +124,6 @@
           "type": "string",
           "enum": [ "monochrome", "maskable", "any" ],
           "default": "any"
-        },
-        "platform": {
-          "$ref": "#/definitions/platform"
         }
       },
       "required": ["src"]
@@ -135,7 +132,8 @@
       "type": "object",
       "properties": {
         "platform": {
-          "$ref": "#/definitions/platform"
+          "description": "The platform it is associated to.",
+          "enum": [ "chrome_web_store", "play", "itunes", "windows" ]
         },
         "url": {
           "description": "The URL where the application can be found.",
@@ -167,10 +165,6 @@
         }
       },
       "required": ["platform"]
-    },
-    "platform": {
-      "description": "The platform it is associated to.",
-      "enum": [ "play", "itunes", "windows" ]
     },
     "shortcut_item": {
       "type": "object",


### PR DESCRIPTION
The spec dropped the `platform` member from `ManifestImageResource`. It was never implemented by any browser. It remains for external application resources. Also, the `chrome_web_store` platform was added to match the [platforms wiki](https://github.com/w3c/manifest/wiki/Platforms).