### PR TITLE
feat(schemas/github-action): support composite run steps

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -1,139 +1,64 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#name",
-  "properties": {
-    "name": {
-      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#name",
-      "description": "The name of your action. GitHub displays the name in the Actions tab to help visually identify actions in each job.",
+  "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions",
+  "definitions": {
+    "pre-if": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#pre-if",
+      "description": "Allows you to define conditions for the `pre:` action execution. The `pre:` action will only run if the conditions in `pre-if` are met. If not set, then `pre-if` defaults to `always()`. Note that the `step` context is unavailable, as no steps have run yet.",
       "type": "string"
     },
-    "author": {
-      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#author",
-      "description": "The name of the action's author.",
+    "post-if": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#post-if",
+      "description": "Allows you to define conditions for the `post:` action execution. The `post:` action will only run if the conditions in `post-if` are met. If not set, then `post-if` defaults to `always()`.",
       "type": "string"
     },
-    "description": {
-      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#description",
-      "description": "A short description of the action.",
-      "type": "string"
-    },
-    "inputs": {
-      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputs",
-      "description": "Input parameters allow you to specify data that the action expects to use during runtime. GitHub stores input parameters as environment variables. Input ids with uppercase letters are converted to lowercase during runtime. We recommended using lowercase input ids.",
-      "type": "object",
-      "patternProperties": {
-        "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_id",
-          "description": "A string identifier to associate with the input. The value of <input_id> is a map of the input's metadata. The <input_id> must be a unique identifier within the inputs object. The <input_id> must start with a letter or _ and contain only alphanumeric characters, -, or _.",
-          "type": "object",
-          "properties": {
-            "description": {
-              "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddescription",
-              "description": "A string description of the input parameter.",
-              "type": "string"
-            },
-            "deprecationMessage": {
-              "description": "A string shown to users using the deprecated input.",
-              "type": "string"
-            },
-            "required": {
-              "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_idrequired",
-              "description": "A boolean to indicate whether the action requires the input parameter. Set to true when the parameter is required.",
-              "type": "boolean"
-            },
-            "default": {
-              "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
-              "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file.",
-              "type": "string"
-            }
-          },
-          "required": [
-            "description",
-            "required"
-          ],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "outputs": {
-      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#outputs",
-      "description": "Output parameters allow you to specify the data that subsequent actions can use later in the workflow after the action that defines these outputs has run. For example, if you had an action that performed the addition of two inputs (x + y = z), the action could output the sum (z) for other actions to use as an input. Output ids with uppercase letters are converted to lowercase during runtime. We recommended using lowercase output ids.",
-      "type": "object",
-      "patternProperties": {
-        "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#outputsoutput_id",
-          "description": "A string identifier to associate with the output. The value of <output_id> is a map of the output's metadata. The <output_id> must be a unique identifier within the outputs object. The <output_id> must start with a letter or _ and contain only alphanumeric characters, -, or _.",
-          "type": "object",
-          "properties": {
-            "description": {
-              "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#outputsoutput_iddescription",
-              "description": "A string description of the output parameter.",
-              "type": "string"
-            }
-          },
-          "required": [
-            "description"
-          ],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "runs": {
-      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#runs",
-      "description": "The command to run when the action executes.",
+    "runs-javascript": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions",
+      "description": "Configures the path to the action's code and the application used to execute the code.",
       "type": "object",
       "properties": {
         "using": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#using",
-          "description": "The application to use to execute the code specified in main.",
-          "type": "string",
-          "enum": [
-            "node12",
-            "docker",
-            "composite"
-          ]
-        },
-        "env": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#env",
-          "description": "Specifies a key/value map of environment variables to set in the virtual environment.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing",
+          "description": "The application used to execute the code specified in `main`.",
+          "const": "node12"
         },
         "main": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#main",
-          "description": "Required for JavaScript actions: The code file that contains your action code. The application specified with the using syntax will execute this file.",
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsmain",
+          "description": "The file that contains your action code. The application specified in `using` executes this file.",
           "type": "string"
         },
-        "image": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#image",
-          "description": "Required for container actions: The Docker image to use as the container to run the action. The value can be the Docker base image name, a local Dockerfile in your repository, a public docker Hub or registry. To reference a Dockerfile local to your repository, use a path relative to the root of the repository. The application specified with the using syntax will execute this file.",
+        "pre": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#pre",
+          "description": "Allows you to run a script at the start of a job, before the `main:` action begins. For example, you can use `pre:` to run a prerequisite setup script. The application specified with the `using` syntax will execute this file. The `pre:` action always runs by default but you can override this using `pre-if`.",
           "type": "string"
         },
-        "entrypoint": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#entrypoint",
-          "description": "Optional for container actions: Overrides the Docker ENTRYPOINT in the Dockerfile, or sets it if one wasn't already specified. If an action does not use the runs keyword, the commands in entrypoint will execute. The Docker ENTRYPOINT instruction has a shell form and exec form. The Docker ENTRYPOINT documentation recommends using the exec form of the ENTRYPOINT instruction.",
-          "type": "string"
-        },
-        "args": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#args",
-          "description": "Optional for container actions: An array of strings that define the inputs for a Docker container. Inputs can include hardcoded strings. GitHub passes the args to the container's ENTRYPOINT when the container starts up.\nThe args are used in place of the CMD instruction in a Dockerfile. If you use CMD in your Dockerfile, use the guidelines ordered by preference:\n- Document required arguments in the action's README and omit them from the CMD instruction.\n- Use defaults that allow using the action without specifying any args.\n- If the action exposes a --help flag, or something similar, use that as the default to make your action self-documenting.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "pre-if": {
+          "$ref": "#/definitions/pre-if"
         },
         "post": {
-          "description": "The code file that contains the code to be executed at the end of the workflow. The application specified with the `using` syntax will execute this file.",
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#post",
+          "description": "Allows you to run a script at the end of a job, once the `main:` action has completed. For example, you can use `post:` to terminate certain processes or remove unneeded files. The application specified with the `using` syntax will execute this file. The `post:` action always runs by default but you can override this using `post-if`.",
           "type": "string"
         },
         "post-if": {
-          "$comment": "https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions",
-          "description": "You can use the `post-if` conditional to prevent the `post` file from running unless a condition is met. You can use any supported context and expression to create a conditional.\n\nExpressions in a `post-if` conditional do not require the `${{ }}` syntax.",
-          "type": "string"
+          "$ref": "#/definitions/post-if"
+        }
+      },
+      "required": [
+        "using",
+        "main"
+      ],
+      "additionalProperties": false
+    },
+    "runs-composite": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-composite-run-steps-actions",
+      "description": "Configures the path to the composite action, and the application used to execute the code.",
+      "type": "object",
+      "properties": {
+        "using": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-1",
+          "description": "To use a composite run steps action, set this to 'composite'.",
+          "const": "composite"
         },
         "steps": {
           "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runssteps",
@@ -200,79 +125,170 @@
         }
       },
       "required": [
-        "using"
-      ],
-      "oneOf": [
-        {
-          "properties": {
-            "using": {
-              "const": "node12"
-            },
-            "image": {
-              "not": {}
-            },
-            "entrypoint": {
-              "not": {}
-            },
-            "args": {
-              "not": {}
-            },
-            "steps": {
-              "not": {}
-            }
-          },
-          "required": [
-            "main"
-          ]
-        },
-        {
-          "properties": {
-            "using": {
-              "const": "docker"
-            },
-            "main": {
-              "not": {}
-            },
-            "steps": {
-              "not": {}
-            }
-          },
-          "required": [
-            "image"
-          ]
-        },
-        {
-          "properties": {
-            "using": {
-              "const": "composite"
-            },
-            "main": {
-              "not": {}
-            },
-            "image": {
-              "not": {}
-            },
-            "entrypoint": {
-              "not": {}
-            },
-            "args": {
-              "not": {}
-            }
-          },
-          "required": [
-            "steps"
-          ]
-        }
+        "using",
+        "steps"
       ],
       "additionalProperties": false
     },
+    "runs-docker": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-docker-actions",
+      "description": "Configures the image used for the Docker action.",
+      "type": "object",
+      "properties": {
+        "using": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-2",
+          "description": "You must set this value to 'docker'.",
+          "const": "docker"
+        },
+        "image": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsimage",
+          "description": "The Docker image to use as the container to run the action. The value can be the Docker base image name, a local `Dockerfile` in your repository, or a public image in Docker Hub or another registry. To reference a `Dockerfile` local to your repository, use a path relative to your action metadata file. The `docker` application will execute this file.",
+          "type": "string"
+        },
+        "env": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsenv",
+          "description": "Specifies a key/value map of environment variables to set in the container environment.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "entrypoint": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsentrypoint",
+          "description": "Overrides the Docker `ENTRYPOINT` in the `Dockerfile`, or sets it if one wasn't already specified. Use `entrypoint` when the `Dockerfile` does not specify an `ENTRYPOINT` or you want to override the `ENTRYPOINT` instruction. If you omit `entrypoint`, the commands you specify in the Docker `ENTRYPOINT` instruction will execute. The Docker `ENTRYPOINT instruction has a *shell* form and *exec* form. The Docker `ENTRYPOINT` documentation recommends using the *exec* form of the `ENTRYPOINT` instruction.",
+          "type": "string"
+        },
+        "pre-entrypoint": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#pre-entrypoint",
+          "description": "Allows you to run a script before the `entrypoint` action begins. For example, you can use `pre-entrypoint:` to run a prerequisite setup script. GitHub Actions uses `docker run` to launch this action, and runs the script inside a new container that uses the same base image. This means that the runtime state is different from the main `entrypoint` container, and any states you require must be accessed in either the workspace, `HOME`, or as a `STATE_` variable. The `pre-entrypoint:` action always runs by default but you can override this using `pre-if`.",
+          "type": "string"
+        },
+        "pre-if": {
+          "$ref": "#/definitions/pre-if"
+        },
+        "post-entrypoint": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#post-entrypoint",
+          "description": "Allows you to run a cleanup script once the `runs.entrypoint` action has completed. GitHub Actions uses `docker run` to launch this action. Because GitHub Actions runs the script inside a new container using the same base image, the runtime state is different from the main `entrypoint` container. You can access any state you need in either the workspace, `HOME`, or as a `STATE_` variable. The `post-entrypoint:` action always runs by default but you can override this using `post-if`.",
+          "type": "string"
+        },
+        "post-if": {
+          "$ref": "#/definitions/post-if"
+        },
+        "args": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsargs",
+          "description": "An array of strings that define the inputs for a Docker container. Inputs can include hardcoded strings. GitHub passes the `args` to the container's `ENTRYPOINT` when the container starts up.\nThe `args` are used in place of the `CMD` instruction in a `Dockerfile`. If you use `CMD` in your `Dockerfile`, use the guidelines ordered by preference:\n- Document required arguments in the action's README and omit them from the `CMD` instruction.\n- Use defaults that allow using the action without specifying any `args`.\n- If the action exposes a `--help` flag, or something similar, use that to make your action self-documenting.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "using",
+        "image"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "name": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#name",
+      "description": "The name of your action. GitHub displays the `name` in the Actions tab to help visually identify actions in each job.",
+      "type": "string"
+    },
+    "author": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#author",
+      "description": "The name of the action's author.",
+      "type": "string"
+    },
+    "description": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#description",
+      "description": "A short description of the action.",
+      "type": "string"
+    },
+    "inputs": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs",
+      "description": "Input parameters allow you to specify data that the action expects to use during runtime. GitHub stores input parameters as environment variables. Input ids with uppercase letters are converted to lowercase during runtime. We recommended using lowercase input ids.",
+      "type": "object",
+      "patternProperties": {
+        "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_id",
+          "description": "A string identifier to associate with the input. The value of `<input_id>` is a map of the input's metadata. The `<input_id>` must be a unique identifier within the inputs object. The `<input_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.",
+          "type": "object",
+          "properties": {
+            "description": {
+              "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddescription",
+              "description": "A string description of the input parameter.",
+              "type": "string"
+            },
+            "deprecationMessage": {
+              "description": "A string shown to users using the deprecated input.",
+              "type": "string"
+            },
+            "required": {
+              "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_idrequired",
+              "description": "A boolean to indicate whether the action requires the input parameter. Set to `true` when the parameter is required.",
+              "type": "boolean"
+            },
+            "default": {
+              "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
+              "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "required"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "outputs": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs",
+      "description": "Output parameters allow you to declare data that an action sets. Actions that run later in a workflow can use the output data set in previously run actions. For example, if you had an action that performed the addition of two inputs (x + y = z), the action could output the sum (z) for other actions to use as an input.\nIf you don't declare an output in your action metadata file, you can still set outputs and use them in a workflow.",
+      "type": "object",
+      "patternProperties": {
+        "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_id",
+          "description": "A string identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the outputs object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.",
+          "type": "object",
+          "properties": {
+            "description": {
+              "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_iddescription",
+              "description": "A string description of the output parameter.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "description"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "runs": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/runs-javascript"
+        },
+        {
+          "$ref": "#/definitions/runs-composite"
+        },
+        {
+          "$ref": "#/definitions/runs-docker"
+        }
+      ]
+    },
     "branding": {
-      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#branding",
-      "description": "You can use a color and Feather icon to create a badge to personalize and distinguish your action in GitHub Marketplace. For more information, see \"GitHub Actions in the GitHub Marketplace\" in the GitHub Developer documentation.",
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding",
+      "description": "You can use a color and Feather icon to create a badge to personalize and distinguish your action. Badges are shown next to your action name in GitHub Marketplace.",
       "type": "object",
       "properties": {
         "color": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#color",
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#brandingcolor",
           "description": "The background color of the badge.",
           "type": "string",
           "enum": [
@@ -287,7 +303,7 @@
           ]
         },
         "icon": {
-          "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#icon",
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#brandingicon",
           "description": "The name of the Feather icon to use.",
           "type": "string",
           "enum": [

--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -91,7 +91,8 @@
           "type": "string",
           "enum": [
             "node12",
-            "docker"
+            "docker",
+            "composite"
           ]
         },
         "env": {
@@ -133,6 +134,69 @@
           "$comment": "https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions",
           "description": "You can use the `post-if` conditional to prevent the `post` file from running unless a condition is met. You can use any supported context and expression to create a conditional.\n\nExpressions in a `post-if` conditional do not require the `${{ }}` syntax.",
           "type": "string"
+        },
+        "steps": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runssteps",
+          "description": "The run steps that you plan to run in this action.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "run": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun",
+                "description": "The command you want to run. This can be inline or a script in your action repository.",
+                "type": "string"
+              },
+              "shell": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsshell",
+                "description": "The shell where you want to run the command.",
+                "type": "string",
+                "anyOf": [
+                  {
+                    "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell"
+                  },
+                  {
+                    "enum": [
+                      "bash",
+                      "pwsh",
+                      "python",
+                      "sh",
+                      "cmd",
+                      "powershell"
+                    ]
+                  }
+                ]
+              },
+              "name": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsname",
+                "description": "The name of the composite run step.",
+                "type": "string"
+              },
+              "id": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsid",
+                "description": "A unique identifier for the step. You can use the `id` to reference the step in contexts.",
+                "type": "string"
+              },
+              "env": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsenv",
+                "description": "Sets a map of environment variables for only that step.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "working-directory": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsworking-directory",
+                "description": "Specifies the working directory where the command is run.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "run",
+              "shell"
+            ],
+            "additionalProperties": false
+          }
         }
       },
       "required": [
@@ -152,6 +216,9 @@
             },
             "args": {
               "not": {}
+            },
+            "steps": {
+              "not": {}
             }
           },
           "required": [
@@ -165,10 +232,35 @@
             },
             "main": {
               "not": {}
+            },
+            "steps": {
+              "not": {}
             }
           },
           "required": [
             "image"
+          ]
+        },
+        {
+          "properties": {
+            "using": {
+              "const": "composite"
+            },
+            "main": {
+              "not": {}
+            },
+            "image": {
+              "not": {}
+            },
+            "entrypoint": {
+              "not": {}
+            },
+            "args": {
+              "not": {}
+            }
+          },
+          "required": [
+            "steps"
           ]
         }
       ],

--- a/src/test/github-action/composite-run-steps.json
+++ b/src/test/github-action/composite-run-steps.json
@@ -1,0 +1,34 @@
+{
+  "name": "Test composite run steps",
+  "description": "Multiple run steps bundled into an action",
+  "inputs": {
+    "who-to-greet": {
+      "description": "Who to greet",
+      "required": false,
+      "default": "World"
+    }
+  },
+  "runs": {
+    "using": "composite",
+    "steps": [
+      {
+        "name": "Say hi",
+        "run": "echo Hello ${{ inputs.who-to-greet }}.",
+        "shell": "bash"
+      },
+      {
+        "id": "pleasantries",
+        "run": "echo \"Nice to meet you!\"",
+        "shell": "pwsh"
+      },
+      {
+        "env": {
+          "FOO": "BAR"
+        },
+        "run": "echo $FOO",
+        "shell": "bash --noprofile {0}",
+        "working-directory": "$HOME"
+      }
+    ]
+  }
+}

--- a/src/test/github-action/docker.json
+++ b/src/test/github-action/docker.json
@@ -1,0 +1,28 @@
+{
+  "name": "Test Docker action",
+  "description": "A container-based action",
+  "inputs": {
+    "who-to-greet": {
+      "description": "Who to greet",
+      "required": false,
+      "default": "World"
+    }
+  },
+  "runs": {
+    "using": "docker",
+    "image": "Dockerfile",
+    "args": ["bzz"],
+    "env": {
+      "FOO": "bar"
+    },
+    "pre-entrypoint": "setup.sh",
+    "pre-if": "always()",
+    "entrypoint": "main.sh",
+    "post-entrypoint": "cleanup.sh",
+    "post-if": "success()"
+  },
+  "branding": {
+    "icon": "award",
+    "color": "green"
+  }
+}

--- a/src/test/github-action/javascript.json
+++ b/src/test/github-action/javascript.json
@@ -1,0 +1,23 @@
+{
+  "name": "Test JavaScript action",
+  "description": "",
+  "inputs": {
+    "item": {
+      "description": "The thing",
+      "required": true
+    }
+  },
+  "outputs": {
+    "result": {
+      "description": "Transformed thing"
+    }
+  },
+  "runs": {
+    "using": "node12",
+    "pre": "setup.js",
+    "pre-if": "runner.os == linux",
+    "main": "index.js",
+    "post-if": "runner.os == linux",
+    "post": "cleanup.js"
+  }
+}


### PR DESCRIPTION
This PR updates the `github-action` json schema with support for the [new composite run steps](https://github.blog/changelog/2020-08-07-github-actions-composite-run-steps/) and `pre*`/`post*` scripts. It also updates all `$comment` links to GitHub's new docs site.