### PR TITLE
Allow CircleCI job executor to be defined as an object and accept parameters

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -927,6 +927,23 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "type": "object",
+            "required": ["executor"],
+            "properties": {
+              "executor": {
+                "description": "Executor stanza to use for the job",
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "description": "The name of the executor to use (defined via the top level executors map).",
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         ],
         "required": ["steps"],

--- a/src/test/circleciconfig/job-executors.json
+++ b/src/test/circleciconfig/job-executors.json
@@ -1,0 +1,28 @@
+{
+  "version": 2.1,
+  "jobs": {
+    "string-executor": {
+      "executor": "executor-1",
+      "steps": [
+        "checkout"
+      ]
+    },
+    "object-executor": {
+      "executor": {
+        "name": "executor-2"
+      },
+      "steps": [
+        "checkout"
+      ]
+    },
+    "object-executor-with-parameters": {
+      "executor": {
+        "name": "executor-3",
+        "size": "small"
+      },
+      "steps": [
+        "checkout"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The documentation is pretty confusing, but it shows that it's a possible and valid configuration. https://circleci.com/docs/2.0/configuration-reference/#example-usage-3