### PR TITLE
JSON file must not have BOM

### DIFF
--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -242,6 +242,13 @@ module.exports = function (grunt) {
       let selectedParserModeString =  strongMode ? "(strong mode)  " : "(default mode) ";
       // Start validate the JSON schema
       console.log(`${selectedParserModeString}validate   | ${schema_full_path_name}`);
+
+      // Check for BOM in JSON
+      const buffer = fs.readFileSync(schema_full_path_name);
+      if (buffer[0] > 127){
+        throw new Error(`Schema file must not have BOM: ${schema_full_path_name}`);
+      }
+
       const x = grunt.file.readJSON(schema_full_path_name);
       validator(x, selectedParserMode);
       console.log(`${selectedParserModeString}pass       | ${schema_full_path_name}`);

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -155,7 +155,16 @@
     "ninjs-1_1.json",
     "ninjs-1_2.json",
     "swagger-2_0.json",
-    "webjob-publish-settings.json"
+    "webjob-publish-settings.json",
+    "---> below this line is for failed BOM in JSON file <---",
+    "bootstraprc.json",
+    "content-security-policy-report-2.json",
+    "docfx.json",
+    "htmlhint.json",
+    "modernizrrc.json",
+    "templatesources.json",
+    "typings.json",
+    "typingsrc.json"
   ],
   "strongmode": [
    ]


### PR DESCRIPTION
issue #1282
Notice a few schema must be added to src/schema-validation.json or else the grunt task schemasafe will fail.
These new one are the one that are not yet added to the list that some thing is wrong with validation/test/BOM

This is a partial fix.
There must be a extra grunt task 'checkexternalurl' added that read catalog.json and verify the external link for:
- broken URL
- external JSON should be given the same validation process as the local one.
The result of 'checkexternalurl' must never generate a build error, because schemastore have never control of the content.
Only a list of error that can be used to notify/fix the external schema. 
 