### PR TITLE
feat(schemas/json/package): Add `typesVersions` property

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -196,6 +196,42 @@
           "description": "Note that the \"typings\" field is synonymous with \"types\", and could be used as well.",
           "type": "string"
         },
+        "typesVersions": {
+          "description": "The \"typesVersions\" field is used since TypeScript 3.1 to support features that were only made available in newer TypeScript versions.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Contains overrides for the TypeScript version that matches the version range matching the property key.",
+            "type": "object",
+            "properties": {
+              "*": {
+                "description": "Maps all file paths to the file paths specified in the array.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[^*]*(?:\\*[^*]*)?$"
+                }
+              }
+            },
+            "patternProperties": {
+              "^[^*]+$": {
+                "description": "Maps the file path matching the property key to the file paths specified in the array.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "^[^*]*\\*[^*]*$": {
+                "description": "Maps file paths matching the pattern specified in property key to file paths specified in the array.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[^*]*(?:\\*[^*]*)?$"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
         "man": {
           "type": ["array", "string"],
           "description": "Specify either a single file or an array of filenames to put in place for the man program to find.",


### PR DESCRIPTION
This adds the `typesVersions` property that was [introduced in **TypeScript 3.1**][ts31-typesversions] to the `package.json` schema.

[ts31-typesversions]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions