### PR TITLE
Update the hadolint rules

### DIFF
--- a/src/schemas/json/hadolint.json
+++ b/src/schemas/json/hadolint.json
@@ -103,7 +103,7 @@
           },
           {
             "const": "DL3018",
-            "description": "Pin versions in apk add. Instead of `apk add \u003cpackage\u003e` use `apk add \u003cpackage\u003e=\u003cversion\u003e`.",
+            "description": "Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`.",
             "$comment": "https://github.com/hadolint/hadolint/wiki/DL3018"
           },
           {
@@ -153,8 +153,78 @@
           },
           {
             "const": "DL3028",
-            "description": "Pin versions in gem install. Instead of `gem install \u003cgem\u003e` use `gem install \u003cgem\u003e:\u003cversion\u003e`",
+            "description": "Pin versions in gem install. Instead of `gem install <gem>` use `gem install <gem>:<version>`",
             "$comment": "https://github.com/hadolint/hadolint/wiki/DL3028"
+          },
+          {
+            "const": "DL3029",
+            "description": "Do not use --platform flag with FROM.",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3029"
+          },
+          {
+            "const": "DL3030",
+            "description": "Use the `-y` switch to avoid manual input `yum install -y <package>`",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3030"
+          },
+          {
+            "const": "DL3031",
+            "description": "Do not use `yum update`",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3031"
+          },
+          {
+            "const": "DL3032",
+            "description": "`yum clean all` missing after yum command.",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3032"
+          },
+          {
+            "const": "DL3033",
+            "description": "Specify version with `yum install -y <package>-<version>`",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3033"
+          },
+          {
+            "const": "DL3034",
+            "description": "Non-interactive switch missing from `zypper` command: `zypper install -y`",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3034"
+          },
+          {
+            "const": "DL3035",
+            "description": "Do not use `zypper update`.",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3035"
+          },
+          {
+            "const": "DL3036",
+            "description": "`zypper clean` missing after zypper use.",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3036"
+          },
+          {
+            "const": "DL3037",
+            "description": "Specify version with `zypper install -y <package>[=]<version>`.",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3037"
+          },
+          {
+            "const": "DL3038",
+            "description": "Use the `-y` switch to avoid manual input `dnf install -y <package>`",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3038"
+          },
+          {
+            "const": "DL3039",
+            "description": "Do not use `dnf update`",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3039"
+          },
+          {
+            "const": "DL3040",
+            "description": "`dnf clean all` missing after dnf command.",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3040"
+          },
+          {
+            "const": "DL3041",
+            "description": "Specify version with `dnf install -y <package>-<version>`",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3041"
+          },
+          {
+            "const": "DL3042",
+            "description": "Avoid cache directory with `pip install --no-cache-dir <package>`.",
+            "$comment": "https://github.com/hadolint/hadolint/wiki/DL3042"
           },
           {
             "const": "DL4000",
@@ -218,7 +288,7 @@
           },
           {
             "const": "SC1045",
-            "description": "It's not `foo \u0026; bar`, just `foo \u0026 bar`.",
+            "description": "It's not `foo &; bar`, just `foo & bar`.",
             "$comment": "https://github.com/koalaman/shellcheck/wiki/SC1045"
           },
           {
@@ -293,12 +363,12 @@
           },
           {
             "const": "SC2002",
-            "description": "Useless cat. Consider cmd < file | .. or cmd file | .. instead.",
+            "description": "Useless cat. Consider `cmd < file | ..` or `cmd file | ..` instead.",
             "$comment": "https://github.com/koalaman/shellcheck/wiki/SC2002"
           },
           {
             "const": "SC2015",
-            "description": "Note that A && B || C is not if-then-else. C may run when A is true.",
+            "description": "Note that `A && B || C` is not if-then-else. C may run when A is true.",
             "$comment": "https://github.com/koalaman/shellcheck/wiki/SC2015"
           },
           {
@@ -348,7 +418,7 @@
           },
           {
             "const": "SC2164",
-            "description": "Use cd ... || exit in case cd fails.",
+            "description": "Use `cd ... || exit` in case `cd` fails.",
             "$comment": "https://github.com/koalaman/shellcheck/wiki/SC2164"
           }
         ]


### PR DESCRIPTION
The rules and descriptions are taken from the README.md in the hadolint repo.
https://github.com/hadolint/hadolint/blob/master/README.md

This adds a couple of new rules which hadolint added but which are not reflected in the schema.