### PR TITLE
[package.json] make type field an enum and add peerDependenciesMeta

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -283,8 +283,10 @@
           }
         },
         "type": {
-          "description": "The type field defines how .js and extensionless files should be treated within a particular package.json file’s package scope. Supported values: \"commonjs\" (default) or \"module\".",
-          "type": "string"
+          "description": "When set to \"module\", the type field allows a package to specify all .js files within are ES modules. If the \"type\" field is omitted or set to \"commonjs\", all .js files are treated as CommonJS.",
+          "type": "string",
+          "enum": ["commonjs", "module"],
+          "default": "commonjs"
         },
         "types": {
           "description": "Set the types property to point to your bundled declaration file",
@@ -498,6 +500,20 @@
         },
         "peerDependencies": {
           "$ref": "#/definitions/dependency"
+        },
+        "peerDependenciesMeta": {
+          "description": "When a user installs your package, warnings are emitted if packages specified in \"peerDependencies\" are not already installed. The \"peerDependenciesMeta\" field serves to provide more information on how your peer dependencies are utilized. Most commonly, it allows peer dependencies to be marked as optional. Metadata for this field is specified with a simple hash of the package name to a metadata object.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "optional": {
+                "description": "Specifies that this peer dependency is optional and should not be installed automatically.",
+                "type": "boolean"
+              }
+            }
+          }
         },
         "resolutions": {
           "$ref": "#/definitions/dependency"


### PR DESCRIPTION

1. The `type` field only allows "commonjs" or "module", so I changed it to an enum instead of a flexible string.
2. `peerDependenciesMeta` is designed with flexibility for any sort of peer dependency metadata, but it's currently only really used for marking a peer dependency as optional.
 