### PR TITLE
Expo Schema: Fixed color regex to allow all hex-digits

### DIFF
--- a/src/schemas/json/expo-37.0.0.json
+++ b/src/schemas/json/expo-37.0.0.json
@@ -106,7 +106,7 @@
         "backgroundColor": {
           "description": "The background color for your app, behind any of your React views.",
           "type": "string",
-          "pattern": "^#|(&#x23;)\\d{6}$",
+          "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
           "meta": {
             "regexHuman": "6 character long hex color string, eg: `'#000000'`"
           }
@@ -114,7 +114,7 @@
         "primaryColor": {
           "description": "On Android, this will determine the color of your app in the multitasker. Currently this is not used on iOS, but it may be used for other purposes in the future.",
           "type": "string",
-          "pattern": "^#|(&#x23;)\\d{6}$",
+          "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
           "meta": {
             "regexHuman": "6 character long hex color string, eg: `'#000000'`"
           }
@@ -146,7 +146,7 @@
             "color": {
               "description": "Tint color for the push notification image when it appears in the notification tray.",
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }
@@ -223,7 +223,7 @@
             "backgroundColor": {
               "description": "Color to fill the loading screen background",
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }
@@ -250,7 +250,7 @@
         "androidStatusBarColor": {
           "description": "DEPRECATED. Use `androidStatusBar` instead.",
           "type": "string",
-          "pattern": "^#|(&#x23;)\\d{6}$",
+          "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
           "meta": {
             "deprecated": true,
             "regexHuman": "6 character long hex color string, eg: `'#000000'`"
@@ -271,7 +271,7 @@
             "backgroundColor": {
               "description": "Specifies the background color of the status bar.",
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }
@@ -302,7 +302,7 @@
             "backgroundColor": {
               "description": "Specifies the background color of the navigation bar.",
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }
@@ -421,7 +421,7 @@
             "backgroundColor": {
               "description": "The background color for your iOS app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }
@@ -569,7 +569,7 @@
                 "backgroundColor": {
                   "description": "Color to fill the loading screen background",
                   "type": "string",
-                  "pattern": "^#|(&#x23;)\\d{6}$",
+                  "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
                   "meta": {
                     "regexHuman": "6 character long hex color string, eg: `'#000000'`"
                   }
@@ -648,7 +648,7 @@
             "backgroundColor": {
               "description": "The background color for your Android app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }
@@ -699,7 +699,7 @@
                 "backgroundColor": {
                   "description": "Color to use as the background for your app's Adaptive Icon on Android.",
                   "type": "string",
-                  "pattern": "^#|(&#x23;)\\d{6}$",
+                  "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
                   "meta": {
                     "regexHuman": "6 character long hex color string, eg: `'#000000'`"
                   }
@@ -797,7 +797,7 @@
                 "backgroundColor": {
                   "description": "Color to fill the loading screen background",
                   "type": "string",
-                  "pattern": "^#|(&#x23;)\\d{6}$",
+                  "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
                   "meta": {
                     "regexHuman": "6 character long hex color string, eg: `'#000000'`"
                   }
@@ -1008,7 +1008,7 @@
                 "#4630EB"
               ],
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }
@@ -1073,7 +1073,7 @@
                 "#ffffff"
               ],
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }
@@ -1245,7 +1245,7 @@
                 "backgroundColor": {
                   "description": "Color to fill the loading screen background",
                   "type": "string",
-                  "pattern": "^#|(&#x23;)\\d{6}$",
+                  "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
                   "meta": {
                     "regexHuman": "6 character long hex color string, eg: `'#000000'`"
                   }
@@ -1327,7 +1327,7 @@
             "backgroundColor": {
               "description": "Color to fill the loading screen background",
               "type": "string",
-              "pattern": "^#|(&#x23;)\\d{6}$",
+              "pattern": "^#|(&#x23;)[0-9a-fA-F]{6}$",
               "meta": {
                 "regexHuman": "6 character long hex color string, eg: `'#000000'`"
               }


### PR DESCRIPTION
In the Expo schema, colors where only allowed to contain digits between 0-9. This is not enough for hex-values.
The regex now allows all hex digits from 0-9 and a-f.