### PR TITLE
Add tests for KSP-CKAN and KSP-AVC

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1824,20 +1824,20 @@
       "url": "https://json-stat.org/format/schema/2.0/"
     },
     {
-      "name": "KSP-AVC 1.4.1",
+      "name": "KSP-AVC",
       "description": "The .version file format for KSP-AVC",
       "fileMatch": [
         "*.version"
       ],
-      "url": "https://json.schemastore.org/ksp-avc"
+      "url": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/master/KSP-AVC.schema.json"
     },
     {
-      "name": "KSP-CKAN 1.27",
-      "description": "Metadata spec v1.27 for KSP-CKAN",
+      "name": "KSP-CKAN",
+      "description": "Metadata spec for KSP-CKAN",
       "fileMatch": [
         "*.ckan"
       ],
-      "url": "https://json.schemastore.org/ksp-ckan"
+      "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/CKAN.schema"
     },
     {
       "name": "JSON Schema Draft 4",

--- a/src/test/ksp-avc/KspMaxVersion.version
+++ b/src/test/ksp-avc/KspMaxVersion.version
@@ -1,0 +1,23 @@
+{
+  "NAME": "KspVersion & KspMaxVersion",
+  "URL": "file://D:/GitHub/schemastore/src/test/ksp-avc/KspMaxVersion.version",
+  "VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 1,
+    "PATCH": 6,
+    "BUILD": 2
+  },
+  "KSP_VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 2,
+    "PATCH": 0
+  },
+  "KSP_VERSION_MAX":
+  {
+    "MAJOR": 1,
+    "MINOR": 4,
+    "PATCH": 1
+  }
+}

--- a/src/test/ksp-avc/KspMinMaxVersion.version
+++ b/src/test/ksp-avc/KspMinMaxVersion.version
@@ -1,0 +1,29 @@
+{
+  "NAME": "KspVersion, KspMinVersion & KspMaxVersion",
+  "URL": "file://D:/GitHub/schemastore/src/test/ksp-avc/KspMinMaxVersion.version",
+  "VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 1,
+    "PATCH": 6,
+    "BUILD": 2
+  },
+  "KSP_VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 2,
+    "PATCH": 0
+  },
+  "KSP_VERSION_MIN":
+  {
+    "MAJOR": 1,
+    "MINOR": 2,
+    "PATCH": 0
+  },
+  "KSP_VERSION_MAX":
+  {
+    "MAJOR": 1,
+    "MINOR": 2,
+    "PATCH": 0
+  }
+}

--- a/src/test/ksp-avc/KspMinVersion.version
+++ b/src/test/ksp-avc/KspMinVersion.version
@@ -1,0 +1,23 @@
+{
+  "NAME": "KspVersion & KspMinVersion",
+  "URL": "file://D:/GitHub/schemastore/src/test/ksp-avc/KspMinVersion.version",
+  "VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 1,
+    "PATCH": 6,
+    "BUILD": 2
+  },
+  "KSP_VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 2,
+    "PATCH": 0
+  },
+  "KSP_VERSION_MIN":
+  {
+    "MAJOR": 1,
+    "MINOR": 2,
+    "PATCH": 0
+  }
+}

--- a/src/test/ksp-avc/KspVersion.version
+++ b/src/test/ksp-avc/KspVersion.version
@@ -1,0 +1,17 @@
+{
+  "NAME": "KspVersion",
+  "URL": "file://D:/GitHub/schemastore/src/test/ksp-avc/KspVersion.version",
+  "VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 1,
+    "PATCH": 6,
+    "BUILD": 2
+  },
+  "KSP_VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 4,
+    "PATCH": 1
+  }
+}

--- a/src/test/ksp-avc/KspVersionComplete.version
+++ b/src/test/ksp-avc/KspVersionComplete.version
@@ -1,0 +1,53 @@
+{
+  "NAME": "Complete version file",
+  "URL": "file://D:/GitHub/schemastore/src/test/ksp-avc/KspVersionComplete.version",
+  "DOWNLOAD": "https://awesomemod.example/AwesomeMod.zip",
+  "CHANGE_LOG": "Your changes since last release",
+  "CHANGE_LOG_URL": "https://awesomemod.example/Changelog.txt",
+  "GITHUB":
+  {
+    "USERNAME": "YourGitHubUserName",
+    "REPOSITORY": "YourGitHubRepository",
+    "ALLOW_PRE_RELEASE": false
+  },
+  "KERBAL_STUFF_URL": "https://kerbalstuff.com/mod/1/AwesomeMod",
+  "VERSION":
+  {
+    "MAJOR": 1,
+    "MINOR": 1,
+    "PATCH": 0,
+    "BUILD": 0
+  },
+  "KSP_VERSION":
+  {
+    "MAJOR": 0,
+    "MINOR": 24,
+    "PATCH": 2
+  },
+  "KSP_VERSION_MIN":
+  {
+    "MAJOR": 0,
+    "MINOR": 24,
+    "PATCH": 0
+  },
+  "KSP_VERSION_MAX":
+  {
+    "MAJOR": 0,
+    "MINOR": 24,
+    "PATCH": 2
+  },
+  "DISALLOW_VERSION_OVERRIDE": true,
+  "ASSEMBLY_NAME": "NameOfYour.dll",
+  "KSP_VERSION_INCLUDE": [ "0.23" ],
+  "KSP_VERSION_EXCLUDE": [ "0.22" ],
+  "LOCAL_HAS_PRIORITY": true,
+  "REMOTE_HAS_PRIORITY": true,
+  "INSTALL_LOC":
+  {
+    "NAME": "ModName",
+    "PATH": "Path",
+    "DIRECTORY": "DirName",
+    "FILE": "FileName",
+    "MESSAGE": "Display this message" 
+  }
+}

--- a/src/test/ksp-ckan/Firespitter-6.3.5.ckan
+++ b/src/test/ksp-ckan/Firespitter-6.3.5.ckan
@@ -1,0 +1,43 @@
+{
+  "spec_version": 1,
+  "identifier": "Firespitter",
+  "license": "restricted",
+  "comment": "Our version really depends on FirespitterCore",
+  "ksp_version_min": "0.24.2",
+  "resources": {
+    "repository": "https://github.com/snjo/Firespitter",
+    "kerbalstuff": "https://kerbalstuff.com/mod/63/Firespitter",
+    "homepage": "http://forum.kerbalspaceprogram.com/showthread.php/24551-Firespitter"
+  },
+  "depends": [
+    {
+      "name": "FirespitterCore",
+      "min_version": "7.0.5398.27328"
+    }
+  ],
+  "x_supports": [
+    {
+      "name": "PartCatalog"
+    }
+  ],
+  "install": [
+    {
+      "file": "Firespitter",
+      "install_to": "GameData",
+      "filter": "Firespitter.dll",
+      "comment": "The DLL is installed from FirespitterCore"
+    },
+    {
+      "file": "PartCatalog",
+      "install_to": "GameData",
+      "comment": "Firespitter graphics for PartCatalog"
+    }
+  ],
+  "name": "Firespitter",
+  "abstract": "Propeller plane and helicopter parts",
+  "author": "Snjo",
+  "version": "6.3.5",
+  "download": "https://kerbalstuff.com/mod/63/Firespitter/download/6.3.5",
+  "x_generated_by": "netkan",
+  "download_size": 37457313
+}

--- a/src/test/ksp-ckan/MissionTest-1.0.ckan
+++ b/src/test/ksp-ckan/MissionTest-1.0.ckan
@@ -1,0 +1,18 @@
+{
+  "spec_version": "v1.25",
+  "name": "Mission: Awesome",
+  "identifier": "Mission-Awesome",
+  "abstract": "Testing the missions from the Mission Builder.",
+  "download": "https://awesomemod.example/AwesomeMod.zip",
+  "license": "CC-BY-SA",
+  "author": "CKAN Team",
+  "version": "1.0",
+  "release_status": "stable",
+  "ksp_version": "1.4.1",
+  "install": [
+    {
+      "file": "AwesomeMission",
+      "install_to": "Missions"
+    }
+  ]
+}

--- a/src/test/ksp-ckan/ModuleManager-2.5.1.ckan
+++ b/src/test/ksp-ckan/ModuleManager-2.5.1.ckan
@@ -1,0 +1,18 @@
+{
+  "spec_version": 1,
+  "name": "Module Manager",
+  "identifier": "ModuleManager",
+  "abstract": "Modify KSP configs without conflict",
+  "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/lastSuccessfulBuild/artifact/ModuleManager-2.5.1.zip",
+  "license": "CC-BY-SA",
+  "author": [ "ialdabaoth", "Sarbian" ],
+  "version": "2.5.1",
+  "release_status": "stable",
+  "ksp_version": "0.25",
+  "install": [
+    {
+      "file": "ModuleManager.2.5.1.dll",
+      "install_to": "GameData"
+    }
+  ]
+}


### PR DESCRIPTION
**Changes**:
* Moved `KSP-CKAN` and `KSP-AVC` to self-hosting
* Added tests for `KSP-CKAN`
* Added test for `KSP-AVC`

If I move these schemas to self-hosting, do I need to remove them from the repo or can I leave them in?
