### PR TITLE
Fix typo in schema-catalog.json

### DIFF
--- a/src/schemas/json/schema-catalog.json
+++ b/src/schemas/json/schema-catalog.json
@@ -5,7 +5,7 @@
 
   "type": "object",
   "additionalProperties": false,
-  "required": [ "schemas", "version", "$schema" ],
+  "required": ["schemas", "version", "$schema"],
 
   "properties": {
     "schemas": {
@@ -13,11 +13,11 @@
       "description": "A list of JSON schema references.",
       "items": {
         "type": "object",
-        "required": [ "name", "url", "description" ],
+        "required": ["name", "url", "description"],
         "additionalProperties": false,
         "properties": {
           "fileMatch": {
-            "description": "A Mimimatch expression for matching up file names with a schema.",
+            "description": "A Minimatch expression for matching up file names with a schema.",
             "uniqueItems": true,
             "type": "array",
             "items": {
@@ -53,11 +53,10 @@
       "description": "The schema version of the catalog",
       "type": "number"
     },
-    "$schema":{
+    "$schema": {
       "description": "Link to https://json.schemastore.org/schema-catalog.json",
       "type": "string",
       "enum": ["https://json.schemastore.org/schema-catalog.json"]
     }
-
   }
 }


### PR DESCRIPTION
Replace "Mimimatch" with "Minimatch".
Fix style with prettier.