### PR TITLE
[chunky pr] Update tsconfig.json schema

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -105,7 +105,9 @@
     "---> package.json use 'tsType'<---",
     "package.json",
     "---> tsconfig.json uses vscode-specific json schema extensions <---",
-    "tsconfig.json"
+    "tsconfig.json",
+    "---> tsoa imports the tsconfig.json <---",
+    "tsoa.json"
   ],
   "missingcatalogurl": [
     "---> below this line are schema, that are included from other schema<---",

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -104,7 +104,9 @@
     "---> proxies.json use 'defaultSnippets'<---",
     "proxies.json",
     "---> package.json use 'tsType'<---",
-    "package.json"
+    "package.json",
+    "---> tsconfig.json uses vscode-specific json schema extensions <---",
+    "tsconfig.json"
   ],
   "missingcatalogurl": [
     "---> below this line are schema, that are included from other schema<---",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -69,7 +69,6 @@
             "charset": {
               "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
               "type": "string",
-              "deprecationMessage": "Deprecated",
               "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
@@ -92,7 +91,6 @@
             "diagnostics": {
               "description": "Output compiler performance information after building.",
               "type": "boolean",
-              "deprecationMessage": "Deprecated",
               "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
@@ -564,7 +562,6 @@
               "description": "Disable truncating types in error messages.",
               "type": "boolean",
               "default": false,
-              "deprecationMessage": "Deprecated",
               "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
@@ -767,7 +764,6 @@
               "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
               "type": "boolean",
               "default": false,
-              "deprecationMessage": "Deprecated",
               "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -2,7 +2,6 @@
   "title": "JSON schema for the TypeScript compiler's configuration file",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://json.schemastore.org/tsconfig",
-
   "definitions": {
     "//": {
       "explainer": "https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#overview",
@@ -68,266 +67,324 @@
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "charset": {
-              "description": "The character set of the input files. This setting is deprecated.",
-              "type": "string"
+              "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
+              "type": "string",
+              "deprecationMessage": "Deprecated",
+              "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
-              "description": "Enables building for project references. Requires TypeScript version 3.0 or later.",
+              "description": "Enable constraints that allow a TypeScript project to be used with project references.",
               "type": "boolean",
-              "default": true
+              "default": true,
+              "markdownDescription": "Enable constraints that allow a TypeScript project to be used with project references.\n\nSee more: https://www.typescriptlang.org/tsconfig#composite"
             },
             "declaration": {
-              "description": "Generates corresponding d.ts files.",
+              "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Generate .d.ts files from TypeScript and JavaScript files in your project.\n\nSee more: https://www.typescriptlang.org/tsconfig#declaration"
             },
             "declarationDir": {
-              "description": "Specify output directory for generated declaration files. Requires TypeScript version 2.0 or later.",
-              "type": ["string", "null"]
+              "description": "Specify the output directory for generated declaration files.",
+              "type": ["string", "null"],
+              "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
-              "description": "Show diagnostic information. This setting is deprecated. See `extendedDiagnostics.`",
-              "type": "boolean"
+              "description": "Output compiler performance information after building.",
+              "type": "boolean",
+              "deprecationMessage": "Deprecated",
+              "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
-              "description": "Recommend IDE's to load referenced composite projects dynamically instead of loading them all immediately. Requires TypeScript version 4.0 or later.",
-              "type": "boolean"
+              "description": "Reduce the number of projects loaded automatically by TypeScript.",
+              "type": "boolean",
+              "markdownDescription": "Reduce the number of projects loaded automatically by TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad"
+            },
+            "noPropertyAccessFromIndexSignature": {
+              "description": "Enforces using indexed accessors for keys declared using an indexed type",
+              "type": "boolean",
+              "markdownDescription": "Enforces using indexed accessors for keys declared using an indexed type\n\nSee more: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature"
             },
             "emitBOM": {
               "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitBOM"
             },
             "emitDeclarationOnly": {
-              "description": "Only emit '.d.ts' declaration files. Requires TypeScript version 2.8 or later.",
+              "description": "Only output d.ts files and not JavaScript files.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Only output d.ts files and not JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDeclarationOnly"
             },
             "incremental": {
-              "description": "Enable incremental compilation. Requires TypeScript version 3.4 or later.",
-              "type": "boolean"
+              "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
+              "type": "boolean",
+              "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "tsBuildInfoFile": {
-              "description": "Specify file to store incremental compilation information. Requires TypeScript version 3.4 or later.",
+              "description": "Specify the folder for .tsbuildinfo incremental compilation files.",
               "default": ".tsbuildinfo",
-              "type": "string"
+              "type": "string",
+              "markdownDescription": "Specify the folder for .tsbuildinfo incremental compilation files.\n\nSee more: https://www.typescriptlang.org/tsconfig#tsBuildInfoFile"
             },
-
             "inlineSourceMap": {
-              "description": "Emit a single file with source maps instead of having a separate file. Requires TypeScript version 1.5 or later.",
+              "description": "Include sourcemap files inside the emitted JavaScript.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Include sourcemap files inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSourceMap"
             },
             "inlineSources": {
-              "description": "Emit the source alongside the sourcemaps within a single file; requires --inlineSourceMap to be set. Requires TypeScript version 1.5 or later.",
+              "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Include source code in the sourcemaps inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSources"
             },
             "jsx": {
-              "description": "Specify JSX code generation: 'preserve', 'react', 'react-jsx', 'react-jsxdev' or 'react-native'. Requires TypeScript version 2.2 or later.",
-              "enum": [ "preserve", "react", "react-jsx", "react-jsxdev", "react-native" ]
-            },
-            "reactNamespace": {
-              "description": "Specify the object invoked for createElement and __spread when targeting 'react' JSX emit.",
-              "type": "string",
-              "default": "React"
-            },
-            "jsxFactory": {
-              "description": "Specify the JSX factory function to use when targeting react JSX emit, e.g. 'React.createElement' or 'h'. Requires TypeScript version 2.1 or later.",
-              "type": "string",
-              "default": "React.createElement"
-            },
-            "jsxFragmentFactory": {
-              "description": "Specify the JSX Fragment reference to use for fragements when targeting react JSX emit, e.g. 'React.Fragment' or 'Fragment'. Requires TypeScript version 4.0 or later.",
-              "type": "string",
-              "default": "React.Fragment"
-            },
-            "jsxImportSource": {
-              "description": "Declare the module specifier to be used for importing the `jsx` and `jsxs` factory functions when using jsx as \"react-jsx\" or \"react-jsxdev\". Requires TypeScript version 4.1 or later.",
-              "type": "string",
-              "default": "react"
-            },
-            "listFiles": {
-              "description": "Print names of files part of the compilation.",
-              "type": "boolean",
-              "default": false
-            },
-            "mapRoot": {
-              "description": "Specify the location where debugger should locate map files instead of generated locations",
-              "type": "string"
-            },
-            "module": {
-              "description": "Specify module code generation: 'None', 'CommonJS', 'AMD', 'System', 'UMD', 'ES6', 'ES2015', 'ES2020' or 'ESNext'. Only 'AMD' and 'System' can be used in conjunction with --outFile.",
-              "type": "string",
-              "anyOf": [
-                {
-                  "enum": [ "CommonJS", "AMD", "System", "UMD", "ES6", "ES2015", "ES2020", "ESNext", "None" ]
-                },
-                {
-                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|201[567]|2020|[Nn][Ee][Xx][Tt])|[Nn][Oo][Nn][Ee])$"
-                }
+              "description": "Specify what JSX code is generated.",
+              "enum": [
+                "preserve",
+                "react",
+                "react-jsx",
+                "react-jsxdev",
+                "react-native"
               ]
             },
-            "moduleResolution": {
-              "description": "Specifies module resolution strategy: 'node' (Node) or 'classic' (TypeScript pre 1.6) .",
+            "reactNamespace": {
+              "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
+              "type": "string",
+              "default": "React",
+              "markdownDescription": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.\n\nSee more: https://www.typescriptlang.org/tsconfig#reactNamespace"
+            },
+            "jsxFactory": {
+              "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
+              "type": "string",
+              "default": "React.createElement",
+              "markdownDescription": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFactory"
+            },
+            "jsxFragmentFactory": {
+              "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
+              "type": "string",
+              "default": "React.Fragment",
+              "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
+            },
+            "jsxImportSource": {
+              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.`",
+              "type": "string",
+              "default": "react",
+              "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.`\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
+            },
+            "listFiles": {
+              "description": "Print all of the files read during the compilation.",
+              "type": "boolean",
+              "default": false,
+              "markdownDescription": "Print all of the files read during the compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listFiles"
+            },
+            "mapRoot": {
+              "description": "Specify the location where debugger should locate map files instead of generated locations.",
+              "type": "string",
+              "markdownDescription": "Specify the location where debugger should locate map files instead of generated locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#mapRoot"
+            },
+            "module": {
+              "description": "Specify what module code is generated.",
               "type": "string",
               "anyOf": [
                 {
                   "enum": [
-                    "Classic",
-                    "Node"
+                    "CommonJS",
+                    "AMD",
+                    "System",
+                    "UMD",
+                    "ES6",
+                    "ES2015",
+                    "ES2020",
+                    "ESNext",
+                    "None"
                   ]
+                },
+                {
+                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|201[567]|2020|[Nn][Ee][Xx][Tt])|[Nn][Oo][Nn][Ee])$"
+                }
+              ],
+              "markdownDescription": "Specify what module code is generated.\n\nSee more: https://www.typescriptlang.org/tsconfig#module"
+            },
+            "moduleResolution": {
+              "description": "Specify how TypeScript looks up a file from a given module specifier.",
+              "type": "string",
+              "anyOf": [
+                {
+                  "enum": ["Classic", "Node"]
                 },
                 {
                   "pattern": "^(([Nn]ode)|([Cc]lassic))$"
                 }
               ],
-              "default": "classic"
+              "default": "classic",
+              "markdownDescription": "Specify how TypeScript looks up a file from a given module specifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleResolution"
             },
             "newLine": {
-              "description": "Specifies the end of line sequence to be used when emitting files: 'crlf' (Windows) or 'lf' (Unix). Requires TypeScript version 1.5 or later.",
+              "description": "Set the newline character for emitting files.",
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [
-                    "crlf",
-                    "lf"
-                  ]
+                  "enum": ["crlf", "lf"]
                 },
                 {
                   "pattern": "^(CRLF|LF|crlf|lf)$"
                 }
-              ]
+              ],
+              "markdownDescription": "Set the newline character for emitting files.\n\nSee more: https://www.typescriptlang.org/tsconfig#newLine"
             },
             "noEmit": {
-              "description": "Do not emit output.",
+              "description": "Disable emitting file from a compilation.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable emitting file from a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmit"
             },
             "noEmitHelpers": {
-              "description": "Do not generate custom helper functions like __extends in compiled output. Requires TypeScript version 1.5 or later.",
+              "description": "Disable generating custom helper functions like `__extends` in compiled output.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable generating custom helper functions like `__extends` in compiled output.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitHelpers"
             },
             "noEmitOnError": {
-              "description": "Do not emit outputs if any type checking errors were reported. Requires TypeScript version 1.4 or later.",
+              "description": "Disable emitting files if any type checking errors are reported.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable emitting files if any type checking errors are reported.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitOnError"
             },
             "noImplicitAny": {
-              "description": "Warn on expressions and declarations with an implied 'any' type. Enabling this setting is recommended.",
-              "type": "boolean"
-            },
-            "noImplicitOverride": {
-              "description": "Ensure overriding members in derived classes are marked with an override modifier.",
+              "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
               "type": "boolean",
-              "default": false
+              "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
             },
             "noImplicitThis": {
-              "description": "Raise error on 'this' expressions with an implied any type. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
-              "type": "boolean"
+              "description": "Enable error reporting when `this` is given the type `any`.",
+              "type": "boolean",
+              "markdownDescription": "Enable error reporting when `this` is given the type `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitThis"
             },
             "noUnusedLocals": {
-              "description": "Report errors on unused locals. Requires TypeScript version 2.0 or later.",
+              "description": "Enable error reporting when a local variables aren't read.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Enable error reporting when a local variables aren't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
-              "description": "Report errors on unused parameters. Requires TypeScript version 2.0 or later.",
+              "description": "Raise an error when a function parameter isn't read",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Raise an error when a function parameter isn't read\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedParameters"
             },
             "noLib": {
-              "description": "Do not include the default library file (lib.d.ts).",
+              "description": "Disable including any library files, including the default lib.d.ts.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable including any library files, including the default lib.d.ts.\n\nSee more: https://www.typescriptlang.org/tsconfig#noLib"
             },
             "noResolve": {
-              "description": "Do not add triple-slash references or module import targets to the list of compiled files.",
+              "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.\n\nSee more: https://www.typescriptlang.org/tsconfig#noResolve"
             },
             "noStrictGenericChecks": {
-              "description": "Disable strict checking of generic signatures in function types. Requires TypeScript version 2.4 or later.",
+              "description": "Disable strict checking of generic signatures in function types.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
             },
             "skipDefaultLibCheck": {
-              "description": "Use `skipLibCheck` instead. Skip type checking of default library declaration files.",
+              "description": "Skip type checking .d.ts files that are included with TypeScript.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Skip type checking .d.ts files that are included with TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck"
             },
             "skipLibCheck": {
-              "description": "Skip type checking of declaration files. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
+              "description": "Skip type checking all .d.ts files.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
-              "description": "Concatenate and emit output to single file.",
-              "type": "string"
+              "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
+              "type": "string",
+              "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
-              "description": "Redirect output structure to the directory.",
-              "type": "string"
+              "description": "Specify an output folder for all emitted files.",
+              "type": "string",
+              "markdownDescription": "Specify an output folder for all emitted files.\n\nSee more: https://www.typescriptlang.org/tsconfig#outDir"
             },
             "preserveConstEnums": {
-              "description": "Do not erase const enum declarations in generated code.",
+              "description": "Disable erasing `const enum` declarations in generated code.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable erasing `const enum` declarations in generated code.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveConstEnums"
             },
             "preserveSymlinks": {
-              "description": "Do not resolve symlinks to their real path; treat a symlinked file like a real one.",
+              "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveSymlinks"
             },
             "preserveWatchOutput": {
-              "description": "Keep outdated console output in watch mode instead of clearing the screen.",
-              "type": "boolean"
+              "description": "Disable wiping the console in watch mode",
+              "type": "boolean",
+              "markdownDescription": "Disable wiping the console in watch mode\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveWatchOutput"
             },
             "pretty": {
-              "description": "Stylize errors and messages using color and context (experimental).",
+              "description": "Enable color and formatting in output to make compiler errors easier to read",
               "type": "boolean",
-              "default": true
+              "default": true,
+              "markdownDescription": "Enable color and formatting in output to make compiler errors easier to read\n\nSee more: https://www.typescriptlang.org/tsconfig#pretty"
             },
             "removeComments": {
-              "description": "Do not emit comments to output.",
+              "description": "Disable emitting comments.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable emitting comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#removeComments"
             },
             "rootDir": {
-              "description": "Specifies the root directory of input files. Use to control the output directory structure with --outDir.",
-              "type": "string"
+              "description": "Specify the root folder within your source files.",
+              "type": "string",
+              "markdownDescription": "Specify the root folder within your source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDir"
             },
             "isolatedModules": {
-              "description": "Unconditionally emit imports for unresolved files.",
+              "description": "Ensure that each file can be safely transpiled without relying on other imports.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Ensure that each file can be safely transpiled without relying on other imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedModules"
             },
             "sourceMap": {
-              "description": "Generates corresponding '.map' file.",
+              "description": "Create source map files for emitted JavaScript files.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Create source map files for emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceMap"
             },
             "sourceRoot": {
-              "description": "Specifies the location where debugger should locate TypeScript files instead of source locations.",
-              "type": "string"
+              "description": "Specify the root path for debuggers to find the reference source code.",
+              "type": "string",
+              "markdownDescription": "Specify the root path for debuggers to find the reference source code.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceRoot"
             },
             "suppressExcessPropertyErrors": {
-              "description": "Suppress excess property checks for object literals. It is recommended to use @ts-ignore comments instead of enabling this setting.",
+              "description": "Disable reporting of excess property errors during the creation of object literals.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
-              "description": "Suppress noImplicitAny errors for indexing objects lacking index signatures. It is recommended to use @ts-ignore comments instead of enabling this setting.",
+              "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
-              "description": "Do not emit declarations for code that has an '@internal' annotation.",
-              "type": "boolean"
+              "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
+              "type": "boolean",
+              "markdownDescription": "Disable emitting declarations that have `@internal` in their JSDoc comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#stripInternal"
             },
             "target": {
-              "description": "Specify ECMAScript target version: 'ES3', 'ES5', 'ES6'/'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ESNext'",
+              "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": "string",
               "default": "ES3",
               "anyOf": [
@@ -348,14 +405,15 @@
                 {
                   "pattern": "^([Ee][Ss]([356]|(20(1[56789]|20))|[Nn][Ee][Xx][Tt]))$"
                 }
-              ]
+              ],
+              "markdownDescription": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.\n\nSee more: https://www.typescriptlang.org/tsconfig#target"
             },
             "watch": {
               "description": "Watch input files.",
               "type": "boolean"
             },
             "fallbackPolling": {
-              "description": "Specify the polling strategy to use when the system runs out of or doesn't support native file watchers. Requires TypeScript version 3.8 or later.",
+              "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
               "enum": [
                 "fixedPollingInterval",
                 "priorityPollingInterval",
@@ -363,7 +421,7 @@
               ]
             },
             "watchDirectory": {
-              "description": "Specify the strategy for watching directories under systems that lack recursive file-watching functionality. Requires TypeScript version 3.8 or later.",
+              "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
               "enum": [
                 "useFsEvents",
                 "fixedPollingInterval",
@@ -372,7 +430,7 @@
               "default": "useFsEvents"
             },
             "watchFile": {
-              "description": "Specify the strategy for watching individual files. Requires TypeScript version 3.8 or later.",
+              "description": "Specify how the TypeScript watch mode works.",
               "enum": [
                 "fixedPollingInterval",
                 "priorityPollingInterval",
@@ -383,51 +441,61 @@
               "default": "useFsEvents"
             },
             "experimentalDecorators": {
-              "description": "Enables experimental support for ES7 decorators.",
-              "type": "boolean"
+              "description": "Enable experimental support for TC39 stage 2 draft decorators.",
+              "type": "boolean",
+              "markdownDescription": "Enable experimental support for TC39 stage 2 draft decorators.\n\nSee more: https://www.typescriptlang.org/tsconfig#experimentalDecorators"
             },
             "emitDecoratorMetadata": {
-              "description": "Emit design-type metadata for decorated declarations in source.",
-              "type": "boolean"
+              "description": "Emit design-type metadata for decorated declarations in source files.",
+              "type": "boolean",
+              "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata"
             },
             "allowUnusedLabels": {
-              "description": "Do not report errors on unused labels. Requires TypeScript version 1.8 or later.",
-              "type": "boolean"
+              "description": "Disable error reporting for unused labels.",
+              "type": "boolean",
+              "markdownDescription": "Disable error reporting for unused labels.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnusedLabels"
             },
             "noImplicitReturns": {
-              "description": "Report error when not all code paths in function return a value. Requires TypeScript version 1.8 or later.",
+              "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Enable error reporting for codepaths that do not explicitly return in a function.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitReturns"
             },
             "noUncheckedIndexedAccess": {
-              "description": "Add `undefined` to an un-declared field in a type. Requires TypeScript version 4.1 or later.",
-              "type": "boolean"
+              "description": "Add `undefined` to a type when accessed using an index.",
+              "type": "boolean",
+              "markdownDescription": "Add `undefined` to a type when accessed using an index.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess"
             },
             "noFallthroughCasesInSwitch": {
-              "description": "Report errors for fallthrough cases in switch statement. Requires TypeScript version 1.8 or later.",
+              "description": "Enable error reporting for fallthrough cases in switch statements.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Enable error reporting for fallthrough cases in switch statements.\n\nSee more: https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch"
             },
             "allowUnreachableCode": {
-              "description": "Do not report errors on unreachable code. Requires TypeScript version 1.8 or later.",
-              "type": "boolean"
+              "description": "Disable error reporting for unreachable code.",
+              "type": "boolean",
+              "markdownDescription": "Disable error reporting for unreachable code.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnreachableCode"
             },
             "forceConsistentCasingInFileNames": {
-              "description": "Disallow inconsistently-cased references to the same file. Enabling this setting is recommended.",
+              "description": "Ensure that casing is correct in imports.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
-              "description": "Emit a v8 CPI profile during the compiler run, which may provide insight into slow builds. Requires TypeScript version 3.7 or later.",
+              "description": "Emit a v8 CPU profile of the compiler run for debugging.",
               "type": "string",
-              "default": "profile.cpuprofile"
+              "default": "profile.cpuprofile",
+              "markdownDescription": "Emit a v8 CPU profile of the compiler run for debugging.\n\nSee more: https://www.typescriptlang.org/tsconfig#generateCpuProfile"
             },
             "baseUrl": {
-              "description": "Base directory to resolve non-relative module names.",
-              "type": "string"
+              "description": "Specify the base directory to resolve non-relative module names.",
+              "type": "string",
+              "markdownDescription": "Specify the base directory to resolve non-relative module names.\n\nSee more: https://www.typescriptlang.org/tsconfig#baseUrl"
             },
             "paths": {
-              "description": "Specify path mapping to be computed relative to baseUrl option.",
+              "description": "Specify a set of entries that re-map imports to additional lookup locations.",
               "type": "object",
               "additionalProperties": {
                 "type": "array",
@@ -436,10 +504,11 @@
                   "type": "string",
                   "description": "Path mapping to be computed relative to baseUrl option."
                 }
-              }
+              },
+              "markdownDescription": "Specify a set of entries that re-map imports to additional lookup locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#paths"
             },
             "plugins": {
-              "description": "List of TypeScript language server plugins to load. Requires TypeScript version 2.3 or later.",
+              "description": "Specify a list of language service plugins to include.",
               "type": "array",
               "items": {
                 "type": "object",
@@ -449,68 +518,80 @@
                     "type": "string"
                   }
                 }
-              }
+              },
+              "markdownDescription": "Specify a list of language service plugins to include.\n\nSee more: https://www.typescriptlang.org/tsconfig#plugins"
             },
             "rootDirs": {
-              "description": "Specify list of root directories to be used when resolving modules. Requires TypeScript version 2.0 or later.",
+              "description": "Allow multiple folders to be treated as one when resolving modules.",
               "type": "array",
               "uniqueItems": true,
               "items": {
                 "type": "string"
-              }
+              },
+              "markdownDescription": "Allow multiple folders to be treated as one when resolving modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDirs"
             },
             "typeRoots": {
-              "description": "Specify list of directories for type definition files to be included. Requires TypeScript version 2.0 or later.",
+              "description": "Specify multiple folders that act like `./node_modules/@types`.",
               "type": "array",
               "uniqueItems": true,
               "items": {
                 "type": "string"
-              }
+              },
+              "markdownDescription": "Specify multiple folders that act like `./node_modules/@types`.\n\nSee more: https://www.typescriptlang.org/tsconfig#typeRoots"
             },
             "types": {
-              "description": "Type declaration files to be included in compilation. Requires TypeScript version 2.0 or later.",
+              "description": "Specify type package names to be included without being referenced in a source file.",
               "type": "array",
               "uniqueItems": true,
               "items": {
                 "type": "string"
-              }
+              },
+              "markdownDescription": "Specify type package names to be included without being referenced in a source file.\n\nSee more: https://www.typescriptlang.org/tsconfig#types"
             },
             "traceResolution": {
-              "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
+              "description": "Log paths used during the `moduleResolution` process.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Log paths used during the `moduleResolution` process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
             },
             "allowJs": {
-              "description": "Allow javascript files to be compiled. Requires TypeScript version 1.8 or later.",
+              "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowJs"
             },
             "noErrorTruncation": {
-              "description": "Do not truncate error messages. This setting is deprecated.",
+              "description": "Disable truncating types in error messages.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "deprecationMessage": "Deprecated",
+              "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
-              "description": "Allow default imports from modules with no default export. This does not affect code emit, just typechecking. Requires TypeScript version 1.8 or later.",
-              "type": "boolean"
+              "description": "Allow 'import x from y' when a module doesn't have a default export.",
+              "type": "boolean",
+              "markdownDescription": "Allow 'import x from y' when a module doesn't have a default export.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports"
             },
             "noImplicitUseStrict": {
-              "description": "Do not emit 'use strict' directives in module output.",
+              "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Disable adding 'use strict' directives in emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitUseStrict"
             },
             "listEmittedFiles": {
-              "description": "Enable to list all emitted files. Requires TypeScript version 2.0 or later.",
+              "description": "Print the names of emitted files after a compilation.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Print the names of emitted files after a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listEmittedFiles"
             },
             "disableSizeLimit": {
-              "description": "Disable size limit for JavaScript project. Requires TypeScript version 2.0 or later.",
+              "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSizeLimit"
             },
             "lib": {
-              "description": "List of library files to be included in the compilation. Possible values are: 'ES5', 'ES6', 'ES2015', 'ES7', 'ES2016', 'ES2017', 'ES2018', 'ESNext', 'DOM', 'DOM.Iterable', 'WebWorker', 'ScriptHost', 'ES2015.Core', 'ES2015.Collection', 'ES2015.Generator', 'ES2015.Iterable', 'ES2015.Promise', 'ES2015.Proxy', 'ES2015.Reflect', 'ES2015.Symbol', 'ES2015.Symbol.WellKnown', 'ES2016.Array.Include', 'ES2017.object', 'ES2017.Intl', 'ES2017.SharedMemory', 'ES2017.String', 'ES2017.TypedArrays', 'ES2018.Intl', 'ES2018.Promise', 'ES2018.RegExp', 'ESNext.AsyncIterable', 'ESNext.Array', 'ESNext.Intl', 'ESNext.Symbol'. Requires TypeScript version 2.0 or later.",
+              "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
               "type": "array",
               "uniqueItems": true,
               "items": {
@@ -520,7 +601,6 @@
                     "enum": [
                       "ES5",
                       "ES6",
-
                       "ES2015",
                       "ES2015.Collection",
                       "ES2015.Core",
@@ -531,36 +611,30 @@
                       "ES2015.Reflect",
                       "ES2015.Symbol.WellKnown",
                       "ES2015.Symbol",
-
                       "ES2016",
                       "ES2016.Array.Include",
-
                       "ES2017",
                       "ES2017.Intl",
                       "ES2017.Object",
                       "ES2017.SharedMemory",
                       "ES2017.String",
                       "ES2017.TypedArrays",
-
                       "ES2018",
                       "ES2018.AsyncGenerator",
                       "ES2018.AsyncIterable",
                       "ES2018.Intl",
                       "ES2018.Promise",
                       "ES2018.Regexp",
-
                       "ES2019",
                       "ES2019.Array",
                       "ES2019.Object",
                       "ES2019.String",
                       "ES2019.Symbol",
-
                       "ES2020",
                       "ES2020.BigInt",
                       "ES2020.Promise",
                       "ES2020.String",
                       "ES2020.Symbol.WellKnown",
-
                       "ESNext",
                       "ESNext.Array",
                       "ESNext.AsyncIterable",
@@ -569,12 +643,9 @@
                       "ESNext.Promise",
                       "ESNext.String",
                       "ESNext.Symbol",
-
                       "DOM",
                       "DOM.Iterable",
-
                       "ScriptHost",
-
                       "WebWorker",
                       "WebWorker.ImportScripts"
                     ]
@@ -613,116 +684,134 @@
                     "pattern": "^[Ww][Ee][Bb][Ww][Oo][Rr][Kk][Ee][Rr](\\.[Ii][Mm][Pp][Oo][Rr][Tt][Ss][Cc][Rr][Ii][Pp][Tt][Ss])?$"
                   }
                 ]
-              }
+              },
+              "markdownDescription": "Specify a set of bundled library declaration files that describe the target runtime environment.\n\nSee more: https://www.typescriptlang.org/tsconfig#lib"
             },
             "strictNullChecks": {
-              "description": "Enable strict null checks. Enabling this setting is recommended. Requires TypeScript version 2.0 or later.",
+              "description": "When type checking, take into account `null` and `undefined`.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
-              "description": "The maximum dependency depth to search under node_modules and load JavaScript files. Only applicable with --allowJs.",
+              "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
               "type": "number",
-              "default": 0
+              "default": 0,
+              "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
-              "description": "Import emit helpers (e.g. '__extends', '__rest', etc..) from tslib. Requires TypeScript version 2.1 or later.",
+              "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Allow importing helper functions from tslib once per project, instead of including them per-file.\n\nSee more: https://www.typescriptlang.org/tsconfig#importHelpers"
             },
             "importsNotUsedAsValues": {
-              "description": "This flag controls how imports work. When set to `remove`, imports that only reference types are dropped. When set to `preserve`, imports are never dropped. When set to `error`, imports that can be replaced with `import type` will result in a compiler error. Requires TypeScript version 3.8 or later.",
+              "description": "Specify emit/checking behavior for imports that are only used for types.",
               "default": "remove",
-              "enum": [
-                "remove",
-                "preserve",
-                "error"
-              ]
+              "enum": ["remove", "preserve", "error"]
             },
             "alwaysStrict": {
-              "description": "Parse in strict mode and emit 'use strict' for each source file. Requires TypeScript version 2.1 or later.",
-              "type": "boolean"
+              "description": "Ensure 'use strict' is always emitted.",
+              "type": "boolean",
+              "markdownDescription": "Ensure 'use strict' is always emitted.\n\nSee more: https://www.typescriptlang.org/tsconfig#alwaysStrict"
             },
             "strict": {
-              "description": "Enable all strict type checking options. Enabling this setting is recommended. Requires TypeScript version 2.3 or later.",
+              "description": "Enable all strict type checking options.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Enable all strict type checking options.\n\nSee more: https://www.typescriptlang.org/tsconfig#strict"
             },
             "strictBindCallApply": {
-              "description": "Enable stricter checking of of the `bind`, `call`, and `apply` methods on functions. Enabling this setting is recommended. Requires TypeScript version 3.2 or later.",
+              "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBindCallApply"
             },
             "downlevelIteration": {
-              "description": "Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. Requires TypeScript version 2.3 or later.",
+              "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Emit more compliant, but verbose and less performant JavaScript for iteration.\n\nSee more: https://www.typescriptlang.org/tsconfig#downlevelIteration"
             },
             "checkJs": {
-              "description": "Report errors in .js files. Requires TypeScript version 2.3 or later.",
+              "description": "Enable error reporting in type-checked JavaScript files.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
             },
             "strictFunctionTypes": {
-              "description": "Disable bivariant parameter checking for function types. Enabling this setting is recommended. Requires TypeScript version 2.6 or later.",
+              "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictFunctionTypes"
             },
             "strictPropertyInitialization": {
-              "description": "Ensure non-undefined class properties are initialized in the constructor. Enabling this setting is recommended. Requires TypeScript version 2.7 or later.",
+              "description": "Check for class properties that are declared but not set in the constructor.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
-              "description": "Emit '__importStar' and '__importDefault' helpers for runtime babel ecosystem compatibility and enable '--allowSyntheticDefaultImports' for typesystem compatibility. Enabling this setting is recommended. Requires TypeScript version 2.7 or later.",
+              "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
-              "description": "Allow accessing UMD globals from modules. Requires TypeScript version 3.5 or later.",
+              "description": "Allow accessing UMD globals from modules.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Allow accessing UMD globals from modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUmdGlobalAccess"
             },
             "keyofStringsOnly": {
-              "description": "Resolve 'keyof' to string valued property names only (no numbers or symbols). This setting is deprecated. Requires TypeScript version 2.9 or later.",
+              "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "deprecationMessage": "Deprecated",
+              "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {
-              "description": "Emit ECMAScript standard class fields. Requires TypeScript version 3.7 or later.",
+              "description": "Emit ECMAScript-standard-compliant class fields.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Emit ECMAScript-standard-compliant class fields.\n\nSee more: https://www.typescriptlang.org/tsconfig#useDefineForClassFields"
             },
             "declarationMap": {
-              "description": "Generates a sourcemap for each corresponding '.d.ts' file. Requires TypeScript version 2.9 or later.",
+              "description": "Create sourcemaps for d.ts files.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Create sourcemaps for d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationMap"
             },
             "resolveJsonModule": {
-              "description": "Include modules imported with '.json' extension. Requires TypeScript version 2.9 or later.",
+              "description": "Enable importing .json files",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Enable importing .json files\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
-              "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it. Requires TypeScript version 3.8 or later.",
-              "type": "boolean"
+              "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
+              "type": "boolean",
+              "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "extendedDiagnostics": {
-              "description": "Show verbose diagnostic information.",
+              "description": "Output more detailed compiler performance information after building.",
               "type": "boolean",
-              "default": false
+              "default": false,
+              "markdownDescription": "Output more detailed compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#extendedDiagnostics"
             },
             "listFilesOnly": {
               "description": "Print names of files that are part of the compilation and then stop processing.",
               "type": "boolean"
             },
             "disableSourceOfProjectReferenceRedirect": {
-              "description": "Disable use of source files instead of declaration files from referenced projects. Requires TypeScript version 3.7 or later.",
-              "type": "boolean"
+              "description": "Disable preferring source files instead of declaration files when referencing composite projects",
+              "type": "boolean",
+              "markdownDescription": "Disable preferring source files instead of declaration files when referencing composite projects\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSourceOfProjectReferenceRedirect"
             },
             "disableSolutionSearching": {
-              "description": "Disable solution searching for this project. Requires TypeScript version 3.8 or later.",
-              "type": "boolean"
+              "description": "Opt a project out of multi-project reference checking when editing.",
+              "type": "boolean",
+              "markdownDescription": "Opt a project out of multi-project reference checking when editing.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSolutionSearching"
             }
           }
         }
@@ -826,10 +915,7 @@
             "ignoreDiagnostics": {
               "description": "Ignore TypeScript warnings by diagnostic code.",
               "items": {
-                "type": [
-                  "string",
-                  "number"
-                ]
+                "type": ["string", "number"]
               },
               "type": "array",
               "uniqueItems": true
@@ -885,17 +971,35 @@
   },
   "type": "object",
   "allOf": [
-    { "$ref": "#/definitions/compilerOptionsDefinition" },
-    { "$ref": "#/definitions/compileOnSaveDefinition" },
-    { "$ref": "#/definitions/typeAcquisitionDefinition" },
-    { "$ref": "#/definitions/extendsDefinition" },
-    { "$ref": "#/definitions/tsNodeDefinition" },
+    {
+      "$ref": "#/definitions/compilerOptionsDefinition"
+    },
+    {
+      "$ref": "#/definitions/compileOnSaveDefinition"
+    },
+    {
+      "$ref": "#/definitions/typeAcquisitionDefinition"
+    },
+    {
+      "$ref": "#/definitions/extendsDefinition"
+    },
+    {
+      "$ref": "#/definitions/tsNodeDefinition"
+    },
     {
       "anyOf": [
-        { "$ref": "#/definitions/filesDefinition" },
-        { "$ref": "#/definitions/excludeDefinition" },
-        { "$ref": "#/definitions/includeDefinition" },
-        { "$ref": "#/definitions/referencesDefinition" }
+        {
+          "$ref": "#/definitions/filesDefinition"
+        },
+        {
+          "$ref": "#/definitions/excludeDefinition"
+        },
+        {
+          "$ref": "#/definitions/includeDefinition"
+        },
+        {
+          "$ref": "#/definitions/referencesDefinition"
+        }
       ]
     }
   ]


### PR DESCRIPTION
Hi! I've taken some of the TypeScript tooling to automate improvements to the tsconfig schema. Basically, at this point when we update the website + docs to a new version of TypeScript, then it forces us to update the schema too. 

![Screen Shot 2021-03-25 at 2 22 10 PM](https://user-images.githubusercontent.com/49038/112489264-33399080-8d76-11eb-87a9-f15ca8a595ef.png)

This PR is a bunch of things rolled into one:

- Prettier applied to the JSON (using the site's settings)
- Sorted JSON keys for compilerOptions (for better diffs and easier 3rd party contributions)
- Consistent single line descriptions across the site, TSC and JSON Schema (which have been bike-shedded _a lot_ internally)
- Schema extensions which [are supported](https://github.com/microsoft/vscode/blob/197f453aa9560872370e4b8e4b3b2f9a93c4ad68/src/vs/base/common/jsonSchema.ts#L56) in VS Code. The main goal using the `markdownDescription` is that it supports clickable links, and our one-liners are in Markdown already.

Because there are a few systematic changes, I apologize in advance for the tricky diff to look through.

Our tooling will take into account changes to the schema sent through PRs to this repo when we do updates, so no need to change the source of truth.

Some previous versions of the descriptions included the allowed variables in the main description, is this something you want to keep?
