### PR TITLE
Allow numbers as env var values for appveyor

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -6,7 +6,11 @@
       "anyOf": [
         {
           "type": "string",
-          "description": "just a regular string"
+          "description": "This value will be used directly (regular string)"
+        },
+        {
+          "type": "number",
+          "description": "This value will be treated as a string even though it is a number"
         },
         {
           "type": "object",


### PR DESCRIPTION
AppVeyor's YAML configuration validation tool allows this:
https://ci.appveyor.com/tools/validate-yaml
The observed behavior is for numeric types to be converted
to strings verbatim. That is, it is as if they had been quoted.

Ref #633