### PR TITLE
Add new `govet` analyzer to golangci-lint.json

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -98,6 +98,7 @@
         "copylocks",
         "deepequalerrors",
         "errorsas",
+        "fieldalignment",
         "findcall",
         "httpresponse",
         "loopclosure",


### PR DESCRIPTION
As `golangci-lint` team doesn't maintain this schema (see https://github.com/golangci/golangci-lint/issues/1846), I suggest to add one new available analyzer to schema.