### PR TITLE
feat(gitlab-ci): support long-hand form of secrets property

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -760,11 +760,44 @@
           "description": "Defines secrets to be injected as environment variables",
           "additionalProperties": {
             "type": "object",
-            "description": "Environment variable name",
+            "description": "Defines an environment variable name for the Vault secret",
             "properties": {
               "vault": {
-                "type": "string",
-                "description": "The secret to be fetched from Vault (e.g. 'production/db/password@ops' translates to secret 'ops/data/production/db', field `password`)"
+                "description": "Use vault to specify secrets provided by Hashicorp’s Vault. See https://docs.gitlab.com/ee/ci/yaml/README.html#secrets",
+                "oneOf": [
+                  {
+                    "description": "The shorthand form to specify the secret to be fetched from Vault as a string (e.g. 'production/db/password@ops' translates to secret 'ops/data/production/db', field `password`)",
+                    "type": "string"
+                  },
+                  {
+                    "description": "The longhand form to specify the secret to be fetched from Vault as an object",
+                    "type": "object",
+                    "properties": {
+                      "engine": {
+                        "description": "An object specifying the Vault backend",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "The name of the Vault backend (e.g. 'kv-v2')",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "The path of the Vault backend (e.g. 'ops')",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "path": {
+                        "description": "The path of the Vault secret (e.g. 'production/db')",
+                        "type": "string"
+                      },
+                      "field": {
+                        "description": "The field of the Vault secret (e.g. 'password')",
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
               }
             }
           }


### PR DESCRIPTION
Prior to this change, only the short-hand form was supported:

```yaml
foo:
  secrets:
    ENV_VAR:
      vault: "production/db/password@ops"
```

This change introduces support for long-hand version of defining
secrets:

```yaml
foo:
  secrets:
    ENV_VAR:
      vault:
        engine:
          name: kv-v2
          path: ops
        path: production/db
        field: password
```

See GitLab CI [docs](https://docs.gitlab.com/ee/ci/yaml/#secretsvault)
for more details.

Example produced using this schema locally:

![Screen Shot 2021-03-15 at 10 50 41 PM](https://user-images.githubusercontent.com/6811830/111263997-06ea7b00-85e4-11eb-8ed4-8ffe5a5b948c.png)