### PR TITLE
Add support for multiple file includes in Gitlab CI schema

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -294,9 +294,21 @@
               "type": "string"
             },
             "file": {
-              "description": "Relative path from project root (`/`) to the `yaml`/`yml` file template.",
-              "type": "string",
-              "pattern": "\\.ya?ml$"
+              "oneOf": [
+                {
+                  "description": "Relative path from project root (`/`) to the `yaml`/`yml` file template.",
+                  "type": "string",
+                  "pattern": "\\.ya?ml$"
+                },
+                {
+                  "description": "List of files by relative path from project root (`/`) to the `yaml`/`yml` file template.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "\\.ya?ml$"
+                  }
+                }
+              ]
             }
           },
           "required": ["project", "file"]

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -60,7 +60,7 @@
     {
       "project": "my-group/my-project",
       "ref": "master",
-      "file": [ "/templates/.gitlab-ci-template.yml", "/templates/.gitlab-ci-include-template.yml" ]
+      "file": [ "/templates/.gitlab-ci-template.yml", "/templates/another-template-to-include.yml" ]
     }
   ],
   "build": {

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -56,6 +56,11 @@
       "project": "my-group/my-project",
       "ref": "master",
       "file": "/templates/.gitlab-ci-template.yml"
+    },
+    {
+      "project": "my-group/my-project",
+      "ref": "master",
+      "file": [ "/templates/.gitlab-ci-template.yml", "/templates/.gitlab-ci-include-template.yml" ]
     }
   ],
   "build": {


### PR DESCRIPTION
Gitlab CI supports multiple file includes. Support was added in 13.6 via feature flag. The feature flag was removed in 13.8 making it global.

https://docs.gitlab.com/ee/ci/yaml/#multiple-files-from-a-project