### PR TITLE
add ORY Hydra, Oathkeeper and Keto schemas to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -962,6 +962,17 @@
       "url": "https://json.schemastore.org/htmlhint"
     },
     {
+      "name": "hydra.yml",
+      "description": "ORY Hydra configuration file",
+      "fileMatch": [
+        "hydra.json",
+        "hydra.yml",
+        "hydra.yaml",
+        "hydra.toml"
+      ],
+      "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
+    },
+    {
       "name": "imageoptimizer.json",
       "description": "Schema for imageoptimizer.json files",
       "fileMatch": [
@@ -1083,6 +1094,17 @@
         "jsconfig.json"
       ],
       "url": "https://json.schemastore.org/jsconfig"
+    },
+    {
+      "name": "keto.yml",
+      "description": "ORY Keto configuration file",
+      "fileMatch": [
+        "keto.json",
+        "keto.yml",
+        "keto.yaml",
+        "keto.toml"
+      ],
+      "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/version.schema.json"
     },
     {
       "name": "kustomization.yaml",
@@ -1234,6 +1256,17 @@
       "fileMatch": [
         "nswag.json"
       ]
+    },
+    {
+      "name": "oathkeeper.yml",
+      "description": "ORY Oathkeeper configuration file",
+      "fileMatch": [
+        "oathkeeper.json",
+        "oathkeeper.yml",
+        "oathkeeper.yaml",
+        "oathkeeper.toml"
+      ],
+      "url": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schema/version.schema.json"
     },
     {
       "name": "ocelot.json",


### PR DESCRIPTION
Analogously to #1173, this PR adds a reference to the version mapping schema on master of https://github.com/ory/hydra https://github.com/ory/oathkeeper and https://github.com/ory/keto.
Note that these mapper schemas are autogenerated on every release and therefore the current master always has all releases.