### PR TITLE
Add: grunt task to show schema version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ ClientBin/
 *.[Pp]ublish.xml
 *.pfx
 *.publishsettings
+.DS_Store
 
 # RIA/Silverlight projects
 Generated_Code/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ After adding schema files, register them in [schema catalog](src/api/json/catalo
     "fileMatch": [
         "list of well-known filenames matching schema"
     ],
-    "url": "http://json.schemastore.org/<schemaName>.json"
+    "url": "https://json.schemastore.org/<schemaName>.json"
 }
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,8 @@ remote: # Run the remote build process
 	cd src && \
 	npm install && \
 	npm run remote
+
+maintenance: # Run the maintenance check
+	cd src && \
+	npm install && \
+	npm run maintenance

--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -2,6 +2,9 @@
 
 const pt = require("path");
 const fs = require('fs');
+const catalog = require('./api/json/catalog.json');
+const schemaV4JSON = require('./schemas/json/schema-draft-v4.json');
+const schemaValidation = require('./schema-validation.json');
 const schemaDir = "schemas/json"
 const testPositiveDir = "test"
 const testNegativeDir = "negative_test"
@@ -30,23 +33,6 @@ module.exports = function (grunt) {
   grunt.initConfig({
 
     tv4: {
-
-      // Deprecated -> now use "local_catalog"
-      // catalog: {
-      //   options: {
-      //     root: grunt.file.readJSON("schemas/json/schema-catalog.json")
-      //   },
-      //   src: ["api/json/catalog.json"]
-      // },
-
-      // Deprecated -> now use "local_tv4_only_for_non_compliance_schema"
-      // schemas: {
-      //   options: {
-      //     banUnknown: false,
-      //     root: grunt.file.readJSON("schemas/json/schema-draft-v4.json")
-      //   },
-      //   src: ["schemas/json/*.json", "!schemas/json/ninjs-1.0.json"] // ninjs 1.0 is draft v3
-      // },
       options: {
         schemas: {
           "http://json-schema.org/draft-04/schema#": grunt.file.readJSON("schemas/json/schema-draft-v4.json"),
@@ -118,7 +104,6 @@ module.exports = function (grunt) {
   }
 
   function getUrlFromCatalog(catalogUrl) {
-    const catalog = require('./api/json/catalog.json');
     for (const schema of catalog["schemas"]) {
       catalogUrl(schema["url"]);
       const versions = schema["versions"];
@@ -134,7 +119,6 @@ module.exports = function (grunt) {
 
   async function remoteSchemaFile(schema_1_PassScan){
     const got = require("got");
-    const catalog = require('./api/json/catalog.json');
     const schemas = catalog["schemas"];
     const url_ = require("url");
 
@@ -182,7 +166,6 @@ module.exports = function (grunt) {
         tv4OnlyMode = false,
         logTestFolder = true
       } = {}) {
-    const schemaValidation = grunt.file.readJSON('schema-validation.json');
 
     let callbackParameter = {
       jsonName: undefined,
@@ -375,7 +358,6 @@ module.exports = function (grunt) {
   }
 
   function tv4() {
-    const schemaV4JSON = require('./schemas/json/schema-draft-v4.json');
     let schemaPath = undefined;
     let schemaName = undefined;
     let testSchemaPath = [];
@@ -436,7 +418,6 @@ module.exports = function (grunt) {
   }
 
   function schemasafe(){
-    const schemaValidation = require('./schema-validation.json');
     const { validator } = require('@exodus/schemasafe')
     const textValidate = "validate    | ";
     const textPassSchema         = "pass schema          | ";
@@ -622,11 +603,10 @@ module.exports = function (grunt) {
 
   grunt.registerTask("local_catalog", "Catalog validation", function () {
     const {validator} = require('@exodus/schemasafe');
-    const catalogFile = require("./api/json/catalog.json");
     const catalogSchema = require("./schemas/json/schema-catalog.json");
 
     const validate = validator(catalogSchema, {includeErrors: true});
-    if (validate(catalogFile)) {
+    if (validate(catalog)) {
       grunt.log.ok("catalog.json OK");
     } else {
       grunt.log.error("(Schema file) keywordLocation: " + validate.errors[0].keywordLocation);
@@ -672,7 +652,6 @@ module.exports = function (grunt) {
   })
 
   grunt.registerTask("local_schema-present-in-catalog-list", "local schema must have a url reference in catalog list", function () {
-    const schemaValidation = require('./schema-validation.json');
     const httpsPath = "https://json.schemastore.org"
     let countScan = 0;
     let allCatalogLocalJsonFiles = [];
@@ -703,8 +682,6 @@ module.exports = function (grunt) {
   })
 
   grunt.registerTask("local_catalog-fileMatch-conflict", "note: app.json and *app.json conflicting will not be detected", function () {
-    const catalog = require('./api/json/catalog.json');
-    const schemaValidation = require('./schema-validation.json');
     const fileMatchConflict = schemaValidation["fileMatchConflict"];
     let fileMatchCollection = [];
     // Collect all the "fileMatch" and put it in fileMatchCollection[]

--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -48,7 +48,7 @@
   "name": "bower.json",
   "description": "Bower package description file",
   "fileMatch": [ "bower.json", ".bower.json" ],
-  "url": "http://schemastore.org/schemas/json/bower"
+  "url": "https://json.schemastore.org/bower"
 }
 </pre>
 	<p>

--- a/src/package.json
+++ b/src/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "build": "grunt",
     "validate_links": "grunt validate_links",
-    "remote": "grunt remote_test"
+    "remote": "grunt remote_test",
+    "maintenance": "grunt local_maintenance"
   },
   "devDependencies": {
     "grunt": "^1.1.0",


### PR DESCRIPTION
Some new functionality are added.

### 1)
Show in the build log the total files for each schema versions. Example: 
```
Running "local_count_schema_versions" task
>> Schemas using (2020-12) Total files: 0
>> Schemas using (2019-09) Total files: 2
>> Schemas using (draft-07) Total files: 68
>> Schemas using (draft-06) Total files: 5
>> Schemas using (draft-04) Total files: 217
>> Schemas using (draft-03) Total files: 0
>> Schemas using (draft without version) Total files: 6
>> $schema unknown. Total files: 0
```

`make remote` have similar format output.
```
Running "remote_count_schema_versions" task
>> Schemas using (2020-12) Total files: 0
>> Schemas using (2019-09) Total files: 4
>> Schemas using (draft-07) Total files: 47
>> Schemas using (draft-06) Total files: 5
>> Schemas using (draft-04) Total files: 16
>> Schemas using (draft-03) Total files: 0
>> Schemas using (draft without version) Total files: 0
>> $schema unknown. Total files: 8

```
### 2)
Schemasafe file name are now shown with it (draft) version at the end.
```
>> (default mode)  pass schema          | schemas/json/appveyor.json (draft-04)
>> (default mode)  pass schema          | schemas/json/asmdef.json (draft-06)
>> (default mode)  pass schema          | schemas/json/avro-avsc.json (draft-06)
>> (default mode)  pass schema          | schemas/json/azure-iot-edge-deployment-1.0.json (draft-07)
>> (default mode)  pass schema          | schemas/json/azure-iot-edge-deployment-2.0.json (draft-04)

test folder   : ansible-collection-galaxy
>> (default mode)  pass schema          | schemas/json/ansible-collection-galaxy.json (draft-04)
>> (default mode)  pass positive test   | test/ansible-collection-galaxy/ansible-collection-galaxy.json

```
It is not possible to do this for grunt-tv4 files because it process it own output.

### 3)
`make maintenance` will start two task that are not warrant to be included in the auto build process, but still nice to have it via make.

```
Running "local_check_for_wrong_id" task
>> Forbidden $id in draft-04 (ansible-inventory.json)
>> Forbidden $id in draft-04 (ansible-playbook.json)
>> Forbidden $id in draft-04 (cryproj.52.schema.json)
>> Forbidden $id in draft-04 (cryproj.53.schema.json)
>> Forbidden $id in draft-04 (cryproj.54.schema.json)
>> Forbidden $id in draft-04 (cryproj.55.schema.json)
>> Forbidden $id in draft-04 (cryproj.dev.schema.json)
>> Forbidden $id in draft-04 (cryproj.json)
>> Forbidden $id in draft-04 (schema-catalog.json)
>> Forbidden $id in draft-04 (web-manifest-app-info.json)
>> Forbidden $id in draft-04 (web-manifest.json)

>> Check done

Running "local_test_downgrade_schema_version" task

>> Check if a lower $schema version will also pass the schema validation test
>> asmdef.json (draft-06) is also valid with (draft-04)
>> avro-avsc.json (draft-06) is also valid with (draft-04)
>> behat.json (draft-07) is also valid with (draft-04)
>> bungee-plugin.json (draft-07) is also valid with (draft-04)(also need to change $id to id)
>> golangci-lint.json (2019-09) is also valid with (draft-07)
>> httpmockrc.json (draft-07) is also valid with (draft-04)
>> jovo-language-model.json (draft-07) is also valid with (draft-04)(also need to change $id to id)
>> lerna.json (draft-07) is also valid with (draft-04)(also need to change $id to id)
>> mocharc.json (2019-09) is also valid with (draft-04)(also need to change $id to id)
>> mtad.json (draft-07) is also valid with (draft-04)(also need to change $id to id)
>> mtaext.json (draft-07) is also valid with (draft-04)(also need to change $id to id)
>> netlify.json (draft-07) is also valid with (draft-04)
>> npm-link-up.json (draft-07) is also valid with (draft-04)
>> prometheus.rules.json (draft-07) is also valid with (draft-04)(also need to change $id to id)
>> sponge-mixins.json (draft-07) is also valid with (draft-04)
>> ts-force-config.json (draft-07) is also valid with (draft-04)
>> typewiz.json (draft-07) is also valid with (draft-04)
>> winget-pkgs.json (draft-07) is also valid with (draft-04)
>> workflows.json (draft-07) is also valid with (draft-04)

>> Check done

```
### 4)
Sone minor update in the .gitignore and documentation