### PR TITLE
[github-workflow] Add workflow_dispatch

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -169,6 +169,7 @@
         "release",
         "status",
         "watch",
+        "workflow_dispatch",
         "repository_dispatch"
       ]
     },
@@ -794,6 +795,51 @@
               "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows#watch-event-watch",
               "$ref": "#/definitions/eventObject",
               "description": "Runs your workflow anytime the watch event occurs. More than one activity type triggers this event. For information about the REST API, see https://developer.github.com/v3/activity/starring/."
+            },
+            "workflow_dispatch": {
+              "$comment": "https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/",
+              "description": "You can now create workflows that are manually triggered with the new workflow_dispatch event. You will then see a 'Run workflow' button on the Actions tab, enabling you to easily trigger a run.",
+              "properties": {
+                "inputs": {
+                  "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputs",
+                  "description": "Input parameters allow you to specify data that the action expects to use during runtime. GitHub stores input parameters as environment variables. Input ids with uppercase letters are converted to lowercase during runtime. We recommended using lowercase input ids.",
+                  "type": "object",
+                  "patternProperties": {
+                    "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
+                      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_id",
+                      "description": "A string identifier to associate with the input. The value of <input_id> is a map of the input's metadata. The <input_id> must be a unique identifier within the inputs object. The <input_id> must start with a letter or _ and contain only alphanumeric characters, -, or _.",
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddescription",
+                          "description": "A string description of the input parameter.",
+                          "type": "string"
+                        },
+                        "deprecationMessage": {
+                          "description": "A string shown to users using the deprecated input.",
+                          "type": "string"
+                        },
+                        "required": {
+                          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_idrequired",
+                          "description": "A boolean to indicate whether the action requires the input parameter. Set to true when the parameter is required.",
+                          "type": "boolean"
+                        },
+                        "default": {
+                          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
+                          "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "description",
+                        "required"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
             },
             "repository_dispatch": {
               "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows#external-events-repository_dispatch",


### PR DESCRIPTION
Add workflow_dispatch to event.

ref: [GitHub Actions: Manual triggers with workflow_dispatch The GitHub Blog](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)