### PR TITLE
Add MQTT topic mapping to EdgeHub v1.2

### DIFF
--- a/src/schemas/json/azure-iot-edgehub-deployment-1.2.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.2.json
@@ -88,6 +88,44 @@
                         "mqttBroker": {
                             "type": "object",
                             "properties": {
+                                "bridges": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "endpoint": {
+                                                "type": "string",
+                                                "pattern": "\\$upstream"
+                                            },
+                                            "settings": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "direction": {
+                                                            "type": "string",
+                                                            "pattern": "^in$|^out$"
+                                                        },
+                                                        "topic": {
+                                                            "type": "string",
+                                                            "pattern": "^.*$"
+                                                        },
+                                                        "inPrefix": {
+                                                            "type": "string",
+                                                            "pattern": "^.*$"
+                                                        },
+                                                        "outPrefix": {
+                                                            "type": "string",
+                                                            "pattern": "^.*$"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
                                 "authorizations": {
                                     "type": "array",
                                     "items": {
@@ -100,8 +138,8 @@
                                                     "pattern": "^.+$",
                                                     "examples": [
                                                         "{{iot:identity}}",
-                                                        "MyLeafDevice1",
-                                                        "MyEdgeDevice/MyModule"
+                                                        "contoso.azure-devices.net/MyLeafDevice1",
+                                                        "contoso.azure-devices.net/MyEdgeDevice/MyModule"
                                                     ]
                                                 }
                                             },
@@ -115,7 +153,8 @@
                                         "additionalProperties": false
                                     }
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
                     },
                     "patternProperties": {

--- a/src/test/azure-iot-edgehub-deployment-1.2/deployment.json
+++ b/src/test/azure-iot-edgehub-deployment-1.2/deployment.json
@@ -16,6 +16,22 @@
                 "timeToLiveSecs": 7200
             },
             "mqttBroker": {
+                "bridges": [{
+                        "endpoint": "$upstream",
+                        "settings": [{
+                                "direction": "in",
+                                "topic": "foo/#",
+                                "outPrefix": "/local/topic",
+                                "inPrefix": "remote/topic"
+                            }, {
+                                "direction": "out",
+                                "topic": "",
+                                "inPrefix": "/local/telemetry",
+                                "outPrefix": "/remote/messages"
+                            }
+                        ]
+                    }
+                ],
                 "authorizations": [{
                         "identities": [
                             "ubuntu-01/mqttModule1",


### PR DESCRIPTION
Add another for topic mapping introduced by the new MQTT broker, and fixes a comment mistake from the last change.