### PR TITLE
Add serverless.template to AWS SAM filenames

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -547,6 +547,7 @@
       "name": "AWS CloudFormation Serverless Application Model (SAM)",
       "description": "The AWS Serverless Application Model (AWS SAM, previously known as Project Flourish) extends AWS CloudFormation to provide a simplified way of defining the Amazon API Gateway APIs, AWS Lambda functions, and Amazon DynamoDB tables needed by your serverless application.",
       "fileMatch": [
+        "serverless.template",
         "*.sam.json",
         "*.sam.yml",
         "*.sam.yaml",


### PR DESCRIPTION
a lot of AWS tools create the SAM json/yml file as "serverless.template" in generated project skeletons, e.g. the visual studio plugin: https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/lambda-build-test-severless-app.html#examine-the-files-in-the-serverless-application