### PR TITLE
GitHub Action workflow `runs-on` value set is too restrictive

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -994,6 +994,7 @@
                   "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#github-hosted-runners",
                   "type": "string",
                   "enum": [
+                    "${{ matrix.job.os }}",
                     "${{ matrix.os }}",
                     "macos-latest",
                     "macos-10.15",


### PR DESCRIPTION
closed #1277

**maintenance:**
closed #1194 via #1285
closed #890 via #1285