### PR TITLE
circleci: update docker image list

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -544,26 +544,12 @@
             "version": {
               "description": "If your build requires a specific docker image, you can set it as an image attribute",
               "enum": [
-                "17.03.0-ce",
-                "17.05.0-ce",
-                "17.06.0-ce",
-                "17.06.1-ce",
-                "17.07.0-ce",
-                "17.09.0-ce",
-                "17.10.0-ce",
-                "17.11.0-ce",
-                "17.12.0-ce",
-                "17.12.1-ce",
-                "18.01.0-ce",
-                "18.02.0-ce",
-                "18.03.0-ce",
-                "18.03.1-ce",
-                "18.04.0-ce",
-                "18.05.0-ce",
-                "18.06.0-ce",
+                "19.03.13",
+                "19.03.12",
+                "19.03.8",
                 "18.09.3"
               ],
-              "default": "17.09.0-ce"
+              "default": "19.03.13"
             }
           }
         },


### PR DESCRIPTION
close #1255

Docker Version
To specify the Docker version, you can set it as a version attribute:

      - setup_remote_docker:
          version: 19.03.13
CircleCI supports multiple versions of Docker. The following are the available versions:

19.03.13
19.03.12
19.03.8
18.09.3
Note: The version key is not currently supported on CircleCI Server installations. Contact your system administrator for information about the Docker version installed in your remote Docker environment.


**Maintenance:**  These issue to be close because they are already merge/fixed
close #245 via #339
close #220 via #281
close #440 via #476
close #457 via #481
close #965 via #966
