### PR TITLE
compile_commands.json shouldn't match the schema in commands.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -261,7 +261,7 @@
     {
       "name": "commands.json",
       "description": "Config file for Command Task Runner",
-      "fileMatch": ["commands.json"],
+      "fileMatch": ["commands.json", "!compile_commands.json"],
       "url": "https://json.schemastore.org/commands"
     },
     {


### PR DESCRIPTION
This PR makes sure that `compile_commands.json` does not match the schema defined at "http://json.schemastore.org/commands"