### PR TITLE
fix(schemas/github-action): output value for composite type

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -188,6 +188,60 @@
         "image"
       ],
       "additionalProperties": false
+    },
+    "outputs": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs",
+      "description": "Output parameters allow you to declare data that an action sets. Actions that run later in a workflow can use the output data set in previously run actions. For example, if you had an action that performed the addition of two inputs (x + y = z), the action could output the sum (z) for other actions to use as an input.\nIf you don't declare an output in your action metadata file, you can still set outputs and use them in a workflow.",
+      "type": "object",
+      "patternProperties": {
+        "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_id",
+          "description": "A string identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the outputs object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.",
+          "type": "object",
+          "properties": {
+            "description": {
+              "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_iddescription",
+              "description": "A string description of the output parameter.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "description"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "outputs-composite": {
+      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-run-steps-actions",
+      "description": "Output parameters allow you to declare data that an action sets. Actions that run later in a workflow can use the output data set in previously run actions. For example, if you had an action that performed the addition of two inputs (x + y = z), the action could output the sum (z) for other actions to use as an input.\nIf you don't declare an output in your action metadata file, you can still set outputs and use them in a workflow.",
+      "type": "object",
+      "patternProperties": {
+        "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
+          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_id",
+          "description": "A string identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the outputs object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.",
+          "type": "object",
+          "properties": {
+            "description": {
+              "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_iddescription",
+              "description": "A string description of the output parameter.",
+              "type": "string"
+            },
+            "value": {
+              "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_idvalue",
+              "description": "The value that the output parameter will be mapped to. You can set this to a string or an expression with context. For example, you can use the steps context to set the value of an output to the output value of a step.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   },
   "properties": {
@@ -246,28 +300,7 @@
       "additionalProperties": false
     },
     "outputs": {
-      "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs",
-      "description": "Output parameters allow you to declare data that an action sets. Actions that run later in a workflow can use the output data set in previously run actions. For example, if you had an action that performed the addition of two inputs (x + y = z), the action could output the sum (z) for other actions to use as an input.\nIf you don't declare an output in your action metadata file, you can still set outputs and use them in a workflow.",
-      "type": "object",
-      "patternProperties": {
-        "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
-          "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_id",
-          "description": "A string identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the outputs object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.",
-          "type": "object",
-          "properties": {
-            "description": {
-              "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputsoutput_iddescription",
-              "description": "A string description of the output parameter.",
-              "type": "string"
-            }
-          },
-          "required": [
-            "description"
-          ],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
+      "$comment": "Because of `additionalProperties: false`, this empty schema is needed to allow the `outputs` property. The `outputs` subschema is determined by the if/then/else keywords."
     },
     "runs": {
       "oneOf": [
@@ -568,6 +601,31 @@
         }
       },
       "additionalProperties": false
+    }
+  },
+  "if": {
+    "properties": {
+      "runs": {
+        "properties": {
+          "using": {
+            "const": "composite"
+          }
+        }
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "outputs": {
+        "$ref": "#/definitions/outputs-composite"
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "outputs": {
+        "$ref": "#/definitions/outputs"
+      }
     }
   },
   "required": [

--- a/src/test/github-action/composite-run-steps.json
+++ b/src/test/github-action/composite-run-steps.json
@@ -8,6 +8,12 @@
       "default": "World"
     }
   },
+  "outputs": {
+    "result": {
+      "description": "Transformed thing",
+      "value": "${{ steps.pleasantries.outputs.greeting }}"
+    }
+  },
   "runs": {
     "using": "composite",
     "steps": [


### PR DESCRIPTION
This PR conditionally applies a subschema for the `outputs` property based on the value of `runs.using`. The effect is to allow and require the `value` property for any `outputs` of a `composite`-type action.

Thanks to @amis92 for pointing out the issue in https://github.com/SchemaStore/schemastore/pull/1183#issuecomment-677793898.