### PR TITLE
Added schemas for Foundry VTT

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -879,6 +879,23 @@
       "url": "https://ffizer.github.io/ffizer/ffizer.schema.json"
     },
     {
+      "name": "Foundry VTT - Manifest",
+      "description": "JSON schema for Foundry VTT system.json and module.json files.",
+      "fileMatch": [
+        "system.json",
+        "module.json"
+      ],
+      "url": "https://gitlab.com/-/snippets/2062623/raw/master/foundryvtt_manifest_schema.json"
+    },
+    {
+      "name": "Foundry VTT - Template",
+      "description": "JSON schema for Foundry VTT template.json files.",
+      "fileMatch": [
+        "template.json"
+      ],
+      "url": "https://gitlab.com/-/snippets/2062623/raw/master/foundryvtt_template_schema.json"
+    },
+    {
       "name": "function.json",
       "description": "JSON schema for Azure Functions function.json files",
       "fileMatch": [


### PR DESCRIPTION
I have created schemas to validate the two types of JSON files required by packages created for the Foundry Virtual Tabletop software. I have created them as snippets, so I'm not sure if that's alright. If not, I'll move them over to a dedicated repository, but as they are the only files currently required for working with Foundry, I did not see a need for that yet.