### PR TITLE
Add macOS image entries to appveyor schema (#633)

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -119,6 +119,10 @@
     },
     "imageName": {
       "enum": [
+        "macOS",
+        "macOS-Mojave",
+        "Previous macOS",
+        "Previous macOS-Mojave",
         "Ubuntu",
         "Ubuntu1604",
         "Ubuntu1804",


### PR DESCRIPTION
AppVeyor now offers MacOS build images, and this PR adds those image names to the list of allowed ones specified in the corresponding JSON schema.

* https://www.appveyor.com/blog/2019/11/20/build-macos-projects-with-appveyor/
* https://www.appveyor.com/updates/2020/06/07/