### PR TITLE
[package.json] fix: workspaces & removed unnecessary props

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -142,8 +142,6 @@
       "patternProperties": {
         "^_": {
           "description": "Any property starting with _ is valid.",
-          "additionalProperties": true,
-          "additionalItems": true,
           "tsType": "any"
         }
       },
@@ -615,25 +613,31 @@
           }
         },
         "workspaces": {
-          "description": "To configure your yarn workspaces, please note private should be set to true to use yarn workspaces",
-          "anyof": [
+          "description": "Allows packages within a directory to depend on one another using direct linking of local files. Additionally, dependencies within a workspace are hoisted to the workspace root when possible to reduce duplication. Note: It's also a good idea to set \"private\" to true when using this feature.",
+          "anyOf": [
             {
               "type": "array",
-              "description":"your workspace folders also takes a glob",
-              "items": "string"
+              "description": "Workspace package paths. Glob patterns are supported.",
+              "items": {
+                "type": "string"
+              }
             },
             {
               "type": "object",
               "properties": {
                 "packages": {
                   "type": "array",
-                  "description":"your workspace folder's also takes a glob",
-                  "items": "string"
+                  "description": "Workspace package paths. Glob patterns are supported.",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "nohoist": {
                   "type": "array",
-                  "description":"nohoist your npm packages",
-                  "items": "string"
+                  "description": "Packages to block from hoisting to the workspace root. (Supported in Yarn only.)",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               }
             }


### PR DESCRIPTION
- Removed `"additionalProperties": true` and `"additionalItems": true` from `patternProperties`. They don't actually do anything in this context, and cause warnings in [AJV][ajv] strict mode.
- Changed the workspaces description since it was specific to Yarn and now npm v7+ is gaining support for the feature.
- Fixed the workspaces schema key from `anyof` (no capitalization) to `anyOf`. (this was causing [AJV][ajv] to throw an unsupported key error.)
- Fixed workspace types.

[ajv]: https://github.com/ajv-validator/ajv/tree/v7-beta