### PR TITLE
Add mandatory $schema present check

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -14,7 +14,6 @@
     "azure-iot-edge-deployment-template-1.0.json",
     "azure-iot-edge-deployment-template-2.0.json",
     "bukkit-plugin.json",
-    "chrome-manifest.json",
     "circleciconfig.json",
     "cirrus.json",
     "cloud-sdk-pipeline-config-schema.json",
@@ -159,5 +158,16 @@
     "tsconfig.json",
     "web-manifest.json",
     "web-manifest-app-info.json"
+  ],
+  "unknownFormat": [
+    {
+      "chrome-manifest.json": [
+        "match-pattern",
+        "content-security-policy",
+        "glob-pattern",
+        "mime-type",
+        "permission"
+      ]
+    }
   ]
 }

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -22,7 +22,6 @@
     "cloudify.json",
     "codecov.json",
     "compilerconfig.json",
-    "cosmos-config.json",
     "creatomic.json",
     "dart-build.json",
     "dependabot-2.0.json",

--- a/src/schemas/json/apibuilder.json
+++ b/src/schemas/json/apibuilder.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title":"API Builder Schema",
   "description":"JSON Schema for API Builder's api.json format from https://app.apibuilder.io/doc/apiJson",
   "properties":{

--- a/src/schemas/json/apibuilder.json
+++ b/src/schemas/json/apibuilder.json
@@ -56,7 +56,6 @@
       "$ref":"#/definitions/union"
     },
     "resources":{
-      "type":"object",
       "description":"JSON object defining all of the resources in this API. The key of each object is the name of a type that this resource represents. The type must be the name of a model or an enum.",
       "$ref":"#/definitions/resource"
     },
@@ -184,7 +183,6 @@
           }
         },
         "deprecation":{
-          "type":"object",
           "$ref":"#/definitions/deprecation"
         }
       },
@@ -213,6 +211,7 @@
       "additionalProperties":false
     },
     "deprecation":{
+      "type":"object",
       "description":"JSON Object that indicates that this object is deprecated.",
       "properties":{
         "description":{
@@ -252,7 +251,6 @@
               }
             },
             "deprecation":{
-              "type":"object",
               "$ref":"#/definitions/deprecation"
             }
           },
@@ -286,7 +284,6 @@
           }
         },
         "deprecation":{
-          "type":"object",
           "$ref":"#/definitions/deprecation"
         }
       },
@@ -325,7 +322,6 @@
               }
             },
             "deprecation":{
-              "type":"object",
               "$ref":"#/definitions/deprecation"
             }
           },
@@ -380,7 +376,6 @@
           }
         },
         "deprecation":{
-          "type":"object",
           "$ref":"#/definitions/deprecation"
         },
         "annotations":{
@@ -428,7 +423,6 @@
               }
             },
             "deprecation":{
-              "type":"object",
               "$ref":"#/definitions/deprecation"
             }
           }
@@ -476,7 +470,6 @@
               }
             },
             "deprecation":{
-              "type":"object",
               "$ref":"#/definitions/deprecation"
             }
           },
@@ -517,7 +510,6 @@
           }
         },
         "deprecation":{
-          "type":"object",
           "$ref":"#/definitions/deprecation"
         }
       },
@@ -556,7 +548,6 @@
               }
             },
             "deprecation":{
-              "type":"object",
               "$ref":"#/definitions/deprecation"
             }
           },
@@ -607,7 +598,6 @@
           }
         },
         "deprecation":{
-          "type":"object",
           "$ref":"#/definitions/deprecation"
         }
       },
@@ -664,7 +654,6 @@
           }
         },
         "deprecation":{
-          "type":"object",
           "$ref":"#/definitions/deprecation"
         }
       },
@@ -703,7 +692,6 @@
               }
             },
             "deprecation":{
-              "type":"object",
               "$ref":"#/definitions/deprecation"
             }
           },
@@ -734,7 +722,6 @@
           }
         },
         "deprecation":{
-          "type":"object",
           "$ref":"#/definitions/deprecation"
         }
       },

--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -191,31 +191,28 @@
       "description": "A DevTools extension adds functionality to the Chrome DevTools. It can add new UI panels and sidebars, interact with the inspected page, get information about network requests, and more."
     },
     "externally_connectable": {
-      "type": "object",
       "description": "Declares which extensions, apps, and web pages can connect to your extension via runtime.connect and runtime.sendMessage.",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "ids": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "The IDs of extensions or apps that are allowed to connect. If left empty or unspecified, no extensions or apps can connect."
-            }
-          },
-          "matches": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "The URL patterns for web pages that are allowed to connect. This does not affect content scripts. If left empty or unspecified, no web pages can connect."
-            }
-          },
-          "accepts_tls_channel_id": {
-            "type": "boolean",
-            "default": false,
-            "description": "Indicates that the extension would like to make use of the TLS channel ID of the web page connecting to it. The web page must also opt to send the TLS channel ID to the extension via setting includeTlsChannelId to true in runtime.connect's connectInfo or runtime.sendMessage's options."
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The IDs of extensions or apps that are allowed to connect. If left empty or unspecified, no extensions or apps can connect."
           }
+        },
+        "matches": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The URL patterns for web pages that are allowed to connect. This does not affect content scripts. If left empty or unspecified, no web pages can connect."
+          }
+        },
+        "accepts_tls_channel_id": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates that the extension would like to make use of the TLS channel ID of the web page connecting to it. The web page must also opt to send the TLS channel ID to the extension via setting includeTlsChannelId to true in runtime.connect's connectInfo or runtime.sendMessage's options."
         }
       }
     },

--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -10,9 +10,7 @@
     "manifest_version": {
       "type": "number",
       "description": "One integer specifying the version of the manifest file format your package requires.",
-      "enum": [ 2 ],
-      "minimum": 2,
-      "maximum": 2
+      "enum": [ 2 ]
     },
     "name": {
       "type": "string",

--- a/src/schemas/json/cosmos-config.json
+++ b/src/schemas/json/cosmos-config.json
@@ -92,7 +92,6 @@
     "httpProxy": {
       "description": "Proxy some URLs to a different HTTP server (eg. an API backend dev server). Similar to devServer.proxy in webpack config.",
       "type": "object",
-      "additionalProperties": true,
       "patternProperties": {
         ".*": {
           "anyOf": [

--- a/src/schemas/json/licenses.1.json
+++ b/src/schemas/json/licenses.1.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "http://json-schema.org/draft-04/schema#",
 	"id": "https://tools.wmflabs.org/spdx/schema/licenses.json",
 	"definitions": {
 		"license": {

--- a/src/schemas/json/ninjs-1.0.json
+++ b/src/schemas/json/ninjs-1.0.json
@@ -123,7 +123,7 @@
 						"type" : "string"
 					},
 					"symbols" : {
-						"description" : "Symbols used for a financial instrument linked to the organisation at a specific market place",
+						"description" : "Symbols used for a finanical instrument linked to the organisation at a specific market place",
 						"type" : "array",
 						"items" : {
 							"type" : "object",
@@ -166,7 +166,7 @@
 					"code" : {
 						"description": "The code for the place in a scheme (= controlled vocabulary) which is identified by the scheme property",
 						"type" : "string"
-					}
+					}					
 				}
 			}
 		},
@@ -193,7 +193,7 @@
 					"code" : {
 						"description": "The code for the subject in a scheme (= controlled vocabulary) which is identified by the scheme property",
 						"type" : "string"
-					}
+					}					
 				}
 			}
 		},
@@ -220,7 +220,7 @@
 					"code" : {
 						"description": "The code for the event in a scheme (= controlled vocabulary) which is identified by the scheme property",
 						"type" : "string"
-					}
+					}					
 				}
 			}
 		},
@@ -247,7 +247,7 @@
 					"code" : {
 						"description": "The code for the object in a scheme (= controlled vocabulary) which is identified by the scheme property",
 						"type" : "string"
-					}
+					}					
 				}
 			}
 		},

--- a/src/schemas/json/ninjs-1.1.json
+++ b/src/schemas/json/ninjs-1.1.json
@@ -131,7 +131,7 @@
 						"type" : "string"
 					},
 					"symbols" : {
-						"description" : "Symbols used for a financial instrument linked to the organisation at a specific market place",
+						"description" : "Symbols used for a finanical instrument linked to the organisation at a specific market place",
 						"type" : "array",
 						"items" : {
 							"type" : "object",
@@ -180,7 +180,7 @@
 					"code" : {
 						"description": "The code for the place in a scheme (= controlled vocabulary) which is identified by the scheme property",
 						"type" : "string"
-					}
+					}					
 				}
 			}
 		},
@@ -207,7 +207,7 @@
 					"code" : {
 						"description": "The code for the subject in a scheme (= controlled vocabulary) which is identified by the scheme property",
 						"type" : "string"
-					}
+					}					
 				}
 			}
 		},
@@ -234,7 +234,7 @@
 					"code" : {
 						"description": "The code for the event in a scheme (= controlled vocabulary) which is identified by the scheme property",
 						"type" : "string"
-					}
+					}					
 				}
 			}
 		},
@@ -261,7 +261,7 @@
 					"code" : {
 						"description": "The code for the object in a scheme (= controlled vocabulary) which is identified by the scheme property",
 						"type" : "string"
-					}
+					}					
 				}
 			}
 		},

--- a/src/schemas/json/ninjs-1.2.json
+++ b/src/schemas/json/ninjs-1.2.json
@@ -184,7 +184,7 @@
                     },
                     "symbols": {
                         "title": "Symbols",
-                        "description": "Symbols used for a financial instrument linked to the organisation at a specific market place",
+                        "description": "Symbols used for a finanical instrument linked to the organisation at a specific market place",
                         "type": "array",
                         "items": {
                             "type": "object",
@@ -419,18 +419,18 @@
                     "additionalProperties": false,
                     "properties": {
                         "href": {
-                            "title": "href",
+                            "title": "href", 
                             "description": "The URL for accessing the rendition as a resource. nar:remoteContent@ref",
                             "type": "string",
                             "format": "uri"
                         },
                         "mimetype": {
-                            "title": "mimetype",
+                            "title": "mimetype", 
                             "description": "A MIME type which applies to the rendition. nar:remoteContent@contenttype",
                             "type": "string"
                         },
                         "title": {
-                            "title": "Title",
+                            "title": "Title", 
                             "description": "A title for the link to the rendition resource",
                             "type": "string"
                         },
@@ -445,7 +445,7 @@
                             "type": "number"
                         },
                         "sizeinbytes": {
-                            "title": "Size in bytes",
+                            "title": "Size in bytes", 
                             "description": "The size of the rendition resource in bytes",
                             "type": "number"
                         },

--- a/src/schemas/json/resume.json
+++ b/src/schemas/json/resume.json
@@ -27,7 +27,7 @@
         },
         "image": {
           "type": "string",
-          "description": "URL (as per RFC 3986) to an image in JPEG or PNG format"
+          "description": "URL (as per RFC 3986) to a image in JPEG or PNG format"
         },
         "email": {
           "type": "string",


### PR DESCRIPTION
1)
**Mandatory $schema present check**
Schema without $schema will be process as the newer 2019 standard by schemasafe.
The 2019 behave differently from the older 04, 06 and 07 standard
```
"$ref": ...
"keyword: ...
```
All the keyword after or before "$ref" will be **ignored** in the 04, 06 and 07 standard.
schemasafe will give error because the "keyword" are not process.
This is no longer the behaviour in the newer standard.
To make sure that people are not mixup 'old' and 'new' standard, it is now mandatory to use $schema 

2)
**Add "unknownFormat" list**
Some schema use format that are unknown to schemasafe. These unknown format must be added to  "unknownFormat": [] in schema-validation.json, or else build error.
tv4 validator just ignore these unknown format, so these was never an issue before.  

3)
**Undo the commit** from PR #1441 for the external downloaded schema. This will always create dirty commit on the workstation side after run make. 