### PR TITLE
Typedoc: Change schema for "readme" from "oneOf" to "anyOf"

### DIFF
--- a/src/schemas/json/typedoc.json
+++ b/src/schemas/json/typedoc.json
@@ -142,7 +142,7 @@
     },
     "readme": {
       "description": "Path to the readme file that should be displayed on the index page. Pass none to disable the index page and start the documentation on the globals page.",
-      "oneOf": [
+      "anyOf": [
         {
           "enum": ["none"]
         },


### PR DESCRIPTION
With the current version of the typedoc-schema, I get an error message 
"Validates to more than one variant" when I set "readme" to "none".

In order to allow "readme" to be set to "none", the schema for the "readme"-property needs to be 
"anyOf" and not "oneOf". "onOf" means that *exactly* one of the subschemas is value.
If the value is "none", both schemas are valid, which is only allowed with "anyOf".
