### PR TITLE
Add Dart build configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -393,6 +393,12 @@
       "url": "https://json.schemastore.org/csslintrc"
     },
     {
+      "name": "Dart build configuration",
+      "description": "Configuration for Dart's build system",
+      "fileMatch": ["build.yaml"],
+      "url": "https://json.schemastore.org/dart-build"
+    },
+    {
       "name": "datalogic-scan2deploy-android",
       "description": "Datalogic Scan2Deploy Android file",
       "fileMatch": [".dla.json"],

--- a/src/schemas/json/dart-build.json
+++ b/src/schemas/json/dart-build.json
@@ -1,0 +1,260 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "build.yaml files",
+    "$id": "http://json.schemastore.org/dart-build",
+    "description": "Configuration for Dart's build system",
+    "definitions": {
+      "_listOfGlobs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "buildConfig": {
+        "type": "object",
+        "properties": {
+          "targets": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/buildTarget"
+            }
+          },
+          "builders": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/builderDefinition"
+            }
+          },
+          "post_process_builders": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/postProcessBuilderDefinition"
+            }
+          },
+          "global_options": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/globalBuilderOptions"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "buildTarget": {
+        "type": "object",
+        "properties": {
+          "auto_apply_builders": {
+            "type": "boolean",
+            "default": true
+          },
+          "builders": {
+            "type": "object",
+            "propertyNames": {
+              "$ref": "#/definitions/builderKey"
+            },
+            "additionalProperties": {
+              "$ref": "#/definitions/targetBuilderConfig"
+            },
+            "sources": {
+              "$ref": "#/definitions/inputSet"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "builderDefinition": {
+        "type": "object",
+        "properties": {
+          "builder_factories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "import": {
+            "type": "string"
+          },
+          "build_extensions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "auto_apply": {
+            "$ref": "#/definitions/autoApply",
+            "default": "none"
+          },
+          "required_inputs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "runs_before": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/builderKey"
+            }
+          },
+          "applies_builders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/builderKey"
+            }
+          },
+          "is_optional": {
+            "type": "boolean",
+            "default": false
+          },
+          "build_to": {
+            "$ref": "#/definitions/buildTo",
+            "default": "cache"
+          },
+          "defaults": {
+            "$ref": "#/definitions/targetBuilderConfigDefaults"
+          },
+          "target": {
+            "type": "string",
+            "title": "The name of the dart_library target that contains the import",
+            "deprecationMessage": "May be null or unreliable and should not be used."
+          }
+        },
+        "additionalProperties": false
+      },
+      "postProcessBuilderDefinition": {
+        "type": "object",
+        "properties": {
+          "builder_factory": {
+            "type": "string"
+          },
+          "import": {
+            "type": "string"
+          },
+          "input_extensions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "defaults": {
+            "$ref": "#/definitions/targetBuilderConfigDefaults"
+          }
+        },
+        "additionalProperties": false
+      },
+      "inputSet": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "include": {
+                "$ref": "#/definitions/_listOfGlobs"
+              },
+              "exclude": {
+                "$ref": "#/definitions/_listOfGlobs"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "$comment": "Use List<String> directly, inferred to mean include.",
+            "$ref": "#/definitions/_listOfGlobs"
+          }
+        ]
+      },
+      "targetBuilderConfig": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "generate_for": {
+            "$ref": "#/definitions/inputSet"
+          },
+          "options": {
+            "$ref": "#/definitions/builderOptions"
+          },
+          "dev_options": {
+            "$ref": "#/definitions/builderOptions"
+          },
+          "release_options": {
+            "$ref": "#/definitions/builderOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "targetBuilderConfigDefaults": {
+        "type": "object",
+        "properties": {
+          "generate_for": {
+            "$ref": "#/definitions/inputSet"
+          },
+          "options": {
+            "$ref": "#/definitions/builderOptions"
+          },
+          "dev_options": {
+            "$ref": "#/definitions/builderOptions"
+          },
+          "release_options": {
+            "$ref": "#/definitions/builderOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "globalBuilderOptions": {
+        "type": "object",
+        "properties": {
+          "options": {
+            "$ref": "#/definitions/builderOptions"
+          },
+          "dev_options": {
+            "$ref": "#/definitions/builderOptions"
+          },
+          "release_options": {
+            "$ref": "#/definitions/builderOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "builderOptions": {
+        "type": "object",
+        "title": "Options to apply to a builder",
+        "description": "An arbitrary Map<String, dynamic> of configuration options exposed by the individual builders. See the documentation for the builder you are configuring for guidance.",
+        "additionalProperties": true
+      },
+      "autoApply": {
+        "type": "string",
+        "description": "On which packages the builder is applied by default",
+        "enum": [
+          "none",
+          "dependents",
+          "all_packages",
+          "root_package"
+        ]
+      },
+      "buildTo": {
+        "type": "string",
+        "description": "Whether the outputs should be stored in a hidden cache or in the source directory.",
+        "enum": [
+          "cache",
+          "source"
+        ]
+      },
+      "targetKey": {
+        "type": "string",
+        "title": "An identifier for a target",
+        "description": "A target key has two parts, a package and a name.",
+        "pattern": "^(?:\\w+:)?\\w+|\\$default$"
+      },
+      "builderKey": {
+        "type": "string",
+        "title": "An identifier for a builder",
+        "description": "To construct a key, you join the package name and the builder name with a |.",
+        "pattern": "^\\w*\\|\\w+$"
+      }
+    },
+    "$ref": "#/definitions/buildConfig"
+  }

--- a/src/test/dart-build/sample.json
+++ b/src/test/dart-build/sample.json
@@ -1,0 +1,223 @@
+{
+    "targets": {
+      "$default": {
+        "builders": {
+          "build_web_compilers|entrypoint": {
+            "options": {
+              "compiler": "dart2js",
+              "dart2js_args": [
+                "-O4"
+              ]
+            },
+            "enabled": true,
+            "generate_for": [
+              "web/stack_trace_mapper.dart"
+            ]
+          },
+          "build_web_compilers|_stack_trace_mapper_copy": {
+            "enabled": true
+          },
+          "build_web_compilers|sdk_js_copy": {
+            "enabled": true
+          },
+          "build_web_compilers|sdk_js_cleanup": {
+            "enabled": true
+          }
+        }
+      }
+    },
+    "builders": {
+      "sdk_js_copy": {
+        "import": "package:build_web_compilers/builders.dart",
+        "builder_factories": [
+          "sdkJsCopyBuilder"
+        ],
+        "build_extensions": {
+          "$lib$": [
+            "src/dev_compiler/dart_sdk.js",
+            "src/dev_compiler/require.js"
+          ]
+        },
+        "is_optional": false,
+        "auto_apply": "none",
+        "applies_builders": [
+          "build_web_compilers|sdk_js_cleanup"
+        ],
+        "runs_before": [
+          "build_web_compilers|entrypoint"
+        ]
+      },
+      "dart2js_modules": {
+        "import": "package:build_web_compilers/builders.dart",
+        "builder_factories": [
+          "dart2jsMetaModuleBuilder",
+          "dart2jsMetaModuleCleanBuilder",
+          "dart2jsModuleBuilder"
+        ],
+        "build_extensions": {
+          "$lib$": [
+            ".dart2js.meta_module.raw",
+            ".dart2js.meta_module.clean"
+          ],
+          ".dart": [
+            ".dart2js.module"
+          ]
+        },
+        "is_optional": true,
+        "auto_apply": "none",
+        "required_inputs": [
+          ".dart",
+          ".module.library"
+        ],
+        "applies_builders": [
+          "build_modules|module_cleanup"
+        ]
+      },
+      "ddc_modules": {
+        "import": "package:build_web_compilers/builders.dart",
+        "builder_factories": [
+          "ddcMetaModuleBuilder",
+          "ddcMetaModuleCleanBuilder",
+          "ddcModuleBuilder"
+        ],
+        "build_extensions": {
+          "$lib$": [
+            ".ddc.meta_module.raw",
+            ".ddc.meta_module.clean"
+          ],
+          ".dart": [
+            ".ddc.module"
+          ]
+        },
+        "is_optional": true,
+        "auto_apply": "none",
+        "required_inputs": [
+          ".dart",
+          ".module.library"
+        ],
+        "applies_builders": [
+          "build_modules|module_cleanup"
+        ]
+      },
+      "ddc": {
+        "import": "package:build_web_compilers/builders.dart",
+        "builder_factories": [
+          "ddcKernelBuilder",
+          "ddcBuilder"
+        ],
+        "build_extensions": {
+          ".ddc.module": [
+            ".ddc.dill",
+            ".ddc.js.errors",
+            ".ddc.js",
+            ".ddc.js.map"
+          ]
+        },
+        "is_optional": true,
+        "auto_apply": "all_packages",
+        "required_inputs": [
+          ".ddc.module"
+        ],
+        "applies_builders": [
+          "build_web_compilers|ddc_modules",
+          "build_web_compilers|dart2js_modules",
+          "build_web_compilers|dart_source_cleanup"
+        ]
+      },
+      "entrypoint": {
+        "import": "package:build_web_compilers/builders.dart",
+        "builder_factories": [
+          "webEntrypointBuilder"
+        ],
+        "build_extensions": {
+          ".dart": [
+            ".dart.bootstrap.js",
+            ".dart.js",
+            ".dart.js.map",
+            ".dart.js.tar.gz",
+            ".digests"
+          ]
+        },
+        "required_inputs": [
+          ".dart",
+          ".ddc.js",
+          ".ddc.module",
+          ".dart2js.module"
+        ],
+        "build_to": "cache",
+        "auto_apply": "root_package",
+        "defaults": {
+          "generate_for": {
+            "include": [
+              "web/**",
+              "test/**.dart.browser_test.dart",
+              "example/**",
+              "benchmark/**"
+            ],
+            "exclude": [
+              "test/**.node_test.dart",
+              "test/**.vm_test.dart"
+            ]
+          },
+          "options": {
+            "dart2js_args": [
+              "--minify"
+            ]
+          },
+          "dev_options": {
+            "dart2js_args": [
+              "--enable-asserts"
+            ]
+          },
+          "release_options": {
+            "compiler": "dart2js"
+          }
+        },
+        "applies_builders": [
+          "build_web_compilers|dart2js_archive_extractor"
+        ]
+      },
+      "_stack_trace_mapper_copy": {
+        "import": "tool/copy_builder.dart",
+        "builder_factories": [
+          "copyBuilder"
+        ],
+        "build_extensions": {
+          "web/stack_trace_mapper.dart.js": [
+            "lib/src/dev_compiler_stack_trace/stack_trace_mapper.dart.js"
+          ]
+        },
+        "auto_apply": "none",
+        "build_to": "source"
+      }
+    },
+    "post_process_builders": {
+      "dart2js_archive_extractor": {
+        "import": "package:build_web_compilers/builders.dart",
+        "builder_factory": "dart2jsArchiveExtractor",
+        "defaults": {
+          "release_options": {
+            "filter_outputs": true
+          }
+        }
+      },
+      "dart_source_cleanup": {
+        "import": "package:build_web_compilers/builders.dart",
+        "builder_factory": "dartSourceCleanup",
+        "defaults": {
+          "release_options": {
+            "enabled": true
+          }
+        }
+      },
+      "sdk_js_cleanup": {
+        "import": "package:build_web_compilers/builders.dart",
+        "builder_factory": "sdkJsCleanupBuilder",
+        "defaults": {
+          "release_options": {
+            "enabled": true
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
This adds support for `build.yaml` files, used to configure the [build system](https://github.com/dart-lang/build/) of the Dart programming language.
The schema is mainly based on the documentation for `build.yaml` files [here](https://github.com/dart-lang/build/blob/master/docs/build_yaml_format.md).