### PR TITLE
Allow arbitrary expressions in GitHub Actions workflows jobs.<job_id>.runs-on

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -994,8 +994,6 @@
                   "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#github-hosted-runners",
                   "type": "string",
                   "enum": [
-                    "${{ matrix.job.os }}",
-                    "${{ matrix.os }}",
                     "macos-latest",
                     "macos-10.15",
                     "self-hosted",
@@ -1068,6 +1066,9 @@
                   "additionalItems": {
                     "type": "string"
                   }
+                },
+                {
+                  "$ref": "#/definitions/expressionSyntax"
                 }
               ]
             },


### PR DESCRIPTION
Previously, two specific expressions (`${{ matrix.job.os }}` and `${{ matrix.os }}`) were hardcoded into the schema as enum values for `jobs.<job_id>.runs-on`. This was apparently based on a misunderstanding of [the example in the documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-running-with-more-than-one-operating-system) and an additional example provided in https://github.com/SchemaStore/schemastore/issues/1277. But there is nothing magic about those two expressions. Any arbitrary expression may be used.

Fixes https://github.com/SchemaStore/schemastore/issues/1277