### PR TITLE
fix(package.json) simplify schema and format descriptions

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -3,7 +3,7 @@
   "title": "JSON schema for NPM package.json files",
   "definitions": {
     "person": {
-      "description": "A person who has been involved in creating or maintaining this package",
+      "description": "A person who has been involved in creating or maintaining this package.",
       "type": ["object", "string"],
       "required": ["name"],
       "properties": {
@@ -20,22 +20,6 @@
         }
       }
     },
-    "bundledDependency": {
-      "description": "Array of package names that will be bundled when publishing the package.",
-      "oneOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        {
-          "enum": [
-            false
-          ]
-        }
-      ]
-    },
     "dependency": {
       "description": "Dependencies are specified with a simple hash of package name to version range. The version range is a string which has one or more space-separated descriptors. Dependencies can also be identified with a tarball or git URL.",
       "type": "object",
@@ -44,11 +28,11 @@
       }
     },
     "scriptsInstallAfter": {
-      "description": "Run AFTER the package is installed",
+      "description": "Run AFTER the package is installed.",
       "type": "string"
     },
     "scriptsPublishAfter": {
-      "description": "Run AFTER the package is published",
+      "description": "Run AFTER the package is published.",
       "type": "string"
     },
     "scriptsRestart": {
@@ -56,28 +40,28 @@
       "type": "string"
     },
     "scriptsStart": {
-      "description": "Run by the 'npm start' command",
+      "description": "Run by the 'npm start' command.",
       "type": "string"
     },
     "scriptsStop": {
-      "description": "Run by the 'npm stop' command",
+      "description": "Run by the 'npm stop' command.",
       "type": "string"
     },
     "scriptsTest": {
-      "description": "Run by the 'npm test' command",
+      "description": "Run by the 'npm test' command.",
       "type": "string"
     },
     "scriptsUninstallBefore": {
-      "description": "Run BEFORE the package is uninstalled",
+      "description": "Run BEFORE the package is uninstalled.",
       "type": "string"
     },
     "scriptsVersionBefore": {
-      "description": "Run BEFORE bump the package version",
+      "description": "Run BEFORE bump the package version.",
       "type": "string"
     },
     "packageExportsEntryPath": {
-      "type": "string",
-      "description": "The module path that is resolved when this specifier is imported.",
+      "type": ["string", "null"],
+      "description": "The module path that is resolved when this specifier is imported. Set to `null` to disallow importing this module.",
       "pattern": "^\\./"
     },
     "packageExportsEntryObject": {
@@ -85,25 +69,25 @@
       "description": "Used to specify conditional exports, note that Conditional exports are unsupported in older environments, so it's recommended to use the fallback array option if support for those environments is a concern.",
       "properties": {
         "require": {
-          "$ref": "#/definitions/packageExportsEntryPath",
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this specifier is imported as a CommonJS module using the `require(...)` function."
         },
         "import": {
-          "$ref": "#/definitions/packageExportsEntryPath",
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this specifier is imported as an ECMAScript module using an `import` declaration or the dynamic `import(...)` function."
         },
         "node": {
-          "$ref": "#/definitions/packageExportsEntryPath",
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this environment is Node.js."
         },
         "default": {
-          "$ref": "#/definitions/packageExportsEntryPath",
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when no other export type matches."
         }
       },
       "patternProperties": {
-        "^(?!\\.).": {
-          "$ref": "#/definitions/packageExportsEntryPath",
+        "^(?![\\.0-9]).": {
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this environment matches the property name."
         }
       },
@@ -135,554 +119,566 @@
           "$ref": "#/definitions/packageExportsFallback"
         }
       ]
+    }
+  },
+  "type": "object",
+  "patternProperties": {
+    "^_": {
+      "description": "Any property starting with _ is valid.",
+      "tsType": "any"
+    }
+  },
+  "properties": {
+    "name": {
+      "description": "The name of the package.",
+      "type": "string",
+      "maxLength": 214,
+      "minLength": 1,
+      "pattern": "^(?:@[a-z0-9-*~][a-z0-9-*._~]*/)?[a-z0-9-~][a-z0-9-._~]*$"
     },
-    "coreProperties": {
-      "type": "object",
-
-      "patternProperties": {
-        "^_": {
-          "description": "Any property starting with _ is valid.",
-          "tsType": "any"
-        }
-      },
-
+    "version": {
+      "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency.",
+      "type": "string"
+    },
+    "description": {
+      "description": "This helps people discover your package, as it's listed in 'npm search'.",
+      "type": "string"
+    },
+    "keywords": {
+      "description": "This helps people discover your package as it's listed in 'npm search'.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "homepage": {
+      "description": "The url to the project homepage.",
+      "type": "string"
+    },
+    "bugs": {
+      "description": "The url to your project's issue tracker and / or the email address to which issues should be reported. These are helpful for people who encounter issues with your package.",
+      "type": ["object", "string"],
       "properties": {
-        "name": {
-          "description": "The name of the package.",
+        "url": {
           "type": "string",
-          "maxLength": 214,
-          "minLength": 1,
-          "pattern": "^(?:@[a-z0-9-*~][a-z0-9-*._~]*/)?[a-z0-9-~][a-z0-9-._~]*$"
+          "description": "The url to your project's issue tracker.",
+          "format": "uri"
         },
-        "version": {
-          "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency.",
-          "type": "string"
-        },
-        "description": {
-          "description": "This helps people discover your package, as it's listed in 'npm search'.",
-          "type": "string"
-        },
-        "keywords": {
-          "description": "This helps people discover your package as it's listed in 'npm search'.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "homepage": {
-          "description": "The url to the project homepage.",
-          "type": "string"
-        },
-        "bugs": {
-          "description": "The url to your project's issue tracker and / or the email address to which issues should be reported. These are helpful for people who encounter issues with your package.",
-          "type": ["object", "string"],
-          "properties": {
-            "url": {
-              "type": "string",
-              "description": "The url to your project's issue tracker.",
-              "format": "uri"
-            },
-            "email": {
-              "type": "string",
-              "description": "The email address to which issues should be reported.",
-              "format": "email"
-            }
-          }
-        },
-        "license": {
+        "email": {
           "type": "string",
-          "description": "You should specify a license for your package so that people know how they are permitted to use it, and any restrictions you're placing on it."
-        },
-        "licenses": {
-          "description": "DEPRECATED: Instead, use SPDX expressions, like this: { \"license\": \"ISC\" } or { \"license\": \"(MIT OR Apache-2.0)\" } see: 'https://docs.npmjs.com/files/package.json#license'",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string",
-                "format": "uri"
-              }
-            }
-          }
-        },
-        "author": {
-          "$ref": "#/definitions/person"
-        },
-        "contributors": {
-          "description": "A list of people who contributed to this package.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/person"
-          }
-        },
-        "maintainers": {
-          "description": "A list of people who maintains this package.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/person"
-          }
-        },
-        "files": {
-          "description": "The 'files' field is an array of files to include in your project. If you name a folder in the array, then it will also include the files inside that folder.",
-          "type": "array",
-          "items": {
+          "description": "The email address to which issues should be reported.",
+          "format": "email"
+        }
+      }
+    },
+    "license": {
+      "type": "string",
+      "description": "You should specify a license for your package so that people know how they are permitted to use it, and any restrictions you're placing on it."
+    },
+    "licenses": {
+      "description": "DEPRECATED: Instead, use SPDX expressions, like this: { \"license\": \"ISC\" } or { \"license\": \"(MIT OR Apache-2.0)\" } see: 'https://docs.npmjs.com/files/package.json#license'.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
             "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
           }
+        }
+      }
+    },
+    "author": {
+      "$ref": "#/definitions/person"
+    },
+    "contributors": {
+      "description": "A list of people who contributed to this package.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/person"
+      }
+    },
+    "maintainers": {
+      "description": "A list of people who maintains this package.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/person"
+      }
+    },
+    "files": {
+      "description": "The 'files' field is an array of files to include in your project. If you name a folder in the array, then it will also include the files inside that folder.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "main": {
+      "description": "The main field is a module ID that is the primary entry point to your program.",
+      "type": "string"
+    },
+    "exports": {
+      "description": "The \"exports\" field is used to restrict external access to non-exported module files, also enables a module to import itself using \"name\".",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/packageExportsEntryPath",
+          "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
         },
-        "main": {
-          "description": "The main field is a module ID that is the primary entry point to your program.",
-          "type": "string"
-        },
-        "exports": {
-          "description": "The \"exports\" field is used to restrict external access to non-exported module files, also enables a module to import itself using \"name\".",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/packageExportsEntryPath",
-              "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
-            },
-            {
-              "type": "object",
-              "properties": {
-                ".": {
-                  "$ref": "#/definitions/packageExportsEntryOrFallback",
-                  "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
-                },
-                "./": {
-                  "$ref": "#/definitions/packageExportsEntryOrFallback",
-                  "description": "The module path prefix that is resolved when the module specifier starts with \"name/\", set to \"./\" to allow external modules to import any subpath."
-                }
-              },
-              "patternProperties": {
-                "^\\./": {
-                  "$ref": "#/definitions/packageExportsEntryOrFallback",
-                  "description": "The module path that is resolved when the path component of the module specifier matches the property name."
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "$ref": "#/definitions/packageExportsEntryObject",
-              "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
-            },
-            {
-              "$ref": "#/definitions/packageExportsFallback",
-              "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
-            }
-          ]
-        },
-        "bin": {
-          "type": ["string", "object"],
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "description": "When set to \"module\", the type field allows a package to specify all .js files within are ES modules. If the \"type\" field is omitted or set to \"commonjs\", all .js files are treated as CommonJS.",
-          "type": "string",
-          "enum": ["commonjs", "module"],
-          "default": "commonjs"
-        },
-        "types": {
-          "description": "Set the types property to point to your bundled declaration file",
-          "type": "string"
-        },
-        "typings": {
-          "description": "Note that the \"typings\" field is synonymous with \"types\", and could be used as well.",
-          "type": "string"
-        },
-        "typesVersions": {
-          "description": "The \"typesVersions\" field is used since TypeScript 3.1 to support features that were only made available in newer TypeScript versions.",
+        {
           "type": "object",
-          "additionalProperties": {
-            "description": "Contains overrides for the TypeScript version that matches the version range matching the property key.",
-            "type": "object",
-            "properties": {
-              "*": {
-                "description": "Maps all file paths to the file paths specified in the array.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "pattern": "^[^*]*(?:\\*[^*]*)?$"
-                }
-              }
+          "properties": {
+            ".": {
+              "$ref": "#/definitions/packageExportsEntryOrFallback",
+              "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
             },
-            "patternProperties": {
-              "^[^*]+$": {
-                "description": "Maps the file path matching the property key to the file paths specified in the array.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "^[^*]*\\*[^*]*$": {
-                "description": "Maps file paths matching the pattern specified in property key to file paths specified in the array.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "pattern": "^[^*]*(?:\\*[^*]*)?$"
-                }
-              }
-            },
-            "additionalProperties": false
+            "./": {
+              "$ref": "#/definitions/packageExportsEntryOrFallback",
+              "description": "The module path prefix that is resolved when the module specifier starts with \"name/\", set to \"./\" to allow external modules to import any subpath."
+            }
+          },
+          "patternProperties": {
+            "^\\./": {
+              "$ref": "#/definitions/packageExportsEntryOrFallback",
+              "description": "The module path that is resolved when the path component of the module specifier matches the property name."
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/definitions/packageExportsEntryObject",
+          "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
+        },
+        {
+          "$ref": "#/definitions/packageExportsFallback",
+          "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
+        }
+      ]
+    },
+    "bin": {
+      "type": ["string", "object"],
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "type": {
+      "description": "When set to \"module\", the type field allows a package to specify all .js files within are ES modules. If the \"type\" field is omitted or set to \"commonjs\", all .js files are treated as CommonJS.",
+      "type": "string",
+      "enum": ["commonjs", "module"],
+      "default": "commonjs"
+    },
+    "types": {
+      "description": "Set the types property to point to your bundled declaration file.",
+      "type": "string"
+    },
+    "typings": {
+      "description": "Note that the \"typings\" field is synonymous with \"types\", and could be used as well.",
+      "type": "string"
+    },
+    "typesVersions": {
+      "description": "The \"typesVersions\" field is used since TypeScript 3.1 to support features that were only made available in newer TypeScript versions.",
+      "type": "object",
+      "additionalProperties": {
+        "description": "Contains overrides for the TypeScript version that matches the version range matching the property key.",
+        "type": "object",
+        "properties": {
+          "*": {
+            "description": "Maps all file paths to the file paths specified in the array.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[^*]*(?:\\*[^*]*)?$"
+            }
           }
+        },
+        "patternProperties": {
+          "^[^*]+$": {
+            "description": "Maps the file path matching the property key to the file paths specified in the array.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "^[^*]*\\*[^*]*$": {
+            "description": "Maps file paths matching the pattern specified in property key to file paths specified in the array.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[^*]*(?:\\*[^*]*)?$"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "man": {
+      "type": ["array", "string"],
+      "description": "Specify either a single file or an array of filenames to put in place for the man program to find.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "directories": {
+      "type": "object",
+      "properties": {
+        "bin": {
+          "description": "If you specify a 'bin' directory, then all the files in that folder will be used as the 'bin' hash.",
+          "type": "string"
+        },
+        "doc": {
+          "description": "Put markdown files in here. Eventually, these will be displayed nicely, maybe, someday.",
+          "type": "string"
+        },
+        "example": {
+          "description": "Put example scripts in here. Someday, it might be exposed in some clever way.",
+          "type": "string"
+        },
+        "lib": {
+          "description": "Tell people where the bulk of your library is. Nothing special is done with the lib folder in any way, but it's useful meta info.",
+          "type": "string"
         },
         "man": {
-          "type": ["array", "string"],
-          "description": "Specify either a single file or an array of filenames to put in place for the man program to find.",
+          "description": "A folder that is full of man pages. Sugar to generate a 'man' array by walking the folder.",
+          "type": "string"
+        },
+        "test": {
+          "type": "string"
+        }
+      }
+    },
+    "repository": {
+      "description": "Specify the place where your code lives. This is helpful for people who want to contribute.",
+      "type": ["object", "string"],
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "string"
+        }
+      }
+    },
+    "scripts": {
+      "description": "The 'scripts' member is an object hash of script commands that are run at various times in the lifecycle of your package. The key is the lifecycle event, and the value is the command to run at that point.",
+      "type": "object",
+      "properties": {
+        "prepublish": {
+          "type": "string",
+          "description": "Run BEFORE the package is published (Also run on local npm install without any arguments)."
+        },
+        "prepare": {
+          "type": "string",
+          "description": "Run both BEFORE the package is packed and published, and on local npm install without any arguments. This is run AFTER prepublish, but BEFORE prepublishOnly."
+        },
+        "prepublishOnly": {
+          "type": "string",
+          "description": "Run BEFORE the package is prepared and packed, ONLY on npm publish."
+        },
+        "prepack": {
+          "type": "string",
+          "description": "run BEFORE a tarball is packed (on npm pack, npm publish, and when installing git dependencies)."
+        },
+        "postpack": {
+          "type": "string",
+          "description": "Run AFTER the tarball has been generated and moved to its final destination."
+        },
+        "publish": {
+          "$ref": "#/definitions/scriptsPublishAfter"
+        },
+        "postpublish": {
+          "$ref": "#/definitions/scriptsPublishAfter"
+        },
+        "preinstall": {
+          "type": "string",
+          "description": "Run BEFORE the package is installed."
+        },
+        "install": {
+          "$ref": "#/definitions/scriptsInstallAfter"
+        },
+        "postinstall": {
+          "$ref": "#/definitions/scriptsInstallAfter"
+        },
+        "preuninstall": {
+          "$ref": "#/definitions/scriptsUninstallBefore"
+        },
+        "uninstall": {
+          "$ref": "#/definitions/scriptsUninstallBefore"
+        },
+        "postuninstall": {
+          "type": "string",
+          "description": "Run AFTER the package is uninstalled."
+        },
+        "preversion": {
+          "$ref": "#/definitions/scriptsVersionBefore"
+        },
+        "version": {
+          "$ref": "#/definitions/scriptsVersionBefore"
+        },
+        "postversion": {
+          "type": "string",
+          "description": "Run AFTER bump the package version."
+        },
+        "pretest": {
+          "$ref": "#/definitions/scriptsTest"
+        },
+        "test": {
+          "$ref": "#/definitions/scriptsTest"
+        },
+        "posttest": {
+          "$ref": "#/definitions/scriptsTest"
+        },
+        "prestop": {
+          "$ref": "#/definitions/scriptsStop"
+        },
+        "stop": {
+          "$ref": "#/definitions/scriptsStop"
+        },
+        "poststop": {
+          "$ref": "#/definitions/scriptsStop"
+        },
+        "prestart": {
+          "$ref": "#/definitions/scriptsStart"
+        },
+        "start": {
+          "$ref": "#/definitions/scriptsStart"
+        },
+        "poststart": {
+          "$ref": "#/definitions/scriptsStart"
+        },
+        "prerestart": {
+          "$ref": "#/definitions/scriptsRestart"
+        },
+        "restart": {
+          "$ref": "#/definitions/scriptsRestart"
+        },
+        "postrestart": {
+          "$ref": "#/definitions/scriptsRestart"
+        }
+      },
+      "additionalProperties": {
+        "type": "string",
+        "tsType": "string | undefined"
+      }
+    },
+    "config": {
+      "description": "A 'config' hash can be used to set configuration parameters used in package scripts that persist across upgrades.",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "dependencies": {
+      "$ref": "#/definitions/dependency"
+    },
+    "devDependencies": {
+      "$ref": "#/definitions/dependency"
+    },
+    "optionalDependencies": {
+      "$ref": "#/definitions/dependency"
+    },
+    "peerDependencies": {
+      "$ref": "#/definitions/dependency"
+    },
+    "peerDependenciesMeta": {
+      "description": "When a user installs your package, warnings are emitted if packages specified in \"peerDependencies\" are not already installed. The \"peerDependenciesMeta\" field serves to provide more information on how your peer dependencies are utilized. Most commonly, it allows peer dependencies to be marked as optional. Metadata for this field is specified with a simple hash of the package name to a metadata object.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "optional": {
+            "description": "Specifies that this peer dependency is optional and should not be installed automatically.",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "bundledDependencies": {
+      "description": "Array of package names that will be bundled when publishing the package.",
+      "oneOf": [
+        {
+          "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "directories": {
-          "type": "object",
-          "properties": {
-            "bin": {
-              "description": "If you specify a 'bin' directory, then all the files in that folder will be used as the 'bin' hash.",
-              "type": "string"
-            },
-            "doc": {
-              "description": "Put markdown files in here. Eventually, these will be displayed nicely, maybe, someday.",
-              "type": "string"
-            },
-            "example": {
-              "description": "Put example scripts in here. Someday, it might be exposed in some clever way.",
-              "type": "string"
-            },
-            "lib": {
-              "description": "Tell people where the bulk of your library is. Nothing special is done with the lib folder in any way, but it's useful meta info.",
-              "type": "string"
-            },
-            "man": {
-              "description": "A folder that is full of man pages. Sugar to generate a 'man' array by walking the folder.",
-              "type": "string"
-            },
-            "test": {
-              "type": "string"
-            }
-          }
-        },
-        "repository": {
-          "description": "Specify the place where your code lives. This is helpful for people who want to contribute.",
-          "type": ["object", "string"],
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "directory": {
-              "type": "string"
-            }
-          }
-        },
-        "scripts": {
-          "description": "The 'scripts' member is an object hash of script commands that are run at various times in the lifecycle of your package. The key is the lifecycle event, and the value is the command to run at that point.",
-          "type": "object",
-          "properties": {
-            "prepublish": {
-              "type": "string",
-              "description": "Run BEFORE the package is published (Also run on local npm install without any arguments)"
-            },
-            "prepare": {
-              "type": "string",
-              "description": "Run both BEFORE the package is packed and published, and on local npm install without any arguments. This is run AFTER prepublish, but BEFORE prepublishOnly"
-            },
-            "prepublishOnly": {
-              "type": "string",
-              "description": "Run BEFORE the package is prepared and packed, ONLY on npm publish"
-            },
-            "prepack": {
-              "type": "string",
-              "description": "run BEFORE a tarball is packed (on npm pack, npm publish, and when installing git dependencies)"
-            },
-            "postpack": {
-              "type": "string",
-              "description": "Run AFTER the tarball has been generated and moved to its final destination."
-            },
-            "publish": {
-              "$ref": "#/definitions/scriptsPublishAfter"
-            },
-            "postpublish": {
-              "$ref": "#/definitions/scriptsPublishAfter"
-            },
-            "preinstall": {
-              "type": "string",
-              "description": "Run BEFORE the package is installed"
-            },
-            "install": {
-              "$ref": "#/definitions/scriptsInstallAfter"
-            },
-            "postinstall": {
-              "$ref": "#/definitions/scriptsInstallAfter"
-            },
-            "preuninstall": {
-              "$ref": "#/definitions/scriptsUninstallBefore"
-            },
-            "uninstall": {
-              "$ref": "#/definitions/scriptsUninstallBefore"
-            },
-            "postuninstall": {
-              "type": "string",
-              "description": "Run AFTER the package is uninstalled"
-            },
-            "preversion": {
-              "$ref": "#/definitions/scriptsVersionBefore"
-            },
-            "version": {
-              "$ref": "#/definitions/scriptsVersionBefore"
-            },
-            "postversion": {
-              "type": "string",
-              "description": "Run AFTER bump the package version"
-            },
-            "pretest": {
-              "$ref": "#/definitions/scriptsTest"
-            },
-            "test": {
-              "$ref": "#/definitions/scriptsTest"
-            },
-            "posttest": {
-              "$ref": "#/definitions/scriptsTest"
-            },
-            "prestop": {
-              "$ref": "#/definitions/scriptsStop"
-            },
-            "stop": {
-              "$ref": "#/definitions/scriptsStop"
-            },
-            "poststop": {
-              "$ref": "#/definitions/scriptsStop"
-            },
-            "prestart": {
-              "$ref": "#/definitions/scriptsStart"
-            },
-            "start": {
-              "$ref": "#/definitions/scriptsStart"
-            },
-            "poststart": {
-              "$ref": "#/definitions/scriptsStart"
-            },
-            "prerestart": {
-              "$ref": "#/definitions/scriptsRestart"
-            },
-            "restart": {
-              "$ref": "#/definitions/scriptsRestart"
-            },
-            "postrestart": {
-              "$ref": "#/definitions/scriptsRestart"
-            }
-          },
-          "additionalProperties": {
-            "type": "string",
-            "tsType": "string | undefined"
-          }
-        },
-        "config": {
-          "description": "A 'config' hash can be used to set configuration parameters used in package scripts that persist across upgrades.",
-          "type": "object",
-          "additionalProperties": true
-        },
-        "dependencies": {
-          "$ref": "#/definitions/dependency"
-        },
-        "devDependencies": {
-          "$ref": "#/definitions/dependency"
-        },
-        "optionalDependencies": {
-          "$ref": "#/definitions/dependency"
-        },
-        "peerDependencies": {
-          "$ref": "#/definitions/dependency"
-        },
-        "peerDependenciesMeta": {
-          "description": "When a user installs your package, warnings are emitted if packages specified in \"peerDependencies\" are not already installed. The \"peerDependenciesMeta\" field serves to provide more information on how your peer dependencies are utilized. Most commonly, it allows peer dependencies to be marked as optional. Metadata for this field is specified with a simple hash of the package name to a metadata object.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "optional": {
-                "description": "Specifies that this peer dependency is optional and should not be installed automatically.",
-                "type": "boolean"
-              }
-            }
-          }
-        },
-        "resolutions": {
-          "$ref": "#/definitions/dependency"
-        },
-        "engines": {
-          "type": "object",
-          "properties": {
-            "node": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": {
+        {
+          "enum": [
+            false
+          ]
+        }
+      ]
+    },
+    "bundleDependencies": {
+      "description": "DEPRECATED: This field is honored, but \"bundledDependencies\" is the correct field name.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
             "type": "string"
           }
         },
-        "engineStrict": {
+        {
+          "enum": [
+            false
+          ]
+        }
+      ]
+    },
+    "resolutions": {
+      "$ref": "#/definitions/dependency"
+    },
+    "engines": {
+      "type": "object",
+      "properties": {
+        "node": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "engineStrict": {
+      "type": "boolean"
+    },
+    "os": {
+      "description": "Specify which operating systems your module will run on.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "cpu": {
+      "description": "Specify that your code only runs on certain cpu architectures.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "preferGlobal": {
+      "type": "boolean",
+      "description": "DEPRECATED: This option used to trigger an npm warning, but it will no longer warn. It is purely there for informational purposes. It is now recommended that you install any binaries as local devDependencies wherever possible."
+    },
+    "private": {
+      "description": "If set to true, then npm will refuse to publish it.",
+      "oneOf": [
+        {
           "type": "boolean"
         },
-        "os": {
-          "description": "You can specify which operating systems your module will run on",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "cpu": {
-          "description": "If your code only runs on certain cpu architectures, you can specify which ones.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "preferGlobal": {
-          "type": "boolean",
-          "description": "DEPRECATED: This option used to trigger an npm warning, but it will no longer warn. It is purely there for informational purposes. It is now recommended that you install any binaries as local devDependencies wherever possible."
-        },
-        "private": {
-          "description": "If set to true, then npm will refuse to publish it.",
-          "oneOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "enum": [
-                "false",
-                "true"
-              ]
-            }
+        {
+          "enum": [
+            "false",
+            "true"
           ]
+        }
+      ]
+    },
+    "publishConfig": {
+      "type": "object",
+      "properties": {
+        "access": {
+          "type": "string",
+          "enum": ["public", "restricted"]
         },
-        "publishConfig": {
-          "type": "object",
-          "properties": {
-            "access": {
-              "type": "string",
-              "enum": ["public", "restricted"]
-            },
-            "tag": {
-              "type": "string"
-            },
-            "registry": {
-              "type": "string",
-              "format": "uri"
-            }
-          },
-          "additionalProperties": true
-        },
-        "dist": {
-          "type": "object",
-          "properties": {
-            "shasum": {
-              "type": "string"
-            },
-            "tarball": {
-              "type": "string"
-            }
-          }
-        },
-        "readme": {
+        "tag": {
           "type": "string"
         },
-        "module": {
-          "description": "An ECMAScript module ID that is the primary entry point to your program.",
+        "registry": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": true
+    },
+    "dist": {
+      "type": "object",
+      "properties": {
+        "shasum": {
           "type": "string"
         },
-        "esnext": {
-          "description": "A module ID with untranspiled code that is the primary entry point to your program.",
-          "type": ["string", "object"],
-          "properties": {
-            "main": {
-              "type": "string"
-            },
-            "browser": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": {
+        "tarball": {
+          "type": "string"
+        }
+      }
+    },
+    "readme": {
+      "type": "string"
+    },
+    "module": {
+      "description": "An ECMAScript module ID that is the primary entry point to your program.",
+      "type": "string"
+    },
+    "esnext": {
+      "description": "A module ID with untranspiled code that is the primary entry point to your program.",
+      "type": ["string", "object"],
+      "properties": {
+        "main": {
+          "type": "string"
+        },
+        "browser": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "workspaces": {
+      "description": "Allows packages within a directory to depend on one another using direct linking of local files. Additionally, dependencies within a workspace are hoisted to the workspace root when possible to reduce duplication. Note: It's also a good idea to set \"private\" to true when using this feature.",
+      "anyOf": [
+        {
+          "type": "array",
+          "description": "Workspace package paths. Glob patterns are supported.",
+          "items": {
             "type": "string"
           }
         },
-        "workspaces": {
-          "description": "Allows packages within a directory to depend on one another using direct linking of local files. Additionally, dependencies within a workspace are hoisted to the workspace root when possible to reduce duplication. Note: It's also a good idea to set \"private\" to true when using this feature.",
-          "anyOf": [
-            {
+        {
+          "type": "object",
+          "properties": {
+            "packages": {
               "type": "array",
               "description": "Workspace package paths. Glob patterns are supported.",
               "items": {
                 "type": "string"
               }
             },
-            {
-              "type": "object",
-              "properties": {
-                "packages": {
-                  "type": "array",
-                  "description": "Workspace package paths. Glob patterns are supported.",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "nohoist": {
-                  "type": "array",
-                  "description": "Packages to block from hoisting to the workspace root. (Supported in Yarn only.)",
-                  "items": {
-                    "type": "string"
-                  }
-                }
+            "nohoist": {
+              "type": "array",
+              "description": "Packages to block from hoisting to the workspace root. Currently only supported in Yarn only.",
+              "items": {
+                "type": "string"
               }
             }
-          ]
-        }
-      }
-    },
-    "jspmDefinition": {
-      "properties": {
-        "jspm": { "$ref": "#/definitions/coreProperties" }
-      }
-    }
-  },
-  "allOf": [
-    { "$ref": "#/definitions/coreProperties" },
-    { "$ref": "#/definitions/jspmDefinition" },
-    {
-      "anyOf": [
-        {
-          "properties": {
-            "bundleDependencies": {
-              "$ref": "#/definitions/bundledDependency"
-            }
-          },
-          "not": {
-            "properties": {
-              "bundledDependencies": {}
-            },
-            "required": ["bundledDependencies"]
-          }
-        },
-        {
-          "properties": {
-            "bundledDependencies": {
-              "$ref": "#/definitions/bundledDependency"
-            }
-          },
-          "not": {
-            "properties": {
-              "bundleDependencies": {}
-            },
-            "required": ["bundleDependencies"]
           }
         }
       ]
+    },
+    "jspm": { "$ref": "#" }
+  },
+  "anyOf": [
+    { 
+      "type": "object",
+      "not": {
+        "required": ["bundledDependencies", "bundleDependencies"]
+      }
+    },
+    {
+      "type": "object",
+      "not": {
+        "required": ["bundleDependencies"]
+      },
+      "required": ["bundledDependencies"]
+    },
+    {
+      "type": "object",
+      "not": {
+        "required": ["bundledDependencies"]
+      },
+      "required": ["bundleDependencies"]
     }
   ]
 }


### PR DESCRIPTION
Sorry for the wave of `package.json` patches I've been submitting. I've been working with that schema a lot over the last few weeks and keep finding things to improve it.

This PR looks way more daunting than it actually is. I was thinking about how to simplify this schema to make it more welcoming for newcomers to submit patches. It's a bit complicated at the moment.

## Changes

1. Make sure all descriptions end with a period for the sake of consistency.
2. Removed `coreProperties` from `definitions` and instead placed the fields for that definition on the main schema.
3. Removed `bundleDependency` from `definitions` and instead added `bundleDependencies` and `bundledDependencies` properties so they can use different descriptions. 
4. Marked `bundleDependencies` as `DEPRECATED` in its description, since the canonical field is `bundledDependencies`.
5. Removed `jspm` from `definitions` and instead added it as a main property and used `$ref` to point it to the root schema... the `jspm` field is used by jspm to essentially override any fields in `package.json`. Doing it this way greatly simplifies things, though it does allow someone to infinitely nest "jsdom" props -- but it's an edge case I doubt anyone would ever hit and I think the simplification is worth it.
6. Simplified the `anyOf` schema to ensure you can use either `bundleDependencies` or `bundledDependencies`, but never both.

I tested all of these changes extensively in AJV and everything passed.