### PR TITLE
fix: support objects in variables

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -495,7 +495,7 @@
       "type": "object",
       "description": "Defines environment variables for specific jobs or globally. Job level property overrides global variables. If a job sets `variables: {}`, all global variables are turned off.",
       "additionalProperties": {
-        "type": ["string", "integer"]
+        "type": ["string", "integer", "object"]
       }
     },
     "timeout": {


### PR DESCRIPTION
Enables support for prefilled variables in manual pipelines:

```yaml
variables:
  DEPLOY_ENVIRONMENT:
    value: "staging"  # Deploy to staging by default
    description: "The deployment target. Change this variable to 'canary' or 'production' if needed."
```

https://docs.gitlab.com/ee/ci/yaml/#prefill-variables-in-manual-pipelines
Signed-off-by: Peter Benjamin <petermbenjamin@gmail.com>