### PR TITLE
fix: added types jsconfig parameter

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -426,6 +426,14 @@
                 "type": "string"
               }
             },
+            "types": {
+              "description": "Type declaration files to be included in compilation. Requires TypeScript version 2.0 or later.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
             "allowSyntheticDefaultImports": {
               "description": "Allow default imports from modules with no default export. This does not affect code emit, just typechecking.",
               "type": "boolean"


### PR DESCRIPTION
Good day. Our project uses vscode and with jsconfig.json we will implement JS typing. Recently we faced the problem of mixing types from different `@types` packages and the task was to divide the project into subprojects with its own jsconfig.json and exclude the established dependency on the need to exclude mixing of types with the same names. This type implements a global constant, the name of which is the same in the two subprojects, but the types can be different, and this creates a problem.

In tsconfig.json it is possible to explicitly specify the types used in the project https://www.typescriptlang.org/tsconfig#types and this is implemented in the scheme as https://github.com/SchemaStore/schemastore/blame/27612065234778feaac216ce14dd47846fe0a2dd/src/schemas/json/tsconfig.json#L465

It can be reproduced using the following repositories, where the project has a server and client folder with different types.
https://github.com/CocaColaBear/types-ragemp-s/blob/master/index.d.ts#L505
https://github.com/CocaColaBear/types-ragemp-c/blob/master/index.d.ts#L3381

As a result, vscode perfectly understands the added types parameter in jsconfig.json and excludes unwanted types. I propose to make this parameter for jsconfig.json