### PR TITLE
Set gitlab-ci to match all files ending with .gitlab-ci.yml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -988,7 +988,7 @@
       "name": "gitlab-ci",
       "description": "JSON schema for configuring Gitlab CI",
       "fileMatch": [
-        ".gitlab-ci.yml"
+        "*.gitlab-ci.yml"
       ],
       "url": "https://json.schemastore.org/gitlab-ci.json"
     },


### PR DESCRIPTION
The purpose is to make scheme match not only files `.gitlab-ci.yml`. But also all files ending with `.gitlab-ci.yml`.
I think this should be added because a lot of gitlab ci templates have name structure like this, also this naming pattern is suggested in templates development manual.
- [Performance.gitlab-ci.yml](https://docs.gitlab.com/ee/development/cicd/templates.html#backward-compatibility)
- [\<template-name\>.gitlab-ci.yml](https://docs.gitlab.com/ee/development/cicd/templates.html#stable-version)
- [Container-Scanning.gitlab-ci.yml](https://docs.gitlab.com/ee/user/application_security/container_scanning/#configuration)
- [gitlab built-in templates](https://gitlab.com/gitlab-org/gitlab/-/tree/master/lib/gitlab/ci/templates)
- [gitlab.org repository templates](https://gitlab.com/gitlab-org/gitlab/-/tree/master/.gitlab/ci)

Personally I'm creating my own templates with prefix for each one.