### PR TITLE
Add Mega-Linter schema + CI section in documentation

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1282,6 +1282,22 @@
       "url": "https://json.schemastore.org/lsdlschema"
     },
     {
+      "name": "Mega-Linter configuration",
+      "description": "JSON schema for Mega-Linter configuration file (for Mega-Linter users)",
+      "fileMatch": [
+        ".mega-linter.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/nvuillam/mega-linter/master/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json"
+    },
+    {
+      "name": "Mega-Linter descriptor",
+      "description": "JSON schema for Mega-Linter descriptor files (for Mega-Linter contributors)",
+      "fileMatch": [
+        "*.megalinter-descriptor.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/nvuillam/mega-linter/master/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
+    },
+    {
       "name": "Microsoft Band Web Tile",
       "description": "Microsoft Band Web Tile manifest file",
       "url": "https://json.schemastore.org/band-manifest"

--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -85,6 +85,17 @@
 </article>
 
 <article>
+    <h3 id="ci">Supporting Continuous Integration tools</h3>
+    <p>
+        CI/CD applications can detect all JSON and YAML files and validate them if a matching schema is found on SchemaStore.org
+    </p>
+
+    <ul>
+        <li><a href="https://nvuillam.github.io/mega-linter/" target="_blank">Mega-Linter</a></li>
+    </ul>
+</article>
+
+<article>
     <h3 id="contribute">Contribute</h3>
     <p>
         <img src="/img/octocat.png" width="250" height="208" alt="Hosted on GitHub" class="right" />


### PR DESCRIPTION
[Mega-Linter](https://nvuillam.github.io/mega-linter/) is a linters aggregator for CI, containing advanced configuration YAML files

1. New Json schemas in catalog:
- Mega-Linter configuration (it is big but most of it is automatically generated during Mega-Linter build)
- Mega-Linter descriptor

Note: Schemas are self-hosted but tested during Mega-Linter own CI using python jsonschema package

2. Update documentation to add CI section
Mega-Linter includes automated detection and validation of all JSON and YAML files matching a schema on schemastore.org, using [v8r](https://nvuillam.github.io/mega-linter/descriptors/json_v8r/)