### PR TITLE
fix(member-ordering) Extend the outdated list of enums with accessor …

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -1328,7 +1328,13 @@
                   "private-constructor",
                   "public-instance-method",
                   "protected-instance-method",
-                  "private-instance-method"
+                  "private-instance-method",
+                  "public-static-accessor",
+                  "protected-static-accessor",
+                  "private-static-accessor",
+                  "public-instance-accessor",
+                  "protected-instance-accessor",
+                  "private-instance-accessor"
                 ]
               },
               "minItems": 1,


### PR DESCRIPTION
The existing ruleset revolving around member-ordering is outdated.
This PR will extend the existing enums allowed with the lacking accessors.

U can find the allowed list of enums in the docs of tslint: https://palantir.github.io/tslint/rules/member-ordering/