### PR TITLE
added containerlab json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2825,7 +2825,7 @@
         "*.clab.yaml",
         "*.clab.yml"
       ],
-      "url": "https://raw.githubusercontent.com/srl-wim/container-lab/master/schemas/clab.schema.json"
+      "url": "https://raw.githubusercontent.com/srl-labs/containerlab/master/schemas/clab.schema.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2815,6 +2815,17 @@
         "Taskfile.yml"
       ],
       "url": "https://json.schemastore.org/taskfile.json"
+    },
+    {
+      "name": "Containerlab",
+      "description": "JSON Schema for Containerlab topology definition files.",
+      "fileMatch": [
+        "*-clab.yaml",
+        "*-clab.yml",
+        "*.clab.yaml",
+        "*.clab.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/srl-wim/container-lab/master/schemas/clab.schema.json"
     }
   ]
 }


### PR DESCRIPTION
Hello,
this PR adds [Containerlab](https://containerlab.srlinux.dev) JSON schema for its topology definition files, which are expressed in YAML.

Containerlab is an Nokia Networks opensource project aimed at enabling building container-based lab topologies for multivendor network operating systems.