### PR TITLE
Version schemas for EdgeAgent and EdgeHub deployment manifests separately

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -110,6 +110,24 @@
       "url": "https://json.schemastore.org/avro-avsc"
     },
     {
+      "name": "Azure IoT EdgeAgent deployment",
+      "description": "Azure IoT EdgeAgent deployment schema",
+      "url": "https://json.schemastore.org/azure-iot-edgeagent-deployment-1.1",
+      "versions": {
+        "1.0": "https://json.schemastore.org/azure-iot-edgeagent-deployment-1.0",
+        "1.1": "https://json.schemastore.org/azure-iot-edgeagent-deployment-1.1"
+      }
+    },
+    {
+      "name": "Azure IoT EdgeHub deployment",
+      "description": "Azure IoT EdgeHub deployment schema",
+      "url": "https://json.schemastore.org/azure-iot-edgehub-deployment-1.1",
+      "versions": {
+        "1.0": "https://json.schemastore.org/azure-iot-edgehub-deployment-1.0",
+        "1.1": "https://json.schemastore.org/azure-iot-edgehub-deployment-1.1"
+      }
+    },
+    {
       "name": "Azure IoT Edge deployment",
       "description": "Azure IoT Edge deployment schema",
       "url": "https://json.schemastore.org/azure-iot-edge-deployment-2.0",

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.0.json
@@ -1,0 +1,251 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "title": "JSON schema for Azure IoT EdgeAgent Deployment version 1.0",
+    "required": [
+        "$edgeAgent"
+    ],
+    "properties": {
+        "$edgeAgent": {
+            "type": "object",
+            "title": "Configuration for the edgeAgent module",
+            "required": [
+                "properties.desired"
+            ],
+            "properties": {
+                "properties.desired": {
+                    "type": "object",
+                    "required": [
+                        "schemaVersion",
+                        "runtime",
+                        "systemModules",
+                        "modules"
+                    ],
+                    "properties": {
+                        "schemaVersion": {
+                            "type": "string",
+                            "pattern": "1.0"
+                        },
+                        "runtime": {
+                            "type": "object",
+                            "required": [
+                                "type",
+                                "settings"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "$ref": "#/definitions/moduleType"
+                                },
+                                "settings": {
+                                    "type": "object",
+                                    "properties": {
+                                        "minDockerVersion": {
+                                            "type": "string",
+                                            "examples": [
+                                                "v1.25"
+                                            ]
+                                        },
+                                        "loggingOptions": {
+                                            "type": "string"
+                                        },
+                                        "registryCredentials": {
+                                            "type": "object",
+                                            "patternProperties": {
+                                                "^.+$": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "username",
+                                                        "password",
+                                                        "address"
+                                                    ],
+                                                    "properties": {
+                                                        "username": {
+                                                            "type": "string"
+                                                        },
+                                                        "password": {
+                                                            "type": "string"
+                                                        },
+                                                        "address": {
+                                                            "type": "string",
+                                                            "pattern": "^[^\\s]+$"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "systemModules": {
+                            "type": "object",
+                            "required": [
+                                "edgeAgent",
+                                "edgeHub"
+                            ],
+                            "properties": {
+                                "edgeAgent": {
+                                    "type": "object",
+                                    "required": [
+                                        "type",
+                                        "settings"
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "$ref": "#/definitions/moduleType"
+                                        },
+                                        "settings": {
+                                            "$ref": "#/definitions/moduleSettings"
+                                        },
+                                        "env": {
+                                            "$ref": "#/definitions/env"
+                                        }
+                                    }
+                                },
+                                "edgeHub": {
+                                    "type": "object",
+                                    "title": "The Edgehub Schema",
+                                    "required": [
+                                        "type",
+                                        "settings",
+                                        "status",
+                                        "restartPolicy"
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "$ref": "#/definitions/moduleType"
+                                        },
+                                        "settings": {
+                                            "$ref": "#/definitions/moduleSettings"
+                                        },
+                                        "env": {
+                                            "$ref": "#/definitions/env"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/status"
+                                        },
+                                        "restartPolicy": {
+                                            "$ref": "#/definitions/restartPolicy"
+                                        }
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "modules": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^[a-zA-Z0-9_-]+$": {
+                                    "type": "object",
+                                    "required": [
+                                        "type",
+                                        "status",
+                                        "restartPolicy",
+                                        "settings"
+                                    ],
+                                    "properties": {
+                                        "version": {
+                                            "type": "string",
+                                            "examples": [
+                                                "1.0"
+                                            ]
+                                        },
+                                        "type": {
+                                            "$ref": "#/definitions/moduleType"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/status"
+                                        },
+                                        "restartPolicy": {
+                                            "$ref": "#/definitions/restartPolicy"
+                                        },
+                                        "env": {
+                                            "$ref": "#/definitions/env"
+                                        },
+                                        "settings": {
+                                            "$ref": "#/definitions/moduleSettings"
+                                        }
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+            "type": "object",
+            "required": [
+                "properties.desired"
+            ],
+            "properties": {
+                "properties.desired": {
+                    "type": "object"
+                }
+            }
+        }
+    },
+    "definitions": {
+        "moduleType": {
+            "enum": [
+                "docker"
+            ]
+        },
+        "status": {
+            "enum": [
+                "running",
+                "stopped"
+            ]
+        },
+        "restartPolicy": {
+            "enum": [
+                "never",
+                "on-failure",
+                "on-unhealthy",
+                "always"
+            ]
+        },
+        "moduleSettings": {
+            "type": "object",
+            "required": [
+                "image"
+            ],
+            "properties": {
+                "image": {
+                    "type": "string",
+                    "examples": [
+                        "mcr.microsoft.com/azureiotedge-agent:1.0"
+                    ]
+                },
+                "createOptions": {
+                    "$ref": "#/definitions/createOptions"
+                }
+            }
+        },
+        "env": {
+            "type": "object",
+            "patternProperties": {
+                "^[^\\+#$\\s\\.]+$": {
+                    "type": "object",
+                    "required": [
+                        "value"
+                    ],
+                    "properties": {
+                        "value": {
+                            "type": ["number", "string", "boolean"]
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "createOptions": {
+            "type": "string",
+            "contentMediaType": "application/json"
+        }
+    }
+}

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -1,0 +1,324 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "title": "JSON schema for Azure IoT EdgeAgent Deployment version 1.1",
+    "required": [
+        "$edgeAgent",
+    ],
+    "properties": {
+        "$edgeAgent": {
+            "type": "object",
+            "title": "Configuration for the edgeAgent module",
+            "required": [
+                "properties.desired"
+            ],
+            "properties": {
+                "properties.desired": {
+                    "type": "object",
+                    "required": [
+                        "schemaVersion",
+                        "runtime",
+                        "systemModules",
+                        "modules"
+                    ],
+                    "properties": {
+                        "schemaVersion": {
+                            "type": "string",
+                            "pattern": "1.1"
+                        },
+                        "runtime": {
+                            "type": "object",
+                            "required": [
+                                "type",
+                                "settings"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "$ref": "#/definitions/moduleType"
+                                },
+                                "settings": {
+                                    "type": "object",
+                                    "properties": {
+                                        "minDockerVersion": {
+                                            "type": "string",
+                                            "examples": [
+                                                "v1.25"
+                                            ]
+                                        },
+                                        "loggingOptions": {
+                                            "type": "string"
+                                        },
+                                        "registryCredentials": {
+                                            "type": "object",
+                                            "patternProperties": {
+                                                "^[^\\.\\$# ]+$": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "username",
+                                                        "password",
+                                                        "address"
+                                                    ],
+                                                    "properties": {
+                                                        "username": {
+                                                            "type": "string"
+                                                        },
+                                                        "password": {
+                                                            "type": "string"
+                                                        },
+                                                        "address": {
+                                                            "type": "string",
+                                                            "pattern": "^[^\\s]+$"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "patternProperties": {
+                                        "^[^\\.\\$# ]+$": {
+                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "patternProperties": {
+                                "^[^\\.\\$# ]+$": {
+                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "systemModules": {
+                            "type": "object",
+                            "required": [
+                                "edgeAgent",
+                                "edgeHub"
+                            ],
+                            "properties": {
+                                "edgeAgent": {
+                                    "type": "object",
+                                    "required": [
+                                        "type",
+                                        "settings"
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "$ref": "#/definitions/moduleType"
+                                        },
+                                        "settings": {
+                                            "$ref": "#/definitions/moduleSettings"
+                                        },
+                                        "env": {
+                                            "$ref": "#/definitions/env"
+                                        },
+                                        "imagePullPolicy": {
+                                            "$ref": "#/definitions/imagePullPolicy"
+                                        }
+                                    },
+                                    "patternProperties": {
+                                        "^[^\\.\\$# ]+$": {
+                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "edgeHub": {
+                                    "type": "object",
+                                    "title": "The Edgehub Schema",
+                                    "required": [
+                                        "type",
+                                        "settings",
+                                        "status",
+                                        "restartPolicy"
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "$ref": "#/definitions/moduleType"
+                                        },
+                                        "settings": {
+                                            "$ref": "#/definitions/moduleSettings"
+                                        },
+                                        "env": {
+                                            "$ref": "#/definitions/env"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/status"
+                                        },
+                                        "restartPolicy": {
+                                            "$ref": "#/definitions/restartPolicy"
+                                        },
+                                        "imagePullPolicy": {
+                                            "$ref": "#/definitions/imagePullPolicy"
+                                        },
+                                        "startupOrder": {
+                                            "$ref": "#/definitions/startupOrder"
+                                        }
+                                    },
+                                    "patternProperties": {
+                                        "^[^\\.\\$# ]+$": {
+                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "modules": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^[a-zA-Z0-9_-]+$": {
+                                    "type": "object",
+                                    "required": [
+                                        "type",
+                                        "status",
+                                        "restartPolicy",
+                                        "settings"
+                                    ],
+                                    "properties": {
+                                        "version": {
+                                            "type": "string",
+                                            "examples": [
+                                                "1.0"
+                                            ]
+                                        },
+                                        "type": {
+                                            "$ref": "#/definitions/moduleType"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/status"
+                                        },
+                                        "restartPolicy": {
+                                            "$ref": "#/definitions/restartPolicy"
+                                        },
+                                        "env": {
+                                            "$ref": "#/definitions/env"
+                                        },
+                                        "settings": {
+                                            "$ref": "#/definitions/moduleSettings"
+                                        },
+                                        "imagePullPolicy": {
+                                            "$ref": "#/definitions/imagePullPolicy"
+                                        },
+                                        "startupOrder": {
+                                            "$ref": "#/definitions/startupOrder"
+                                        }
+                                    },
+                                    "patternProperties": {
+                                        "^[^\\.\\$# ]+$": {
+                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "patternProperties": {
+                        "^[^\\.\\$# ]+$": {
+                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+            "type": "object",
+            "required": [
+                "properties.desired"
+            ],
+            "properties": {
+                "properties.desired": {
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false,
+    "definitions": {
+        "moduleType": {
+            "enum": [
+                "docker"
+            ]
+        },
+        "status": {
+            "enum": [
+                "running",
+                "stopped"
+            ]
+        },
+        "restartPolicy": {
+            "enum": [
+                "never",
+                "on-failure",
+                "on-unhealthy",
+                "always"
+            ]
+        },
+        "imagePullPolicy": {
+            "enum": [
+                "never",
+                "on-create"
+            ]
+        },
+        "startupOrder": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "moduleSettings": {
+            "type": "object",
+            "required": [
+                "image"
+            ],
+            "properties": {
+                "image": {
+                    "type": "string",
+                    "examples": [
+                        "mcr.microsoft.com/azureiotedge-agent:1.0"
+                    ]
+                },
+                "createOptions": {
+                    "$ref": "#/definitions/createOptions"
+                }
+            },
+            "patternProperties": {
+                "^[^\\.\\$# ]+$": {
+                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                }
+            },
+            "additionalProperties": false
+        },
+        "env": {
+            "type": "object",
+            "patternProperties": {
+                "^[^\\+#$\\s\\.]+$": {
+                    "type": "object",
+                    "required": [
+                        "value"
+                    ],
+                    "properties": {
+                        "value": {
+                            "type": ["number", "string", "boolean"]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "createOptions": {
+            "type": "string",
+            "contentMediaType": "application/json"
+        }
+    }
+}

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -3,7 +3,7 @@
     "type": "object",
     "title": "JSON schema for Azure IoT EdgeAgent Deployment version 1.1",
     "required": [
-        "$edgeAgent",
+        "$edgeAgent"
     ],
     "properties": {
         "$edgeAgent": {

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.0.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "title": "JSON schema for Azure IoT EdgeHub Deployment version 1.0",
+    "required": [
+        "$edgeHub"
+    ],
+    "properties": {
+        "$edgeHub": {
+            "type": "object",
+            "title": "Configuration for the edgeHub module",
+            "required": [
+                "properties.desired"
+            ],
+            "properties": {
+                "properties.desired": {
+                    "type": "object",
+                    "required": [
+                        "schemaVersion",
+                        "routes"
+                    ],
+                    "properties": {
+                        "schemaVersion": {
+                            "type": "string",
+                            "pattern": "1.0"
+                        },
+                        "routes": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^.+$": {
+                                    "type": "string",
+                                    "examples": [
+                                        "FROM /* INTO $upstream"
+                                    ],
+                                    "pattern": "^.+$"
+                                }
+                            }
+                        },
+                        "storeAndForwardConfiguration": {
+                            "type": "object",
+                            "required": [
+                                "timeToLiveSecs"
+                            ],
+                            "properties": {
+                                "timeToLiveSecs": {
+                                    "type": "integer",
+                                    "examples": [
+                                        7200
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+            "type": "object",
+            "required": [
+                "properties.desired"
+            ],
+            "properties": {
+                "properties.desired": {
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.1.json
@@ -1,0 +1,115 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "title": "JSON schema for Azure IoT EdgeHub Deployment version 1.1",
+    "required": [
+        "$edgeHub"
+    ],
+    "properties": {
+        "$edgeHub": {
+            "type": "object",
+            "title": "Configuration for the edgeHub module",
+            "required": [
+                "properties.desired"
+            ],
+            "properties": {
+                "properties.desired": {
+                    "type": "object",
+                    "required": [
+                        "schemaVersion",
+                        "routes"
+                    ],
+                    "properties": {
+                        "schemaVersion": {
+                            "type": "string",
+                            "pattern": "1.1"
+                        },
+                        "routes": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^[^\\.\\$# ]+$": {
+                                    "anyOf": [{
+                                            "type": "object",
+                                            "required": [
+                                                "route"
+                                            ],
+                                            "properties": {
+                                                "route": {
+                                                    "type": "string",
+                                                    "examples": [
+                                                        "FROM /* INTO $upstream"
+                                                    ],
+                                                    "pattern": "^.+$"
+                                                },
+                                                "priority": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "maximum": 9
+                                                },
+                                                "timeToLiveSecs": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "maximum": 4294967295
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }, {
+                                            "type": "string",
+                                            "examples": [
+                                                "FROM /* INTO $upstream"
+                                            ],
+                                            "pattern": "^.+$"
+                                        }
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "storeAndForwardConfiguration": {
+                            "type": "object",
+                            "required": [
+                                "timeToLiveSecs"
+                            ],
+                            "properties": {
+                                "timeToLiveSecs": {
+                                    "type": "integer",
+                                    "examples": [
+                                        7200
+                                    ]
+                                }
+                            },
+                            "patternProperties": {
+                                "^[^\\.\\$# ]+$": {
+                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "patternProperties": {
+                        "^[^\\.\\$# ]+$": {
+                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+            "type": "object",
+            "required": [
+                "properties.desired"
+            ],
+            "properties": {
+                "properties.desired": {
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/test/azure-iot-edgeagent-deployment-1.0/deployment.json
+++ b/src/test/azure-iot-edgeagent-deployment-1.0/deployment.json
@@ -1,0 +1,69 @@
+{
+    "$edgeAgent": {
+        "properties.desired": {
+            "schemaVersion": "1.0",
+            "runtime": {
+                "type": "docker",
+                "settings": {
+                    "minDockerVersion": "v1.25",
+                    "loggingOptions": "",
+                    "registryCredentials": {
+                        "test": {
+                            "address": "test",
+                            "password": "ddd",
+                            "username": "test"
+                        }
+                    }
+                }
+            },
+            "systemModules": {
+                "edgeAgent": {
+                    "type": "docker",
+                    "settings": {
+                        "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+                        "createOptions": "{}"
+                    }
+                },
+                "edgeHub": {
+                    "type": "docker",
+                    "status": "running",
+                    "restartPolicy": "always",
+                    "settings": {
+                        "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+                        "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}],\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
+                    },
+                    "env": {
+                        "OptimizeForPerformance": {
+                            "value": "false"
+                        },
+                        "ddd": {
+                            "value": "s"
+                        }
+                    }
+                }
+            },
+            "modules": {
+                "tempSensor": {
+                    "version": "1.0",
+                    "type": "docker",
+                    "status": "running",
+                    "restartPolicy": "always",
+                    "settings": {
+                        "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
+                        "createOptions": "{}"
+                    }
+                },
+                "CMODULE": {
+                    "version": "1.0",
+                    "type": "docker",
+                    "status": "running",
+                    "restartPolicy": "always",
+                    "settings": {
+                        "image": "localhost:5000/cmodule:0.0.1-amd64",
+                        "createOptions": "{}"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/azure-iot-edgeagent-deployment-1.1/deployment.json
+++ b/src/test/azure-iot-edgeagent-deployment-1.1/deployment.json
@@ -1,0 +1,72 @@
+{
+    "$edgeAgent": {
+        "properties.desired": {
+            "schemaVersion": "1.1",
+            "runtime": {
+                "type": "docker",
+                "settings": {
+                    "minDockerVersion": "v1.25",
+                    "loggingOptions": "",
+                    "registryCredentials": {
+                        "test": {
+                            "address": "test",
+                            "password": "ddd",
+                            "username": "test"
+                        }
+                    }
+                }
+            },
+            "systemModules": {
+                "edgeAgent": {
+                    "type": "docker",
+                    "settings": {
+                        "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+                        "createOptions": "{}"
+                    }
+                },
+                "edgeHub": {
+                    "type": "docker",
+                    "status": "running",
+                    "restartPolicy": "always",
+                    "settings": {
+                        "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+                        "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}],\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
+                    },
+                    "env": {
+                        "OptimizeForPerformance": {
+                            "value": "false"
+                        },
+                        "ddd": {
+                            "value": "s"
+                        },
+                        "BooleanEnv": {
+                            "value": true
+                        }
+                    }
+                }
+            },
+            "modules": {
+                "tempSensor": {
+                    "version": "1.0",
+                    "type": "docker",
+                    "status": "running",
+                    "restartPolicy": "always",
+                    "settings": {
+                        "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
+                        "createOptions": "{}"
+                    }
+                },
+                "CMODULE": {
+                    "version": "1.0",
+                    "type": "docker",
+                    "status": "running",
+                    "restartPolicy": "always",
+                    "settings": {
+                        "image": "localhost:5000/cmodule:0.0.1-amd64",
+                        "createOptions": "{}"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/azure-iot-edgehub-deployment-1.0/deployment.json
+++ b/src/test/azure-iot-edgehub-deployment-1.0/deployment.json
@@ -1,0 +1,15 @@
+{
+    "$edgeHub": {
+        "properties.desired": {
+            "schemaVersion": "1.0",
+            "routes": {
+                "csharpToIoTHub": "FROM /messages/modules/csharp/outputs/* INTO $upstream",
+                "sensorTocmodule": "FROM /messages/modules/tempSensor/outputs/temperatureOutput INTO BrokeredEndpoint(\"/modules/cmodule/inputs/input1\")",
+                "cmoduleToIoTHub": "FROM /messages/modules/cmodule/outputs/* INTO $upstream"
+            },
+            "storeAndForwardConfiguration": {
+                "timeToLiveSecs": 7200
+            }
+        }
+    }
+}

--- a/src/test/azure-iot-edgehub-deployment-1.1/deployment.json
+++ b/src/test/azure-iot-edgehub-deployment-1.1/deployment.json
@@ -1,0 +1,20 @@
+{
+    "$edgeHub": {
+        "properties.desired": {
+            "schemaVersion": "1.1",
+            "routes": {
+                "csharpToIoTHub": "FROM /messages/modules/csharp/outputs/* INTO $upstream",
+                "sensorTocmodule": "FROM /messages/modules/tempSensor/outputs/temperatureOutput INTO BrokeredEndpoint(\"/modules/cmodule/inputs/input1\")",
+                "cmoduleToIoTHub": "FROM /messages/modules/cmodule/outputs/* INTO $upstream",
+                "pri0": {
+                    "route": "FROM /messages/* INTO $upstream",
+                    "priority": 0,
+                    "timeToLiveSecs": 60
+                }
+            },
+            "storeAndForwardConfiguration": {
+                "timeToLiveSecs": 7200
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds new independent schema files for EdgeAgent 1.0/1.1, and EdgeHub 1.0/1.1.

EdgeAgent and EdgeHub are two separate components that can rev their schemas at different frequencies, so having a combined schema for both like we used to is not a maintainable approach.  Going forward, these separated schema files should be the source the truth for deployment manifests, and the existing combined schemas will be deprecated.