### PR TITLE
Add CityJSON schema definition

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -225,7 +225,7 @@
     {
       "name": "CityJSON",
       "description": "Schema for the representation of 3D city models",
-      "url": "https://github.com/cityjson/specs/blob/master/schemas/cityjson.min.schema.json"
+      "url": "https://raw.githubusercontent.com/cityjson/specs/master/schemas/cityjson.min.schema.json"
     },
     {
       "name": "CircleCI config.yml",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -223,6 +223,11 @@
       }
     },
     {
+      "name": "CityJSON",
+      "description": "Schema for the representation of 3D city models",
+      "url": "https://github.com/cityjson/specs/blob/master/schemas/cityjson.min.schema.json"
+    },
+    {
       "name": "CircleCI config.yml",
       "description": "Schema for CircleCI 2.0 config files",
       "fileMatch": [".circleci/config.yml"],


### PR DESCRIPTION
Adds a definition for [CityJSON](https://cityjson.org), a schema definition for representing 3D city models using JSON.