### PR TITLE
Update prometheus.json

### DIFF
--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -278,7 +278,10 @@
               "null"
             ],
             "additionalProperties": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "basic_auth": {


### PR DESCRIPTION
`params` in `scrape_configs` is supposed to be an array of strings, not a string. See [the docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).

I tested this locally to be sure.