### PR TITLE
fix: toc_levels can either be a list of integers, or a range: `1..6`

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -505,10 +505,10 @@
           "description": "Specifies options for the syntax highlighter set via the syntax_highlighter configuration option."
         },
         "toc_levels": {
-          "type": "integer",
+          "type": "string",
           "title": "Defines the levels that are used for the table of contents",
           "description": "The individual levels can be specified by separating them with commas (e.g. 1,2,3) or by using the range syntax (e.g. 1..3). Only the specified levels are used for the table of contents.",
-          "enum": [1,2,3,4,5,6]
+          "pattern": "^\\d((\\.\\.\\d)?|(\\,\\d)*)$"
         },
         "transliterated_header_ids": {
           "type": "boolean",


### PR DESCRIPTION
Fixes https://github.com/SchemaStore/schemastore/issues/1362

Previously the schema defined the valid values for `toc_levels` to be an enum of `[1,2,3,4,5,6]` but the description says that it should either be a comma delimited list of numbers, or a range formed by two numbers with two dots between, i.e. `1..6`

https://kramdown.gettalong.org/options.html#option-toc-levels

This should change the type to a string that matches against a regex that requires that the string is one of those.

It doesn't match against `12,23` or `1..100`, but I'm not sure that's a problem?