### PR TITLE
Add Gradle Enterprise schema.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2421,6 +2421,18 @@
           "**/api.json"
       ],
       "url": "http://json.schemastore.org/apibuilder.json"
+    },
+    {
+      "name": "Gradle Enterprise",
+      "description": "Gradle Enterprise configuration schema",
+      "fileMatch": [
+        "*.yml",
+        "*.yaml"
+      ],
+      "url": "https://docs.grdev.net/gradle-enterprise/schema/gradle-enterprise-config-schema-1.json",
+      "versions": {
+        "1.0": "https://docs.grdev.net/gradle-enterprise/schema/gradle-enterprise-config-schema-1.json"
+      }
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2431,12 +2431,12 @@
       "name": "Gradle Enterprise",
       "description": "Gradle Enterprise configuration schema",
       "fileMatch": [
-        "*.yml",
-        "*.yaml"
+        "*gradle-enterprise.yml",
+        "*gradle-enterprise.yaml"
       ],
-      "url": "https://docs.grdev.net/gradle-enterprise/schema/gradle-enterprise-config-schema-1.json",
+      "url": "https://docs.grdev.net/enterprise/admin/schema/gradle-enterprise-config-schema-1.json",
       "versions": {
-        "1.0": "https://docs.grdev.net/gradle-enterprise/schema/gradle-enterprise-config-schema-1.json"
+        "1.0": "https://docs.grdev.net/enterprise/admin/schema/gradle-enterprise-config-schema-1.json"
       }
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -352,7 +352,9 @@
     {
       "name": "cloudify",
       "description": "Cloudify Blueprint",
-      "fileMatch": ["*.cfy.yaml"],
+      "fileMatch": [
+        "*.cfy.yaml"
+      ],
       "url": "https://json.schemastore.org/cloudify"
     },
     {
@@ -1902,7 +1904,10 @@
     {
       "name": "Vela Pipeline Configuration",
       "description": "Vela Pipeline Configuration File",
-      "fileMatch": [".vela.yml", ".vela.yaml"],
+      "fileMatch": [
+        ".vela.yml",
+        ".vela.yaml"
+      ],
       "url": "https://github.com/go-vela/types/releases/latest/download/schema.json"
     },
     {
@@ -2418,7 +2423,7 @@
       "name": "API Builder",
       "description": "apibuilder.io schema",
       "fileMatch": [
-          "**/api.json"
+        "**/api.json"
       ],
       "url": "http://json.schemastore.org/apibuilder.json"
     },


### PR DESCRIPTION
Thanks for this amazing project. We'd like to add a schema for [Gradle Enterprise](https://gradle.com/gradle-enterprise-solution-overview/).

We're planning to use automation to create this type of PRs, whenever new versions of the schema are available. Hence, I've also pushed some formatting alignment in the existing catalog, i.e. so far, most of the arrays followed this structure:

```
"key": [
  "value1",
  "value2"
]
```

I've formatted the couple of them that weren't following that.
