### PR TITLE
Add pm2 ecosystem config json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -738,6 +738,16 @@
       ]
     },
     {
+      "name": "ecosystem.json",
+      "description": "pm2 ecosystem config file",
+      "fileMatch": [
+        "ecosystem.json",
+        "ecosystem.yml",
+        "ecosystem.yaml"
+      ],
+      "url": "https://json.schemastore.org/pm2-ecosystem"
+    },
+    {
       "name": "Esquio",
       "description": "JSON schema for Esquio configuration files",
       "url": "https://json.schemastore.org/esquio"

--- a/src/schemas/json/pm2-ecosystem.json
+++ b/src/schemas/json/pm2-ecosystem.json
@@ -1,0 +1,351 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "pm2 ecosystem config file",
+  "definitions": {
+    "app": {
+      "type": "object",
+      "properties": {
+        "script": {
+          "type": "string",
+          "description": "Path of the script to launch"
+        },
+        "name": {
+          "type": "string",
+          "description": "Process name in the process list. Defaults to script filename without the extension (app for app.js)"
+        },
+        "cwd": {
+          "type": "string",
+          "description": "Current working directory to start the process with. Defaults to CWD of the current environment (from your shell)"
+        },
+        "args": {
+          "type": [
+            "array",
+            "string"
+          ],
+          "description": "Arguments to pass to the script",
+          "items": {
+            "type": "string"
+          }
+        },
+        "interpreter": {
+          "type": "string",
+          "description": "Interpreter absolute path. Defaults to node"
+        },
+        "node_args": {
+          "type": [
+            "array",
+            "string"
+          ],
+          "description": "Arguments to pass to the interpreter",
+          "items": {
+            "type": "string"
+          }
+        },
+        "output": {
+          "type": "string",
+          "description": "File path for stdout (each line is appended to this file)",
+          "default": "~/.pm2/logs/-out.log"
+        },
+        "error": {
+          "type": "string",
+          "description": "File path for stderr (each line is appended to this file)",
+          "default": "~/.pm2/logs/-error.err"
+        },
+        "log": {
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "description": "File path for combined stdout and stderr (each line is appended to this file)",
+          "default": "/dev/null"
+        },
+        "disable_logs": {
+          "type": "boolean",
+          "description": "Disable all logs storage"
+        },
+        "log_type": {
+          "type": "string",
+          "description": "Define a specific log output type",
+          "enum": [
+            "json"
+          ]
+        },
+        "log_date_format": {
+          "type": "string",
+          "description": "Format for log timestamps in moment.js format (eg YYYY-MM-DD HH:mm Z)"
+        },
+        "env": {
+          "type": [
+            "object",
+            "string"
+          ],
+          "description": "Specify environment variables to be injected",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "max_memory_restart": {
+          "type": [
+            "string",
+            "number"
+          ],
+          "description": "Restart the app if an amount of memory is exceeded (format: /0-9?/ K for KB, ‘M’ for MB, ‘G’ for GB, default to B)"
+        },
+        "pid_file": {
+          "type": "string",
+          "description": "File path where the pid of the started process is written by pm2. Defaults to ~/.pm2/pids/app_name-id.pid"
+        },
+        "restart_delay": {
+          "type": "number",
+          "description": "Time in ms to wait before restarting a crashing app"
+        },
+        "source_map_support": {
+          "type": "boolean",
+          "description": "Enable or disable the source map support",
+          "default": true
+        },
+        "disable_source_map_support": {
+          "type": "boolean",
+          "description": "Enable or disable the source map support"
+        },
+        "wait_ready": {
+          "type": "boolean",
+          "description": "Make the process wait for a process.send(‘ready’)"
+        },
+        "instances": {
+          "type": "number",
+          "description": "Number of instances to be started in cluster mode",
+          "default": 1
+        },
+        "kill_timeout": {
+          "type": "number",
+          "description": "Time in ms before sending the final SIGKILL signal after SIGINT",
+          "default": 1600
+        },
+        "listen_timeout": {
+          "type": "number",
+          "description": "Time in ms before forcing a reload if app is still not listening/has still not sent ready"
+        },
+        "cron_restart": {
+          "type": "string",
+          "description": "A cron pattern to restart your app"
+        },
+        "merge_logs": {
+          "type": "boolean",
+          "description": "In cluster mode, merge each type of logs into a single file (instead of having one for each cluster)"
+        },
+        "vizion": {
+          "type": "boolean",
+          "description": "Enable or disable the versioning metadatas (vizion library)",
+          "default": true
+        },
+        "autorestart": {
+          "type": "boolean",
+          "description": "Enable or disable auto restart after process failure",
+          "default": true
+        },
+        "watch": {
+          "type": [
+            "boolean",
+            "array",
+            "string"
+          ],
+          "description": "Enable or disable the watch mode"
+        },
+        "ignore_watch": {
+          "type": [
+            "array",
+            "string"
+          ],
+          "description": "List of paths to ignore (regex)"
+        },
+        "watch_options": {
+          "type": "object",
+          "description": "Object that will be used as an options with chokidar (refer to chokidar documentation)"
+        },
+        "min_uptime": {
+          "type": [
+            "number",
+            "string"
+          ],
+          "description": "Minimum uptime of the app to be considered started (format is /[0-9]+(h|m|s)?/, for hours, minutes, seconds, default to ms)",
+          "default": 1000
+        },
+        "max_restarts": {
+          "type": "number",
+          "description": "Number of times a script is restarted when it exits in less than min_uptime",
+          "default": 16
+        },
+        "exec_mode": {
+          "type": "string",
+          "description": "Set the execution mode",
+          "enum": [
+            "fork",
+            "cluster"
+          ],
+          "default": "fork"
+        },
+        "force": {
+          "type": "boolean",
+          "description": "Start a script even if it is already running (only the script path is considered)"
+        },
+        "append_env_to_name": {
+          "type": "boolean",
+          "description": "Append the environment name to the app name"
+        },
+        "post_update": {
+          "type": "array",
+          "description": "List of commands executed after a pull/upgrade operation performed from Keymetrics dashboard",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trace": {
+          "type": "boolean",
+          "description": "Enable or disable the transaction tracing"
+        },
+        "disable_trace": {
+          "type": "boolean",
+          "description": "Enable or disable the transaction tracing",
+          "default": true
+        },
+        "increment_var": {
+          "type": "string",
+          "description": "Specify the name of an environment variable to inject which increments for each cluster"
+        },
+        "instance_var": {
+          "type": "string",
+          "description": "Rename the NODE_APP_INSTANCE environment variable. Defaults to NODE_APP_INSTANCE"
+        },
+        "pmx": {
+          "type": "boolean",
+          "description": "Enable or disable apm wrapping",
+          "default": true
+        },
+        "automation": {
+          "type": "boolean",
+          "description": "Enable or disable apm wrapping",
+          "default": true
+        },
+        "treekill": {
+          "type": "boolean",
+          "description": "Only kill the main process, not detached children",
+          "default": true
+        },
+        "port": {
+          "type": "number",
+          "description": "Shortcut to inject a PORT environment variable"
+        },
+        "uid": {
+          "type": "string",
+          "description": "Set user id. Defaults to current user uid"
+        },
+        "gid": {
+          "type": "string",
+          "description": "Set group id. Defaults to current user gid"
+        }
+      },
+      "patternProperties": {
+        "^env_\\S*$": {
+          "type": [
+            "object",
+            "string"
+          ],
+          "description": "Specify environment variables to be injected when using –env",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "script"
+      ]
+    },
+    "deploymentEnvironment": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "SSH key path. Defaults to $HOME/.ssh"
+        },
+        "user": {
+          "type": "string",
+          "description": "SSH user"
+        },
+        "host": {
+          "type": [
+            "array",
+            "string"
+          ],
+          "description": "SSH host",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ssh_options": {
+          "type": [
+            "string",
+            "array"
+          ],
+          "description": "SSH options with no command-line flag, see ‘man ssh’",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ref": {
+          "type": "string",
+          "description": "GIT remote/branch"
+        },
+        "repo": {
+          "type": "string",
+          "description": "GIT remote"
+        },
+        "path": {
+          "type": "string",
+          "description": "path in the server"
+        },
+        "pre-setup": {
+          "type": "string",
+          "description": "Pre-setup command or path to a script on your local machine"
+        },
+        "post-setup": {
+          "type": "string",
+          "description": "Post-setup commands or path to a script on the host machine"
+        },
+        "pre-deploy-local": {
+          "type": "string",
+          "description": "pre-deploy action"
+        },
+        "post-deploy": {
+          "type": "string",
+          "description": "post-deploy action"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "apps": {
+      "type": "array",
+      "description": "The apps property is an array of object where each object contains the configuration for each process.",
+      "items": {
+        "$ref": "#/definitions/app"
+      }
+    },
+    "deploy": {
+      "type": "object",
+      "description": "The deploy property is an object where each of its properties is an object which defines a deployment environment.",
+      "properties": {
+        "production": {
+          "$ref": "#/definitions/deploymentEnvironment"
+        },
+        "staging": {
+          "$ref": "#/definitions/deploymentEnvironment"
+        },
+        "development": {
+          "$ref": "#/definitions/deploymentEnvironment"
+        }
+      }
+    }
+  }
+}

--- a/src/test/pm2-ecosystem/ecosystem.json
+++ b/src/test/pm2-ecosystem/ecosystem.json
@@ -1,0 +1,39 @@
+{
+  "apps": [
+    {
+      "name": "API",
+      "script": "app.js",
+      "env": {
+        "COMMON_VARIABLE": "true"
+      },
+      "env_production": {
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "name": "WEB",
+      "script": "web.js"
+    }
+  ],
+  "deploy": {
+    "production": {
+      "user": "node",
+      "host": "212.83.163.1",
+      "ref": "origin/master",
+      "repo": "git@github.com:repo.git",
+      "path": "/var/www/production",
+      "post-deploy": "npm install && pm2 startOrRestart ecosystem.json --env production"
+    },
+    "dev": {
+      "user": "node",
+      "host": "212.83.163.1",
+      "ref": "origin/master",
+      "repo": "git@github.com:repo.git",
+      "path": "/var/www/development",
+      "post-deploy": "npm install && pm2 startOrRestart ecosystem.json --env dev",
+      "env": {
+        "NODE_ENV": "dev"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the schema of pm2 ecosystem config file for (json|ya?ml).

Notes:
1. The schema is borrowed from the "Runtime" documentation [reference](https://pm2.io/docs/runtime/reference/ecosystem-file/).
2. Users of old(er) pm2 might be able to use this without any modifications. But YMMV. Issues are welcome, PRs are awesome.
3. This schema is quite permissive, to better accommodate future changes.