### PR TITLE
Fixes to generators schema

### DIFF
--- a/src/schemas/json/template.json
+++ b/src/schemas/json/template.json
@@ -20,7 +20,7 @@
         },
         "parameters": {
           "properties": {
-            "action": {
+            "value": {
               "description": "The value to be assigned to the symbol",
               "type": "string"
             }
@@ -115,12 +115,7 @@
           "enum": [ "regex" ]
         },
         "parameters": {
-          "required": [ "action" ],
           "properties": {
-            "action": {
-              "description": "Must be the string literal \"replace\"",
-              "enum": [ "replace" ]
-            },
             "source": {
               "description": "The name of a different parameter in the template configuration. A copy of its value will be used by this generator's regex to generate the value for this parameter. The value of the source parameter is not modified",
               "type": "string"

--- a/src/test/template/generatorstest.json
+++ b/src/test/template/generatorstest.json
@@ -1,0 +1,192 @@
+{
+  "author": "Vlada Shubina",
+  "classifications": [ "Web", "MVC" ],
+  "name": "Test Generator",
+  "defaultName": "TestGenerator",
+  "identity": "Test.Generator",
+  "groupIdentity": "Test.Generator",
+  "shortName": "testgen",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Test.Generator",
+  "preferNameDirectory": true,
+  "primaryOutputs": [ { "path": "Test.Generator" } ],
+  "sources": [
+    {
+
+    }
+  ],
+  "symbols": {
+    "createddate": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "5001"
+      },
+      "replaces": "1234"
+    },
+    "ownername": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "John Smith (a)",
+      "defaultValue": "John Doe"
+    },
+    "nameUpper": {
+      "type": "generated",
+      "generator": "casing",
+      "parameters": {
+        "source": "ownername",
+        "toLower": false
+      },
+      "replaces": "John Smith (U)"
+    },
+    "nameLower": {
+      "type": "generated",
+      "generator": "casing",
+      "parameters": {
+        "source": "ownername",
+        "toLower": true
+      },
+      "replaces": "John Smith (l)"
+    },
+    "MessageYear": {
+      "type": "parameter",
+      "datatype": "int"
+    },
+    "ThisYear": {
+      "type": "generated",
+      "generator": "now",
+      "parameters": {
+        "format": "yyyy"
+      }
+    },
+    "YearReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "MessageYear",
+        "fallbackVariableName": "ThisYear"
+      },
+      "replaces": "1234"
+    },
+    "myconstant": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "5001"
+      },
+      "replaces": "1234"
+    },
+    "IndividualAuth": {
+      "type": "computed",
+      "value": "(auth == \"IndividualB2C\")"
+    },
+    "KestrelPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "fallback": 5000
+      }
+    },
+    "id01": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "myid01",
+      "parameters": {
+        "format": "N"
+      }
+    },
+    "id02": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "myid02",
+      "parameters": {
+        "format": "D"
+      }
+    },
+    "id03": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "myid03",
+      "parameters": {
+        "format": "B"
+      }
+    },
+    "id04": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "myid04",
+      "parameters": {
+        "format": "P"
+      }
+    },
+    "id05": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "myid05",
+      "parameters": {
+        "format": "X"
+      }
+    },
+    "createddatenow": {
+      "type": "generated",
+      "generator": "now",
+      "parameters": {
+        "format": "MM/dd/yyyy"
+      },
+      "replaces": "01/01/1999"
+    },
+    "myRandomNumber": {
+      "type": "generated",
+      "generator": "random",
+      "parameters": {
+        "low": 0,
+        "high": 10000
+      },
+      "replaces": "4321"
+    },
+    "test": {
+      "type": "parameter",
+      "datatype": "string"
+    },
+    "example": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "abc",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(test == '123')",
+            "value": "456"
+          },
+          {
+            "condition": "(test == '789')",
+            "value": "012"
+          }
+        ]
+      }
+    },
+    "case3": {
+      "type": "generated",
+      "generator": "regex",
+      "dataType": "string",
+      "replaces": "case3",
+      "parameters": {
+        "source": "case1",
+        "steps": [
+          {
+            "regex": "\\.",
+            "replacement": ""
+          }
+        ]
+      }
+    }
+  },
+  "guids": [
+    "baf04077-a3c0-454b-ac6f-9fec00b8e170"
+  ]
+}


### PR DESCRIPTION
fixes dotnet/templating#1626 adds missing property "value" to constant generator
fixes dotnet/templating#2423 action property in regex generator is not required

added test to check generators