### PR TITLE
Restore whitesourceScan stage definition

### DIFF
--- a/src/schemas/json/cloud-sdk-pipeline-config-schema.json
+++ b/src/schemas/json/cloud-sdk-pipeline-config-schema.json
@@ -398,6 +398,32 @@
                     },
                     "additionalProperties": true
                 },
+                "whitesourceScan": {
+                    "description": "Configure credentials for WhiteSource scans. The minimum required Maven WhiteSource plugin version is 18.6.2, ensure this in the plugins section of the project pom.xml file.\n\nPipeline will execute npx whitesource run for npm projects. Please ensure that all package.json files have a name and version configured so that it is possible to distinguish between the different packages.",
+                    "type": "object",
+                    "properties": {
+                        "product": {
+                            "description": "Name of your product in WhiteSource.",
+                            "type": "string"
+                        },
+                        "staticVersion": {
+                            "description": "Overwrites the respective version in the whitesource UI per scan with the staticVersion. Per default for every new version of a pom/package.json a new project will be created in the whitesource UI. To deactivate the creation of new projects and always have a fixed version for each project in the whitesource UI, configure the staticVersion.",
+                            "type": "string"
+                        },
+                        "credentialsId": {
+                            "$ref": "#/definitions/credentialsId"
+                        },
+                        "whitesourceUserTokenCredentialsId": {
+                            "description": "Unique identifier of the Secret Text on Jenkins server that stores WhiteSource userKey of a user. This is required only if the administrator of the WhiteSource service has enabled additional access level control. More details can be found here.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "product",
+                        "credentialsId"
+                    ],
+                    "additionalProperties": true
+                },
                 "sourceClearScan": {
                     "description": "Configure SourceClear scans.Note: Please note that the SourceClear stage of this pipeline is not actively maintained anymore. In case of issues, feel free to contribute to this project by opening a pull request.",
                     "type": "object",


### PR DESCRIPTION
Partially reverts https://github.com/SchemaStore/schemastore/pull/1268
The config for a current version of the pipeline shall not include the restored parameters, however, older versions of the pipeline validate the config against the current version of the schema, which is an unfortunate oversight. So please merge as soon as possible, we have no other way to fix pipeline for clients. :-(