### PR TITLE
A few fixes for compile-commands.json

### DIFF
--- a/src/schemas/json/compile-commands.json
+++ b/src/schemas/json/compile-commands.json
@@ -9,26 +9,41 @@
     "commandObject": {
       "properties": {
         "directory": {
-          "description": "The working directory of the compilation",
+          "description": "The working directory of the compilation. All paths specified in the command or file fields must be either absolute or relative to this directory.",
           "type": "string"
         },
         "file": {
-          "description": "The main translation unit source processed by this compilation step",
+          "description": "The main translation unit source processed by this compilation step. This is used by tools as the key into the compilation database. There can be multiple command objects for the same file, for example if the same source file is compiled with different configurations.",
           "type": "string"
         },
         "command": {
-          "description": "The compile command executed",
+          "description": "The compile command executed. After JSON unescaping, this must be a valid command to rerun the exact compilation step for the translation unit in the environment the build system uses. Parameters use shell quoting and shell escaping of quotes, with '\"' and '\\' being the only special characters. Shell expansion is not supported.",
           "type": "string"
         },
         "arguments": {
-          "description": "The compile command executed as list of strings",
-          "type": "string"
+          "description": "The compile command executed as list of strings.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "output": {
-          "description": "The name of the output created by this compilation step",
+          "description": "The name of the output created by this compilation step. This field is optional. It can be used to distinguish different processing modes of the same input file.",
           "type": "string"
         }
-      }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "directory", "file", "command"
+          ]
+        },
+        {
+          "required": [
+            "directory", "file", "arguments"
+          ]
+        }
+      ]
     }
   },
 

--- a/src/test/compile-commands/compile_commands.json
+++ b/src/test/compile-commands/compile_commands.json
@@ -1,0 +1,12 @@
+[
+    {
+        "arguments": ["c++", "foo.cpp", "-o", "foo"],
+        "directory": "/some/directory",
+        "file": "foo.cpp"
+    },
+    {
+        "command": "c++ foo.cpp -o foo",
+        "directory": "/some/directory",
+        "file": "foo.cpp"
+    }
+]


### PR DESCRIPTION
1) Add more descriptive text.
2) The "arguments" are an array, not a string.
3) Add "required" keys.
4) Add a test file.