### PR TITLE
ui5.yaml: Add fileMatch patterns

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2013,7 +2013,10 @@
       "fileMatch": [
         "ui5.yaml",
         "*-ui5.yaml",
-        "*.ui5.yaml"
+        "*.ui5.yaml",
+        "ui5-deploy.yaml",
+        "ui5-dist.yaml",
+        "ui5-local.yaml"
       ],
       "url": "https://sap.github.io/ui5-tooling/schema/ui5.yaml.json"
     },


### PR DESCRIPTION
Adds some commonly used file names.
The generic pattern "ui5-*.yaml" would cause side-effects, see
https://github.com/SchemaStore/schemastore/pull/1039.