### PR TITLE
Add JSON schema for JFrog File Specs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1210,6 +1210,16 @@
       "url": "https://jenkins-x.io/schemas/jx-requirements.json"
     },
     {
+      "name": "JFrog File Spec",
+      "description": "JFrog File Spec schema definition",
+      "fileMatch": [
+        "**/filespecs/*.json",
+        "*filespec*.json",
+        "*.filespec"
+      ],
+      "url": "https://raw.githubusercontent.com/jfrog/jfrog-cli/master/schema/filespec-schema.json"
+    },
+    {
       "name": "Jovo Language Models",
       "description": "JSON Schema for Jovo language Models (https://www.jovo.tech/docs/model)",
       "url": "https://json.schemastore.org/jovo-language-model"


### PR DESCRIPTION
#### JFrog File Specs
File Specs can be used to specify the details of files you want to upload or download to or from Artifactory. They are specified in JSON format and are currently supported in JFrog CLI, Jenkins Artifactory Plug-in, TeamCity Artifactory Plug-in, and Bamboo Artifactory Plug-in.

Read more about file specs:
https://www.jfrog.com/confluence/display/JFROG/Using+File+Specs
https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-UsingFileSpecs
https://jfrog.com/blog/use-file-specs-in-your-cicd-to-get-full-control-of-your-artifacts

--- 
**File Spec Schema**
The suggested schema is available here: https://github.com/jfrog/jfrog-cli/blob/master/schema/filespec-schema.json


**Tests**
The tests are available here: https://github.com/jfrog/jfrog-cli/blob/master/schema/filespecschema_test.go
The tests on the schema are running automatically for each commit in the [JFrog CLI GitHub repository](https://github.com/jfrog/jfrog-cli). The tests validate each one of the specs here: https://github.com/jfrog/jfrog-cli/tree/master/testdata/specs.
