### PR TITLE
Add Schema for GitHub Funding

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -932,6 +932,17 @@
       "url": "https://json.schemastore.org/github-action"
     },
     {
+      "name": "GitHub Funding",
+      "description": "YAML schema for GitHub Funding",
+      "fileMatch": [
+        ".github/funding.yml",
+        ".github/funding.yaml",
+        "funding.yml",
+        "funding.yaml"
+      ],
+      "url": "https://json.schemastore.org/github-funding"
+    },
+    {
       "name": "GitHub Workflow",
       "description": "YAML schema for GitHub Workflow",
       "fileMatch": [

--- a/src/schemas/json/github-funding.json
+++ b/src/schemas/json/github-funding.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository",
+  "title": "GitHub Funding",
+  "description": "You can add a sponsor button in your repository to increase the visibility of funding options for your open source project.",
+  "type": "object",
+  "properties": {
+    "community_bridge": {
+      "title": "CommunityBridge",
+      "description": "Project name on CommunityBridge.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "github": {
+      "title": "GitHub Sponsors",
+      "description": "Username or usernames on GitHub.",
+      "type": [
+        "string",
+        "array",
+        "null"
+      ],
+      "items": {
+        "title": "Username",
+        "description": "Username on GitHub.",
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "issuehunt": {
+      "title": "IssueHunt",
+      "description": "Username on IssueHunt.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "ko_fi": {
+      "title": "Ko-fi",
+      "description": "Username on Ko-fi.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "liberapay": {
+      "title": "Liberapay",
+      "description": "Username on Liberapay.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "open_collective": {
+      "title": "Open Collective",
+      "description": "Username on Open Collective.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "otechie": {
+      "title": "Otechie",
+      "description": "Username on Otechie.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "patreon": {
+      "title": "Patreon",
+      "description": "Username on Pateron.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "tidelift": {
+      "title": "Tidelift",
+      "description": "Platform and package on Tidelift.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[A-Za-z]+\/.+$"
+    },
+    "custom": {
+      "title": "Custom URL",
+      "description": "Link or links where funding is accepted on external locations.",
+      "type": [
+        "string",
+        "array",
+        "null"
+      ],
+      "format": "uri-reference",
+      "items": {
+        "title": "Link",
+        "description": "Link to an external location.",
+        "type": "string",
+        "format": "uri-reference"
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/src/test/github-funding/babel.json
+++ b/src/test/github-funding/babel.json
@@ -1,0 +1,7 @@
+{
+  "github": [
+    "babel"
+  ],
+  "open_collective": "babel",
+  "custom": null
+}

--- a/src/test/github-funding/ebookfoundation.json
+++ b/src/test/github-funding/ebookfoundation.json
@@ -1,0 +1,12 @@
+{
+  "github": "EbookFoundation",
+  "patreon": null,
+  "open_collective": null,
+  "ko_fi": null,
+  "tidelift": null,
+  "community_bridge": null,
+  "liberapay": null,
+  "issuehunt": null,
+  "otechie": null,
+  "custom": null
+}

--- a/src/test/github-funding/elypia.json
+++ b/src/test/github-funding/elypia.json
@@ -1,0 +1,8 @@
+{
+  "github": [
+    "elypia"
+  ],
+  "custom": [
+    "https://elypia.org/donate"
+  ]
+}

--- a/src/test/github-funding/imagemagick.json
+++ b/src/test/github-funding/imagemagick.json
@@ -1,0 +1,4 @@
+{
+  "github": "ImageMagick",
+  "custom": "https://imagemagick.org/script/support.php"
+}

--- a/src/test/github-funding/schemastore.json
+++ b/src/test/github-funding/schemastore.json
@@ -1,0 +1,3 @@
+{
+  "github": "madskristensen"
+}


### PR DESCRIPTION
Adds a YAML schema for the GitHub funding health file. (`FUNDING.yml`)

Matches:
* `.github/funding.yml` - the location in a normal repository
* `funding.yml` - the location in a health file repository (.github)

Uses the `FUNDING.yml` from other repositories for tests in `/src/tests/`.