### PR TITLE
feat: add ORY Kratos config schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -938,6 +938,12 @@
       "url": "https://json.schemastore.org/openfin"
     },
     {
+      "name": "kratos.yml",
+      "description": "ORY Kratos configuration file",
+      "fileMatch": ["kratos.json", "kratos.yml", "kratos.yaml"],
+      "url": "https://raw.githubusercontent.com/ory/kratos/master/.schema/version.schema.json"
+    },
+    {
       "name": "package.json",
       "description": "NPM configuration file",
       "fileMatch": ["package.json"],


### PR DESCRIPTION
This PR adds the @ory Kratos config schema to the catalog. Please note that we automatically maintain the schema (https://github.com/ory/cli/pull/13) to map the top level config key `version` to the corresponding schema on GitHub (as described in https://github.com/ory/kratos/pull/608). This way we eliminate the need to determine the version as users specify it directly (similar to the kubernetes API version key).