### PR TITLE
fix: wrong field name in tsconfig/jsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -384,8 +384,9 @@
               "type": "string",
               "default": "profile.cpuprofile"
             },
-            "importNotUsedAsValues": {
+            "importsNotUsedAsValues": {
               "description": "This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.",
+              "default": "remove",
               "enum": ["remove", "preserve", "error"]
             },
             "baseUrl": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -417,10 +417,6 @@
               "type": "string",
               "default": "profile.cpuprofile"
             },
-            "importNotUsedAsValues": {
-              "description": "This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.",
-              "enum": ["remove", "preserve", "error"]
-            },
             "baseUrl": {
               "description": "Base directory to resolve non-relative module names.",
               "type": "string"
@@ -630,8 +626,7 @@
               "default": false
             },
             "importsNotUsedAsValues": {
-              "description": "Specify emit/checking behavior for imports that are only used for types. Requires TypeScript version 3.8 or later.",
-              "type": "string",
+              "description": "This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.",
               "default": "remove",
               "enum": [
                 "remove",


### PR DESCRIPTION
- "importNotUsedAsValues" does not exist. tsc will error on this field name.
the actual field name is "importsNotUsedAsValues".
- tsconfig already had it (and the one with the typo was a wrong duplicate). copied the better description though.
- jsconfig needed the correct name.

ref: https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues