### PR TITLE
fix: Allow compilerOptions.declarationMap in jsconfig.json

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -497,6 +497,10 @@
               "description": "Emit ECMAScript standard class fields. Requires TypeScript version 3.7 or later.",
               "type": "boolean"
             },
+            "declarationMap": {
+              "description": "Generates a sourcemap for each corresponding '.d.ts' file. Requires TypeScript version 2.9 or later.",
+              "type": "boolean"
+            },
             "resolveJsonModule": {
               "description": "Include modules imported with '.json' extension. Requires TypeScript version 2.9 or later.",
               "type": "boolean"

--- a/src/test/jsconfig/jsconfig-emit-dts.json
+++ b/src/test/jsconfig/jsconfig-emit-dts.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "target": "esnext"
+  }
+}


### PR DESCRIPTION
Like tsconfig.json, jsconfig.json supports the `compilerOptions.declarationMap` field. This field works as intended; when given a jsconfig.json file with the `-p` CLI option, TypeScript will happily emit type declarations AND sourcemaps for them.

This fixes a possible oversight in 3470539747ed113060b06331ef1f860090db0988 which added compilerOptions.declarationMap to tsconfig.json.