### PR TITLE
[github-funding]: add .github/FUNDING.yml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -949,10 +949,9 @@
       "name": "GitHub Funding",
       "description": "YAML schema for GitHub Funding",
       "fileMatch": [
+        ".github/FUNDING.yml",
         ".github/funding.yml",
-        ".github/funding.yaml",
-        "funding.yml",
-        "funding.yaml"
+        ".github/funding.yaml"
       ],
       "url": "https://json.schemastore.org/github-funding"
     },


### PR DESCRIPTION
without FUNDING.yml there is no code completion

remove:
"funding.yml"
"funding.yaml"
so it can be use by other project