### PR TITLE
[github-workflow] support expression syntax for job matrix strategy

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1120,7 +1120,14 @@
                 "matrix": {
                   "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix",
                   "description": "A build matrix is a set of different configurations of the virtual environment. For example you might run a job against more than one supported version of a language, operating system, or tool. Each configuration is a copy of the job that runs and reports a status.\nYou can specify a matrix by supplying an array for the configuration options. For example, if the GitHub virtual environment supports Node.js versions 6, 8, and 10 you could specify an array of those versions in the matrix.\nWhen you define a matrix of operating systems, you must set the required runs-on keyword to the operating system of the current job, rather than hard-coding the operating system name. To access the operating system name, you can use the matrix.os context parameter to set runs-on. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-                  "type": "object",
+                  "oneOf": [
+                    {
+                      "type": "object"
+                    },
+                    {
+                      "$ref": "#/definitions/expressionSyntax"
+                    }
+                  ],
                   "patternProperties": {
                     "^(in|ex)clude$": {
                       "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build",

--- a/src/test/github-workflow/matrix_from_json.json
+++ b/src/test/github-workflow/matrix_from_json.json
@@ -1,0 +1,33 @@
+{
+  "name": "Test on Pull",
+  "on": [
+    "push"
+  ],
+  "jobs": {
+    "build": {
+      "runs-on": "ubuntu-latest",
+      "continue-on-error": "${{ matrix.experimental }}",
+      "strategy": {
+        "fail-fast": true,
+        "matrix": "${{fromJson(needs.job1.outputs.matrix)}}"
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v1"
+        },
+        {
+          "uses": "actions/setup-node@v1",
+          "with": {
+            "node-version": "${{ matrix.node-version }}"
+          }
+        },
+        {
+          "run": "npm run lint"
+        },
+        {
+          "run": "npm test"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is my first time writing json schema so I'd appreciate it if someone could sense check my approach. (Doing so doesn't require knowledge of GitHub workflows.)

### Context

Most of the time a job matrix will be defined by an object per the schema definition already on master. Per the existing additionalProperties, these properties should all be arrays except for the special cases of "include" and "exclude" defined in the existing patternProperties.

Examples:

```yaml
strategy:
  matrix:
    node: [6, 8, 10]
```

```yaml
strategy:
  matrix:
    os: [macos-latest, windows-latest, ubuntu-18.04]
    node: [4, 6, 8, 10]
    include:
      # includes a new variable of npm with a value of 2
      # for the matrix leg matching the os and version
      - os: windows-latest
        node: 4
        npm: 2
```

(More examples on GitHub docs [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-running-with-more-than-one-version-of-nodejs).)

**However**, you should also be able to define a matrix using GitHub's expression syntax. This is useful for defining a jobs matrix dynamically in the workflow itself. Example:

```yaml
strategy:
  matrix: ${{fromJson(needs.job1.outputs.matrix)}}
```

(This is taken from the docs [here](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#example-6).)

### Changes

The change in this PR is pretty small, just switching from a type of object to using the oneOf keyword.

The intent is that if an object is given, the existing rules (in patternProperties and additionalProperties) will continue to be applied, but if a string is given then it must match the expressionSyntax definition.

In my testing, this appears to be the case, but it would be great if someone with greater familiarity with json schemas could confirm the approach I've taken.

Thanks!