### PR TITLE
Add gitlab-ci parallel matrix support

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -969,11 +969,35 @@
           "$ref": "#/definitions/retry"
         },
         "parallel": {
-          "type": "integer",
           "description": "Parallel will split up a single job into several, and provide `CI_NODE_INDEX` and `CI_NODE_TOTAL` environment variables for the running jobs.",
-          "default": 0,
-          "minimum": 2,
-          "maximum": 50
+          "oneOf": [
+            {
+              "type": "integer",
+              "description": "Creates N instances of the same job that run in parallel.",
+              "default": 0,
+              "minimum": 2,
+              "maximum": 50
+            },
+            {
+              "type": "object",
+              "properties": {
+                "matrix": {
+                  "type": "array",
+                  "description": "Defines different variables for jobs that are running in parallel.",
+                  "items": {
+                    "type": "object",
+                    "description": "Defines environment variables for specific job.",
+                    "additionalProperties": {
+                      "type": ["string", "number", "array"]
+                    }
+                  },
+                  "maxItems": 50
+                }
+              },
+              "additionalProperties": false,
+              "required": ["matrix"]
+            }
+          ]
         },
         "interruptible": {
           "$ref": "#/definitions/interruptible"

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -311,5 +311,47 @@
       "project": "my/deployment",
       "branch": "stable"
     }
+  },
+  "parallel-integer": {
+    "stage": "test",
+    "script": ["echo ${CI_NODE_INDEX} ${CI_NODE_TOTAL}"],
+    "parallel": 5
+  },
+  "parallel-matrix-simple": {
+    "stage": "test",
+    "script": ["echo ${MY_VARIABLE}"],
+    "parallel": {
+      "matrix": [
+        {
+          "MY_VARIABLE": 0
+        },
+        {
+          "MY_VARIABLE": "sample"
+        },
+        {
+          "MY_VARIABLE": ["element0", 1, "element2"]
+        }
+      ]
+    }
+  },
+  "parallel-matrix-gitlab-docs": {
+    "stage": "deploy",
+    "script": ["bin/deploy"],
+    "parallel": {
+      "matrix": [
+        {
+          "PROVIDER": "aws",
+          "STACK": ["app1", "app2"]
+        },
+        {
+          "PROVIDER": "ovh",
+          "STACK": ["monitoring", "backup", "app"]
+        },
+        {
+          "PROVIDER": ["gcp", "vultr"],
+          "STACK": ["data", "processing"]
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
Add support for defining code from https://docs.gitlab.com/ee/ci/yaml/#parallel-matrix-jobs
```yaml
deploystacks:
  stage: deploy
  script:
    - bin/deploy
  parallel:
    matrix:
      - PROVIDER: aws
        STACK:
          - monitoring
          - app1
          - app2
      - PROVIDER: ovh
        STACK: [monitoring, backup, app]
      - PROVIDER: [gcp, vultr]
        STACK: [data, processing]
```
Ref: #1341

## Tests:
- `parallel-integer` - parallel job with integer (old style)
- `parallel-matrix-simple` - simple set of synthetic variables of different types `integer`, `string`, `array`
- `parallel-matrix-gitlab-docs` - example from gitlab docs