### PR TITLE
fix(github-workflow): escape `{` and `}` in pattern to be unicode compatible

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -192,7 +192,7 @@
     },
     "expressionSyntax": {
       "type": "string",
-      "pattern": "^\\${{.*}}$"
+      "pattern": "^\\$\\{\\{.*\\}\\}$"
     },
     "globs": {
       "type": "array",


### PR DESCRIPTION
IntelliJ uses the unicode flag when checking patterns, so currently this pattern causes an error when validating:

> Schema validation: Cannot check the string by pattern because of an error: Illegal repetition near index 2 ^\${{.*}}$ ^ 

While the spec doesn't say (iirc) the unicode flag must be used when regex validation, escaping these characters doesn't have any downside, and is technically the right thing since it's explicitly marking the characters as "plain" rather than special.