### PR TITLE
Add depends_on attribute to pipelines in Drone schema

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -370,6 +370,12 @@
         },
         "trigger": {
           "$ref": "#/definitions/allConditions"
+        },
+        "depends_on": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/nonEmptyString"
+          }
         }
       }
     },
@@ -408,7 +414,8 @@
         "platform": {},
         "workspace": {},
         "clone": {},
-        "trigger": {}
+        "trigger": {},
+        "depends_on": {}
       }
     },
     "pipeline_kubernetes": {
@@ -471,7 +478,8 @@
         "platform": {},
         "workspace": {},
         "clone": {},
-        "trigger": {}
+        "trigger": {},
+        "depends_on": {}
       }
     },
     "pipeline_exec": {
@@ -494,7 +502,8 @@
         "platform": {},
         "workspace": {},
         "clone": {},
-        "trigger": {}
+        "trigger": {},
+        "depends_on": {}
       }
     },
     "pipeline_ssh": {
@@ -537,7 +546,8 @@
         "platform": {},
         "workspace": {},
         "clone": {},
-        "trigger": {}
+        "trigger": {},
+        "depends_on": {}
       }
     },
     "pipeline_digitalocean": {
@@ -563,7 +573,8 @@
         "platform": {},
         "workspace": {},
         "clone": {},
-        "trigger": {}
+        "trigger": {},
+        "depends_on": {}
       }
     },
     "pipeline_macstadium": {
@@ -583,7 +594,8 @@
         "platform": {},
         "workspace": {},
         "clone": {},
-        "trigger": {}
+        "trigger": {},
+        "depends_on": {}
       }
     },
     "step": {


### PR DESCRIPTION
Allows the depends_on attribute to be set on pipelines. https://docs.drone.io/yaml/docker/#the-depends_on-attribute

 This link is specifically to the docker pipeline reference but depends_on is available on all pipelines.