### PR TITLE
Make Ansible Role match more specific

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -24,8 +24,8 @@
       "description": "Ansible role task files",
       "url": "https://json.schemastore.org/ansible-role-2.9",
       "fileMatch": [
-        "**/tasks/*.yml",
-        "**/tasks/*.yaml"
+        "**/roles/**/tasks/*.yml",
+        "**/roles/**/tasks/*.yaml"
       ],
       "versions": {
         "2.0": "https://json.schemastore.org/ansible-role-2.0",


### PR DESCRIPTION
Not sure if it's the right place to report this, but I'm receiving the wrong file matches for files that aren't supposed to be validated as Ansible tasks by using the [vscode-yaml](https://github.com/redhat-developer/vscode-yaml):

![image](https://user-images.githubusercontent.com/1991286/111836795-268ce680-88f7-11eb-8628-298e46e9374a.png)

That file is from a Concourse CI pipeline, [inside the `ci/tasks` folder](https://github.com/redhat-developer/vscode-yaml/issues/145#issuecomment-478661866).

It was reported before in https://github.com/redhat-developer/vscode-yaml/issues/145 and https://github.com/redhat-developer/vscode-yaml/issues/337 (that uses schemastore as an upstream). 

Unfortunately, the extension does not permit disable a specific file matcher or json-schema (see https://github.com/redhat-developer/vscode-yaml/issues/245).

However, another idea to fix this is to make the file match for ansible more specific. Please, correct me if I'm wrong, but ansible tasks are usually [inside the `roles` folder](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html). This would fix the previous issues by matching tasks that are children to roles folder.