### PR TITLE
Update urls from dev to prod.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2535,9 +2535,9 @@
         "*gradle-enterprise.yml",
         "*gradle-enterprise.yaml"
       ],
-      "url": "https://docs.grdev.net/enterprise/admin/schema/gradle-enterprise-config-schema-1.json",
+      "url": "https://docs.gradle.com/enterprise/admin/schema/gradle-enterprise-config-schema-1.json",
       "versions": {
-        "1.0": "https://docs.grdev.net/enterprise/admin/schema/gradle-enterprise-config-schema-1.json"
+        "1.0": "https://docs.gradle.com/enterprise/admin/schema/gradle-enterprise-config-schema-1.json"
       }
     },
     {


### PR DESCRIPTION
We've recently migrated our schema location from a dev server to a prod one. The dev one is still in use, but the definitive one is the prod one.