### PR TITLE
[tsconfig.json] Add missing compilerOptions

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -592,6 +592,22 @@
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it.",
               "type": "boolean"
+            },
+            "extendedDiagnostics": {
+              "description": "Show verbose diagnostic information.",
+              "type": "boolean"
+            },
+            "listFilesOnly": {
+              "description": "Print names of files that are part of the compilation and then stop processing.",
+              "type": "boolean"
+            },
+            "disableSourceOfProjectReferenceRedirect": {
+              "description": "Disable use of source files instead of declaration files from referenced projects.",
+              "type": "boolean"
+            },
+            "disableSolutionSearching": {
+              "description": "Disable solution searching for this project.",
+              "type": "boolean"
             }
           }
         }


### PR DESCRIPTION
* extendedDiagnostics
* listFilesOnly
* disableSourceOfProjectReferenceRedirect
* disableSolutionSearching

The descriptions are pulled from `require('typescript').optionDeclarations`