### PR TITLE
Remove credentialId from required parameters in appUrls

### DIFF
--- a/src/schemas/json/cloud-sdk-pipeline-config-schema.json
+++ b/src/schemas/json/cloud-sdk-pipeline-config-schema.json
@@ -1020,8 +1020,7 @@
                     }
                 },
                 "required": [
-                    "url",
-                    "credentialId"
+                    "url"
                 ],
                 "additionalProperties": false
             }

--- a/src/schemas/json/cloud-sdk-pipeline-config-schema.json
+++ b/src/schemas/json/cloud-sdk-pipeline-config-schema.json
@@ -1015,8 +1015,8 @@
                         "type": "string"
                     },
                     "parameters": {
-                        "description": "Additional parameters can be passed for each end-to-end test deployment by specifying optional parameters for an application URL. These parameters are appended to the npm command during execution.",
-                        "type": "string"
+                        "description": "Additional parameters can be passed for each end-to-end test deployment by specifying optional parameters for an application URL. These parameters are appended to the npm command during execution. These parameters must be a list of strings, where each string corresponds to one element of the parameters. For example, if the parameter `--tag scenario1` should be passed to the test, specify parameters: ['--tag', 'scenario1'].",
+                        "type": "array"
                     }
                 },
                 "required": [


### PR DESCRIPTION
The `credentialId` parameter is not mandatory anymore.