### PR TITLE
Update gitlab-ci.json to reflect changes to the "action" option of "job:environment"

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -879,8 +879,8 @@
               "description": "The name of a job to execute when the environment is about to be stopped."
             },
             "action": {
-              "enum": ["stop"],
-              "description": "Stops this environment so that it is inactive."
+              "enum": ["start","prepare","stop"],
+              "description": "Specifies what this job will do. 'start' (default) indicates the job will start the deployment. 'prepare' indicates this will not affect the deployment. 'stop' indicates this will stop the deployment."
             },
             "auto_stop_in": {
               "type": "string",


### PR DESCRIPTION
Action holds 3 values:

- `start` which is default and indicates the environment has been started in this job
- `prepare` indicates it won't affect the environment but will still associate the environment with this job (for environment specific variables)
- `stop` indicates it will stop the environment in this job