### PR TITLE
update: the resolution definition in package.json

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -528,7 +528,8 @@
       ]
     },
     "resolutions": {
-      "$ref": "#/definitions/dependency"
+      "description": "Resolutions is used to support selective version resolutions, which lets you define custom package versions or ranges inside your dependencies. See: https://classic.yarnpkg.com/en/docs/selective-version-resolutions",
+      "type": "object"
     },
     "engines": {
       "type": "object",


### PR DESCRIPTION
This pr fixes #1390.

The resolution definition is only uses by yarn. And this pr make it more clearly.
