### PR TITLE
Update Drone schema

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -340,7 +340,19 @@
           "$ref": "#/definitions/platform"
         },
         "workspace": {
-          "type": "string"
+          "type": "array",
+          "oneOf": [
+            {
+              "required": [
+                "path",
+              ]
+            }
+          ],
+          "properties": {
+            "path": {
+              "$ref": "#/definitions/nonEmptyString"
+            },
+          }
         },
         "clone": {
           "type": "object",

--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -339,19 +339,18 @@
         "platform": {
           "$ref": "#/definitions/platform"
         },
-        "workspace": {
+        "workspace":{
           "type": "array",
-          "oneOf": [
-            {
-              "required": [
-                "path",
-              ]
+          "items": {
+            "type": "object",
+            "required": [
+              "path"
+            ],
+            "properties": {
+              "path": {
+                "$ref":"#/definitions/nonEmptyString"
+              }
             }
-          ],
-          "properties": {
-            "path": {
-              "$ref": "#/definitions/nonEmptyString"
-            },
           }
         },
         "clone": {


### PR DESCRIPTION
According to the spec: https://docs.drone.io/pipeline/docker/syntax/workspace/

The value of "workspace" should be an array of objects containing "path" of string in a docker pipeline. In other kind of pipelines, the workspace is not configurable anyway.