### PR TITLE
add: two extra grunt task for validation 

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -131,5 +131,48 @@
     "ninjs-1.0.json"
   ],
   "strongmode": [
-   ]
+   ],
+  "missingcatalogurl": [
+    "---> below this line are schema, that are included from other schema<---",
+    "web-manifest.json",
+    "web-manifest-app-info.json",
+    "lsdlschema-0.7.json",
+    "lsdlschema-1.0.json",
+    "lsdlschema-1.2.json",
+    "lsdlschema-2.0.json",
+    "lsdlschema-3.0.json",
+    "---> below this line are schema, that link the URL to external site but still have the schema.json on this site <---",
+    "ksp-ckan.json",
+    "ksp-avc.json",
+    "neoload.json",
+    "---> below this line are schema, that is used by tv4 validator <---",
+    "schema-draft-v4.json",
+    "---> below this line are schema, that have no URL in schema. Do not know yet what to do with it.<---",
+    "compilerdefaults.json",
+    "content-security-policy-report-2.json",
+    "install.json",
+    "jasonette.json",
+    "json-api-1.0.json",
+    "licenses.1.json",
+    "npm-link-up.json",
+    "sarif-2.0.0-csd.2.beta.2018-10-10.json",
+    "sarif-2.0.0-csd.2.beta.2019-01-09.json",
+    "sarif-2.0.0-csd.2.beta.2019-01-24.json",
+    "sarif-2.1.0-rtm.0.json",
+    "sarif-2.1.0-rtm.1.json",
+    "sarif-external-property-file-2.1.0-rtm.0.json",
+    "sarif-external-property-file-2.1.0-rtm.1.json",
+    "sarif-external-property-file.json",
+    "sarif.json",
+    "stylintrc.json",
+    "toolinfo.1.1.0.json",
+    "renovate.json"
+  ],
+  "fileMatchConflict": [
+    "plugin.yml",
+    ".jsbeautifyrc",
+    "info.json",
+    "manifest.json",
+    "*.cryproj"
+  ]
 }


### PR DESCRIPTION
"local_catalog-fileMatch-conflict"
Will check if there are no duplicated schema.fileMatch values
**Bypass method** is to add a extra array item in "fileMatchConflict" (see ./schema-validation.json)
There are already some items in the list.

--------------
"local_schema-present-in-catalog-list"
Will check if local schema have a url reference in catalog list
**Bypass method** is to add a extra array item in "missingcatalogurl" (see ./schema-validation.json)
There are already some items in the list.

--------------
i have notice that this WIP PR #763 pass the build process with out catalog list item. It will fail now. 