### PR TITLE
Add Detekt schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -617,6 +617,15 @@
       "url": "https://json.schemastore.org/dependabot-2.0"
     },
     {
+      "name": "detekt.yml",
+      "description": "Detekt Configuration File schema",
+      "fileMatch": [
+        "detekt.yml",
+        "detekt.yaml"
+      ],
+      "url": "https://json.schemastore.org/detekt"
+    },
+    {
       "name": "docfx.json",
       "description": "A JSON schema for DocFx configuraton files",
       "fileMatch": [

--- a/src/schemas/json/detekt.json
+++ b/src/schemas/json/detekt.json
@@ -1,0 +1,2480 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "build": {
+      "type": "object",
+      "properties": {
+        "maxIssues": {
+          "type": "number"
+        },
+        "excludeCorrectable": {
+          "type": "boolean"
+        },
+        "weights": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "validation": {
+          "type": "boolean"
+        },
+        "warningsAsErrors": {
+          "type": "boolean"
+        },
+        "excludes": {
+          "type": "string"
+        }
+      }
+    },
+    "processors": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "console-reports": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "output-reports": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "exclude": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "comments": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "excludes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AbsentOrWrongFileLicense": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "licenseTemplateFile": {
+              "type": "string"
+            }
+          }
+        },
+        "CommentOverPrivateFunction": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "CommentOverPrivateProperty": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EndOfSentenceFormat": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "endOfSentenceFormat": {
+              "type": "string"
+            }
+          }
+        },
+        "UndocumentedPublicClass": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "searchInNestedClass": {
+              "type": "boolean"
+            },
+            "searchInInnerClass": {
+              "type": "boolean"
+            },
+            "searchInInnerObject": {
+              "type": "boolean"
+            },
+            "searchInInnerInterface": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UndocumentedPublicFunction": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UndocumentedPublicProperty": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "complexity": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "ComplexCondition": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "number"
+            }
+          }
+        },
+        "ComplexInterface": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "number"
+            },
+            "includeStaticDeclarations": {
+              "type": "boolean"
+            },
+            "includePrivateDeclarations": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ComplexMethod": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "number"
+            },
+            "ignoreSingleWhenExpression": {
+              "type": "boolean"
+            },
+            "ignoreSimpleWhenEntries": {
+              "type": "boolean"
+            },
+            "ignoreNestingFunctions": {
+              "type": "boolean"
+            },
+            "nestingFunctions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "LabeledExpression": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ignoredLabels": {
+              "type": "array",
+              "items": {
+                "items": {}
+              }
+            }
+          }
+        },
+        "LargeClass": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "number"
+            }
+          }
+        },
+        "LongMethod": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "number"
+            }
+          }
+        },
+        "LongParameterList": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "functionThreshold": {
+              "type": "number"
+            },
+            "constructorThreshold": {
+              "type": "number"
+            },
+            "ignoreDefaultParameters": {
+              "type": "boolean"
+            },
+            "ignoreDataClasses": {
+              "type": "boolean"
+            },
+            "ignoreAnnotated": {
+              "type": "array",
+              "items": {
+                "items": {}
+              }
+            }
+          }
+        },
+        "MethodOverloading": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "number"
+            }
+          }
+        },
+        "NestedBlockDepth": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "number"
+            }
+          }
+        },
+        "ReplaceSafeCallChainWithRun": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "StringLiteralDuplication": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "threshold": {
+              "type": "number"
+            },
+            "ignoreAnnotation": {
+              "type": "boolean"
+            },
+            "excludeStringsWithLessThan5Characters": {
+              "type": "boolean"
+            },
+            "ignoreStringsRegex": {
+              "type": "string"
+            }
+          }
+        },
+        "TooManyFunctions": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "thresholdInFiles": {
+              "type": "number"
+            },
+            "thresholdInClasses": {
+              "type": "number"
+            },
+            "thresholdInInterfaces": {
+              "type": "number"
+            },
+            "thresholdInObjects": {
+              "type": "number"
+            },
+            "thresholdInEnums": {
+              "type": "number"
+            },
+            "ignoreDeprecated": {
+              "type": "boolean"
+            },
+            "ignorePrivate": {
+              "type": "boolean"
+            },
+            "ignoreOverridden": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "coroutines": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "GlobalCoroutineUsage": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "RedundantSuspendModifier": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SuspendFunWithFlowReturnType": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "empty-blocks": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "EmptyCatchBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "allowedExceptionNameRegex": {
+              "type": "string"
+            }
+          }
+        },
+        "EmptyClassBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyDefaultConstructor": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyDoWhileBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyElseBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyFinallyBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyForBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyFunctionBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ignoreOverridden": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyIfBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyInitBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyKtFile": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptySecondaryConstructor": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyTryBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyWhenBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EmptyWhileBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "exceptions": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "ExceptionRaisedInUnexpectedLocation": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "methodNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "InstanceOfCheckForException": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "NotImplementedDeclaration": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "PrintStackTrace": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "RethrowCaughtException": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ReturnFromFinally": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ignoreLabeled": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SwallowedException": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ignoredExceptionTypes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allowedExceptionNameRegex": {
+              "type": "string"
+            }
+          }
+        },
+        "ThrowingExceptionFromFinally": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ThrowingExceptionInMain": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ThrowingExceptionsWithoutMessageOrCause": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exceptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "ThrowingNewInstanceOfSameException": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "TooGenericExceptionCaught": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exceptionNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allowedExceptionNameRegex": {
+              "type": "string"
+            }
+          }
+        },
+        "TooGenericExceptionThrown": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "exceptionNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "formatting": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "android": {
+          "type": "boolean"
+        },
+        "autoCorrect": {
+          "type": "boolean"
+        },
+        "AnnotationOnSeparateLine": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "AnnotationSpacing": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ArgumentListWrapping": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ChainWrapping": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "CommentSpacing": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EnumEntryNameCase": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "Filename": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "FinalNewline": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            },
+            "insertFinalNewLine": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ImportOrdering": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            },
+            "layout": {
+              "type": "string"
+            }
+          }
+        },
+        "Indentation": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            },
+            "indentSize": {
+              "type": "number"
+            },
+            "continuationIndentSize": {
+              "type": "number"
+            }
+          }
+        },
+        "MaximumLineLength": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "maxLineLength": {
+              "type": "number"
+            }
+          }
+        },
+        "ModifierOrdering": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "MultiLineIfElse": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoBlankLineBeforeRbrace": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoConsecutiveBlankLines": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoEmptyClassBody": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoEmptyFirstLineInMethodBlock": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoLineBreakAfterElse": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoLineBreakBeforeAssignment": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoMultipleSpaces": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoSemicolons": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoTrailingSpaces": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoUnitReturn": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoUnusedImports": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoWildcardImports": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "PackageName": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ParameterListWrapping": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            },
+            "indentSize": {
+              "type": "number"
+            }
+          }
+        },
+        "SpacingAroundColon": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingAroundComma": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingAroundCurly": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingAroundDot": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingAroundDoubleColon": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingAroundKeyword": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingAroundOperators": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingAroundParens": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingAroundRangeOperator": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingBetweenDeclarationsWithAnnotations": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingBetweenDeclarationsWithComments": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        },
+        "StringTemplate": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "autoCorrect": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "naming": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "ClassNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "classPattern": {
+              "type": "string"
+            }
+          }
+        },
+        "ConstructorParameterNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "parameterPattern": {
+              "type": "string"
+            },
+            "privateParameterPattern": {
+              "type": "string"
+            },
+            "excludeClassPattern": {
+              "type": "string"
+            },
+            "ignoreOverridden": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EnumNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "enumEntryPattern": {
+              "type": "string"
+            }
+          }
+        },
+        "ForbiddenClassName": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "forbiddenName": {
+              "type": "array",
+              "items": {
+                "items": {}
+              }
+            }
+          }
+        },
+        "FunctionMaxLength": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "maximumFunctionNameLength": {
+              "type": "number"
+            }
+          }
+        },
+        "FunctionMinLength": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "minimumFunctionNameLength": {
+              "type": "number"
+            }
+          }
+        },
+        "FunctionNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "functionPattern": {
+              "type": "string"
+            },
+            "excludeClassPattern": {
+              "type": "string"
+            },
+            "ignoreOverridden": {
+              "type": "boolean"
+            },
+            "ignoreAnnotated": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "FunctionParameterNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "parameterPattern": {
+              "type": "string"
+            },
+            "excludeClassPattern": {
+              "type": "string"
+            },
+            "ignoreOverridden": {
+              "type": "boolean"
+            }
+          }
+        },
+        "InvalidPackageDeclaration": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "rootPackage": {
+              "type": "string"
+            }
+          }
+        },
+        "MatchingDeclarationName": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "mustBeFirst": {
+              "type": "boolean"
+            }
+          }
+        },
+        "MemberNameEqualsClassName": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ignoreOverridden": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NonBooleanPropertyPrefixedWithIs": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "ObjectPropertyNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "constantPattern": {
+              "type": "string"
+            },
+            "propertyPattern": {
+              "type": "string"
+            },
+            "privatePropertyPattern": {
+              "type": "string"
+            }
+          }
+        },
+        "PackageNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "packagePattern": {
+              "type": "string"
+            }
+          }
+        },
+        "TopLevelPropertyNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "constantPattern": {
+              "type": "string"
+            },
+            "propertyPattern": {
+              "type": "string"
+            },
+            "privatePropertyPattern": {
+              "type": "string"
+            }
+          }
+        },
+        "VariableMaxLength": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "maximumVariableNameLength": {
+              "type": "number"
+            }
+          }
+        },
+        "VariableMinLength": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "minimumVariableNameLength": {
+              "type": "number"
+            }
+          }
+        },
+        "VariableNaming": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "variablePattern": {
+              "type": "string"
+            },
+            "privateVariablePattern": {
+              "type": "string"
+            },
+            "excludeClassPattern": {
+              "type": "string"
+            },
+            "ignoreOverridden": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "performance": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "ArrayPrimitive": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ForEachOnRange": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "SpreadOperator": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "UnnecessaryTemporaryInstantiation": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "potential-bugs": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "Deprecation": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "DuplicateCaseInWhenExpression": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EqualsAlwaysReturnsTrueOrFalse": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EqualsWithHashCodeExist": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ExplicitGarbageCollectionCall": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "HasPlatformType": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "IgnoredReturnValue": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "restrictToAnnotatedMethods": {
+              "type": "boolean"
+            },
+            "returnValueAnnotations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "ImplicitDefaultLocale": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ImplicitUnitReturnType": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "allowExplicitReturnType": {
+              "type": "boolean"
+            }
+          }
+        },
+        "InvalidRange": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "IteratorHasNextCallsNextMethod": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "IteratorNotThrowingNoSuchElementException": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "LateinitUsage": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "excludeAnnotatedProperties": {
+              "type": "array",
+              "items": {
+                "items": {}
+              }
+            },
+            "ignoreOnClassesPattern": {
+              "type": "string"
+            }
+          }
+        },
+        "MapGetWithNotNullAssertionOperator": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "MissingWhenCase": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NullableToStringCall": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "RedundantElseInWhen": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnconditionalJumpStatementInLoop": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnnecessaryNotNullOperator": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnnecessarySafeCall": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnreachableCode": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnsafeCallOnNullableType": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnsafeCast": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UselessPostfixExpression": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "WrongEqualsTypeParameter": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "style": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "ClassOrdering": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "CollapsibleIfStatements": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "DataClassContainsFunctions": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "conversionFunctionPrefix": {
+              "type": "string"
+            }
+          }
+        },
+        "DataClassShouldBeImmutable": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EqualsNullCall": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "EqualsOnSignatureLine": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ExplicitCollectionElementAccessMethod": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ExplicitItLambdaParameter": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ExpressionBodySyntax": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "includeLineWrapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ForbiddenComment": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allowedPatterns": {
+              "type": "string"
+            }
+          }
+        },
+        "ForbiddenImport": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "imports": {
+              "type": "array",
+              "items": {
+                "items": {}
+              }
+            },
+            "forbiddenPatterns": {
+              "type": "string"
+            }
+          }
+        },
+        "ForbiddenMethodCall": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "methods": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "ForbiddenPublicDataClass": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ignorePackages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "ForbiddenVoid": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ignoreOverridden": {
+              "type": "boolean"
+            },
+            "ignoreUsageInGenerics": {
+              "type": "boolean"
+            }
+          }
+        },
+        "FunctionOnlyReturningConstant": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "ignoreOverridableFunction": {
+              "type": "boolean"
+            },
+            "excludedFunctions": {
+              "type": "string"
+            },
+            "excludeAnnotatedFunction": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "LibraryCodeMustSpecifyReturnType": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "LibraryEntitiesShouldNotBePublic": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "LoopWithTooManyJumpStatements": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "maxJumpCount": {
+              "type": "number"
+            }
+          }
+        },
+        "MagicNumber": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignoreNumbers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignoreHashCodeFunction": {
+              "type": "boolean"
+            },
+            "ignorePropertyDeclaration": {
+              "type": "boolean"
+            },
+            "ignoreLocalVariableDeclaration": {
+              "type": "boolean"
+            },
+            "ignoreConstantDeclaration": {
+              "type": "boolean"
+            },
+            "ignoreCompanionObjectPropertyDeclaration": {
+              "type": "boolean"
+            },
+            "ignoreAnnotation": {
+              "type": "boolean"
+            },
+            "ignoreNamedArgument": {
+              "type": "boolean"
+            },
+            "ignoreEnums": {
+              "type": "boolean"
+            },
+            "ignoreRanges": {
+              "type": "boolean"
+            }
+          }
+        },
+        "MandatoryBracesIfStatements": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "MandatoryBracesLoops": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "MaxLineLength": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "maxLineLength": {
+              "type": "number"
+            },
+            "excludePackageStatements": {
+              "type": "boolean"
+            },
+            "excludeImportStatements": {
+              "type": "boolean"
+            },
+            "excludeCommentStatements": {
+              "type": "boolean"
+            }
+          }
+        },
+        "MayBeConst": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ModifierOrder": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NestedClassesVisibility": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NewLineAtEndOfFile": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "NoTabs": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "OptionalAbstractKeyword": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "OptionalUnit": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "OptionalWhenBraces": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "PreferToOverPairSyntax": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ProtectedMemberInFinalClass": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "RedundantExplicitType": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "RedundantVisibilityModifierRule": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ReturnCount": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "max": {
+              "type": "number"
+            },
+            "excludedFunctions": {
+              "type": "string"
+            },
+            "excludeLabeled": {
+              "type": "boolean"
+            },
+            "excludeReturnFromLambda": {
+              "type": "boolean"
+            },
+            "excludeGuardClauses": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SafeCast": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SerialVersionUIDInSerializableClass": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "SpacingBetweenPackageAndImports": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "ThrowsCount": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "max": {
+              "type": "number"
+            }
+          }
+        },
+        "TrailingWhitespace": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnderscoresInNumericLiterals": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "acceptableDecimalLength": {
+              "type": "number"
+            }
+          }
+        },
+        "UnnecessaryAbstractClass": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludeAnnotatedClasses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "UnnecessaryAnnotationUseSiteTarget": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnnecessaryApply": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnnecessaryInheritance": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnnecessaryLet": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnnecessaryParentheses": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UntilInsteadOfRangeTo": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnusedImports": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnusedPrivateClass": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UnusedPrivateMember": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "allowedNames": {
+              "type": "string"
+            }
+          }
+        },
+        "UseArrayLiteralsInAnnotations": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UseCheckNotNull": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UseCheckOrError": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UseDataClass": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludeAnnotatedClasses": {
+              "type": "array",
+              "items": {
+                "items": {}
+              }
+            },
+            "allowVars": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UseEmptyCounterpart": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UseIfInsteadOfWhen": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UseRequire": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UseRequireNotNull": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UselessCallOnNotNull": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "UtilityClassWithPublicConstructor": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "VarCouldBeVal": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            }
+          }
+        },
+        "WildcardImport": {
+          "type": "object",
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "excludes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "excludeImports": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/detekt/default-detekt-config.json
+++ b/src/test/detekt/default-detekt-config.json
@@ -1,0 +1,1099 @@
+{
+  "build": {
+    "maxIssues": 0,
+    "excludeCorrectable": false,
+    "weights": null
+  },
+  "config": {
+    "validation": true,
+    "warningsAsErrors": false,
+    "excludes": ""
+  },
+  "processors": {
+    "active": true,
+    "exclude": [
+      "DetektProgressListener"
+    ]
+  },
+  "console-reports": {
+    "active": true,
+    "exclude": [
+      "ProjectStatisticsReport",
+      "ComplexityReport",
+      "NotificationReport",
+      "FileBasedFindingsReport"
+    ]
+  },
+  "output-reports": {
+    "active": true,
+    "exclude": null
+  },
+  "comments": {
+    "active": true,
+    "excludes": [
+      "**/test/**",
+      "**/androidTest/**",
+      "**/commonTest/**",
+      "**/jvmTest/**",
+      "**/jsTest/**",
+      "**/iosTest/**"
+    ],
+    "AbsentOrWrongFileLicense": {
+      "active": false,
+      "licenseTemplateFile": "license.template"
+    },
+    "CommentOverPrivateFunction": {
+      "active": false
+    },
+    "CommentOverPrivateProperty": {
+      "active": false
+    },
+    "EndOfSentenceFormat": {
+      "active": false,
+      "endOfSentenceFormat": "([.?!][ \\t\\n\\r\\f<])|([.?!:]$)"
+    },
+    "UndocumentedPublicClass": {
+      "active": false,
+      "searchInNestedClass": true,
+      "searchInInnerClass": true,
+      "searchInInnerObject": true,
+      "searchInInnerInterface": true
+    },
+    "UndocumentedPublicFunction": {
+      "active": false
+    },
+    "UndocumentedPublicProperty": {
+      "active": false
+    }
+  },
+  "complexity": {
+    "active": true,
+    "ComplexCondition": {
+      "active": true,
+      "threshold": 4
+    },
+    "ComplexInterface": {
+      "active": false,
+      "threshold": 10,
+      "includeStaticDeclarations": false,
+      "includePrivateDeclarations": false
+    },
+    "ComplexMethod": {
+      "active": true,
+      "threshold": 15,
+      "ignoreSingleWhenExpression": false,
+      "ignoreSimpleWhenEntries": false,
+      "ignoreNestingFunctions": false,
+      "nestingFunctions": [
+        "run",
+        "let",
+        "apply",
+        "with",
+        "also",
+        "use",
+        "forEach",
+        "isNotNull",
+        "ifNull"
+      ]
+    },
+    "LabeledExpression": {
+      "active": false,
+      "ignoredLabels": []
+    },
+    "LargeClass": {
+      "active": true,
+      "threshold": 600
+    },
+    "LongMethod": {
+      "active": true,
+      "threshold": 60
+    },
+    "LongParameterList": {
+      "active": true,
+      "functionThreshold": 6,
+      "constructorThreshold": 7,
+      "ignoreDefaultParameters": false,
+      "ignoreDataClasses": true,
+      "ignoreAnnotated": []
+    },
+    "MethodOverloading": {
+      "active": false,
+      "threshold": 6
+    },
+    "NestedBlockDepth": {
+      "active": true,
+      "threshold": 4
+    },
+    "ReplaceSafeCallChainWithRun": {
+      "active": false
+    },
+    "StringLiteralDuplication": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "threshold": 3,
+      "ignoreAnnotation": true,
+      "excludeStringsWithLessThan5Characters": true,
+      "ignoreStringsRegex": "$^"
+    },
+    "TooManyFunctions": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "thresholdInFiles": 11,
+      "thresholdInClasses": 11,
+      "thresholdInInterfaces": 11,
+      "thresholdInObjects": 11,
+      "thresholdInEnums": 11,
+      "ignoreDeprecated": false,
+      "ignorePrivate": false,
+      "ignoreOverridden": false
+    }
+  },
+  "coroutines": {
+    "active": true,
+    "GlobalCoroutineUsage": {
+      "active": false
+    },
+    "RedundantSuspendModifier": {
+      "active": false
+    },
+    "SuspendFunWithFlowReturnType": {
+      "active": false
+    }
+  },
+  "empty-blocks": {
+    "active": true,
+    "EmptyCatchBlock": {
+      "active": true,
+      "allowedExceptionNameRegex": "_|(ignore|expected).*"
+    },
+    "EmptyClassBlock": {
+      "active": true
+    },
+    "EmptyDefaultConstructor": {
+      "active": true
+    },
+    "EmptyDoWhileBlock": {
+      "active": true
+    },
+    "EmptyElseBlock": {
+      "active": true
+    },
+    "EmptyFinallyBlock": {
+      "active": true
+    },
+    "EmptyForBlock": {
+      "active": true
+    },
+    "EmptyFunctionBlock": {
+      "active": true,
+      "ignoreOverridden": false
+    },
+    "EmptyIfBlock": {
+      "active": true
+    },
+    "EmptyInitBlock": {
+      "active": true
+    },
+    "EmptyKtFile": {
+      "active": true
+    },
+    "EmptySecondaryConstructor": {
+      "active": true
+    },
+    "EmptyTryBlock": {
+      "active": true
+    },
+    "EmptyWhenBlock": {
+      "active": true
+    },
+    "EmptyWhileBlock": {
+      "active": true
+    }
+  },
+  "exceptions": {
+    "active": true,
+    "ExceptionRaisedInUnexpectedLocation": {
+      "active": false,
+      "methodNames": [
+        "toString",
+        "hashCode",
+        "equals",
+        "finalize"
+      ]
+    },
+    "InstanceOfCheckForException": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ]
+    },
+    "NotImplementedDeclaration": {
+      "active": false
+    },
+    "PrintStackTrace": {
+      "active": false
+    },
+    "RethrowCaughtException": {
+      "active": false
+    },
+    "ReturnFromFinally": {
+      "active": false,
+      "ignoreLabeled": false
+    },
+    "SwallowedException": {
+      "active": false,
+      "ignoredExceptionTypes": [
+        "InterruptedException",
+        "NumberFormatException",
+        "ParseException",
+        "MalformedURLException"
+      ],
+      "allowedExceptionNameRegex": "_|(ignore|expected).*"
+    },
+    "ThrowingExceptionFromFinally": {
+      "active": false
+    },
+    "ThrowingExceptionInMain": {
+      "active": false
+    },
+    "ThrowingExceptionsWithoutMessageOrCause": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "exceptions": [
+        "IllegalArgumentException",
+        "IllegalStateException",
+        "IOException"
+      ]
+    },
+    "ThrowingNewInstanceOfSameException": {
+      "active": false
+    },
+    "TooGenericExceptionCaught": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "exceptionNames": [
+        "ArrayIndexOutOfBoundsException",
+        "Error",
+        "Exception",
+        "IllegalMonitorStateException",
+        "NullPointerException",
+        "IndexOutOfBoundsException",
+        "RuntimeException",
+        "Throwable"
+      ],
+      "allowedExceptionNameRegex": "_|(ignore|expected).*"
+    },
+    "TooGenericExceptionThrown": {
+      "active": true,
+      "exceptionNames": [
+        "Error",
+        "Exception",
+        "Throwable",
+        "RuntimeException"
+      ]
+    }
+  },
+  "formatting": {
+    "active": true,
+    "android": false,
+    "autoCorrect": true,
+    "AnnotationOnSeparateLine": {
+      "active": false,
+      "autoCorrect": true
+    },
+    "AnnotationSpacing": {
+      "active": false,
+      "autoCorrect": true
+    },
+    "ArgumentListWrapping": {
+      "active": false,
+      "autoCorrect": true
+    },
+    "ChainWrapping": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "CommentSpacing": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "EnumEntryNameCase": {
+      "active": false,
+      "autoCorrect": true
+    },
+    "Filename": {
+      "active": true
+    },
+    "FinalNewline": {
+      "active": true,
+      "autoCorrect": true,
+      "insertFinalNewLine": true
+    },
+    "ImportOrdering": {
+      "active": false,
+      "autoCorrect": true,
+      "layout": "idea"
+    },
+    "Indentation": {
+      "active": false,
+      "autoCorrect": true,
+      "indentSize": 4,
+      "continuationIndentSize": 4
+    },
+    "MaximumLineLength": {
+      "active": true,
+      "maxLineLength": 120
+    },
+    "ModifierOrdering": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "MultiLineIfElse": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoBlankLineBeforeRbrace": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoConsecutiveBlankLines": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoEmptyClassBody": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoEmptyFirstLineInMethodBlock": {
+      "active": false,
+      "autoCorrect": true
+    },
+    "NoLineBreakAfterElse": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoLineBreakBeforeAssignment": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoMultipleSpaces": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoSemicolons": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoTrailingSpaces": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoUnitReturn": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoUnusedImports": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "NoWildcardImports": {
+      "active": true
+    },
+    "PackageName": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "ParameterListWrapping": {
+      "active": true,
+      "autoCorrect": true,
+      "indentSize": 4
+    },
+    "SpacingAroundColon": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "SpacingAroundComma": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "SpacingAroundCurly": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "SpacingAroundDot": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "SpacingAroundDoubleColon": {
+      "active": false,
+      "autoCorrect": true
+    },
+    "SpacingAroundKeyword": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "SpacingAroundOperators": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "SpacingAroundParens": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "SpacingAroundRangeOperator": {
+      "active": true,
+      "autoCorrect": true
+    },
+    "SpacingBetweenDeclarationsWithAnnotations": {
+      "active": false,
+      "autoCorrect": true
+    },
+    "SpacingBetweenDeclarationsWithComments": {
+      "active": false,
+      "autoCorrect": true
+    },
+    "StringTemplate": {
+      "active": true,
+      "autoCorrect": true
+    }
+  },
+  "naming": {
+    "active": true,
+    "ClassNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "classPattern": "[A-Z][a-zA-Z0-9]*"
+    },
+    "ConstructorParameterNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "parameterPattern": "[a-z][A-Za-z0-9]*",
+      "privateParameterPattern": "[a-z][A-Za-z0-9]*",
+      "excludeClassPattern": "$^",
+      "ignoreOverridden": true
+    },
+    "EnumNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "enumEntryPattern": "[A-Z][_a-zA-Z0-9]*"
+    },
+    "ForbiddenClassName": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "forbiddenName": []
+    },
+    "FunctionMaxLength": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "maximumFunctionNameLength": 30
+    },
+    "FunctionMinLength": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "minimumFunctionNameLength": 3
+    },
+    "FunctionNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "functionPattern": "([a-z][a-zA-Z0-9]*)|(`.*`)",
+      "excludeClassPattern": "$^",
+      "ignoreOverridden": true,
+      "ignoreAnnotated": [
+        "Composable"
+      ]
+    },
+    "FunctionParameterNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "parameterPattern": "[a-z][A-Za-z0-9]*",
+      "excludeClassPattern": "$^",
+      "ignoreOverridden": true
+    },
+    "InvalidPackageDeclaration": {
+      "active": false,
+      "rootPackage": ""
+    },
+    "MatchingDeclarationName": {
+      "active": true,
+      "mustBeFirst": true
+    },
+    "MemberNameEqualsClassName": {
+      "active": true,
+      "ignoreOverridden": true
+    },
+    "NonBooleanPropertyPrefixedWithIs": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ]
+    },
+    "ObjectPropertyNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "constantPattern": "[A-Za-z][_A-Za-z0-9]*",
+      "propertyPattern": "[A-Za-z][_A-Za-z0-9]*",
+      "privatePropertyPattern": "(_)?[A-Za-z][_A-Za-z0-9]*"
+    },
+    "PackageNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "packagePattern": "[a-z]+(\\.[a-z][A-Za-z0-9]*)*"
+    },
+    "TopLevelPropertyNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "constantPattern": "[A-Z][_A-Z0-9]*",
+      "propertyPattern": "[A-Za-z][_A-Za-z0-9]*",
+      "privatePropertyPattern": "_?[A-Za-z][_A-Za-z0-9]*"
+    },
+    "VariableMaxLength": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "maximumVariableNameLength": 64
+    },
+    "VariableMinLength": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "minimumVariableNameLength": 1
+    },
+    "VariableNaming": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "variablePattern": "[a-z][A-Za-z0-9]*",
+      "privateVariablePattern": "(_)?[a-z][A-Za-z0-9]*",
+      "excludeClassPattern": "$^",
+      "ignoreOverridden": true
+    }
+  },
+  "performance": {
+    "active": true,
+    "ArrayPrimitive": {
+      "active": true
+    },
+    "ForEachOnRange": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ]
+    },
+    "SpreadOperator": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ]
+    },
+    "UnnecessaryTemporaryInstantiation": {
+      "active": true
+    }
+  },
+  "potential-bugs": {
+    "active": true,
+    "Deprecation": {
+      "active": false
+    },
+    "DuplicateCaseInWhenExpression": {
+      "active": true
+    },
+    "EqualsAlwaysReturnsTrueOrFalse": {
+      "active": true
+    },
+    "EqualsWithHashCodeExist": {
+      "active": true
+    },
+    "ExplicitGarbageCollectionCall": {
+      "active": true
+    },
+    "HasPlatformType": {
+      "active": false
+    },
+    "IgnoredReturnValue": {
+      "active": false,
+      "restrictToAnnotatedMethods": true,
+      "returnValueAnnotations": [
+        "*.CheckReturnValue",
+        "*.CheckResult"
+      ]
+    },
+    "ImplicitDefaultLocale": {
+      "active": false
+    },
+    "ImplicitUnitReturnType": {
+      "active": false,
+      "allowExplicitReturnType": true
+    },
+    "InvalidRange": {
+      "active": true
+    },
+    "IteratorHasNextCallsNextMethod": {
+      "active": true
+    },
+    "IteratorNotThrowingNoSuchElementException": {
+      "active": true
+    },
+    "LateinitUsage": {
+      "active": false,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "excludeAnnotatedProperties": [],
+      "ignoreOnClassesPattern": ""
+    },
+    "MapGetWithNotNullAssertionOperator": {
+      "active": false
+    },
+    "MissingWhenCase": {
+      "active": true
+    },
+    "NullableToStringCall": {
+      "active": false
+    },
+    "RedundantElseInWhen": {
+      "active": true
+    },
+    "UnconditionalJumpStatementInLoop": {
+      "active": false
+    },
+    "UnnecessaryNotNullOperator": {
+      "active": false
+    },
+    "UnnecessarySafeCall": {
+      "active": false
+    },
+    "UnreachableCode": {
+      "active": true
+    },
+    "UnsafeCallOnNullableType": {
+      "active": true
+    },
+    "UnsafeCast": {
+      "active": false
+    },
+    "UselessPostfixExpression": {
+      "active": false
+    },
+    "WrongEqualsTypeParameter": {
+      "active": true
+    }
+  },
+  "style": {
+    "active": true,
+    "ClassOrdering": {
+      "active": false
+    },
+    "CollapsibleIfStatements": {
+      "active": false
+    },
+    "DataClassContainsFunctions": {
+      "active": false,
+      "conversionFunctionPrefix": "to"
+    },
+    "DataClassShouldBeImmutable": {
+      "active": false
+    },
+    "EqualsNullCall": {
+      "active": true
+    },
+    "EqualsOnSignatureLine": {
+      "active": false
+    },
+    "ExplicitCollectionElementAccessMethod": {
+      "active": false
+    },
+    "ExplicitItLambdaParameter": {
+      "active": false
+    },
+    "ExpressionBodySyntax": {
+      "active": false,
+      "includeLineWrapping": false
+    },
+    "ForbiddenComment": {
+      "active": true,
+      "values": [
+        "TODO:",
+        "FIXME:",
+        "STOPSHIP:"
+      ],
+      "allowedPatterns": ""
+    },
+    "ForbiddenImport": {
+      "active": false,
+      "imports": [],
+      "forbiddenPatterns": ""
+    },
+    "ForbiddenMethodCall": {
+      "active": false,
+      "methods": [
+        "kotlin.io.println",
+        "kotlin.io.print"
+      ]
+    },
+    "ForbiddenPublicDataClass": {
+      "active": false,
+      "ignorePackages": [
+        "*.internal",
+        "*.internal.*"
+      ]
+    },
+    "ForbiddenVoid": {
+      "active": false,
+      "ignoreOverridden": false,
+      "ignoreUsageInGenerics": false
+    },
+    "FunctionOnlyReturningConstant": {
+      "active": true,
+      "ignoreOverridableFunction": true,
+      "excludedFunctions": "describeContents",
+      "excludeAnnotatedFunction": [
+        "dagger.Provides"
+      ]
+    },
+    "LibraryCodeMustSpecifyReturnType": {
+      "active": true
+    },
+    "LibraryEntitiesShouldNotBePublic": {
+      "active": false
+    },
+    "LoopWithTooManyJumpStatements": {
+      "active": true,
+      "maxJumpCount": 1
+    },
+    "MagicNumber": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "ignoreNumbers": [
+        "-1",
+        "0",
+        "1",
+        "2"
+      ],
+      "ignoreHashCodeFunction": true,
+      "ignorePropertyDeclaration": false,
+      "ignoreLocalVariableDeclaration": false,
+      "ignoreConstantDeclaration": true,
+      "ignoreCompanionObjectPropertyDeclaration": true,
+      "ignoreAnnotation": false,
+      "ignoreNamedArgument": true,
+      "ignoreEnums": false,
+      "ignoreRanges": false
+    },
+    "MandatoryBracesIfStatements": {
+      "active": false
+    },
+    "MandatoryBracesLoops": {
+      "active": false
+    },
+    "MaxLineLength": {
+      "active": true,
+      "maxLineLength": 120,
+      "excludePackageStatements": true,
+      "excludeImportStatements": true,
+      "excludeCommentStatements": false
+    },
+    "MayBeConst": {
+      "active": true
+    },
+    "ModifierOrder": {
+      "active": true
+    },
+    "NestedClassesVisibility": {
+      "active": false
+    },
+    "NewLineAtEndOfFile": {
+      "active": true
+    },
+    "NoTabs": {
+      "active": false
+    },
+    "OptionalAbstractKeyword": {
+      "active": true
+    },
+    "OptionalUnit": {
+      "active": false
+    },
+    "OptionalWhenBraces": {
+      "active": false
+    },
+    "PreferToOverPairSyntax": {
+      "active": false
+    },
+    "ProtectedMemberInFinalClass": {
+      "active": true
+    },
+    "RedundantExplicitType": {
+      "active": false
+    },
+    "RedundantVisibilityModifierRule": {
+      "active": false
+    },
+    "ReturnCount": {
+      "active": true,
+      "max": 2,
+      "excludedFunctions": "equals",
+      "excludeLabeled": false,
+      "excludeReturnFromLambda": true,
+      "excludeGuardClauses": false
+    },
+    "SafeCast": {
+      "active": true
+    },
+    "SerialVersionUIDInSerializableClass": {
+      "active": false
+    },
+    "SpacingBetweenPackageAndImports": {
+      "active": false
+    },
+    "ThrowsCount": {
+      "active": true,
+      "max": 2
+    },
+    "TrailingWhitespace": {
+      "active": false
+    },
+    "UnderscoresInNumericLiterals": {
+      "active": false,
+      "acceptableDecimalLength": 5
+    },
+    "UnnecessaryAbstractClass": {
+      "active": true,
+      "excludeAnnotatedClasses": [
+        "dagger.Module"
+      ]
+    },
+    "UnnecessaryAnnotationUseSiteTarget": {
+      "active": false
+    },
+    "UnnecessaryApply": {
+      "active": false
+    },
+    "UnnecessaryInheritance": {
+      "active": true
+    },
+    "UnnecessaryLet": {
+      "active": false
+    },
+    "UnnecessaryParentheses": {
+      "active": false
+    },
+    "UntilInsteadOfRangeTo": {
+      "active": false
+    },
+    "UnusedImports": {
+      "active": false
+    },
+    "UnusedPrivateClass": {
+      "active": true
+    },
+    "UnusedPrivateMember": {
+      "active": false,
+      "allowedNames": "(_|ignored|expected|serialVersionUID)"
+    },
+    "UseArrayLiteralsInAnnotations": {
+      "active": false
+    },
+    "UseCheckNotNull": {
+      "active": false
+    },
+    "UseCheckOrError": {
+      "active": false
+    },
+    "UseDataClass": {
+      "active": false,
+      "excludeAnnotatedClasses": [],
+      "allowVars": false
+    },
+    "UseEmptyCounterpart": {
+      "active": false
+    },
+    "UseIfInsteadOfWhen": {
+      "active": false
+    },
+    "UseRequire": {
+      "active": false
+    },
+    "UseRequireNotNull": {
+      "active": false
+    },
+    "UselessCallOnNotNull": {
+      "active": true
+    },
+    "UtilityClassWithPublicConstructor": {
+      "active": true
+    },
+    "VarCouldBeVal": {
+      "active": false
+    },
+    "WildcardImport": {
+      "active": true,
+      "excludes": [
+        "**/test/**",
+        "**/androidTest/**",
+        "**/commonTest/**",
+        "**/jvmTest/**",
+        "**/jsTest/**",
+        "**/iosTest/**"
+      ],
+      "excludeImports": [
+        "java.util.*",
+        "kotlinx.android.synthetic.*"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is a generated schema from default-detekt-config.json.

Notes:
1. Null values are properly typed
2. Integers are changed to numbers (prime source of future issues)

Fixes #1234  

Since change in configuration mechanism is [proposed](https://github.com/SchemaStore/schemastore/issues/1234#issuecomment-706876022), we might be able to generate schemas directly from detekt's code, instead of relying on inference. Meanwhile this should be good enough.