### PR TITLE
Adjust schema for mocharc.json: change require to an array

### DIFF
--- a/src/schemas/json/mocharc.json
+++ b/src/schemas/json/mocharc.json
@@ -38,7 +38,7 @@
       "file"                 : { "$ref": "#/definitions/string-array" } ,
       "ignore"               : { "$ref": "#/definitions/string-array" } ,
       "recursive"            : { "$ref": "#/definitions/bool"         } ,
-      "require"              : { "$ref": "#/definitions/string"       } ,
+      "require"              : { "$ref": "#/definitions/string-array" } ,
       "sort"                 : { "$ref": "#/definitions/bool"         } ,
       "watch"                : { "$ref": "#/definitions/bool"         } ,
       "watch-files"          : { "$ref": "#/definitions/string-array" } ,

--- a/src/test/mocharc/mocharc.test.json
+++ b/src/test/mocharc/mocharc.test.json
@@ -34,7 +34,10 @@
     "foo=bar",
     "baz=quux"
   ],
-  "require": "@babel/register",
+  "require": [
+    "@babel/register",
+    "/path/to/some/file"
+  ],
   "retries": 1,
   "slow": 75,
   "sort": false,


### PR DESCRIPTION
This allows the require property to be either an array or a string, both of which are supported by mocha.
_Personally, I need to require `ts-node/register` and a file with global test setup hooks before running the test suites._

This is not a breaking change to the schema, as the `string-array` definition allows either a string (which keeps backwards compatibility) or a string array.
