### PR TITLE
Update GitHub Actions Virtual Environments

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -994,17 +994,17 @@
                   "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#github-hosted-runners",
                   "type": "string",
                   "enum": [
-                    "macos-latest",
                     "macos-10.15",
                     "macos-11.0",
+                    "macos-latest",
                     "self-hosted",
                     "ubuntu-16.04",
                     "ubuntu-18.04",
                     "ubuntu-20.04",
                     "ubuntu-latest",
-                    "windows-latest",
+                    "windows-2016",
                     "windows-2019",
-                    "windows-2016"
+                    "windows-latest"
                   ]
                 },
                 {

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -996,6 +996,7 @@
                   "enum": [
                     "macos-latest",
                     "macos-10.15",
+                    "macos-11.0",
                     "self-hosted",
                     "ubuntu-16.04",
                     "ubuntu-18.04",

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1003,7 +1003,8 @@
                     "ubuntu-20.04",
                     "ubuntu-latest",
                     "windows-latest",
-                    "windows-2019"
+                    "windows-2019",
+                    "windows-2016"
                   ]
                 },
                 {


### PR DESCRIPTION
GitHub [recently announced](https://github.com/actions/virtual-environments/issues/1814) support for macOS 11 (Big Sur).

This PR adds the corresponding `macos-11.0` identifier to the list of `runs-on` values. This PR also adds `windows-2016`, which appears [in the official list of available virtual environments](https://github.com/actions/virtual-environments#available-environments), but was missing from the schema.