### PR TITLE
Allow parameter for parallelism in CircleCI

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -952,8 +952,16 @@
           },
           "parallelism": {
             "description": "Number of parallel instances of this job to run (default: 1)",
-            "type": "integer",
-            "default": 1
+            "default": 1,
+            "oneOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string",
+                "pattern": "^<<.+\\..+>>$"
+              }
+            ]
           },
           "environment": {
             "description": "A map of environment variable names and variables (NOTE: these will override any environment variables you set in the CircleCI web interface).",

--- a/src/test/circleciconfig/parallelism.json
+++ b/src/test/circleciconfig/parallelism.json
@@ -1,0 +1,26 @@
+{
+  "version": 2.1,
+  "jobs": {
+    "parallel-integer-job": {
+      "executor": "machine-executor",
+      "parallelism": 2,
+      "steps": [
+        "run"
+      ]
+    },
+    "parallel-string-job": {
+      "executor": "machine-executor",
+      "parameters": {
+        "parallel": {
+          "description": null,
+          "type": "integer",
+          "default": 5
+        }
+      },
+      "parallelism": "<< parameters.parallel >>",
+      "steps": [
+        "run"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The [parallelism](https://circleci.com/docs/2.0/configuration-reference/#parallelism) attribute supports setting it via [parameters](https://circleci.com/docs/2.0/configuration-reference/#parameters-requires-version-21).

Example:

```yml
parallelism: << parameters.parallelism >>
```