### PR TITLE
Fix added link for bitbucket pipelines manifest

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -196,8 +196,7 @@
       "description": "Bitbucket Pipelines CI/CD manifest schema",
       "url": "https://bitbucket.org/atlassianlabs/atlascode/raw/main/resources/schemas/pipelines-schema.json",
       "fileMatch": [
-        "bitbucket-pipelines.yml",
-        "bitbucket-pipelines.yaml"
+        "bitbucket-pipelines.yml"
       ]
     },
     {


### PR DESCRIPTION
Previously in 09da22f the bitbucket pipelines manifest JSON schema has
been linked in catalog.json for the first time.

It introduced two file-names matching the schema of which one was wrong.

The wrong file-name is with the .yaml extension, the correct name is with
the .yml extension.

Fix is to remove the wrong file-name from the catalogs' file-match array
for bitbucket-pipelines.yml JSON schema.

JSON-Catalog-Name: bitbucket-pipelines
Ref: 09da22fa5688395e01c72ecbe2633a005f2f237b
Caused-By: #1126