### PR TITLE
Add startupOrder for EdgeHub and modules (1/2)

### DIFF
--- a/src/schemas/json/azure-iot-edge-deployment-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-2.0.json
@@ -33,7 +33,8 @@
                                 "schemaVersion": {
                                     "type": "string",
                                     "examples": [
-                                        "1.0"
+                                        "1.0",
+                                        "1.1"
                                     ]
                                 },
                                 "runtime": {
@@ -162,6 +163,9 @@
                                                 },
                                                 "imagePullPolicy": {
                                                     "$ref": "#/definitions/imagePullPolicy"
+                                                },
+                                                "startupOrder": {
+                                                    "$ref": "#/definitions/startupOrder"
                                                 }
                                             },
                                             "patternProperties": {
@@ -209,6 +213,9 @@
                                                 },
                                                 "imagePullPolicy": {
                                                     "$ref": "#/definitions/imagePullPolicy"
+                                                },
+                                                "startupOrder": {
+                                                    "$ref": "#/definitions/startupOrder"
                                                 }
                                             },
                                             "patternProperties": {
@@ -249,7 +256,8 @@
                                 "schemaVersion": {
                                     "type": "string",
                                     "examples": [
-                                        "1.0"
+                                        "1.0",
+                                        "1.1"
                                     ]
                                 },
                                 "routes": {
@@ -370,6 +378,11 @@
                 "never",
                 "on-create"
             ]
+        },
+        "startupOrder": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
         },
         "moduleSettings": {
             "type": "object",


### PR DESCRIPTION
First commit.  The second will be an equivalent change to the azure-iot-edge-deployment-template-2.0.json, but to pass tests it has a dependency on the 'startupOrder' definition existing at the given URL.