### PR TITLE
Fix netlify.json schema so collection `extension` field accepts any string.

### DIFF
--- a/src/schemas/json/netlify.json
+++ b/src/schemas/json/netlify.json
@@ -72,8 +72,8 @@
           "type": "string"
         },
         "extension": {
-          "enum": ["yml", "yaml", "toml", "json", "md", "markdown", "html"],
-          "description": "the file extension searched for when finding existing entries in a folder collection and it determines the file extension used to save new collection items"
+          "description": "the file extension searched for when finding existing entries in a folder collection and it determines the file extension used to save new collection items",
+          "type": "string"
         }
       },
       "required": ["name"],


### PR DESCRIPTION
Currently the netlify extension field is set to accept the following enum.

```json
"extension": {
  "enum": ["yml", "yaml", "toml", "json", "md", "markdown", "html"],
  "description": "the file extension searched for when finding existing entries in a folder collection and it determines the file extension used to save new collection items"
}
```

This PR corrects the schema to accept `"type": "string"` for this field because Netlify allows for a **custom extension** to be specified as an alternative to the pre-defined extension types.

> Reference: https://www.netlifycms.org/docs/configuration-options/#extension-and-format