### PR TITLE
template.json schema: type should be required property with allowed values "project" and "item"

### DIFF
--- a/src/schemas/json/template.json
+++ b/src/schemas/json/template.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
 
   "type": "object",
-  "required": [ "author", "classifications", "identity", "name", "shortName" ],
+  "required": [ "author", "classifications", "identity", "name", "shortName", "tags" ],
 
   "definitions": {
     "datatype": {
@@ -949,17 +949,15 @@
     "tags": {
       "description": "Common information about templates, these are effectively interchangeable with choice type parameter symbols",
       "type": "object",
+      "required": ["type"],
       "properties": {
         "language": {
           "description": "The programming language the template primarily contains or is intended for use with",
           "type": "string"
         },
         "type": {
-          "description": "The type of template. Commonly this is either project or item (and special checks are performed for these values to show only project or item type templates in certain contexts) but any string is allowed",
-          "anyOf": [
-            { "enum": [ "project", "item" ] },
-            { "type": "string" }
-          ]
+          "description": "The type of template: project or item",
+          "enum": [ "project", "item" ]
         }
       }
     },


### PR DESCRIPTION
fixes dotnet/templating#2586
Visual Studio supports only "project" and "item" type, and the field is mandatory.
- Make type a required property in the template.json schema
- Only allowed values are "project", "item"