### PR TITLE
[web-manifest-app-info] move app info properties into own schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1889,13 +1889,13 @@
       "url": "https://json.schemastore.org/webextension"
     },
     {
-      "name": "Web Manifest",
+      "name": "Web App Manifest",
       "description": "Web Application manifest file",
       "fileMatch": [
         "manifest.json",
         "*.webmanifest"
       ],
-      "url": "https://json.schemastore.org/web-manifest"
+      "url": "https://json.schemastore.org/web-manifest-combined"
     },
     {
       "name": "webjobs-list.json",

--- a/src/schemas/json/web-manifest-app-info.json
+++ b/src/schemas/json/web-manifest-app-info.json
@@ -1,0 +1,31 @@
+{
+  "title": "JSON schema for Web Application manifest files with app information extensions",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+
+  "properties": {
+    "categories": {
+      "description": "Describes the expected application categories to which the web application belongs.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "description": {
+      "description": "Description of the purpose of the web application",
+      "type": "string"
+    },
+    "iarc_rating_id": {
+      "description": "Represents an ID value of the IARC rating of the web application. It is intended to be used to determine which ages the web application is appropriate for.",
+      "type": "string"
+    },
+    "screenshots": {
+      "description": "The screenshots member is an array of image objects represent the web application in common usage scenarios.",
+      "type": "array",
+      "items": {
+        "$ref": "web-manifest.json#/definitions/manifest_image_resource"
+      }
+    }
+  }
+}

--- a/src/schemas/json/web-manifest-app-info.json
+++ b/src/schemas/json/web-manifest-app-info.json
@@ -24,7 +24,7 @@
       "description": "The screenshots member is an array of image objects represent the web application in common usage scenarios.",
       "type": "array",
       "items": {
-        "$ref": "web-manifest.json#/definitions/manifest_image_resource"
+        "$ref": "https://json.schemastore.org/web-manifest.json#/definitions/manifest_image_resource"
       }
     }
   }

--- a/src/schemas/json/web-manifest-combined.json
+++ b/src/schemas/json/web-manifest-combined.json
@@ -2,8 +2,8 @@
   "title": "JSON schema for Web Application manifest files",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "allOf": [{
-    "$ref": "./web-manifest.json"
+    "$ref": "https://json.schemastore.org/web-manifest.json"
   }, {
-    "$ref": "./web-manifest-app-info.json"
+    "$ref": "https://json.schemastore.org/web-manifest-app-info.json"
   }]
 }

--- a/src/schemas/json/web-manifest-combined.json
+++ b/src/schemas/json/web-manifest-combined.json
@@ -1,0 +1,9 @@
+{
+  "title": "JSON schema for Web Application manifest files",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [{
+    "$ref": "./web-manifest.json"
+  }, {
+    "$ref": "./web-manifest-app-info.json"
+  }]
+}

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -9,17 +9,6 @@
       "description": "The background_color member describes the expected background color of the web application.",
       "type": "string"
     },
-    "categories": {
-      "description": "Describes the expected application categories to which the web application belongs.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "description": {
-      "description": "Description of the purpose of the web application",
-      "type": "string"
-    },
     "dir": {
       "description": "The base direction of the manifest.",
       "enum": [ "ltr", "rtl", "auto" ],
@@ -29,10 +18,6 @@
       "description": "The item represents the developer's preferred display mode for the web application.",
       "enum": [ "fullscreen", "standalone", "minimal-ui", "browser" ],
       "default": "browser"
-    },
-    "iarc_rating_id": {
-      "description": "Represents an ID value of the IARC rating of the web application. It is intended to be used to determine which ages the web application is appropriate for.",
-      "type": "string"
     },
     "icons": {
       "description": "The icons member is an array of icon objects that can serve as iconic representations of the web application in various contexts.",
@@ -67,13 +52,6 @@
     "scope": {
       "description": "A string that represents the navigation scope of this web application's application context.",
       "type": "string"
-    },
-    "screenshots": {
-      "description": "The screenshots member is an array of image objects represent the web application in common usage scenarios.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/manifest_image_resource"
-      }
     },
     "short_name": {
       "description": "A string that represents a short version of the name of the web application.",


### PR DESCRIPTION
From the Web App Manifest side, we intend to publish a new, separate note Web Applications Info from the spec (https://github.com/w3c/manifest/pull/924), and move some of the manifest properties there (`categories`, `description`, etc.). As a result, we would need to have a separate JSON Schema for `manifest.json|*.webmanifest` files.