### PR TITLE
Remove extra properties from Edge manifest

### DIFF
--- a/src/schemas/json/azure-iot-edge-deployment-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-2.0.json
@@ -87,17 +87,7 @@
                                                     "additionalProperties": false
                                                 }
                                             },
-                                            "patternProperties": {
-                                                "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                                }
-                                            },
                                             "additionalProperties": false
-                                        }
-                                    },
-                                    "patternProperties": {
-                                        "^[^\\.\\$# ]+$":{
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                         }
                                     },
                                     "additionalProperties": false
@@ -127,11 +117,6 @@
                                                 },
                                                 "imagePullPolicy": {
                                                     "$ref": "#/definitions/imagePullPolicy"
-                                                }
-                                            },
-                                            "patternProperties": {
-                                                "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                                 }
                                             },
                                             "additionalProperties": false
@@ -166,11 +151,6 @@
                                                 },
                                                 "startupOrder": {
                                                     "$ref": "#/definitions/startupOrder"
-                                                }
-                                            },
-                                            "patternProperties": {
-                                                "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                                 }
                                             },
                                             "additionalProperties": false
@@ -218,20 +198,10 @@
                                                     "$ref": "#/definitions/startupOrder"
                                                 }
                                             },
-                                            "patternProperties": {
-                                                "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                                }
-                                            },
                                             "additionalProperties": false
                                         }
                                     },
                                     "additionalProperties": false
-                                }
-                            },
-                            "patternProperties": {
-                                "^[^\\.\\$# ]+$":{
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                 }
                             },
                             "additionalProperties": false
@@ -316,17 +286,7 @@
                                             ]
                                         }
                                     },
-                                    "patternProperties": {
-                                        "^[^\\.\\$# ]+$":{
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                        }
-                                    },
                                     "additionalProperties": false
-                                }
-                            },
-                            "patternProperties": {
-                                "^[^\\.\\$# ]+$":{
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                 }
                             },
                             "additionalProperties": false
@@ -398,11 +358,6 @@
                 },
                 "createOptions": {
                     "$ref": "#/definitions/createOptions"
-                }
-            },
-            "patternProperties": {
-                "^[^\\.\\$# ]+$":{
-                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                 }
             },
             "additionalProperties": false

--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -87,17 +87,7 @@
                                                     "additionalProperties": false
                                                 }
                                             },
-                                            "patternProperties": {
-                                                "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                                }
-                                            },
                                             "additionalProperties": false
-                                        }
-                                    },
-                                    "patternProperties": {
-                                        "^[^\\.\\$# ]+$":{
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                         }
                                     },
                                     "additionalProperties": false
@@ -127,11 +117,6 @@
                                                 },
                                                 "imagePullPolicy": {
                                                     "$ref": "#/definitions/imagePullPolicy"
-                                                }
-                                            },
-                                            "patternProperties": {
-                                                "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                                 }
                                             },
                                             "additionalProperties": false
@@ -166,11 +151,6 @@
                                                 },
                                                 "startupOrder": {
                                                     "$ref": "#/definitions/startupOrder"
-                                                }
-                                            },
-                                            "patternProperties": {
-                                                "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                                 }
                                             },
                                             "additionalProperties": false
@@ -219,20 +199,10 @@
                                                     "$ref": "#/definitions/startupOrder"
                                                 }
                                             },
-                                            "patternProperties": {
-                                                "^[^\\.\\$# ]+$":{
-                                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                                }
-                                            },
                                             "additionalProperties": false
                                         }
                                     },
                                     "additionalProperties": false
-                                }
-                            },
-                            "patternProperties": {
-                                "^[^\\.\\$# ]+$":{
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                 }
                             },
                             "additionalProperties": false
@@ -298,11 +268,6 @@
                 },
                 "createOptions": {
                     "$ref": "#/definitions/createOptions"
-                }
-            },
-            "patternProperties": {
-                "^[^\\.\\$# ]+$":{
-                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                 }
             },
             "additionalProperties": false

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.0.json
@@ -176,19 +176,7 @@
             }
         }
     },
-    "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-            "type": "object",
-            "required": [
-                "properties.desired"
-            ],
-            "properties": {
-                "properties.desired": {
-                    "type": "object"
-                }
-            }
-        }
-    },
+    "additionalProperties": false,
     "definitions": {
         "moduleType": {
             "enum": [

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -76,17 +76,7 @@
                                             "additionalProperties": false
                                         }
                                     },
-                                    "patternProperties": {
-                                        "^[^\\.\\$# ]+$": {
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                        }
-                                    },
                                     "additionalProperties": false
-                                }
-                            },
-                            "patternProperties": {
-                                "^[^\\.\\$# ]+$": {
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                 }
                             },
                             "additionalProperties": false
@@ -116,11 +106,6 @@
                                         },
                                         "imagePullPolicy": {
                                             "$ref": "#/definitions/imagePullPolicy"
-                                        }
-                                    },
-                                    "patternProperties": {
-                                        "^[^\\.\\$# ]+$": {
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                         }
                                     },
                                     "additionalProperties": false
@@ -155,11 +140,6 @@
                                         },
                                         "startupOrder": {
                                             "$ref": "#/definitions/startupOrder"
-                                        }
-                                    },
-                                    "patternProperties": {
-                                        "^[^\\.\\$# ]+$": {
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                                         }
                                     },
                                     "additionalProperties": false
@@ -207,37 +187,13 @@
                                             "$ref": "#/definitions/startupOrder"
                                         }
                                     },
-                                    "patternProperties": {
-                                        "^[^\\.\\$# ]+$": {
-                                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                        }
-                                    },
                                     "additionalProperties": false
                                 }
                             },
                             "additionalProperties": false
                         }
                     },
-                    "patternProperties": {
-                        "^[^\\.\\$# ]+$": {
-                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                        }
-                    },
                     "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        }
-    },
-    "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-            "type": "object",
-            "required": [
-                "properties.desired"
-            ],
-            "properties": {
-                "properties.desired": {
-                    "type": "object"
                 }
             },
             "additionalProperties": false
@@ -289,11 +245,6 @@
                 },
                 "createOptions": {
                     "$ref": "#/definitions/createOptions"
-                }
-            },
-            "patternProperties": {
-                "^[^\\.\\$# ]+$": {
-                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
                 }
             },
             "additionalProperties": false

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.0.json
@@ -55,19 +55,5 @@
             }
         }
     },
-    "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-            "type": "object",
-            "required": [
-                "properties.desired"
-            ],
-            "properties": {
-                "properties.desired": {
-                    "type": "object"
-                }
-            },
-            "additionalProperties": false
-        }
-    },
     "additionalProperties": false
 }

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.1.json
@@ -78,34 +78,10 @@
                                     ]
                                 }
                             },
-                            "patternProperties": {
-                                "^[^\\.\\$# ]+$": {
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                }
-                            },
                             "additionalProperties": false
                         }
                     },
-                    "patternProperties": {
-                        "^[^\\.\\$# ]+$": {
-                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                        }
-                    },
                     "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        }
-    },
-    "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-            "type": "object",
-            "required": [
-                "properties.desired"
-            ],
-            "properties": {
-                "properties.desired": {
-                    "type": "object"
                 }
             },
             "additionalProperties": false

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.2.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.2.json
@@ -78,11 +78,6 @@
                                     ]
                                 }
                             },
-                            "patternProperties": {
-                                "^[^\\.\\$# ]+$": {
-                                    "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                                }
-                            },
                             "additionalProperties": false
                         },
                         "mqttBroker": {
@@ -157,26 +152,7 @@
                             "additionalProperties": false
                         }
                     },
-                    "patternProperties": {
-                        "^[^\\.\\$# ]+$": {
-                            "type": ["array", "boolean", "integer", "null", "number", "object", "string"]
-                        }
-                    },
                     "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        }
-    },
-    "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-            "type": "object",
-            "required": [
-                "properties.desired"
-            ],
-            "properties": {
-                "properties.desired": {
-                    "type": "object"
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
Properties other than what's explicitly defined are not useful for EdgeAgent/EdgeHub, and should just be disallowed.