### PR TITLE
Allow environment variable values to be of type `number`

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -276,7 +276,7 @@
             "description": "A map of environment variable names and values",
             "type": "object",
             "additionalProperties": {
-              "type": "string"
+              "type": ["string", "number"]
             }
           },
           "auth": {
@@ -404,7 +404,7 @@
             "description": "A map of environment variable names and values.",
             "type": "object",
             "additionalProperties": {
-              "type": "string"
+              "type": ["string", "number"]
             }
           }
         }
@@ -478,7 +478,7 @@
                   "description": "Additional environmental variables, locally scoped to command",
                   "type": "object",
                   "additionalProperties": {
-                    "type": "string"
+                    "type": ["string", "number"]
                   }
                 },
                 "background": {
@@ -959,7 +959,7 @@
             "description": "A map of environment variable names and variables (NOTE: these will override any environment variables you set in the CircleCI web interface).",
             "type": "object",
             "additionalProperties": {
-              "type": "string"
+              "type": ["string", "number"]
             }
           },
           "branches": {


### PR DESCRIPTION
While they all become strings eventually, due to the nature of YAML it's reasonable to have number values, i.e for a variable controlling the port of a database or container:

```
jobs:
  do_something:
    docker:
      - image: circleci/ruby:2.6.6-node
        environment:
          PGUSER: ubuntu
          PGPORT: 5432
          RAILS_ENV: test
    steps:
      - checkout
```

Currently, the above errors like so:

> Schema validation: One of the following property sets is required: property 'machine', or property 'machine', or property 'macos', or property 'executor', or property 'executor' 