### PR TITLE
update: schemasafe to suport remote schema

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -38,15 +38,9 @@
     "dss-2.0.0.json",
     "electron-builder.json",
     "expo-37.0.0.json",
-    "feed.json",
     "geojson.json",
     "github-workflow.json",
     "gitlab-ci.json",
-    "grunt-clean-task.json",
-    "grunt-copy-task.json",
-    "grunt-cssmin-task.json",
-    "grunt-jshint-task.json",
-    "grunt-task.json",
     "haxelib.json",
     "helmfile.json",
     "huskyrc.json",
@@ -108,14 +102,11 @@
     "template.json",
     "toolinfo.1.1.0.json",
     "tslint.json",
-    "tsoa.json",
     "ui5-manifest.json",
     "vega.json",
     "vs-2017.3.host.json",
     "vsix-publish.json",
     "vss-extension.json",
-    "web-manifest-app-info.json",
-    "web-manifest-combined.json",
     "web-types.json",
     "webextension.json",
     "xs-app.json",
@@ -132,6 +123,8 @@
   ],
   "strongmode": [
    ],
+  "laxmode": [
+  ],
   "missingcatalogurl": [
     "---> below this line are schema, that are included from other schema<---",
     "web-manifest.json",
@@ -174,5 +167,13 @@
     "info.json",
     "manifest.json",
     "*.cryproj"
+  ],
+  "externalschema": [
+    "feed-1.json",
+    "jshintrc.json",
+    "grunt-task.json",
+    "tsconfig.json",
+    "web-manifest.json",
+    "web-manifest-app-info.json"
   ]
 }

--- a/src/schemas/json/feed-1.json
+++ b/src/schemas/json/feed-1.json
@@ -1,6 +1,7 @@
 {
   "title": "JSON schema for the JSON Feed format",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/feed-1",
 
   "type": "object",
   "additionalProperties": false,

--- a/src/schemas/json/grunt-task.json
+++ b/src/schemas/json/grunt-task.json
@@ -1,6 +1,7 @@
 {
 	"title": "JSON schema for any Grunt task",
 	"$schema": "http://json-schema.org/draft-04/schema#",
+	"id": "https://json.schemastore.org/grunt-task",
 
 	"type": "object",
 
@@ -57,10 +58,10 @@
 				"src": {
 					"description": "Pattern(s) to match, relative to the 'cwd'.",
 					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
 					"items": {
-						"type": "string",
-						"minLength": 1,
-						"uniqueItems": true
+						"type": "string"
 					}
 				}
 			}
@@ -73,10 +74,10 @@
 							"type": "object",
 							"additionalProperties": {
 								"type": [ "array", "string" ],
+								"uniqueItems": true,
+								"minItems": 1,
 								"items": {
-									"type": "string",
-									"uniqueItems": true,
-									"minItems": 1
+									"type": "string"
 								}
 							}
 						},

--- a/src/schemas/json/jshintrc.json
+++ b/src/schemas/json/jshintrc.json
@@ -1,6 +1,7 @@
 {
 	"title": "JSON schema for JSHint configuration files",
 	"$schema": "http://json-schema.org/draft-04/schema#",
+	"id": "https://json.schemastore.org/jshintrc",
 
 	"type": "object",
 

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "title": "JSON schema for the TypeScript compiler's configuration file",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/tsconfig",
 
   "definitions": {
     "//": {

--- a/src/schemas/json/web-manifest-app-info.json
+++ b/src/schemas/json/web-manifest-app-info.json
@@ -1,6 +1,7 @@
 {
   "title": "JSON schema for Web Application manifest files with app information extensions",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "https://json.schemastore.org/web-manifest-app-info.json",
 
   "type": "object",
 

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -1,6 +1,7 @@
 {
   "title": "JSON schema for Web Application manifest files",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "https://json.schemastore.org/web-manifest.json",
 
   "type": "object",
 


### PR DESCRIPTION
Add schemasafe support for:

---
**External schema**
Schemasafe must load the external schema locally
The external schema json filename must be added to "externalschema" list.
These external schema MUST have root a "$id"

---
**Lax mode**
Use lax mode by adding schema json filename  to "laxmode" list. (This is only for special case.)
- Allows unused keywords to be present in the schema.
- Allows unreachable checks to be present in the schema.

---
Also update the tv4 external file list in Gruntfile.js. 
Remove jshintrc.json and grunt-task.json from list because it no longer used by tv4, is now moved to schemasafe