### PR TITLE
Update schemasafe to the latest master commit

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -5,9 +5,8 @@
   "requires": true,
   "dependencies": {
     "@exodus/schemasafe": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.3.tgz",
-      "integrity": "sha512-GoXw0U2Qaa33m3eUcxuHnHpNvHjNlLo0gtV091XBpaRINaB4X6FGCG5XKxSFNFiPpugUDqNruHzaqpTdDm4AOg==",
+      "version": "github:ExodusMovement/schemasafe#3f4dc5f9f8e92fca105d140296cb1c13eb17df0d",
+      "from": "github:ExodusMovement/schemasafe#3f4dc5f9f8e92fca105d140296cb1c13eb17df0d",
       "dev": true
     },
     "@sindresorhus/is": {

--- a/src/package.json
+++ b/src/package.json
@@ -24,7 +24,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-http": "^2.3.1",
     "grunt-tv4": "^2.1.0",
-    "@exodus/schemasafe": "^1.0.0-rc.3",
+    "@exodus/schemasafe": "ExodusMovement/schemasafe#3f4dc5f9f8e92fca105d140296cb1c13eb17df0d",
     "got": "^11.7.0",
     "find-duplicated-property-keys": "^1.2.4"
   }


### PR DESCRIPTION
Update to the latest [fix](https://github.com/ExodusMovement/schemasafe/pull/139) that are not yet released.
This is an important schemasafe fix or else must implement workaround in the JSON schema.

