### PR TITLE
CircleCI: resource_class moved to additionalProperties section

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -346,12 +346,6 @@
           "properties": {
             "docker": {
               "$ref": "#/definitions/dockerExecutor"
-            },
-            "resource_class": {
-              "description": "Amount of CPU and RAM allocated to each container in a job. (Only works with the `docker` key for paid accounts and is subject to change in a future pricing update. **Note:** Paid accounts must request to use this feature by opening a support ticket (or by contacting their Customer Success Manager when applicable) and non-paid users must request to use this feature by opening a ticket at <https://support.circleci.com/hc/en-us/requests/new>.)",
-              "type": "string",
-              "default": "medium",
-              "enum": ["small", "medium", "medium+", "large", "xlarge"]
             }
           }
         },
@@ -392,6 +386,12 @@
         "type": "object",
         "$ref": "#/definitions/executorChoice",
         "properties": {
+          "resource_class": {
+            "description": "Amount of CPU and RAM allocated to each container in a job. Note: A performance plan is required to access this feature.",
+            "type": "string",
+            "default": "medium",
+            "enum": ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+", "gpu.nvidia.small", "gpu.nvidia.medium", "windows.gpu.nvidia.medium"]
+          },
           "shell": {
             "description": "Shell to use for execution command in all steps. Can be overridden by shell in each step (default: See [Default Shell Options](https://circleci.com/docs/2.0/configuration-reference/#default-shell-options)",
             "type": "string"

--- a/src/test/circleciconfig/executors.json
+++ b/src/test/circleciconfig/executors.json
@@ -1,0 +1,42 @@
+{
+  "version": 2.1,
+  "executors": {
+    "docker-executor": {
+      "docker": [
+        {
+          "image": "circleci/ruby:2.5.1-node-browsers",
+          "auth": {
+            "username": "mydockerhub-user",
+            "password": "$DOCKERHUB_PASSWORD"
+          }
+        }
+      ],
+      "resource_class": "small",
+      "shell": "/bin/bash",
+      "working_directory": "/workspace"
+    },
+    "machine-executor": {
+      "machine": {
+        "image": "ubuntu-1604:202007-01",
+        "docker_layer_caching": true
+      },
+      "resource_class": "xlarge+"
+    },
+    "macos-executor": {
+      "macos": {
+        "xcode": "11.3.0"
+      },
+      "shell": "/bin/zsh",
+      "working_directory": "/projects",
+      "resource_class": "medium"
+    }   
+  },
+  "jobs": {
+    "my-job": {
+      "executor": "machine-executor",
+      "steps": [
+        "run"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
CircleCi config 2.1 (https://circleci.com/docs/2.0/configuration-reference/#executors-requires-version-21) defines resource_class on the executor level, not docker.

Additionally, resource_class enum extended to values defined in circleci reference.

Fixes https://github.com/redhat-developer/vscode-yaml/issues/370