### PR TITLE
feat(catalog): add json schema for .yarnrc.yml files to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2493,6 +2493,14 @@
       "versions": {
         "1.0": "https://docs.grdev.net/enterprise/admin/schema/gradle-enterprise-config-schema-1.json"
       }
+    },
+    {
+      "name": ".yarnrc.yml",
+      "description": "JSON Schema for Yarnrc files",
+      "fileMatch": [
+        ".yarnrc.yml"
+      ],
+      "url": "https://yarnpkg.com/configuration/yarnrc.json"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the JSON schema for `.yarnrc.yml` files to the catalog.

The schema is hosted on the Yarn website at https://yarnpkg.com/configuration/yarnrc.json, as we use it to generate the documentation at https://yarnpkg.com/configuration/yarnrc.

Note: The schema isn't currently versioned in any way.