### PR TITLE
Limit total build time to 10 minutes

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,6 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There was an issue with PR #1450
The tv-4 validator stay in a forever loop. GitHub action keep running till 6 hours timeout. Now it will timeout after 10 minutes.

