### PR TITLE
Add Argo Workflows schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -110,6 +110,11 @@
       "url": "https://raw.githubusercontent.com/architect/parser/v2.3.0/arc-schema.json"
     },
     {
+      "name": "Argo Workflows",
+      "description": "Argo Workflow configuration file",
+      "url": "https://raw.githubusercontent.com/argoproj/argo-workflows/master/api/jsonschema/schema.json"
+    },
+    {
       "name": "Avro Avsc",
       "description": "Avro Schema Avsc file",
       "fileMatch": [


### PR DESCRIPTION
Add schema for [Argo Workflows](https://github.com/argoproj/argo-workflows)

Workflow filenames can match `*.y[a]?ml`, so I omitted the `"fileMatch"` property in the catalog entry.

Thanks!