### PR TITLE
Allow null values as an option for inventory hosts

### DIFF
--- a/src/schemas/json/ansible-inventory.json
+++ b/src/schemas/json/ansible-inventory.json
@@ -12,7 +12,7 @@
           "type": "object",
           "patternProperties": {
             "[a-zA-Z.-_0-9]": {
-              "type": "object"
+              "type": ["object", "null"]
             }
           }
         },

--- a/src/test/ansible-inventory/inventory.json
+++ b/src/test/ansible-inventory/inventory.json
@@ -5,7 +5,8 @@
       },
       "test2": {
         "host_var": "value"
-      }
+      },
+      "test_host_null": null
     },
     "vars": {
       "group_all_var": "value"


### PR DESCRIPTION
Fixes #1271 

### Changes
1. Allow host entries in Ansible inventory files to be null.
2. Add test condition in existing test to cover.