### PR TITLE
github-workflow: support private container registries

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -42,65 +42,69 @@
       ]
     },
     "container": {
-      "oneOf": [
-        {
-          "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer",
-          "description": "The Docker image to use as the container to run the action. The value can be the Docker Hub image name or a public docker registry name.",
+      "type": "object",
+      "properties": {
+        "image": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerimage",
+          "description": "The Docker image to use as the container to run the action. The value can be the Docker Hub image name or a registry name.",
           "type": "string"
         },
-        {
+        "credentials": {
+          "$comment": "https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainercredentials",
+          "description": "If the image's container registry requires authentication to pull the image, you can use credentials to set a map of the username and password. The credentials are the same values that you would provide to the `docker login` command.",
           "type": "object",
           "properties": {
-            "image": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerimage",
-              "description": "The Docker image to use as the container to run the action. The value can be the Docker Hub image name or a public docker registry name.",
+            "username": {
               "type": "string"
             },
-            "env": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerenv",
-              "$ref": "#/definitions/env",
-              "description": "Sets an array of environment variables in the container."
-            },
-            "ports": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerports",
-              "description": "Sets an array of ports to expose on the container.",
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              },
-              "minItems": 1,
-              "additionalItems": false
-            },
-            "volumes": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainervolumes",
-              "description": "Sets an array of volumes for the container to use. You can use volumes to share data between services or other steps in a job. You can specify named Docker volumes, anonymous Docker volumes, or bind mounts on the host.\nTo specify a volume, you specify the source and destination path: <source>:<destinationPath>\nThe <source> is a volume name or an absolute path on the host machine, and <destinationPath> is an absolute path in the container.",
-              "type": "array",
-              "items": {
-                "type": "string",
-                "pattern": "^[^:]+:[^:]+$"
-              },
-              "minItems": 1,
-              "additionalItems": false
-            },
-            "options": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontaineroptions",
-              "description": "Additional Docker container resource options. For a list of options, see https://docs.docker.com/engine/reference/commandline/create/#options.",
+            "password": {
               "type": "string"
             }
+          }
+        },
+        "env": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerenv",
+          "$ref": "#/definitions/env",
+          "description": "Sets an array of environment variables in the container."
+        },
+        "ports": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainerports",
+          "description": "Sets an array of ports to expose on the container.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
-          "required": [
-            "image"
-          ],
-          "additionalProperties": false
+          "minItems": 1,
+          "additionalItems": false
+        },
+        "volumes": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainervolumes",
+          "description": "Sets an array of volumes for the container to use. You can use volumes to share data between services or other steps in a job. You can specify named Docker volumes, anonymous Docker volumes, or bind mounts on the host.\nTo specify a volume, you specify the source and destination path: <source>:<destinationPath>\nThe <source> is a volume name or an absolute path on the host machine, and <destinationPath> is an absolute path in the container.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^:]+:[^:]+$"
+          },
+          "minItems": 1,
+          "additionalItems": false
+        },
+        "options": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontaineroptions",
+          "description": "Additional Docker container resource options. For a list of options, see https://docs.docker.com/engine/reference/commandline/create/#options.",
+          "type": "string"
         }
-      ]
+      },
+      "required": [
+        "image"
+      ],
+      "additionalProperties": false
     },
     "defaults": {
       "type": "object",
@@ -1258,17 +1262,14 @@
             "container": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainer",
               "description": "A container to run any steps in a job that don't already specify a container. If you have steps that use both script and container actions, the container actions will run as sibling containers on the same network with the same volume mounts.\nIf you do not set a container, all steps will run directly on the host specified by runs-on unless a step refers to an action configured to run in a container.",
-              "type": "object",
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/definitions/container"
-                  }
-                ]
-              }
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/container"
+                }
+              ]
             },
             "services": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idservices",

--- a/src/test/github-workflow/containers.json
+++ b/src/test/github-workflow/containers.json
@@ -1,0 +1,34 @@
+{
+  "name": "Test containers",
+  "on": [
+    "push"
+  ],
+  "jobs": {
+    "build": {
+      "runs-on": "ubuntu-latest",
+      "container": {
+        "image": "octocat/ci-image:latest",
+        "credentials": {
+          "username": "mona",
+          "password": "${{ secrets.docker_hub_password}}"
+        }
+      },
+      "services": {
+        "db": {
+          "image": "ghcr.io/octocat/testdb:latest",
+          "credentials": {
+            "username": "${{ github.repository_owner }}",
+            "password": "${{ secrets.ghcr_password }}"
+          }
+        }
+      }
+    },
+    "test": {
+      "runs-on": [
+        "self-hosted",
+        "linux"
+      ],
+      "container": "node:12"
+    }
+  }
+}


### PR DESCRIPTION
Add schema support for the [recently-released ability](https://github.blog/changelog/2020-09-24-github-actions-private-registry-support-for-job-and-service-containers/) to use private container registries in job and service definitions. Also fixes an old issue where `"container": "string"` was invalid.