### PR TITLE
Fix Edge schema to recursively apply property restrictions

### DIFF
--- a/src/schemas/json/azure-iot-edge-deployment-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-2.0.json
@@ -89,7 +89,7 @@
                                             },
                                             "patternProperties": {
                                                 "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                                    "$ref": "#/definitions/additionalPropertyTypes"
                                                 }
                                             },
                                             "additionalProperties": false
@@ -97,7 +97,7 @@
                                     },
                                     "patternProperties": {
                                         "^[^\\.\\$# ]+$":{
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                            "$ref": "#/definitions/additionalPropertyTypes"
                                         }
                                     },
                                     "additionalProperties": false
@@ -131,7 +131,7 @@
                                             },
                                             "patternProperties": {
                                                 "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                                    "$ref": "#/definitions/additionalPropertyTypes"
                                                 }
                                             },
                                             "additionalProperties": false
@@ -170,7 +170,7 @@
                                             },
                                             "patternProperties": {
                                                 "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                                    "$ref": "#/definitions/additionalPropertyTypes"
                                                 }
                                             },
                                             "additionalProperties": false
@@ -220,7 +220,7 @@
                                             },
                                             "patternProperties": {
                                                 "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                                    "$ref": "#/definitions/additionalPropertyTypes"
                                                 }
                                             },
                                             "additionalProperties": false
@@ -231,7 +231,7 @@
                             },
                             "patternProperties": {
                                 "^[^\\.\\$# ]+$":{
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                    "$ref": "#/definitions/additionalPropertyTypes"
                                 }
                             },
                             "additionalProperties": false
@@ -318,7 +318,7 @@
                                     },
                                     "patternProperties": {
                                         "^[^\\.\\$# ]+$":{
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                            "$ref": "#/definitions/additionalPropertyTypes"
                                         }
                                     },
                                     "additionalProperties": false
@@ -326,7 +326,7 @@
                             },
                             "patternProperties": {
                                 "^[^\\.\\$# ]+$":{
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                    "$ref": "#/definitions/additionalPropertyTypes"
                                 }
                             },
                             "additionalProperties": false
@@ -358,6 +358,24 @@
             "enum": [
                 "docker"
             ]
+        },
+        "additionalPropertyTypes" : {
+            "anyOf": [
+                { "type": ["array", "boolean", "integer", "null", "number", "string"] },
+                { "$ref": "#/definitions/nestedObject" }
+            ]
+        },
+        "nestedObject" : {
+            "type": "object",
+            "patternProperties": {
+                "^[^\\.\\$# ]+$":{
+                    "anyOf": [
+                        { "type": ["array", "boolean", "integer", "null", "number", "string"] },
+                        { "$ref": "#/definitions/nestedObject" }
+                    ]
+                }
+            },
+            "additionalProperties": false
         },
         "status": {
             "enum": [
@@ -401,8 +419,8 @@
                 }
             },
             "patternProperties": {
-                "^[^\\.\\$# ]+$":{
-                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                "^[^\\.\\$# ]+$": {
+                    "$ref": "#/definitions/additionalPropertyTypes"
                 }
             },
             "additionalProperties": false

--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -89,7 +89,7 @@
                                             },
                                             "patternProperties": {
                                                 "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                                    "$ref": "https://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/additionalPropertyTypes"
                                                 }
                                             },
                                             "additionalProperties": false
@@ -97,7 +97,7 @@
                                     },
                                     "patternProperties": {
                                         "^[^\\.\\$# ]+$":{
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                            "$ref": "https://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/additionalPropertyTypes"
                                         }
                                     },
                                     "additionalProperties": false
@@ -131,7 +131,7 @@
                                             },
                                             "patternProperties": {
                                                 "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                                    "$ref": "https://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/additionalPropertyTypes"
                                                 }
                                             },
                                             "additionalProperties": false
@@ -170,7 +170,7 @@
                                             },
                                             "patternProperties": {
                                                 "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                                    "$ref": "https://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/additionalPropertyTypes"
                                                 }
                                             },
                                             "additionalProperties": false
@@ -221,7 +221,7 @@
                                             },
                                             "patternProperties": {
                                                 "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                                    "$ref": "https://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/additionalPropertyTypes"
                                                 }
                                             },
                                             "additionalProperties": false
@@ -232,7 +232,7 @@
                             },
                             "patternProperties": {
                                 "^[^\\.\\$# ]+$":{
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                    "$ref": "https://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/additionalPropertyTypes"
                                 }
                             },
                             "additionalProperties": false
@@ -302,7 +302,7 @@
             },
             "patternProperties": {
                 "^[^\\.\\$# ]+$":{
-                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                    "$ref": "https://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/additionalPropertyTypes"
                 }
             },
             "additionalProperties": false

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -78,7 +78,7 @@
                                     },
                                     "patternProperties": {
                                         "^[^\\.\\$# ]+$": {
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                            "$ref": "#/definitions/additionalPropertyTypes"
                                         }
                                     },
                                     "additionalProperties": false
@@ -86,7 +86,7 @@
                             },
                             "patternProperties": {
                                 "^[^\\.\\$# ]+$": {
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                    "$ref": "#/definitions/additionalPropertyTypes"
                                 }
                             },
                             "additionalProperties": false
@@ -120,7 +120,7 @@
                                     },
                                     "patternProperties": {
                                         "^[^\\.\\$# ]+$": {
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                            "$ref": "#/definitions/additionalPropertyTypes"
                                         }
                                     },
                                     "additionalProperties": false
@@ -159,7 +159,7 @@
                                     },
                                     "patternProperties": {
                                         "^[^\\.\\$# ]+$": {
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                            "$ref": "#/definitions/additionalPropertyTypes"
                                         }
                                     },
                                     "additionalProperties": false
@@ -209,7 +209,7 @@
                                     },
                                     "patternProperties": {
                                         "^[^\\.\\$# ]+$": {
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                            "$ref": "#/definitions/additionalPropertyTypes"
                                         }
                                     },
                                     "additionalProperties": false
@@ -220,7 +220,7 @@
                     },
                     "patternProperties": {
                         "^[^\\.\\$# ]+$": {
-                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                            "$ref": "#/definitions/additionalPropertyTypes"
                         }
                     },
                     "additionalProperties": false
@@ -249,6 +249,24 @@
             "enum": [
                 "docker"
             ]
+        },
+        "additionalPropertyTypes" : {
+            "anyOf": [
+                { "type": ["array", "boolean", "integer", "null", "number", "string"] },
+                { "$ref": "#/definitions/nestedObject" }
+            ]
+        },
+        "nestedObject" : {
+            "type": "object",
+            "patternProperties": {
+                "^[^\\.\\$# ]+$":{
+                    "anyOf": [
+                        { "type": ["array", "boolean", "integer", "null", "number", "string"] },
+                        { "$ref": "#/definitions/nestedObject" }
+                    ]
+                }
+            },
+            "additionalProperties": false
         },
         "status": {
             "enum": [
@@ -293,7 +311,7 @@
             },
             "patternProperties": {
                 "^[^\\.\\$# ]+$": {
-                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                    "$ref": "#/definitions/additionalPropertyTypes"
                 }
             },
             "additionalProperties": false

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.1.json
@@ -80,7 +80,7 @@
                             },
                             "patternProperties": {
                                 "^[^\\.\\$# ]+$": {
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                    "$ref": "#/definitions/additionalPropertyTypes"
                                 }
                             },
                             "additionalProperties": false
@@ -88,7 +88,7 @@
                     },
                     "patternProperties": {
                         "^[^\\.\\$# ]+$": {
-                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                            "$ref": "#/definitions/additionalPropertyTypes"
                         }
                     },
                     "additionalProperties": false
@@ -111,5 +111,25 @@
             "additionalProperties": false
         }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "definitions": {
+        "additionalPropertyTypes" : {
+            "anyOf": [
+                { "type": ["array", "boolean", "integer", "null", "number", "string"] },
+                { "$ref": "#/definitions/nestedObject" }
+            ]
+        },
+        "nestedObject" : {
+            "type": "object",
+            "patternProperties": {
+                "^[^\\.\\$# ]+$":{
+                    "anyOf": [
+                        { "type": ["array", "boolean", "integer", "null", "number", "string"] },
+                        { "$ref": "#/definitions/nestedObject" }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    }
 }

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.2.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.2.json
@@ -80,7 +80,7 @@
                             },
                             "patternProperties": {
                                 "^[^\\.\\$# ]+$": {
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                                    "$ref": "#/definitions/additionalPropertyTypes"
                                 }
                             },
                             "additionalProperties": false
@@ -159,7 +159,7 @@
                     },
                     "patternProperties": {
                         "^[^\\.\\$# ]+$": {
-                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
+                            "$ref": "#/definitions/additionalPropertyTypes"
                         }
                     },
                     "additionalProperties": false
@@ -184,6 +184,24 @@
     },
     "additionalProperties": false,
     "definitions": {
+        "additionalPropertyTypes" : {
+            "anyOf": [
+                { "type": ["array", "boolean", "integer", "null", "number", "string"] },
+                { "$ref": "#/definitions/nestedObject" }
+            ]
+        },
+        "nestedObject" : {
+            "type": "object",
+            "patternProperties": {
+                "^[^\\.\\$# ]+$":{
+                    "anyOf": [
+                        { "type": ["array", "boolean", "integer", "null", "number", "string"] },
+                        { "$ref": "#/definitions/nestedObject" }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
         "policy": {
             "type": "array",
             "items": {


### PR DESCRIPTION
The "^[^\\.\\$# ]+$" restriction needs to be applied to properties that contain nested objects, as opposed to just first level properties.