### PR TITLE
Use correct name for script

### DIFF
--- a/src/schemas/json/omnisharp.json
+++ b/src/schemas/json/omnisharp.json
@@ -424,7 +424,7 @@
         }
       }
     },
-    "scripting": {
+    "script": {
       "type": "object",
       "description": "Used to configure C# scripting (CSX files)",
       "properties": {


### PR DESCRIPTION
Correct key for scripting options is `script`, not `scripting`.