### PR TITLE
fix: Added typeRoots types parameters to jsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -426,6 +426,22 @@
                 "type": "string"
               }
             },
+            "typeRoots": {
+              "description": "Specify list of directories for type definition files to be included. Requires TypeScript version 2.0 or later.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "types": {
+              "description": "Type declaration files to be included in compilation. Requires TypeScript version 2.0 or later.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
             "allowSyntheticDefaultImports": {
               "description": "Allow default imports from modules with no default export. This does not affect code emit, just typechecking.",
               "type": "boolean"


### PR DESCRIPTION
Just like `tsconfig.json`, `jsconfig.json` supports the `compilerOptions.typeRoots` and `compilerOptions.types` fields. In our case, the VSCode IDE perfectly accepts these parameters for the task of dividing one project into subprojects, disabling unwanted type declarations and preventing mixing of types for the same declared variables by name with different types, for different purposes.