### PR TITLE
fix: .pmbot.yml does not point to the raw file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -963,7 +963,7 @@
       "name": ".pmbot.yml",
       "description": "Pmbot configuration file",
       "fileMatch": [".pmbot.yml"],
-      "url": "https://github.com/pmbot-io/config/blob/master/pmbot.yml.schema.json"
+      "url": "https://raw.githubusercontent.com/pmbot-io/config/master/pmbot.yml.schema.json"
     },
     {
       "name": "PocketMine plugin.yml",


### PR DESCRIPTION
Hi !

Sorry for this second PR. I realize that I didn't use the raw github url for the `.pmbot.yml` entry.

Thanks again for this great repository !