### PR TITLE
Remove file match for build.yaml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -395,7 +395,6 @@
     {
       "name": "Dart build configuration",
       "description": "Configuration for Dart's build system",
-      "fileMatch": ["build.yaml"],
       "url": "https://json.schemastore.org/dart-build"
     },
     {


### PR DESCRIPTION
Removes the file match for Dart build configuration files (see #1163).

I hope removing the `fileMatch` key doesn't break clients, otherwise I could also set it to an empty array.