### PR TITLE
Workflows schema update Feb 2021

### DIFF
--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -59,13 +59,21 @@
       "additionalProperties": false,
       "properties": {
         "call": {
-          "description": "Required. Use `http.get`, `http.post`, or `http.request` for HTTP requests.",
-          "type": "string",
-          "enum": [
-            "http.get",
-            "http.post",
-            "http.request",
-            "sys.sleep"
+          "description": "Required",
+          "anyOf": [
+            {
+              "description": "Use `http.get`, `http.post`, or `http.request` for HTTP requests.",
+              "type": "string",
+              "enum": [
+                "http.get",
+                "http.post",
+                "http.request",
+                "sys.sleep"
+              ]
+            }, {
+              "description": "A name of a subworkflow within this workflow, or a connector.",
+              "type": "string"
+            }
           ]
         },
         "args": {
@@ -97,7 +105,7 @@
                 "PATCH"
               ]
             },
-            "header": {
+            "headers": {
               "type": "object",
               "description": "Request headers."
             },
@@ -127,10 +135,7 @@
               "type": "number",
               "description": "The number of seconds to sleep."
             }
-          },
-          "required": [
-            "url"
-          ]
+          }
         },
         "assign": {
           "type": "array",
@@ -166,6 +171,10 @@
               },
               "return": {
                 "description": "Stop a workflow's execution and return a value, variable, or expression."
+              },
+              "raise": {
+                "description": "Raise an exception.",
+                "$ref": "#/definitions/raise"
               }
             },
             "required": ["condition"]
@@ -217,7 +226,7 @@
         },
         "except": {
           "description": "Except a try clause.",
-          "allOf": [
+          "oneOf": [
             {
               "$ref": "#/definitions/step"
             },
@@ -238,15 +247,19 @@
         },
         "raise": {
           "description": "Raise an exception.",
-          "anyOf": [{
-            "description": "String message.",
-            "type": "string"
-          }, {
-            "description": "A dictionary.",
-            "type": "object"
-          }]
+          "$ref": "#/definitions/raise"
         }
       }
+    },
+    "raise": {
+      "description": "Raise an exception.",
+      "anyOf": [{
+        "description": "String message.",
+        "type": "string"
+      }, {
+        "description": "A dictionary.",
+        "type": "object"
+      }]
     }
   }
 }

--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -10,6 +10,7 @@
     {
       "description": "A map of subworkflows.",
       "minItems": 1,
+      "additionalProperties": false,
       "patternProperties": {
         "^.*$": {
           "description": "A subworkflow.",
@@ -21,6 +22,7 @@
   "definitions": {
     "subworkflow": {
       "description": "A subworkflow.",
+      "additionalProperties": false,
       "properties": {
         "params": {
           "description": "A list of parameters.",
@@ -43,6 +45,7 @@
         "description": "An object with a single step.",
         "minItems": 1,
         "maxItems": 1,
+        "additionalProperties": false,
         "patternProperties": {
           "^.*$": {
             "description": "A single workflow step.",
@@ -182,6 +185,7 @@
         },
         "retry": {
           "description": "Optional. If omitted, all other fields are required. Options include ${http.default_retry} and ${http.default_retry_non_idempotent}. Allows you to specify a default retry policy to use. If you specify a retry policy, omit all other fields in the retry block.",
+          "additionalProperties": false,
           "properties": {
             "predicate": {
               "type": "string",
@@ -193,6 +197,7 @@
             },
             "backoff": {
               "description": "Block that controls how retries occur.",
+              "additionalProperties": false,
               "properties": {
                 "initial_delay": {
                   "type": "integer",
@@ -217,6 +222,7 @@
               "$ref": "#/definitions/step"
             },
             {
+              "additionalProperties": false,
               "properties": {
                 "as": {
                   "type": "string",


### PR DESCRIPTION
Updates the `workflows.json` schema for a few variants:

- Allows for `string` for `call` property
- Explicit `additionalProperties`
- Allow `raise` on `switch`
- `headers` typo
- `except` oneof mistake

Tested locally. Please merge when possible 😄 