### PR TITLE
Remove sapNpmRegistry parameter from executeNpm step

### DIFF
--- a/src/schemas/json/cloud-sdk-pipeline-config-schema.json
+++ b/src/schemas/json/cloud-sdk-pipeline-config-schema.json
@@ -582,11 +582,6 @@
                             "description": "The default npm registry url to be used as the remote mirror. Bypasses the local download cache if specified.",
                             "type": "string",
                             "default": "npmjs.com"
-                        },
-                        "sapNpmRegistry": {
-                            "description": "The default npm registry url to be used as the remote mirror for the SAP npm packages. Bypasses the local download cache if specified.",
-                            "type": "string",
-                            "default": "npm.sap.com"
                         }
                     }
                 },


### PR DESCRIPTION
The sapNpmRegistry parameter has been removed.