### PR TITLE
Add Taskfile json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2790,6 +2790,15 @@
       "description": "JSON Schema for JSON-e templates.",
       "fileMatch": [],
       "url": "https://json.schemastore.org/jsone"
+    },
+    {
+      "name": "Taskfile YAML Schema",
+      "description": "JSON Schema for Taskfile files.",
+      "fileMatch": [
+        "Taskfile.yaml",
+        "Taskfile.yml"
+      ],
+      "url": "https://json.schemastore.org/taskfile.json"
     }
   ]
 }

--- a/src/schemas/json/taskfile.json
+++ b/src/schemas/json/taskfile.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "description": "Taskfile YAML Schema",
+  "title":"Taskfile YAML Schema",
+  "description": "JSON Schema for Taskfile files.",
   "oneOf": [
     {
       "type": "object",

--- a/src/schemas/json/taskfile_v3.json
+++ b/src/schemas/json/taskfile_v3.json
@@ -1,0 +1,341 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "description": "Taskfile YAML Schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "Specify the Taskfile format that this file conforms to.",
+          "anyOf": [
+            {
+              "type": "number",
+              "enum": [
+                3
+              ]
+            },
+            {
+              "type": "string",
+              "enum": [
+                "3"
+              ]
+            }
+          ]
+        },
+        "env": {
+          "description": "Declare environment variables globally",
+          "$ref": "#/definitions/3/env"
+        },
+        "dotenv": {
+          "type": "array",
+          "description": "Ask Task to include .env file",
+          "items": {
+            "type": "string"
+          }
+        },
+        "includes": {
+          "description": "Imports other tasks from the provided taskfile. The tasks described in the given Taskfiles will be available with the informed namespace.",
+          "type": "object",
+          "patternProperties": {
+            "^.*$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "taskfile": {
+                      "type": "string"
+                    },
+                    "dir": {
+                      "description": "On which directory the included Taskfile will run",
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "silent": {
+          "description": "Silent mode disables echoing of commands for all tasks",
+          "type": "boolean"
+        },
+        "output": {
+          "description": "Defines how the STDOUT and STDERR are printed when running tasks in parallel. The interleaved output prints lines in real time (default). The group output will print the entire output of a command once, after it finishes, so you won’t have live feedback for commands that take a long time to run. The prefix output will prefix every line printed by a command with [task-name] as the prefix, but you can customize the prefix for a command with the prefix: attribute.",
+          "type": "string",
+          "enum": [
+            "interleaved",
+            "group",
+            "prefixed"
+          ],
+          "default": "interleaved"
+        },
+        "method": {
+          "description": "Defines which method is used to check the task is up-to-date. (default: checksum)",
+          "type": "string",
+          "enum": [
+            "none",
+            "checksum",
+            "timestamp"
+          ],
+          "default": "checksum"
+        },
+        "vars": {
+          "description": "Declare variables globally",
+          "$ref": "#/definitions/3/vars"
+        },
+        "tasks": {
+          "description": "Defines your tasks",
+          "$ref": "#/definitions/3/tasks"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "tasks"
+      ]
+    }
+  ],
+  "definitions": {
+    "3": {
+      "env": {
+        "$ref": "#/definitions/3/vars"
+      },
+      "tasks": {
+        "type": "object",
+        "patternProperties": {
+          "^.*$": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/definitions/3/task_call"
+                    }
+                  ]
+                }
+              },
+              {
+                "$ref": "#/definitions/3/task"
+              }
+            ]
+          }
+        }
+      },
+      "task": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "env": {
+            "description": "Environment variables for this task",
+            "$ref": "#/definitions/3/env"
+          },
+          "desc": {
+            "description": "Provides a description for this task. Used by the --list/-l flag",
+            "type": "string"
+          },
+          "summary": {
+            "description": "Provides a summary for this task. Used by the --summary flag",
+            "type": "string"
+          },
+          "vars": {
+            "description": "Declare variables for this task",
+            "$ref": "#/definitions/3/vars"
+          },
+          "label": {
+            "type": "string",
+            "description": "Override the task name print on summary, can be interpolated with variables"
+          },
+          "cmds": {
+            "description": "A list of commands for this task",
+            "$ref": "#/definitions/3/cmds"
+          },
+          "dir": {
+            "description": "Defines where the task will run. Defaults to the directory of the Taskfile",
+            "type": "string"
+          },
+          "deps": {
+            "description": "Declaring tasks here that should run automatically before this task",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/3/task_call"
+                }
+              ]
+            }
+          },
+          "sources": {
+            "description": "List the source files for this task. Will be used to prevent running the task again if nothing changed. Can be a file of a file pattern.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "generates": {
+            "description": "List the files generated by this task. Will be used to prevent running the task again if nothing changed. Can be a file of a file pattern.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "description": "Define a sequence of tests as status of this task. If no error is returned (exit status 0), the task is considered up-to-date",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "method": {
+            "description": "Defines which method is used to check the task is up-to-date. timestamp will compare the timestamp of the sources and generates files. checksum will check the checksum (You will probably want to ignore the .task folder in your .gitignore file). none skips any validation and always run the task",
+            "type": "string",
+            "enum": [
+              "none",
+              "checksum",
+              "timestamp"
+            ],
+            "default": "none"
+          },
+          "silent": {
+            "description": "Silent mode disables echoing of commands before Task runs it",
+            "type": "boolean"
+          },
+          "ignore_error": {
+            "description": "Prevent Task from aborting the execution of tasks even after receiving a status code of 1",
+            "type": "boolean"
+          },
+          "prefix": {
+            "description": "Defines a string to prefix the output of tasks running in parallel. Only used when the output mode is prefix",
+            "type": "string"
+          },
+          "preconditions": {
+            "description": "Defines a list of conditions to be true for the task to run",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/3/precondition"
+            }
+          }
+        }
+      },
+      "cmds": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/3/cmd"
+        }
+      },
+      "cmd": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/definitions/3/cmd_call"
+          },
+          {
+            "$ref": "#/definitions/3/task_call"
+          }
+        ]
+      },
+      "vars": {
+        "type": "object",
+        "patternProperties": {
+          "^.*$": {
+            "anyOf": [
+              {
+                "type": [
+                  "boolean",
+                  "integer",
+                  "null",
+                  "number",
+                  "string"
+                ]
+              },
+              {
+                "$ref": "#/definitions/3/dynamic_var"
+              }
+            ]
+          }
+        }
+      },
+      "dynamic_var": {
+        "type": "object",
+        "properties": {
+          "sh": {
+            "type": "string",
+            "description": "The value will be treated as a command and the output assigned"
+          },
+          "additionalProperties": false
+        }
+      },
+      "task_call": {
+        "type": "object",
+        "properties": {
+          "task": {
+            "description": "Name of the task to run",
+            "type": "string"
+          },
+          "vars": {
+            "description": "Values passed to the task called",
+            "$ref": "#/definitions/3/vars"
+          }
+        }
+      },
+      "cmd_call": {
+        "type": "object",
+        "properties": {
+          "cmd": {
+            "description": "Command to run",
+            "type": "string"
+          },
+          "silent": {
+            "description": "Silent mode disables echoing of command before Task runs it",
+            "type": "boolean"
+          },
+          "ignore_error": {
+            "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "cmd"
+        ]
+      },
+      "precondition": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/definitions/3/precondition_obj"
+          }
+        ]
+      },
+      "precondition_obj": {
+        "type": "object",
+        "properties": {
+          "sh": {
+            "description": "Command to run. If that command returns 1, the condition will fail",
+            "type": "string"
+          },
+          "msg": {
+            "description": "Failure message to display when the condition fails",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/taskfile/Taskfile.json
+++ b/src/test/taskfile/Taskfile.json
@@ -1,0 +1,13 @@
+{
+  "version": "3",
+  "env": {
+    "TEST_ENV": "test"
+  },
+  "tasks": {
+    "run-pre-commit-hook": {
+      "cmds": [
+        "pre-commit run --all-files"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
There is a wonderful make replacement [tool](https://taskfile.dev), written in Go, which execute tasks based on `Taskfile.jml`.
I would like to add a JSON schema for this tool