### PR TITLE
Add StackHead schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1825,6 +1825,31 @@
       "url": "https://json.schemastore.org/sprite"
     },
     {
+      "name": "StackHead CLI config",
+      "description": "Configuration file for StackHead CLI. See https://stackhead.io.",
+      "fileMatch": [
+        ".stackhead-cli.yml"
+      ],
+      "url": "https://schema.stackhead.io/stackhead-cli/tag/v1/-/cli-config.schema.json"
+    },
+    {
+      "name": "StackHead module configuration",
+      "description": "Configuration file for StackHead modules. See https://stackhead.io.",
+      "fileMatch": [
+        "stackhead-module.yml"
+      ],
+      "url": "https://schema.stackhead.io/stackhead/tag/v1/-/module-config.schema.json"
+    },
+    {
+      "name": "StackHead project definition",
+      "description": "Project definition file for deploying projects with StackHead. See https://stackhead.io.",
+      "fileMatch": [
+        "*.stackhead.yml",
+        "*.stackhead.yaml"
+      ],
+      "url": "https://schema.stackhead.io/stackhead/tag/v1/-/project-definition.schema.json"
+    },
+    {
       "name": "Stryker Mutator",
       "description": "Configuration file for Stryker Mutator, the mutation testing framework for JavaScript and friends. See https://stryker-mutator.io.",
       "fileMatch": [


### PR DESCRIPTION
Hi there,

StackHead.io is a personal project for deploying web applications based on a YAML file.
The YAML files are validated via JSONSchema which are also hosted on https://schema.stackhead.io.
I've added them to the catalog with a "v1" version, meaning they will automatically be pointing to the latest v1.* tag.

It's still WIP but I've just released v1.0.0. Even though I'm the only user right now, I'd love to check the schemas within my IDE. :)

Please tell me if you need more information.