### PR TITLE
Add startupOrder for EdgeHub and modules (2/2)

### DIFF
--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -33,7 +33,8 @@
                                 "schemaVersion": {
                                     "type": "string",
                                     "examples": [
-                                        "1.0"
+                                        "1.0",
+                                        "1.1"
                                     ]
                                 },
                                 "runtime": {
@@ -162,6 +163,9 @@
                                                 },
                                                 "imagePullPolicy": {
                                                     "$ref": "#/definitions/imagePullPolicy"
+                                                },
+                                                "startupOrder": {
+                                                    "$ref": "#/definitions/startupOrder"
                                                 }
                                             },
                                             "patternProperties": {
@@ -189,7 +193,8 @@
                                                 "version": {
                                                     "type": "string",
                                                     "examples": [
-                                                        "1.0"
+                                                        "1.0",
+                                                        "1.1"
                                                     ]
                                                 },
                                                 "type": {
@@ -209,6 +214,9 @@
                                                 },
                                                 "imagePullPolicy": {
                                                     "$ref": "#/definitions/imagePullPolicy"
+                                                },
+                                                "startupOrder": {
+                                                    "$ref": "#/definitions/startupOrder"
                                                 }
                                             },
                                             "patternProperties": {
@@ -272,6 +280,9 @@
         },
         "imagePullPolicy": {
             "$ref": "http://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/imagePullPolicy"
+        },
+        "startupOrder": {
+            "$ref": "http://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/startupOrder"
         },
         "moduleSettings": {
             "type": "object",


### PR DESCRIPTION
Second commit.  For tests to pass it depends on the http://json.schemastore.org/azure-iot-edge-deployment-2.0 first having an update with startupOrder defined.