### PR TITLE
Must use https in the catalog URL

### DIFF
--- a/src/schemas/json/schema-catalog.json
+++ b/src/schemas/json/schema-catalog.json
@@ -26,7 +26,9 @@
           },
           "url": {
             "description": "An absolute URL to the schema location",
-            "type": "string"
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://"
           },
           "name": {
             "description": "The name of the schema",
@@ -40,7 +42,8 @@
             "description": "A set of specific version to schema mappings",
             "additionalProperties": {
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "pattern": "^https://"
             }
           }
         }

--- a/src/test/schema-catalog/minimal.json
+++ b/src/test/schema-catalog/minimal.json
@@ -6,7 +6,7 @@
 		{
 			"name": "minimal",
 			"description": "minimal",
-			"url": "http://example.com"
+			"url": "https://example.com"
 		}
 	]
 }

--- a/src/test/schema-catalog/multiple.json
+++ b/src/test/schema-catalog/multiple.json
@@ -7,13 +7,18 @@
 			"name": "minimal",
 			"description": "minimal",
 			"fileMatch": [ "foo.json" ],
-			"url": "http://example.com"
+			"url": "https://example.com"
 		},
 		{
 			"name": "minimal2",
 			"description": "minimal2",
 			"fileMatch": [ "foo.json", "bar.json" ],
-			"url": "http://example.com"
+			"url": "https://example.com",
+			"versions": {
+				"1.0": "https://json.schemastore.org/example_1_0",
+				"1.1": "https://json.schemastore.org/example_1_1"
+			}
+
 		}
 	]
 }


### PR DESCRIPTION
pr #1370 already update the http to https.
It is now not possible anymore to use http in the catalog URL