### PR TITLE
circleciconfig Update setup_remote_docker versions

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -593,10 +593,13 @@
             "version": {
               "description": "If your build requires a specific docker image, you can set it as an image attribute",
               "enum": [
+                "20.10.2",
+                "19.03.14",
                 "19.03.13",
                 "19.03.12",
                 "19.03.8",
-                "18.09.3"
+                "18.09.3",
+                "17.09.0-ce"
               ],
               "default": "19.03.13"
             }


### PR DESCRIPTION
The [list of versions](https://circleci.com/docs/2.0/building-docker-images/#docker-version) which are supported in setup_remote_docker has changed.