### PR TITLE
[gitlab-ci] Various fixes for scheme

### DIFF
--- a/src/negative_test/gitlab-ci/job_variables_must_not_contain_objects.json
+++ b/src/negative_test/gitlab-ci/job_variables_must_not_contain_objects.json
@@ -1,0 +1,12 @@
+{
+  "gitlab-ci-variables-object": {
+    "stage": "test",
+    "script": ["true"],
+    "variables": {
+      "DEPLOY_ENVIRONMENT": {
+        "value": "staging",
+        "description": "The deployment target. Change this variable to 'canary' or 'production' if needed."
+      }
+    }
+  }
+}

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -32,7 +32,6 @@
     "expo-37.0.0.json",
     "geojson.json",
     "github-workflow.json",
-    "gitlab-ci.json",
     "jasonette.json",
     "jdt.json",
     "ksp-avc.json",

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -13,7 +13,7 @@
     "services": { "$ref": "#/definitions/services" },
     "before_script": { "$ref": "#/definitions/before_script" },
     "after_script": { "$ref": "#/definitions/after_script" },
-    "variables": { "$ref": "#/definitions/variables" },
+    "variables": { "$ref": "#/definitions/globalVariables" },
     "cache": { "$ref": "#/definitions/cache" },
     "default": {
       "type": "object",
@@ -101,7 +101,7 @@
           "items": {
             "type": "string"
           },
-          "minLength": 1
+          "minItems": 1
         },
         "exclude": {
           "type": "array",
@@ -109,7 +109,7 @@
           "items": {
             "type": "string"
           },
-          "minLength": 1
+          "minItems": 1
         },
         "expose_as": {
           "type": "string",
@@ -165,7 +165,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "minLength": 1
+                  "minItems": 1
                 }
               ]
             },
@@ -182,7 +182,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "minLength": 1
+                  "minItems": 1
                 }
               ]
             },
@@ -419,7 +419,40 @@
     "secrets": {
       "type": "object",
       "description": "Defines secrets to be injected as environment variables",
-      "items": {}
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "description": "Environment variable name",
+          "properties": {
+            "vault": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The secret to be fetched from Vault (e.g. 'production/db/password@ops' translates to secret 'ops/data/production/db', field `password`)"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "engine": {
+                      "type": "object",
+                      "properties": {
+                        "name": { "type": "string" },
+                        "path": { "type": "string" }
+                      },
+                      "required": ["name", "path"]
+                    },
+                    "path": { "type": "string" },
+                    "field": { "type": "string" }
+                  },
+                  "required": ["engine", "path", "field"]
+                }
+              ]
+            }
+          },
+          "required": ["vault"]
+        }
+      }
     },
     "before_script": {
       "type": "array",
@@ -491,11 +524,29 @@
         }
       }
     },
+    "globalVariables": {
+      "anyOf": [
+        { "$ref": "#/definitions/variables" },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" },
+              "description": {
+                "type": "string",
+                "description": "Explains what the variable is used for, what the acceptable values are."
+              }
+            }
+          }
+        }
+      ]
+    },
     "variables": {
       "type": "object",
-      "description": "Defines environment variables for specific jobs or globally. Job level property overrides global variables. If a job sets `variables: {}`, all global variables are turned off.",
+      "description": "Defines environment variables for specific jobs or globally. Job level property overrides global variables. If a job sets `variables: {}`, all global variables are turned off. You can use the value and description keywords to define variables that are prefilled when running a pipeline manually.",
       "additionalProperties": {
-        "type": ["string", "integer", "object"]
+        "type": ["string", "integer"]
       }
     },
     "timeout": {
@@ -780,20 +831,7 @@
         "rules": { "$ref": "#/definitions/rules" },
         "variables": { "$ref": "#/definitions/variables" },
         "cache": { "$ref": "#/definitions/cache" },
-        "secrets": {
-          "type": "object",
-          "description": "Defines secrets to be injected as environment variables",
-          "additionalProperties": {
-            "type": "object",
-            "description": "Environment variable name",
-            "properties": {
-              "vault": {
-                "type": "string",
-                "description": "The secret to be fetched from Vault (e.g. 'production/db/password@ops' translates to secret 'ops/data/production/db', field `password`)"
-              }
-            }
-          }
-        },
+        "secrets": { "$ref": "#/definitions/secrets" },
         "script": {
           "description": "Shell scripts executed by the Runner. The only required property of jobs. Be careful with special characters (e.g. `:`, `{`, `}`, `&`) and use single or double quotes to avoid issues.",
           "oneOf": [

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -525,6 +525,7 @@
       }
     },
     "globalVariables": {
+      "description": "Defines environment variables globally. Job level property overrides global variables. If a job sets `variables: {}`, all global variables are turned off. You can use the value and description keywords to define variables that are prefilled when running a pipeline manually.",
       "anyOf": [
         { "$ref": "#/definitions/variables" },
         {
@@ -544,7 +545,7 @@
     },
     "variables": {
       "type": "object",
-      "description": "Defines environment variables for specific jobs or globally. Job level property overrides global variables. If a job sets `variables: {}`, all global variables are turned off. You can use the value and description keywords to define variables that are prefilled when running a pipeline manually.",
+      "description": "Defines environment variables for specific jobs. Job level property overrides global variables. If a job sets `variables: {}`, all global variables are turned off.",
       "additionalProperties": {
         "type": ["string", "integer"]
       }

--- a/src/test/gitlab-ci/gitlab-ci.json
+++ b/src/test/gitlab-ci/gitlab-ci.json
@@ -60,7 +60,10 @@
     {
       "project": "my-group/my-project",
       "ref": "master",
-      "file": [ "/templates/.gitlab-ci-template.yml", "/templates/another-template-to-include.yml" ]
+      "file": [
+        "/templates/.gitlab-ci-template.yml",
+        "/templates/another-template-to-include.yml"
+      ]
     }
   ],
   "build": {

--- a/src/test/gitlab-ci/variables.json
+++ b/src/test/gitlab-ci/variables.json
@@ -1,0 +1,22 @@
+{
+  "variables": {
+    "DEPLOY_ENVIRONMENT": {
+      "value": "staging",
+      "description": "The deployment target. Change this variable to 'canary' or 'production' if needed."
+    }
+  },
+  "gitlab-ci-variables-string": {
+    "stage": "test",
+    "script": ["true"],
+    "variables": {
+      "TEST_VAR": "String variable"
+    }
+  },
+  "gitlab-ci-variables-integer": {
+    "stage": "test",
+    "script": ["true"],
+    "variables": {
+      "canonical": 685230
+    }
+  }
+}


### PR DESCRIPTION
### Why did I create this PR
1. I want to fix definitions for job variables.
    But to after fixing variables I've found that only top level variables support object type.
1. So to test this I have to create positive and negative tests.
1. To create negative tests I have to fix gitlab-ci scheme.

### PR details
Fix gitlab-ci to pass schema test to support negative tests
Add [secrets](https://docs.gitlab.com/ee/ci/yaml/README.html#secrets) definition with full inner object structure.

Create global variables definition with additional object property for [prefill variables](https://docs.gitlab.com/ee/ci/yaml/README.html#prefill-variables-in-manual-pipelines).
```yaml
# This is valid
variables:
  VARIABLE:
    value: DEFAULT
    description: "Variable test"
```

Remove additional object property from job variables, because objects are only supported at top level. 
Ref: #1504
```yaml
# This is invalid
test_job:
  script:
    - true
  variables:
    VARIABLE:
      value: DEFAULT
      description: "Variable test"
```

Add positive test for variables.
Add negative test for variables.