### PR TITLE
Azure Iot Edge deployment - allow chunked createOptions

### DIFF
--- a/src/schemas/json/azure-iot-edge-deployment-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-2.0.json
@@ -355,8 +355,10 @@
                     "examples": [
                         "mcr.microsoft.com/azureiotedge-agent:1.0"
                     ]
-                },
-                "createOptions": {
+                }
+            },
+            "patternProperties": {
+                "^((?i)createOptions)(?<num>[0-9]*)$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },
@@ -372,7 +374,11 @@
                     ],
                     "properties": {
                         "value": {
-                            "type": ["number", "string", "boolean"]
+                            "type": [
+                                "number",
+                                "string",
+                                "boolean"
+                            ]
                         }
                     },
                     "additionalProperties": false

--- a/src/schemas/json/azure-iot-edge-deployment-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-2.0.json
@@ -358,7 +358,7 @@
                 }
             },
             "patternProperties": {
-                "^(?i)createOptions[0-9]*$": {
+                "^(createoptions|createOptions)[0-9]*$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },

--- a/src/schemas/json/azure-iot-edge-deployment-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-2.0.json
@@ -358,7 +358,7 @@
                 }
             },
             "patternProperties": {
-                "^((?i)createOptions)(?<num>[0-9]*)$": {
+                "^(?i)createOptions([0-9]*)$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },

--- a/src/schemas/json/azure-iot-edge-deployment-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-2.0.json
@@ -358,7 +358,7 @@
                 }
             },
             "patternProperties": {
-                "^(?i)createOptions([0-9]*)$": {
+                "^(?i)createOptions[0-9]*$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },

--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -230,11 +230,11 @@
             },
             "additionalProperties": false
         },
-        "$schema-template":{
-            "type":"string"
+        "$schema-template": {
+            "type": "string"
         },
-        "$schema":{
-            "type":"string"
+        "$schema": {
+            "type": "string"
         }
     },
     "additionalProperties": false,
@@ -265,8 +265,10 @@
                     "examples": [
                         "mcr.microsoft.com/azureiotedge-agent:1.0"
                     ]
-                },
-                "createOptions": {
+                }
+            },
+            "patternProperties": {
+                "^((?i)createOptions)(?<num>[0-9]*)$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },
@@ -276,7 +278,10 @@
             "$ref": "https://json.schemastore.org/azure-iot-edge-deployment-2.0#/definitions/env"
         },
         "createOptions": {
-            "type": ["object", "string"],
+            "type": [
+                "object",
+                "string"
+            ],
             "contentMediaType": "application/json"
         }
     }

--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -268,7 +268,7 @@
                 }
             },
             "patternProperties": {
-                "^((?i)createOptions)(?<num>[0-9]*)$": {
+                "^(?i)createOptions([0-9]*)$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },

--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -268,7 +268,7 @@
                 }
             },
             "patternProperties": {
-                "^(?i)createOptions[0-9]*$": {
+                "^(createoptions|createOptions)[0-9]*$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },

--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -268,7 +268,7 @@
                 }
             },
             "patternProperties": {
-                "^(?i)createOptions([0-9]*)$": {
+                "^(?i)createOptions[0-9]*$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -245,7 +245,7 @@
                 }
             },
             "patternProperties": {
-                "^(?i)createOptions[0-9]*$": {
+                "^(createoptions|createOptions)[0-9]*$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -242,8 +242,10 @@
                     "examples": [
                         "mcr.microsoft.com/azureiotedge-agent:1.0"
                     ]
-                },
-                "createOptions": {
+                }
+            },
+            "patternProperties": {
+                "^((?i)createOptions)(?<num>[0-9]*)$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },
@@ -259,7 +261,11 @@
                     ],
                     "properties": {
                         "value": {
-                            "type": ["number", "string", "boolean"]
+                            "type": [
+                                "number",
+                                "string",
+                                "boolean"
+                            ]
                         }
                     },
                     "additionalProperties": false

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -245,7 +245,7 @@
                 }
             },
             "patternProperties": {
-                "^(?i)createOptions([0-9]*)$": {
+                "^(?i)createOptions[0-9]*$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -245,7 +245,7 @@
                 }
             },
             "patternProperties": {
-                "^((?i)createOptions)(?<num>[0-9]*)$": {
+                "^(?i)createOptions([0-9]*)$": {
                     "$ref": "#/definitions/createOptions"
                 }
             },


### PR DESCRIPTION
Updated schema to allow createOptions that are chunked: createOptions, createOptions01 and so on. 