### PR TITLE
Update drone.json to add missing 'network_mode'

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -666,6 +666,13 @@
             "image": {
               "$ref": "#/definitions/nonEmptyString"
             },
+            "network_mode": {
+              "type": "string",
+              "enum": [
+                "bridge",
+                "host"
+              ]
+            },
             "privileged": {
               "type": "boolean"
             },


### PR DESCRIPTION
Adding 'network_mode' which is missing from 'step_docker', but is defined in the documentation here:
https://docs.drone.io/yaml/docker/#the-step-object