### PR TITLE
Added missing parameter for omni sharp

### DIFF
--- a/src/schemas/json/omnisharp.json
+++ b/src/schemas/json/omnisharp.json
@@ -479,6 +479,11 @@
         "enableScriptNuGetReferences": {
           "type": "boolean",
           "default": false
+        },
+        "rspFilePath" : {
+          "type": "string",
+          "default": "",
+          "description": "A response file (.rsp) is used to provide the command line arguments that are used to run the roslyn script compiler process. You can use this to override the default namespace includes amoung other things."
         }
       }
     },


### PR DESCRIPTION
rspFilePath always existed but was not provided. I am not sure if the description is too verbose for your liking but I figured since it's a bit more abstract of at topic it would be useful to at least say what you can do with it. 