### PR TITLE
Add Environment to github-workflow schema

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -143,6 +143,27 @@
       },
       "minProperties": 1
     },
+    "environment": {
+      "$comment": "https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idenvironment",
+      "description": "The environment that the job references",
+      "type": "object",
+      "properties": {
+        "name": {
+          "$comment": "https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-using-a-single-environment-name",
+          "description": "The environment that the job references.",
+          "type": "string"
+        },
+        "url": {
+          "$comment": "https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-using-environment-name-and-url",
+          "description": "A deployment URL",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
     "event": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows",
       "type": "string",
@@ -1071,6 +1092,18 @@
                 },
                 {
                   "$ref": "#/definitions/expressionSyntax"
+                }
+              ]
+            },
+            "environment": {
+              "$comment": "https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idenvironment",
+              "description": "The environment that the job references.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/environment"
                 }
               ]
             },

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -150,7 +150,7 @@
       "properties": {
         "name": {
           "$comment": "https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-using-a-single-environment-name",
-          "description": "The environment that the job references.",
+          "description": "The name of the environment configured in the repo.",
           "type": "string"
         },
         "url": {

--- a/src/test/github-workflow/environments.json
+++ b/src/test/github-workflow/environments.json
@@ -1,0 +1,20 @@
+{
+    "name": "Test environment",
+    "on": [
+      "push"
+    ],
+    "jobs": {
+      "build": {
+        "runs-on": "ubuntu-latest",
+        "environment": {
+          "name": "production",
+          "url": "http://www.example.com"
+        }
+      },
+      "test": {
+        "runs-on": "ubuntu-latest",
+        "environment": "staging"
+      }
+    }
+  }
+  


### PR DESCRIPTION
Fixes #1407 by adding Environment schema

Added an initial test for the environment schema, but noticed these aren't running, logged #1408 to address, but feel like this shouldn't block updating the schema (since other validation is disabled)