### PR TITLE
Github Action Dependabot v2.0 schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -584,6 +584,14 @@
       "url": "https://json.schemastore.org/dependabot"
     },
     {
+      "name": "dependabot-v2.json",
+      "description": "A JSON schema for the Github Action's dependabot.yml files",
+      "fileMatch": [
+        ".github/dependabot.yml"
+      ],
+      "url": "https://json.schemastore.org/dependabot-2.0"
+    },
+    {
       "name": "docfx.json",
       "description": "A JSON schema for DocFx configuraton files",
       "fileMatch": [

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -1,0 +1,296 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Github Dependabot v2 config",
+  "definitions": {
+    "dependency-type": {
+      "type": "string",
+      "enum": [
+        "direct",
+        "indirect",
+        "all",
+        "production",
+        "development"
+      ],
+      "x-intellij-enum-metadata": {
+        "direct": {
+          "description": "All explicitly defined dependencies."
+        },
+        "indirect": {
+          "description": "Dependencies of direct dependencies (also known as sub-dependencies, or transient dependencies)."
+        },
+        "all": {
+          "description": "All explicitly defined dependencies. For bundler, pip, composer, cargo, also the dependencies of direct dependencies."
+        },
+        "production": {
+          "description": "Only dependencies in the 'Product dependency group'."
+        },
+        "development": {
+          "description": "Only dependencies in the 'Development dependency group'."
+        }
+      }
+    },
+    "versioning-strategy": {
+      "type": "string",
+      "enum": [
+        "lockfile-only",
+        "auto",
+        "widen",
+        "increase",
+        "increase-if-necessary"
+      ],
+      "x-intellij-enum-metadata": {
+        "lockfile-only": {
+          "description": "Only create pull requests to update lockfiles updates. Ignore any new versions that would require package manifest changes."
+        },
+        "auto": {
+          "description": "Follow the default strategy described above."
+        },
+        "widen": {
+          "description": "Relax the version requirement to include both the new and old version, when possible."
+        },
+        "increase": {
+          "description": "Always increase the version requirement to match the new version."
+        },
+        "increase-if-necessary": {
+          "description": "Increase the version requirement only when required by the new version."
+        }
+      }
+    },
+    "package-ecosystem": {
+      "type": "string",
+      "enum": [
+        "bundler",
+        "cargo",
+        "composer",
+        "docker",
+        "elm",
+        "gitsubmodule",
+        "github-actions",
+        "gomod",
+        "gradle",
+        "maven",
+        "mix",
+        "npm",
+        "nuget",
+        "pip",
+        "terraform"
+      ]
+    },
+    "schedule-day": {
+      "type": "string",
+      "enum": [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday"
+      ]
+    },
+    "schedule-interval": {
+      "type": "string",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "update": {
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Customize which updates are allowed",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dependency-name": {
+                "type": "string"
+              },
+              "dependency-type": {
+                "$ref": "#/definitions/dependency-type"
+              }
+            }
+          }
+        },
+        "assignees": {
+          "description": "Assignees to set on pull requests",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minimum": 1
+        },
+        "commit-message": {
+          "description": "Commit message preferences",
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "type": "string"
+            },
+            "prefix-development": {
+              "type": "string"
+            },
+            "include": {
+              "type": "string",
+              "enum": [
+                "scope"
+              ],
+              "default": "scope"
+            }
+          }
+        },
+        "directory": {
+          "description": "Location of package manifests",
+          "type": "string",
+          "default": "/"
+        },
+        "ignore": {
+          "description": "Ignore certain dependencies or versions",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dependency-name": {
+                "type": "string"
+              },
+              "dependency-type": {
+                "$ref": "#/definitions/dependency-type"
+              },
+              "versions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "labels": {
+          "description": "Labels to set on pull requests",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "dependencies"
+          ]
+        },
+        "milestone": {
+          "description": "Milestone to set on pull requests",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "open-pull-requests-limit": {
+          "description": "Limit number of open pull requests for version updates",
+          "type": "integer",
+          "default": 5
+        },
+        "package-ecosystem": {
+          "description": "Package manager to use",
+          "$ref": "#/definitions/package-ecosystem"
+        },
+        "pull-request-branch-name": {
+          "description": "Pull request branch name preferences",
+          "type": "object",
+          "properties": {
+            "separator": {
+              "description": "Change separator for PR branch name",
+              "type": "string",
+              "default": "/"
+            }
+          },
+          "required": [
+            "separator"
+          ]
+        },
+        "rebase-strategy": {
+          "description": "Disable automatic rebasing",
+          "type": "string",
+          "enum": [
+            "auto",
+            "disabled"
+          ],
+          "default": "auto"
+        },
+        "reviewers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Reviewers to set on pull requests",
+          "minimum": 1
+        },
+        "schedule": {
+          "description": "Schedule preferences",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "$ref": "#/definitions/schedule-interval"
+            },
+            "day": {
+              "$ref": "#/definitions/schedule-day",
+              "description": "Specify an alternative day to check for updates"
+            },
+            "time": {
+              "type": "string",
+              "description": "Specify an alternative time of day to check for updates (format: hh:mm)"
+            },
+            "timezone": {
+              "type": "string",
+              "description": "The time zone identifier must be from the Time Zone database maintained by IANA",
+              "default": "05:00 UTC"
+            }
+          }
+        },
+        "target-branch": {
+          "type": "string",
+          "description": "Branch to create pull requests against"
+        },
+        "versioning-strategy": {
+          "description": "How to update manifest version requirements",
+          "$ref": "#/definitions/versioning-strategy"
+        }
+      },
+      "required": [
+        "package-ecosystem",
+        "directory",
+        "schedule"
+      ]
+    }
+  }
+  "type": "object",
+  "properties": {
+    "version": {
+      "anyOf": [
+        {
+          "type": "string",
+          "default": "2"
+        },
+        {
+          "type": "integer",
+          "default": 2
+        }
+      ]
+    },
+    "updates": {
+      "type": "array",
+      "items": {
+        "title": "Package Ecosystem",
+        "description": "Element for each one package manager that you want GitHub Dependabot to monitor for new versions",
+        "$ref": "#/definitions/update"
+      }
+    }
+  },
+  "required": [
+    "version",
+    "updates"
+  ]
+}

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -265,7 +265,7 @@
         "schedule"
       ]
     }
-  }
+  },
   "type": "object",
   "properties": {
     "version": {

--- a/src/test/dependabot-2.0/example.json
+++ b/src/test/dependabot-2.0/example.json
@@ -1,0 +1,113 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "github-actions",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      }
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "allow": [
+        {
+          "dependency-name": "lodash"
+        },
+        {
+          "dependency-name": "react*"
+        }
+      ]
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "assignees": [
+        "octocat"
+      ]
+    },
+    {
+      "package-ecosystem": "composer",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "prefix": "Composer",
+        "include": "scope"
+      }
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "ignore": [
+        {
+          "dependency-name": "express",
+          "versions": [
+            "4.x",
+            "5.x"
+          ]
+        },
+        {
+          "dependency-name": "loadash"
+        }
+      ]
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "labels": [
+        "npm",
+        "dependencies"
+      ]
+    },
+    {
+      "package-ecosystem": "pip",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "open-pull-requests-limit": 10
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily",
+        "time": "09:00"
+      }
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "weekly",
+        "day": "sunday"
+      },
+      "labels": [
+        "npm dependencies"
+      ]
+    },
+    {
+      "package-ecosystem": "pip",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "versioning-strategy": "lockfile-only"
+    }
+  ]
+}


### PR DESCRIPTION
I've added a v2 schema for @dependabot (https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates) which is executed as Github Action. 

The old one left as is, and created new one in the catalog, as they are using different file naming patterns.

Let me know if any extras required