### PR TITLE
feat(tslint): support string items for `groups` of ordered-imports

### DIFF
--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -3153,21 +3153,28 @@
                   "groups": {
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
+                      "oneOf": [
+                        {
                           "type": "string"
                         },
-                        "match": {
-                          "type": "string"
-                        },
-                        "order": {
-                          "type": "number"
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "match": {
+                              "type": "string"
+                            },
+                            "order": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "match",
+                            "order"
+                          ]
                         }
-                      },
-                      "required": [
-                        "match",
-                        "order"
                       ]
                     }
                   },

--- a/src/test/tslint/tslint-test24.json
+++ b/src/test/tslint/tslint-test24.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../schemas/json/tslint.json",
+  "rules": {
+    "ordered-imports": [
+      true,
+      {
+        "groups": ["a", "b", "c"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
https://palantir.github.io/tslint/rules/ordered-imports/