### PR TITLE
Fix dvc.yaml's filematch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -527,7 +527,7 @@
     {
       "name": "dvc.yaml",
       "description": "JSON Schema for dvc.yaml file",
-      "fileMatch": ["**/dvc.yaml"],
+      "fileMatch": ["dvc.yaml"],
       "url": "https://raw.githubusercontent.com/iterative/dvcyaml-schema/master/schema.json"
     },
     {


### PR DESCRIPTION
Looks like pycharm has issues with pattern-based filematching

Ref: #1186