### PR TITLE
Fetch github tags as versions for urls

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9,7 +9,7 @@
         ".angular-cli.json",
         "angular-cli.json"
       ],
-      "url": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/schema.json"
+      "url": "https://raw.githubusercontent.com/angular/angular-cli/v10.1.6/packages/angular/cli/lib/config/schema.json"
     },
     {
       "name": "Ansible Role",
@@ -99,7 +99,7 @@
         "arc.yml",
         "arc.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/architect/parser/master/schema.json"
+      "url": "https://raw.githubusercontent.com/architect/parser/v2.3.0/arc-schema.json"
     },
     {
       "name": "Avro Avsc",
@@ -138,7 +138,7 @@
         "azure-pipelines.yml",
         "azure-pipelines.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json"
+      "url": "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/v1.174.2/service-schema.json"
     },
     {
       "name": "Foxx Manifest",
@@ -248,7 +248,7 @@
       "fileMatch": [
         "bsconfig.json"
       ],
-      "url": "https://bucklescript.github.io/bucklescript/docson/build-schema.json"
+      "url": "https://raw.githubusercontent.com/rescript-lang/rescript-compiler/8.2.0/docs/docson/build-schema.json"
     },
     {
       "name": "Bukkit plugin.yml",
@@ -308,7 +308,7 @@
       "fileMatch": [
         "*.camelk.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/apache/camel-k-runtime/master/camel-k-loader-yaml/camel-k-loader-yaml/src/generated/resources/camel-yaml-dsl.json"
+      "url": "https://raw.githubusercontent.com/apache/camel-k-runtime/camel-k-runtime-parent-1.5.0/camel-k-loader-yaml/camel-k-loader-yaml/src/generated/resources/camel-yaml-dsl.json"
     },
     {
       "name": "Carafe",
@@ -322,7 +322,7 @@
     {
       "name": "CityJSON",
       "description": "Schema for the representation of 3D city models",
-      "url": "https://raw.githubusercontent.com/cityjson/specs/master/schemas/cityjson.min.schema.json"
+      "url": "https://raw.githubusercontent.com/cityjson/specs/1.0.1/schemas/cityjson.min.schema.json"
     },
     {
       "name": "CircleCI config.yml",
@@ -450,7 +450,7 @@
         "cloudformation.yml",
         "cloudformation.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json"
+      "url": "https://raw.githubusercontent.com/awslabs/goformation/v4.15.0/schema/cloudformation.schema.json"
     },
     {
       "name": "AWS CloudFormation Serverless Application Model (SAM)",
@@ -463,7 +463,7 @@
         "sam.yml",
         "sam.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/awslabs/goformation/master/schema/sam.schema.json"
+      "url": "https://raw.githubusercontent.com/awslabs/goformation/v4.15.0/schema/sam.schema.json"
     },
     {
       "name": "coffeelint.json",
@@ -511,7 +511,7 @@
       "fileMatch": [
         "cypress.json"
       ],
-      "url": "https://raw.githubusercontent.com/cypress-io/cypress/develop/cli/schema/cypress.schema.json"
+      "url": "https://raw.githubusercontent.com/cypress-io/cypress/v5.3.0/cli/schema/cypress.schema.json"
     },
     {
       "name": ".creatomic",
@@ -529,7 +529,7 @@
         "cspell.json",
         "cSpell.json"
       ],
-      "url": "https://raw.githubusercontent.com/streetsidesoftware/cspell/master/cspell.schema.json"
+      "url": "https://raw.githubusercontent.com/streetsidesoftware/cspell/cspell4/cspell.schema.json"
     },
     {
       "name": ".csscomb.json",
@@ -615,7 +615,7 @@
       "fileMatch": [
         ".dolittle/artifacts.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/master/Schemas/Artifacts.Configuration/artifacts.json"
+      "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/v5.0.0/Schemas/Artifacts.Configuration/artifacts.json"
     },
     {
       "name": "Dolittle Bounded Context Configuration",
@@ -623,7 +623,7 @@
       "fileMatch": [
         "bounded-context.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Applications.Configuration/bounded-context.json"
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/v5.1.1/Schemas/Applications.Configuration/bounded-context.json"
     },
     {
       "name": "Dolittle Event Horizons Configuration",
@@ -631,7 +631,7 @@
       "fileMatch": [
         ".dolittle/event-horizons.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Events/event-horizons.json"
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/v5.1.1/Schemas/Events/event-horizons.json"
     },
     {
       "name": "Dolittle Resources Configuration",
@@ -639,7 +639,7 @@
       "fileMatch": [
         ".dolittle/resources.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/DotNET.Fundamentals/master/Schemas/ResourceTypes.Configuration/resources.json"
+      "url": "https://raw.githubusercontent.com/dolittle/DotNET.Fundamentals/v5.1.0/Schemas/ResourceTypes.Configuration/resources.json"
     },
     {
       "name": "Dolittle Server Configuration",
@@ -647,7 +647,7 @@
       "fileMatch": [
         ".dolittle/server.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Server/server.json"
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/v5.1.1/Schemas/Server/server.json"
     },
     {
       "name": "Dolittle Tenants Configuration",
@@ -655,7 +655,7 @@
       "fileMatch": [
         ".dolittle/tenants.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Tenancy/tenants.json"
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/v5.1.1/Schemas/Tenancy/tenants.json"
     },
     {
       "name": "Dolittle Tenant Map Configuration",
@@ -713,7 +713,7 @@
     {
       "name": "Eclipse Che Devfile",
       "description": "JSON schema for Eclipse Che Devfiles",
-      "url": "https://raw.githubusercontent.com/eclipse/che/master/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
+      "url": "https://raw.githubusercontent.com/eclipse/che/7.19.2/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
       "fileMatch": [
         "devfile.yaml",
         ".devfile.yaml"
@@ -838,7 +838,7 @@
     {
       "name": "GraphQL Mesh",
       "description": "JSON Schema for GraphQL Mesh config file",
-      "url": "https://raw.githubusercontent.com/Urigo/graphql-mesh/master/packages/types/src/config-schema.json",
+      "url": "https://raw.githubusercontent.com/Urigo/graphql-mesh/v0.2.15/packages/types/src/config-schema.json",
       "fileMatch": [
         ".meshrc.yml",
         ".meshrc.yaml",
@@ -851,7 +851,7 @@
     {
       "name": "GraphQL Config",
       "description": "JSON Schema for GraphQL Config config file",
-      "url": "https://raw.githubusercontent.com/kamilkisiela/graphql-config/master/config-schema.json",
+      "url": "https://raw.githubusercontent.com/kamilkisiela/graphql-config/v3.0.3/config-schema.json",
       "fileMatch": [
         "graphql.config.json",
         "graphql.config.js",
@@ -867,7 +867,7 @@
     {
       "name": "GraphQL Code Generator",
       "description": "JSON Schema for GraphQL Code Generator config file",
-      "url": "https://raw.githubusercontent.com/dotansimha/graphql-code-generator/master/website/static/config.schema.json",
+      "url": "https://raw.githubusercontent.com/dotansimha/graphql-code-generator/v1.17.7/website/static/config.schema.json",
       "fileMatch": [
         "codegen.yml",
         "codegen.yaml",
@@ -969,7 +969,7 @@
         "hydra.yaml",
         "hydra.toml"
       ],
-      "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
+      "url": "https://raw.githubusercontent.com/ory/hydra/v1.8.5/.schema/version.schema.json"
     },
     {
       "name": "imageoptimizer.json",
@@ -1107,7 +1107,7 @@
         "keto.yaml",
         "keto.toml"
       ],
-      "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/version.schema.json"
+      "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/config.schema.json"
     },
     {
       "name": "kustomization.yaml",
@@ -1280,7 +1280,7 @@
         "oathkeeper.yaml",
         "oathkeeper.toml"
       ],
-      "url": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schema/version.schema.json"
+      "url": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schemas/config.schema.json"
     },
     {
       "name": "ocelot.json",
@@ -1306,7 +1306,7 @@
         "openapi.yml",
         "openapi.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v3.0/schema.json"
+      "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/3.0.3/schemas/v3.0/schema.json"
     },
     {
       "name": "openfin.json",
@@ -1481,7 +1481,7 @@
       "fileMatch": [
         "*.rules"
       ],
-      "url": "https://json.schemastore.org/prometheus.rules"
+      "url": "https://json.schemastore.org/prometheus.rules.json"
     },
     {
       "name": "proxies.json",
@@ -1656,7 +1656,7 @@
         "skyuxconfig.json",
         "skyuxconfig.*.json"
       ],
-      "url": "https://raw.githubusercontent.com/blackbaud/skyux-builder/master/skyuxconfig-schema.json"
+      "url": "https://raw.githubusercontent.com/blackbaud/skyux-config/4.0.4/skyuxconfig-schema.json"
     },
     {
       "name": "snapcraft",
@@ -1665,7 +1665,7 @@
         ".snapcraft.yaml",
         "snapcraft.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/snapcore/snapcraft/master/schema/snapcraft.json"
+      "url": "https://raw.githubusercontent.com/snapcore/snapcraft/4.3/schema/snapcraft.json"
     },
     {
       "name": "Solidarity",
@@ -1707,7 +1707,7 @@
         "stryker.conf.json",
         "stryker-*.conf.json"
       ],
-      "url": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/api/schema/stryker-core.json"
+      "url": "https://raw.githubusercontent.com/stryker-mutator/stryker/v4.0.0/packages/api/schema/stryker-core.json"
     },
     {
       "name": "StyleCop Analyzers Configuration",
@@ -1715,7 +1715,7 @@
       "fileMatch": [
         "stylecop.json"
       ],
-      "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
+      "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/1.1.118/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
     },
     {
       "name": ".stylelintrc",
@@ -1921,7 +1921,7 @@
       "fileMatch": [
         "version.json"
       ],
-      "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
+      "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/v3.3.37/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
       "name": "vim-addon-info",
@@ -2041,7 +2041,7 @@
       "fileMatch": [
         "*.version"
       ],
-      "url": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/master/KSP-AVC.schema.json"
+      "url": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/1.4.1.5/KSP-AVC.schema.json"
     },
     {
       "name": "KSP-CKAN",
@@ -2049,7 +2049,7 @@
       "fileMatch": [
         "*.ckan"
       ],
-      "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/CKAN.schema"
+      "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/v1.28.0/CKAN.schema"
     },
     {
       "name": "JSON Schema Draft 4",
@@ -2233,7 +2233,7 @@
       "fileMatch": [
         ".taskcat.yml"
       ],
-      "url": "https://raw.githubusercontent.com/aws-quickstart/taskcat/master/taskcat/cfg/config_schema.json"
+      "url": "https://raw.githubusercontent.com/aws-quickstart/taskcat/0.9.20/taskcat/cfg/config_schema.json"
     },
     {
       "name": "BizTalkServerApplicationSchema",
@@ -2263,7 +2263,7 @@
         ".neoload.yml",
         ".neoload.json"
       ],
-      "url": "https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/master/resources/as-code.latest.schema.json"
+      "url": "https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/1.1.4/resources/as-code.latest.schema.json"
     },
     {
       "name": "release drafter",
@@ -2271,7 +2271,7 @@
       "fileMatch": [
         ".github/release-drafter.yml"
       ],
-      "url": "https://raw.githubusercontent.com/release-drafter/release-drafter/master/schema.json"
+      "url": "https://raw.githubusercontent.com/release-drafter/release-drafter/v5.11.0/schema.json"
     },
     {
       "name": "zuul",
@@ -2280,7 +2280,7 @@
         "*zuul.d/*.yaml",
         "*/.zuul.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/pycontribs/zuul-lint/master/zuul_lint/zuul-schema.json"
+      "url": "https://raw.githubusercontent.com/pycontribs/zuul-lint/0.1.1/zuul_lint/zuul-schema.json"
     },
     {
       "name": "Briefcase",
@@ -2296,7 +2296,7 @@
       "fileMatch": [
         "*.har"
       ],
-      "url": "https://raw.githubusercontent.com/ahmadnassri/har-schema/master/lib/har.json"
+      "url": "https://raw.githubusercontent.com/ahmadnassri/har-schema/v2.0.0/lib/har.json"
     },
     {
       "name": "jsdoc",
@@ -2313,7 +2313,7 @@
       "fileMatch": [
         "ray-*-cluster.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/ray-project/ray/master/python/ray/autoscaler/ray-schema.json"
+      "url": "https://raw.githubusercontent.com/ray-project/ray/ray-1.0.0/python/ray/autoscaler/ray-schema.json"
     },
     {
       "name": "Hadolint",
@@ -2382,7 +2382,7 @@
         "**/yippee-*.yml",
         "**/*.yippee.yml"
       ],
-      "url": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json",
+      "url": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/v1.3.2/schema/yippee-ki-json_config_schema.json",
       "versions": {
         "1.1.2": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/v1.1.2/schema/yippee-ki-json_config_schema.json",
         "latest": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json"


### PR DESCRIPTION
This PR uses some heuristics to fetch the most recent "release" of raw github urls. This is done by assuming that the releases are tagged inside git. The idea is that raw github urls should point to a certain release instead of defaulting to a master/main branch if possible. The default branch can be updated and this can cause an url to break. Hopefully raw urls that point to versions will have more permanence. The script is not intended to be integrated in CI at the moment but helps to adjust urls in the catalog.

```bash
$ npm run validate_links

Running "validate_links" task
>> repo https://github.com/angular/angular-cli branch v10.1.6 url should be https://raw.githubusercontent.com/angular/angular-cli/v10.1.6/packages/angular/cli/lib/config/schema.json
...
```