### PR TITLE
Add support for when clause in CircleCI config

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -1053,6 +1053,10 @@
                 }
               ]
             }
+          },
+          "when": {
+            "description": "Specify when to enable or disable the workflow.",
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
See https://circleci.com/docs/2.0/configuration-reference/#using-when-in-workflows

This change only supports string-based logic statements for the when clause.