### PR TITLE
- drone.yml schema

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -275,7 +275,7 @@
         "hmac": {
           "type": "string",
           "minLength": 40,
-          "maxLength": 40
+          "maxLength": 64
         }
       }
     },


### PR DESCRIPTION
hmac can have a length of 64 characters.
drone cli version 1.1.4 creates hmac of 64 characters.