### PR TITLE
tsconfig & jsconfig add missing compiler options and annotations

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -1,13 +1,13 @@
 {
   "title": "JSON schema for the JavaScript configuration file",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "//": {
-    "explainer": "https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#overview",
-    "reference": "https://www.typescriptlang.org/tsconfig",
-    "reference metadata": "https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/scripts/tsconfigRules.ts"
-  },
 
   "definitions": {
+    "//": {
+      "explainer": "https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#overview",
+      "reference": "https://www.typescriptlang.org/tsconfig",
+      "reference metadata": "https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/scripts/tsconfigRules.ts"
+    },
     "filesDefinition": {
       "properties": {
         "files": {

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -196,11 +196,11 @@
               "default": false
             },
             "noImplicitAny": {
-              "description": "Warn on expressions and declarations with an implied 'any' type.",
+              "description": "Warn on expressions and declarations with an implied 'any' type. Enabling this setting is recommended.",
               "type": "boolean"
             },
             "noImplicitThis": {
-              "description": "Raise error on 'this' expressions with an implied any type. Requires TypeScript version 2.0 or later.",
+              "description": "Raise error on 'this' expressions with an implied any type. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
               "type": "boolean"
             },
             "noUnusedLocals": {
@@ -229,7 +229,7 @@
               "default": false
             },
             "skipLibCheck": {
-              "description": "Do not check declaration files. Requires TypeScript version 2.0 or later.",
+              "description": "Do not check declaration files. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
               "type": "boolean",
               "default": false
             },
@@ -270,12 +270,12 @@
               "type": "string"
             },
             "suppressExcessPropertyErrors": {
-              "description": "Suppress excess property checks for object literals. Using this flag is not recommended.",
+              "description": "Suppress excess property checks for object literals. It is recommended to use @ts-ignore comments instead of enabling this setting.",
               "type": "boolean",
               "default": true
             },
             "suppressImplicitAnyIndexErrors": {
-              "description": "Suppress noImplicitAny errors for indexing objects lacking index signatures.",
+              "description": "Suppress noImplicitAny errors for indexing objects lacking index signatures. It is recommended to use @ts-ignore comments instead of enabling this setting.",
               "type": "boolean",
               "default": false
             },
@@ -370,7 +370,7 @@
               "type": "boolean"
             },
             "forceConsistentCasingInFileNames": {
-              "description": "Disallow inconsistently-cased references to the same file.",
+              "description": "Disallow inconsistently-cased references to the same file. Enabling this setting is recommended.",
               "type": "boolean",
               "default": false
             },
@@ -543,7 +543,7 @@
               }
             },
             "strictNullChecks": {
-              "description": "Enable strict null checks. Requires TypeScript version 2.0 or later.",
+              "description": "Enable strict null checks. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
               "type": "boolean",
               "default": false
             },
@@ -557,12 +557,12 @@
               "type": "boolean"
             },
             "strict": {
-              "description": "Enable all strict type checking options. Requires TypeScript version 2.3 or later.",
+              "description": "Enable all strict type checking options. Enabling this setting is recommended. Requires TypeScript version 2.3 or later.",
               "type": "boolean",
               "default": false
             },
             "strictBindCallApply": {
-              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions. Requires TypeScript version 3.2 or later.",
+              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions. Enabling this setting is recommended. Requires TypeScript version 3.2 or later.",
               "type": "boolean",
               "default": false
             },
@@ -572,17 +572,17 @@
               "default": false
             },
             "strictFunctionTypes": {
-              "description": "Disable bivariant parameter checking for function types. Requires TypeScript version 2.6 or later.",
+              "description": "Disable bivariant parameter checking for function types. Enabling this setting is recommended. Requires TypeScript version 2.6 or later.",
               "type": "boolean",
               "default": false
             },
             "strictPropertyInitialization": {
-              "description": "Ensure non-undefined class properties are initialized in the constructor. Requires TypeScript version 2.7 or later.",
+              "description": "Ensure non-undefined class properties are initialized in the constructor. Enabling this setting is recommended. Requires TypeScript version 2.7 or later.",
               "type": "boolean",
               "default": false
             },
             "esModuleInterop": {
-              "description": "Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility and enable '--allowSyntheticDefaultImports' for typesystem compatibility. Requires TypeScript version 2.7 or later.",
+              "description": "Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility and enable '--allowSyntheticDefaultImports' for typesystem compatibility. Enabling this setting is recommended. Requires TypeScript version 2.7 or later.",
               "type": "boolean",
               "default": false
             },
@@ -592,7 +592,7 @@
               "default": false
             },
             "keyofStringsOnly": {
-              "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). Requires TypeScript version 2.9 or later.",
+              "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). This setting is deprecated. Requires TypeScript version 2.9 or later.",
               "type": "boolean",
               "default": false
             },

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -8,6 +8,7 @@
         "files": {
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -22,6 +23,7 @@
         "exclude": {
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -33,6 +35,7 @@
         "include": {
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -62,44 +65,54 @@
           "description": "Instructs the JavaScript language service how to validate and down level compile .js files.",
           "properties": {
             "charset": {
-              "description": "The character set of the input files.",
+              "description": "The character set of the input files. This setting is deprecated.",
               "type": "string"
             },
             "declaration": {
               "description": "Generates corresponding d.ts files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "declarationDir": {
               "type": "string",
               "description": "Specify output directory for generated declaration files. Requires TypeScript version 2.0 or later."
             },
             "diagnostics": {
-              "description": "When down-level compiling, show diagnostic information.",
+              "description": "When down-level compiling, show diagnostic information. This setting is deprecated. See `extendedDiagnostics.`",
+              "type": "boolean"
+            },
+            "disableReferencedProjectLoad": {
+              "description": "Recommend IDE's to load referenced composite projects dynamically instead of loading them all immediately. Requires TypeScript version 4.0 or later.",
               "type": "boolean"
             },
             "emitBOM": {
               "description": "When down-level compiling, emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "emitDeclarationOnly": {
-              "description": "Only emit '.d.ts' declaration files.",
-              "type": "boolean"
+              "description": "Only emit '.d.ts' declaration files. Requires TypeScript version 2.8 or later.",
+              "type": "boolean",
+              "default": false
             },
             "inlineSourceMap": {
-              "description": "When down-level compiling, emit a single file with source maps instead of having a separate file.",
-              "type": "boolean"
+              "description": "When down-level compiling, emit a single file with source maps instead of having a separate file. Requires TypeScript version 1.5 or later.",
+              "type": "boolean",
+              "default": false
             },
             "inlineSources": {
-              "description": "When down-level compiling, emit the source alongside the sourcemaps within a single file; requires --inlineSourceMap to be set.",
-              "type": "boolean"
+              "description": "When down-level compiling, emit the source alongside the sourcemaps within a single file; requires --inlineSourceMap to be set. Requires TypeScript version 1.5 or later.",
+              "type": "boolean",
+              "default": false
             },
             "jsx": {
-              "description": "When down-level compiling, specify JSX code generation: 'preserve', 'react', or 'react-native'.",
+              "description": "When down-level compiling, specify JSX code generation: 'preserve', 'react', or 'react-native'. Requires TypeScript version 2.2 or later.",
               "enum": [ "preserve", "react", "react-native" ]
             },
             "reactNamespace": {
-              "description": "When down-level compiling, specifies the object invoked for createElement and __spread when targeting 'react' JSX emit.",
-              "type": "string"
+              "description": "When down-level compiling, specify the object invoked for createElement and __spread when targeting 'react' JSX emit.",
+              "type": "string",
+              "default": "React"
             },
             "jsxFactory": {
               "description": "Specify the JSX factory function to use when targeting react JSX emit, e.g. 'React.createElement' or 'h'. Requires TypeScript version 2.1 or later.",
@@ -110,6 +123,11 @@
               "description": "Specify the JSX Fragment reference to use for fragements when targeting react JSX emit, e.g. 'React.Fragment' or 'Fragment'. Requires TypeScript version 4.0 or later.",
               "type": "string",
               "default": "React.Fragment"
+            },
+            "jsxImportSource": {
+              "description": "Declare the module specifier to be used for importing the `jsx` and `jsxs` factory functions when using jsx as \"react-jsx\" or \"react-jsxdev\". Requires TypeScript version 4.1 or later.",
+              "type": "string",
+              "default": "react"
             },
             "listFiles": {
               "description": "When down-level compiling, print names of files part of the compilation.",
@@ -148,7 +166,7 @@
               "default": "classic"
             },
             "newLine": {
-              "description": "When down-level compiling, specifies the end of line sequence to be used when emitting files: 'crlf' (Windows) or 'lf' (Unix).",
+              "description": "When down-level compiling, specifies the end of line sequence to be used when emitting files: 'crlf' (Windows) or 'lf' (Unix). Requires TypeScript version 1.5 or later.",
               "type": "string",
               "anyOf": [
                 {
@@ -164,47 +182,56 @@
             },
             "noEmit": {
               "description": "When down-level compiling, do not emit output.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noEmitHelpers": {
-              "description": "When down-level compiling, do not generate custom helper functions like __extends in compiled output.",
-              "type": "boolean"
+              "description": "When down-level compiling, do not generate custom helper functions like __extends in compiled output. Requires TypeScript version 1.5 or later.",
+              "type": "boolean",
+              "default": false
             },
             "noEmitOnError": {
-              "description": "When down-level compiling, do not emit outputs if any type checking errors were reported.",
-              "type": "boolean"
+              "description": "When down-level compiling, do not emit outputs if any type checking errors were reported. Requires TypeScript version 1.4 or later.",
+              "type": "boolean",
+              "default": false
             },
             "noImplicitAny": {
               "description": "Warn on expressions and declarations with an implied 'any' type.",
               "type": "boolean"
             },
             "noImplicitThis": {
-              "description": "Raise error on 'this' expressions with an implied any type.",
+              "description": "Raise error on 'this' expressions with an implied any type. Requires TypeScript version 2.0 or later.",
               "type": "boolean"
             },
             "noUnusedLocals": {
               "description": "Report errors on unused locals. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noUnusedParameters": {
               "description": "Report errors on unused parameters. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noLib": {
               "description": "Do not include the default library file (lib.d.ts).",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noResolve": {
               "description": "When down-level compiling, do not add triple-slash references or module import targets to the list of compiled files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "skipDefaultLibCheck": {
               "description": "Do not check for the default library (lib.d.ts).",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "skipLibCheck": {
               "description": "Do not check declaration files. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "outFile": {
               "description": "When down-level compiling, concatenate and emit output to single file.",
@@ -216,11 +243,13 @@
             },
             "pretty": {
               "description": "When down-level compiling, stylize errors and messages using color and context (experimental).",
-              "type": "boolean"
+              "type": "boolean",
+              "default": true
             },
             "removeComments": {
               "description": "When down-level compiling, do not emit comments to output.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": true
             },
             "rootDir": {
               "description": "When down-level compiling, specifies the root directory of input files. Use to control the output directory structure with --outDir.",
@@ -228,23 +257,27 @@
             },
             "isolatedModules": {
               "description": "When down-level compiling, unconditionally emit imports for unresolved files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": true
             },
             "sourceMap": {
               "description": "When down-level compiling, generates corresponding '.map' file.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": true
             },
             "sourceRoot": {
               "description": "When down-level compiling, specifies the location where debugger should locate JavaScript files instead of source locations.",
               "type": "string"
             },
             "suppressExcessPropertyErrors": {
-              "description": "Suppress excess property checks for object literals.",
-              "type": "boolean"
+              "description": "Suppress excess property checks for object literals. Using this flag is not recommended.",
+              "type": "boolean",
+              "default": true
             },
             "suppressImplicitAnyIndexErrors": {
               "description": "Suppress noImplicitAny errors for indexing objects lacking index signatures.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "stripInternal": {
               "description": "When down-level compiling, do not emit declarations for code that has an '@internal' annotation.",
@@ -278,6 +311,34 @@
               "description": "When down-level compiling, watch input files.",
               "type": "boolean"
             },
+            "fallbackPolling": {
+              "description": "Specify the polling strategy to use when the system runs out of or doesn't support native file watchers. Requires TypeScript version 3.8 or later.",
+              "enum": [
+                "fixedPollingInterval",
+                "priorityPollingInterval",
+                "dynamicPriorityPolling"
+              ]
+            },
+            "watchDirectory": {
+              "description": "Specify the strategy for watching directories under systems that lack recursive file-watching functionality. Requires TypeScript version 3.8 or later.",
+              "enum": [
+                "useFsEvents",
+                "fixedPollingInterval",
+                "dynamicPriorityPolling"
+              ],
+              "default": "useFsEvents"
+            },
+            "watchFile": {
+              "description": "Specify the strategy for watching individual files. Requires TypeScript version 3.8 or later.",
+              "enum": [
+                "fixedPollingInterval",
+                "priorityPollingInterval",
+                "dynamicPriorityPolling",
+                "useFsEvents",
+                "useFsEventsOnParentDirectory"
+              ],
+              "default": "useFsEvents"
+            },
             "experimentalDecorators": {
               "description": "Enables experimental support for ES7 decorators.",
               "type": "boolean"
@@ -291,20 +352,36 @@
               "type": "boolean"
             },
             "noImplicitReturns": {
-              "description": "Report error when not all code paths in function return a value.",
+              "description": "Report error when not all code paths in function return a value. Requires TypeScript version 1.8 or later.",
+              "type": "boolean",
+              "default": false
+            },
+            "noUncheckedIndexedAccess": {
+              "description": "Add `undefined` to an un-declared field in a type. Requires TypeScript version 4.1 or later.",
               "type": "boolean"
             },
             "noFallthroughCasesInSwitch": {
-              "description": "Report errors for fallthrough cases in switch statement.",
-              "type": "boolean"
+              "description": "Report errors for fallthrough cases in switch statement. Requires TypeScript version 1.8 or later.",
+              "type": "boolean",
+              "default": false
             },
             "allowUnreachableCode": {
-              "description": "Do not report errors on unreachable code.",
+              "description": "Do not report errors on unreachable code. Requires TypeScript version 1.8 or later.",
               "type": "boolean"
             },
             "forceConsistentCasingInFileNames": {
               "description": "Disallow inconsistently-cased references to the same file.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
+            },
+            "generateCpuProfile": {
+              "description": "Emit a v8 CPI profile during the compiler run, which may provide insight into slow builds. Requires TypeScript version 3.7 or later.",
+              "type": "string",
+              "default": "profile.cpuprofile"
+            },
+            "importNotUsedAsValues": {
+              "description": "This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.",
+              "enum": ["remove", "preserve", "error"]
             },
             "baseUrl": {
               "description": "Base directory to resolve non-relative module names.",
@@ -315,15 +392,30 @@
               "type": "object",
               "additionalProperties": {
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string",
                   "description": "Path mapping to be computed relative to baseUrl option."
                 }
               }
             },
-            "rootDirs": {
-              "description": "Specify list of root directory to be used when resolving modules.",
+            "plugins": {
+              "description": "List of TypeScript language server plugins to load. Requires TypeScript version 2.3 or later.",
               "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "Plugin name.",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "rootDirs": {
+              "description": "Specify list of root directory to be used when resolving modules. Requires TypeScript version 2.0 or later.",
+              "type": "array",
+              "uniqueItems": true,
               "items": {
                 "type": "string"
               }
@@ -334,11 +426,13 @@
             },
             "noImplicitUseStrict": {
               "description": "When down-level compiling, do not emit 'use strict' directives in module output.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "listEmittedFiles": {
               "description": "When down-level compiling, enable to list all emitted files. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "disableSizeLimit": {
               "description": "Disable size limit for JavaScript project. Requires TypeScript version 2.0 or later.",
@@ -450,7 +544,8 @@
             },
             "strictNullChecks": {
               "description": "Enable strict null checks. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "maxNodeModuleJsDepth": {
               "description": "The maximum dependency depth to search under node_modules and load JavaScript files.",
@@ -463,60 +558,58 @@
             },
             "strict": {
               "description": "Enable all strict type checking options. Requires TypeScript version 2.3 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "strictBindCallApply": {
-              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions.",
-              "type": "boolean"
+              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions. Requires TypeScript version 3.2 or later.",
+              "type": "boolean",
+              "default": false
             },
             "checkJs": {
-              "description": "Report errors in .js files.",
-              "type": "boolean"
+              "description": "Report errors in .js files. Requires TypeScript version 2.3 or later.",
+              "type": "boolean",
+              "default": false
             },
             "strictFunctionTypes": {
               "description": "Disable bivariant parameter checking for function types. Requires TypeScript version 2.6 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "strictPropertyInitialization": {
               "description": "Ensure non-undefined class properties are initialized in the constructor. Requires TypeScript version 2.7 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "esModuleInterop": {
               "description": "Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility and enable '--allowSyntheticDefaultImports' for typesystem compatibility. Requires TypeScript version 2.7 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "allowUmdGlobalAccess": {
-              "description": "Allow accessing UMD globals from modules.",
-              "type": "boolean"
+              "description": "Allow accessing UMD globals from modules. Requires TypeScript version 3.5 or later.",
+              "type": "boolean",
+              "default": false
             },
             "keyofStringsOnly": {
               "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). Requires TypeScript version 2.9 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "useDefineForClassFields": {
               "description": "Emit ECMAScript standard class fields. Requires TypeScript version 3.7 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "declarationMap": {
               "description": "Generates a sourcemap for each corresponding '.d.ts' file. Requires TypeScript version 2.9 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "resolveJsonModule": {
               "description": "Include modules imported with '.json' extension. Requires TypeScript version 2.9 or later.",
-              "type": "boolean"
-            },
-            "plugins": {
-              "description": "List of TypeScript language server plugins to load. Requires TypeScript version 2.3 or later.",
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "description": "Plugin name.",
-                    "type": "string"
-                  }
-                }
-              }
+              "type": "boolean",
+              "default": false
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it.",

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -1,6 +1,11 @@
 {
   "title": "JSON schema for the JavaScript configuration file",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "//": {
+    "explainer": "https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#overview",
+    "reference": "https://www.typescriptlang.org/tsconfig",
+    "reference metadata": "https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/scripts/tsconfigRules.ts"
+  },
 
   "definitions": {
     "filesDefinition": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "title": "JSON schema for the TypeScript compiler's configuration file",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "//": {
-    "explainer": "https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#overview",
-    "reference": "https://www.typescriptlang.org/tsconfig",
-    "reference metadata": "https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/scripts/tsconfigRules.ts"
-  },
 
   "definitions": {
+    "//": {
+      "explainer": "https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#overview",
+      "reference": "https://www.typescriptlang.org/tsconfig",
+      "reference metadata": "https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/scripts/tsconfigRules.ts"
+    },
     "filesDefinition": {
       "properties": {
         "files": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -849,7 +849,7 @@
                 "type": "string"
               },
               "type": "array",
-              "uniqueItems": true,
+              "uniqueItems": true
             },
             "scope": {
               "default": false,

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -209,11 +209,11 @@
               "default": false
             },
             "noImplicitAny": {
-              "description": "Warn on expressions and declarations with an implied 'any' type.",
+              "description": "Warn on expressions and declarations with an implied 'any' type. Enabling this setting is recommended.",
               "type": "boolean"
             },
             "noImplicitThis": {
-              "description": "Raise error on 'this' expressions with an implied any type. Requires TypeScript version 2.0 or later.",
+              "description": "Raise error on 'this' expressions with an implied any type. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
               "type": "boolean"
             },
             "noUnusedLocals": {
@@ -247,7 +247,7 @@
               "default": false
             },
             "skipLibCheck": {
-              "description": "Skip type checking of declaration files. Requires TypeScript version 2.0 or later.",
+              "description": "Skip type checking of declaration files. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
               "type": "boolean",
               "default": false
             },
@@ -302,12 +302,12 @@
               "type": "string"
             },
             "suppressExcessPropertyErrors": {
-              "description": "Suppress excess property checks for object literals. Using this flag is not recommended.",
+              "description": "Suppress excess property checks for object literals. It is recommended to use @ts-ignore comments instead of enabling this setting.",
               "type": "boolean",
               "default": false
             },
             "suppressImplicitAnyIndexErrors": {
-              "description": "Suppress noImplicitAny errors for indexing objects lacking index signatures.",
+              "description": "Suppress noImplicitAny errors for indexing objects lacking index signatures. It is recommended to use @ts-ignore comments instead of enabling this setting.",
               "type": "boolean",
               "default": false
             },
@@ -402,7 +402,7 @@
               "type": "boolean"
             },
             "forceConsistentCasingInFileNames": {
-              "description": "Disallow inconsistently-cased references to the same file.",
+              "description": "Disallow inconsistently-cased references to the same file. Enabling this setting is recommended.",
               "type": "boolean",
               "default": false
             },
@@ -609,7 +609,7 @@
               }
             },
             "strictNullChecks": {
-              "description": "Enable strict null checks. Requires TypeScript version 2.0 or later.",
+              "description": "Enable strict null checks. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
               "type": "boolean",
               "default": false
             },
@@ -638,12 +638,12 @@
               "type": "boolean"
             },
             "strict": {
-              "description": "Enable all strict type checking options. Requires TypeScript version 2.3 or later.",
+              "description": "Enable all strict type checking options. Enabling this setting is recommended. Requires TypeScript version 2.3 or later.",
               "type": "boolean",
               "default": false
             },
             "strictBindCallApply": {
-              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions. Requires TypeScript version 3.2 or later.",
+              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions. Enabling this setting is recommended. Requires TypeScript version 3.2 or later.",
               "type": "boolean",
               "default": false
             },
@@ -658,17 +658,17 @@
               "default": false
             },
             "strictFunctionTypes": {
-              "description": "Disable bivariant parameter checking for function types. Requires TypeScript version 2.6 or later.",
+              "description": "Disable bivariant parameter checking for function types. Enabling this setting is recommended. Requires TypeScript version 2.6 or later.",
               "type": "boolean",
               "default": false
             },
             "strictPropertyInitialization": {
-              "description": "Ensure non-undefined class properties are initialized in the constructor. Requires TypeScript version 2.7 or later.",
+              "description": "Ensure non-undefined class properties are initialized in the constructor. Enabling this setting is recommended. Requires TypeScript version 2.7 or later.",
               "type": "boolean",
               "default": false
             },
             "esModuleInterop": {
-              "description": "Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility and enable '--allowSyntheticDefaultImports' for typesystem compatibility. Requires TypeScript version 2.7 or later.",
+              "description": "Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility and enable '--allowSyntheticDefaultImports' for typesystem compatibility. Enabling this setting is recommended. Requires TypeScript version 2.7 or later.",
               "type": "boolean",
               "default": false
             },
@@ -678,7 +678,7 @@
               "default": false
             },
             "keyofStringsOnly": {
-              "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). Requires TypeScript version 2.9 or later.",
+              "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). This setting is deprecated. Requires TypeScript version 2.9 or later.",
               "type": "boolean",
               "default": false
             },

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -2,8 +2,9 @@
   "title": "JSON schema for the TypeScript compiler's configuration file",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "//": {
-    "docs": "https://www.typescriptlang.org/tsconfig",
-    "rules": "https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/scripts/tsconfigRules.ts"
+    "explainer": "https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#overview",
+    "reference": "https://www.typescriptlang.org/tsconfig",
+    "reference metadata": "https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/scripts/tsconfigRules.ts"
   },
 
   "definitions": {
@@ -628,7 +629,7 @@
               "default": false
             },
             "importsNotUsedAsValues": {
-              "description": "Specify emit/checking behavior for imports that are only used for types",
+              "description": "Specify emit/checking behavior for imports that are only used for types. Requires TypeScript version 3.8 or later.",
               "type": "string",
               "default": "remove",
               "enum": [

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "title": "JSON schema for the TypeScript compiler's configuration file",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "//": {
+    "docs": "https://www.typescriptlang.org/tsconfig",
+    "rules": "https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/scripts/tsconfigRules.ts"
+  },
 
   "definitions": {
     "filesDefinition": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -8,6 +8,7 @@
         "files": {
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -19,6 +20,7 @@
         "exclude": {
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -30,6 +32,7 @@
         "include": {
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -59,64 +62,92 @@
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "charset": {
-              "description": "The character set of the input files.",
+              "description": "The character set of the input files. This setting is deprecated.",
               "type": "string"
             },
             "composite": {
-              "description": "Enables building for project references.",
-              "type": "boolean"
+              "description": "Enables building for project references. Requires TypeScript version 3.0 or later.",
+              "type": "boolean",
+              "default": true
             },
             "declaration": {
               "description": "Generates corresponding d.ts files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "declarationDir": {
               "description": "Specify output directory for generated declaration files. Requires TypeScript version 2.0 or later.",
               "type": ["string", "null"]
             },
             "diagnostics": {
-              "description": "Show diagnostic information.",
+              "description": "Show diagnostic information. This setting is deprecated. See `extendedDiagnostics.`",
+              "type": "boolean"
+            },
+            "disableReferencedProjectLoad": {
+              "description": "Recommend IDE's to load referenced composite projects dynamically instead of loading them all immediately. Requires TypeScript version 4.0 or later.",
               "type": "boolean"
             },
             "emitBOM": {
               "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "emitDeclarationOnly": {
-              "description": "Only emit '.d.ts' declaration files.",
-              "type": "boolean"
+              "description": "Only emit '.d.ts' declaration files. Requires TypeScript version 2.8 or later.",
+              "type": "boolean",
+              "default": false
             },
             "incremental": {
-              "description": "Enable incremental compilation.",
+              "description": "Enable incremental compilation. Requires TypeScript version 3.4 or later.",
               "type": "boolean"
             },
             "tsBuildInfoFile": {
-              "description": "Specify file to store incremental compilation information.",
+              "description": "Specify file to store incremental compilation information. Requires TypeScript version 3.4 or later.",
+              "default": ".tsbuildinfo",
               "type": "string"
             },
 
             "inlineSourceMap": {
-              "description": "Emit a single file with source maps instead of having a separate file.",
-              "type": "boolean"
+              "description": "Emit a single file with source maps instead of having a separate file. Requires TypeScript version 1.5 or later.",
+              "type": "boolean",
+              "default": false
             },
             "inlineSources": {
-              "description": "Emit the source alongside the sourcemaps within a single file; requires --inlineSourceMap to be set.",
-              "type": "boolean"
+              "description": "Emit the source alongside the sourcemaps within a single file; requires --inlineSourceMap to be set. Requires TypeScript version 1.5 or later.",
+              "type": "boolean",
+              "default": false
             },
             "jsx": {
-              "description": "Specify JSX code generation: 'preserve', 'react', 'react-jsx', 'react-jsxdev' or'react-native'.",
+              "description": "Specify JSX code generation: 'preserve', 'react', 'react-jsx', 'react-jsxdev' or'react-native'. Requires TypeScript version 2.2 or later.",
               "enum": [ "preserve", "react", "react-jsx", "react-jsxdev", "react-native" ]
             },
             "reactNamespace": {
-              "description": "Specifies the object invoked for createElement and __spread when targeting 'react' JSX emit.",
-              "type": "string"
+              "description": "Specify the object invoked for createElement and __spread when targeting 'react' JSX emit.",
+              "type": "string",
+              "default": "React"
+            },
+            "jsxFactory": {
+              "description": "Specify the JSX factory function to use when targeting react JSX emit, e.g. 'React.createElement' or 'h'. Requires TypeScript version 2.1 or later.",
+              "type": "string",
+              "default": "React.createElement"
+            },
+            "jsxFragmentFactory": {
+              "description": "Specify the JSX Fragment reference to use for fragements when targeting react JSX emit, e.g. 'React.Fragment' or 'Fragment'. Requires TypeScript version 4.0 or later.",
+              "type": "string",
+              "default": "React.Fragment"
+            },
+            "jsxImportSource": {
+              "description": "Declare the module specifier to be used for importing the `jsx` and `jsxs` factory functions when using jsx as \"react-jsx\" or \"react-jsxdev\". Requires TypeScript version 4.1 or later.",
+              "type": "string",
+              "default": "react"
             },
             "listFiles": {
               "description": "Print names of files part of the compilation.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "mapRoot": {
-              "description": "Specifies the location where debugger should locate map files instead of generated locations",
+              "description": "Specify the location where debugger should locate map files instead of generated locations",
               "type": "string"
             },
             "module": {
@@ -131,8 +162,24 @@
                 }
               ]
             },
+            "moduleResolution": {
+              "description": "Specifies module resolution strategy: 'node' (Node) or 'classic' (TypeScript pre 1.6) .",
+              "type": "string",
+              "anyOf": [
+                {
+                  "enum": [
+                    "Classic",
+                    "Node"
+                  ]
+                },
+                {
+                  "pattern": "^(([Nn]ode)|([Cc]lassic))$"
+                }
+              ],
+              "default": "classic"
+            },
             "newLine": {
-              "description": "Specifies the end of line sequence to be used when emitting files: 'crlf' (Windows) or 'lf' (Unix).",
+              "description": "Specifies the end of line sequence to be used when emitting files: 'crlf' (Windows) or 'lf' (Unix). Requires TypeScript version 1.5 or later.",
               "type": "string",
               "anyOf": [
                 {
@@ -148,50 +195,61 @@
             },
             "noEmit": {
               "description": "Do not emit output.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noEmitHelpers": {
-              "description": "Do not generate custom helper functions like __extends in compiled output.",
-              "type": "boolean"
+              "description": "Do not generate custom helper functions like __extends in compiled output. Requires TypeScript version 1.5 or later.",
+              "type": "boolean",
+              "default": false
             },
             "noEmitOnError": {
-              "description": "Do not emit outputs if any type checking errors were reported.",
-              "type": "boolean"
+              "description": "Do not emit outputs if any type checking errors were reported. Requires TypeScript version 1.4 or later.",
+              "type": "boolean",
+              "default": false
             },
             "noImplicitAny": {
               "description": "Warn on expressions and declarations with an implied 'any' type.",
               "type": "boolean"
             },
             "noImplicitThis": {
-              "description": "Raise error on 'this' expressions with an implied any type.",
+              "description": "Raise error on 'this' expressions with an implied any type. Requires TypeScript version 2.0 or later.",
               "type": "boolean"
             },
             "noUnusedLocals": {
               "description": "Report errors on unused locals. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noUnusedParameters": {
               "description": "Report errors on unused parameters. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noLib": {
               "description": "Do not include the default library file (lib.d.ts).",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noResolve": {
               "description": "Do not add triple-slash references or module import targets to the list of compiled files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "noStrictGenericChecks": {
-              "description": "Disable strict checking of generic signatures in function types.",
-              "type": "boolean"
+              "description": "Disable strict checking of generic signatures in function types. Requires TypeScript version 2.4 or later.",
+              "type": "boolean",
+              "default": false
             },
             "skipDefaultLibCheck": {
-              "type": "boolean"
+              "description": "Use `skipLibCheck` instead. Skip type checking of default library declaration files.",
+              "type": "boolean",
+              "default": false
             },
             "skipLibCheck": {
               "description": "Skip type checking of declaration files. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "outFile": {
               "description": "Concatenate and emit output to single file.",
@@ -203,11 +261,13 @@
             },
             "preserveConstEnums": {
               "description": "Do not erase const enum declarations in generated code.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "preserveSymlinks": {
               "description": "Do not resolve symlinks to their real path; treat a symlinked file like a real one.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "preserveWatchOutput": {
               "description": "Keep outdated console output in watch mode instead of clearing the screen.",
@@ -215,11 +275,13 @@
             },
             "pretty": {
               "description": "Stylize errors and messages using color and context (experimental).",
-              "type": "boolean"
+              "type": "boolean",
+              "default": true
             },
             "removeComments": {
               "description": "Do not emit comments to output.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "rootDir": {
               "description": "Specifies the root directory of input files. Use to control the output directory structure with --outDir.",
@@ -227,23 +289,27 @@
             },
             "isolatedModules": {
               "description": "Unconditionally emit imports for unresolved files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "sourceMap": {
               "description": "Generates corresponding '.map' file.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "sourceRoot": {
               "description": "Specifies the location where debugger should locate TypeScript files instead of source locations.",
               "type": "string"
             },
             "suppressExcessPropertyErrors": {
-              "description": "Suppress excess property checks for object literals.",
-              "type": "boolean"
+              "description": "Suppress excess property checks for object literals. Using this flag is not recommended.",
+              "type": "boolean",
+              "default": false
             },
             "suppressImplicitAnyIndexErrors": {
               "description": "Suppress noImplicitAny errors for indexing objects lacking index signatures.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "stripInternal": {
               "description": "Do not emit declarations for code that has an '@internal' annotation.",
@@ -277,6 +343,34 @@
               "description": "Watch input files.",
               "type": "boolean"
             },
+            "fallbackPolling": {
+              "description": "Specify the polling strategy to use when the system runs out of or doesn't support native file watchers. Requires TypeScript version 3.8 or later.",
+              "enum": [
+                "fixedPollingInterval",
+                "priorityPollingInterval",
+                "dynamicPriorityPolling"
+              ]
+            },
+            "watchDirectory": {
+              "description": "Specify the strategy for watching directories under systems that lack recursive file-watching functionality. Requires TypeScript version 3.8 or later.",
+              "enum": [
+                "useFsEvents",
+                "fixedPollingInterval",
+                "dynamicPriorityPolling"
+              ],
+              "default": "useFsEvents"
+            },
+            "watchFile": {
+              "description": "Specify the strategy for watching individual files. Requires TypeScript version 3.8 or later.",
+              "enum": [
+                "fixedPollingInterval",
+                "priorityPollingInterval",
+                "dynamicPriorityPolling",
+                "useFsEvents",
+                "useFsEventsOnParentDirectory"
+              ],
+              "default": "useFsEvents"
+            },
             "experimentalDecorators": {
               "description": "Enables experimental support for ES7 decorators.",
               "type": "boolean"
@@ -285,41 +379,41 @@
               "description": "Emit design-type metadata for decorated declarations in source.",
               "type": "boolean"
             },
-            "moduleResolution": {
-              "description": "Specifies module resolution strategy: 'node' (Node) or 'classic' (TypeScript pre 1.6) .",
-              "type": "string",
-              "anyOf": [
-                {
-                  "enum": [
-                    "Classic",
-                    "Node"
-                  ]
-                },
-                {
-                  "pattern": "^(([Nn]ode)|([Cc]lassic))$"
-                }
-              ],
-              "default": "classic"
-            },
             "allowUnusedLabels": {
-              "type": "boolean",
-              "description": "Do not report errors on unused labels."
+              "description": "Do not report errors on unused labels. Requires TypeScript version 1.8 or later.",
+              "type": "boolean"
             },
             "noImplicitReturns": {
-              "description": "Report error when not all code paths in function return a value.",
+              "description": "Report error when not all code paths in function return a value. Requires TypeScript version 1.8 or later.",
+              "type": "boolean",
+              "default": false
+            },
+            "noUncheckedIndexedAccess": {
+              "description": "Add `undefined` to an un-declared field in a type. Requires TypeScript version 4.1 or later.",
               "type": "boolean"
             },
             "noFallthroughCasesInSwitch": {
-              "description": "Report errors for fallthrough cases in switch statement.",
-              "type": "boolean"
+              "description": "Report errors for fallthrough cases in switch statement. Requires TypeScript version 1.8 or later.",
+              "type": "boolean",
+              "default": false
             },
             "allowUnreachableCode": {
-              "description": "Do not report errors on unreachable code.",
+              "description": "Do not report errors on unreachable code. Requires TypeScript version 1.8 or later.",
               "type": "boolean"
             },
             "forceConsistentCasingInFileNames": {
               "description": "Disallow inconsistently-cased references to the same file.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
+            },
+            "generateCpuProfile": {
+              "description": "Emit a v8 CPI profile during the compiler run, which may provide insight into slow builds. Requires TypeScript version 3.7 or later.",
+              "type": "string",
+              "default": "profile.cpuprofile"
+            },
+            "importNotUsedAsValues": {
+              "description": "This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.",
+              "enum": ["remove", "preserve", "error"]
             },
             "baseUrl": {
               "description": "Base directory to resolve non-relative module names.",
@@ -330,6 +424,7 @@
               "type": "object",
               "additionalProperties": {
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string",
                   "description": "Path mapping to be computed relative to baseUrl option."
@@ -350,8 +445,9 @@
               }
             },
             "rootDirs": {
-              "description": "Specify list of root directories to be used when resolving modules.",
+              "description": "Specify list of root directories to be used when resolving modules. Requires TypeScript version 2.0 or later.",
               "type": "array",
+              "uniqueItems": true,
               "items": {
                 "type": "string"
               }
@@ -359,6 +455,7 @@
             "typeRoots": {
               "description": "Specify list of directories for type definition files to be included. Requires TypeScript version 2.0 or later.",
               "type": "array",
+              "uniqueItems": true,
               "items": {
                 "type": "string"
               }
@@ -366,33 +463,39 @@
             "types": {
               "description": "Type declaration files to be included in compilation. Requires TypeScript version 2.0 or later.",
               "type": "array",
+              "uniqueItems": true,
               "items": {
                 "type": "string"
               }
             },
             "traceResolution": {
-              "description": "Enable tracing of the name resolution process.",
-              "type": "boolean"
+              "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
+              "type": "boolean",
+              "default": false
             },
             "allowJs": {
-              "description": "Allow javascript files to be compiled.",
-              "type": "boolean"
+              "description": "Allow javascript files to be compiled. Requires TypeScript version 1.8 or later.",
+              "type": "boolean",
+              "default": false
             },
             "noErrorTruncation": {
-              "description": "Do not truncate error messages.",
-              "type": "boolean"
+              "description": "Do not truncate error messages. This setting is deprecated.",
+              "type": "boolean",
+              "default": false
             },
             "allowSyntheticDefaultImports": {
-              "description": "Allow default imports from modules with no default export. This does not affect code emit, just typechecking.",
+              "description": "Allow default imports from modules with no default export. This does not affect code emit, just typechecking. Requires TypeScript version 1.8 or later.",
               "type": "boolean"
             },
             "noImplicitUseStrict": {
               "description": "Do not emit 'use strict' directives in module output.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "listEmittedFiles": {
               "description": "Enable to list all emitted files. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "disableSizeLimit": {
               "description": "Disable size limit for JavaScript project. Requires TypeScript version 2.0 or later.",
@@ -402,6 +505,7 @@
             "lib": {
               "description": "List of library files to be included in the compilation. Possible values are: 'ES5', 'ES6', 'ES2015', 'ES7', 'ES2016', 'ES2017', 'ES2018', 'ESNext', 'DOM', 'DOM.Iterable', 'WebWorker', 'ScriptHost', 'ES2015.Core', 'ES2015.Collection', 'ES2015.Generator', 'ES2015.Iterable', 'ES2015.Promise', 'ES2015.Proxy', 'ES2015.Reflect', 'ES2015.Symbol', 'ES2015.Symbol.WellKnown', 'ES2016.Array.Include', 'ES2017.object', 'ES2017.Intl', 'ES2017.SharedMemory', 'ES2017.String', 'ES2017.TypedArrays', 'ES2018.Intl', 'ES2018.Promise', 'ES2018.RegExp', 'ESNext.AsyncIterable', 'ESNext.Array', 'ESNext.Intl', 'ESNext.Symbol'. Requires TypeScript version 2.0 or later.",
               "type": "array",
+              "uniqueItems": true,
               "items": {
                 "type": "string",
                 "anyOf": [
@@ -506,7 +610,8 @@
             },
             "strictNullChecks": {
               "description": "Enable strict null checks. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "maxNodeModuleJsDepth": {
               "description": "The maximum dependency depth to search under node_modules and load JavaScript files. Only applicable with --allowJs.",
@@ -515,7 +620,8 @@
             },
             "importHelpers": {
               "description": "Import emit helpers (e.g. '__extends', '__rest', etc..) from tslib. Requires TypeScript version 2.1 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "importsNotUsedAsValues": {
               "description": "Specify emit/checking behavior for imports that are only used for types",
@@ -527,86 +633,89 @@
                 "error"
               ]
             },
-            "jsxFactory": {
-              "description": "Specify the JSX factory function to use when targeting react JSX emit, e.g. 'React.createElement' or 'h'. Requires TypeScript version 2.1 or later.",
-              "type": "string",
-              "default": "React.createElement"
-            },
-            "jsxFragmentFactory": {
-              "description": "Specify the JSX Fragment reference to use for fragements when targeting react JSX emit, e.g. 'React.Fragment' or 'Fragment'. Requires TypeScript version 4.0 or later.",
-              "type": "string",
-              "default": "React.Fragment"
-            },
             "alwaysStrict": {
               "description": "Parse in strict mode and emit 'use strict' for each source file. Requires TypeScript version 2.1 or later.",
               "type": "boolean"
             },
             "strict": {
               "description": "Enable all strict type checking options. Requires TypeScript version 2.3 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "strictBindCallApply": {
-              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions.",
-              "type": "boolean"
+              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions. Requires TypeScript version 3.2 or later.",
+              "type": "boolean",
+              "default": false
             },
             "downlevelIteration": {
               "description": "Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. Requires TypeScript version 2.3 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "checkJs": {
               "description": "Report errors in .js files. Requires TypeScript version 2.3 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "strictFunctionTypes": {
               "description": "Disable bivariant parameter checking for function types. Requires TypeScript version 2.6 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "strictPropertyInitialization": {
               "description": "Ensure non-undefined class properties are initialized in the constructor. Requires TypeScript version 2.7 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "esModuleInterop": {
               "description": "Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility and enable '--allowSyntheticDefaultImports' for typesystem compatibility. Requires TypeScript version 2.7 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "allowUmdGlobalAccess": {
-              "description": "Allow accessing UMD globals from modules.",
-              "type": "boolean"
+              "description": "Allow accessing UMD globals from modules. Requires TypeScript version 3.5 or later.",
+              "type": "boolean",
+              "default": false
             },
             "keyofStringsOnly": {
               "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). Requires TypeScript version 2.9 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "useDefineForClassFields": {
               "description": "Emit ECMAScript standard class fields. Requires TypeScript version 3.7 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "declarationMap": {
               "description": "Generates a sourcemap for each corresponding '.d.ts' file. Requires TypeScript version 2.9 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "resolveJsonModule": {
               "description": "Include modules imported with '.json' extension. Requires TypeScript version 2.9 or later.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "assumeChangesOnlyAffectDirectDependencies": {
-              "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it.",
+              "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it. Requires TypeScript version 3.8 or later.",
               "type": "boolean"
             },
             "extendedDiagnostics": {
               "description": "Show verbose diagnostic information.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "listFilesOnly": {
               "description": "Print names of files that are part of the compilation and then stop processing.",
               "type": "boolean"
             },
             "disableSourceOfProjectReferenceRedirect": {
-              "description": "Disable use of source files instead of declaration files from referenced projects.",
+              "description": "Disable use of source files instead of declaration files from referenced projects. Requires TypeScript version 3.7 or later.",
               "type": "boolean"
             },
             "disableSolutionSearching": {
-              "description": "Disable solution searching for this project.",
+              "description": "Disable solution searching for this project. Requires TypeScript version 3.8 or later.",
               "type": "boolean"
             }
           }
@@ -627,6 +736,7 @@
             "include": {
               "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "type": "array",
+              "uniqueItems": true,
               "items": {
                 "type": "string"
               }
@@ -634,6 +744,7 @@
             "exclude": {
               "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "type": "array",
+              "uniqueItems": true,
               "items": {
                 "type": "string"
               }
@@ -646,6 +757,7 @@
       "properties": {
         "references": {
           "type": "array",
+          "uniqueItems": true,
           "description": "Referenced projects. Requires TypeScript version 3.0 or later.",
           "items": {
             "type": "object",
@@ -702,7 +814,8 @@
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "uniqueItems": true
             },
             "ignoreDiagnostics": {
               "description": "Ignore TypeScript warnings by diagnostic code.",
@@ -712,7 +825,8 @@
                   "number"
                 ]
               },
-              "type": "array"
+              "type": "array",
+              "uniqueItems": true
             },
             "logError": {
               "default": false,
@@ -734,7 +848,8 @@
               "items": {
                 "type": "string"
               },
-              "type": "array"
+              "type": "array",
+              "uniqueItems": true,
             },
             "scope": {
               "default": false,


### PR DESCRIPTION
Annotations added according to the official tsconfig documentation:
- Default values
- Recommended values
- Deprecated compiler options
- Required compiler versions for compiler options.

Possible further changes (please give thoughts / recommendations):
- Add newline characters before recommended-value notices, deprecation notices, and "Requires TypeScript version X.X or later" notices.
- Completely remove deprecated compiler options from the schema. I noticed that [`out`](https://www.typescriptlang.org/tsconfig#out) is not in tsconfig nor in jsconfig. jsconfig has removed [`noErrorTruncation`](https://www.typescriptlang.org/tsconfig#noErrorTruncation). Deprecated options that are still in tsconfig and jsconfig are: `charset`, `diagnostics`, and `keyOfStringsOnly`.
- Re-order the options to match their listing-ordering in the typescript website documentation. This would make it easier to compare it with the documentation and check for mismatches requiring updates.