### PR TITLE
Update schema for cypress.io 

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -569,7 +569,7 @@
       "fileMatch": [
         "cypress.json"
       ],
-      "url": "https://raw.githubusercontent.com/cypress-io/cypress/v5.3.0/cli/schema/cypress.schema.json"
+      "url": "https://on.cypress.io/cypress.schema.json"
     },
     {
       "name": ".creatomic",


### PR DESCRIPTION
Fixed the Cypress.io schema to use the URL referenced in the Cypress.io docs as per [this](https://github.com/cypress-io/cypress/issues/15067#issue-806906388) issue