### PR TITLE
[gitlab-ci] Update job environment properties

### DIFF
--- a/src/negative_test/gitlab-ci/default_no_additional_properties.json
+++ b/src/negative_test/gitlab-ci/default_no_additional_properties.json
@@ -1,0 +1,12 @@
+{
+  "default": {
+    "secrets": {
+      "DATABASE_PASSWORD": {
+        "vault": "production/db/password"
+      }
+    },
+    "environment": {
+      "name": "test"
+    }
+  }
+}

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -25,11 +25,11 @@
         "image": { "$ref": "#/definitions/image" },
         "interruptible": { "$ref": "#/definitions/interruptible" },
         "retry": { "$ref": "#/definitions/retry" },
-        "secrets": { "$ref": "#/definitions/secrets" },
         "services": { "$ref": "#/definitions/services" },
         "tags": { "$ref": "#/definitions/tags" },
         "timeout": { "$ref": "#/definitions/timeout" }
-      }
+      },
+      "additionalProperties": false
     },
     "stages": {
       "type": "array",
@@ -939,46 +939,63 @@
           "$ref": "#/definitions/artifacts"
         },
         "environment": {
-          "type": "object",
           "description": "Used to associate environment metadata with a deploy. Environment can have a name and URL attached to it, and will be displayed under /environments under the project.",
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "The name of the environment, e.g. 'qa', 'staging', 'production'.",
-              "minLength": 1
-            },
-            "url": {
-              "type": "string",
-              "description": "When set, this will expose buttons in various places for the current environment in Gitlab, that will take you to the defined URL.",
-              "format": "uri",
-              "pattern": "^(https?://.+|\\$[A-Za-z]+)"
-            },
-            "on_stop": {
-              "type": "string",
-              "description": "The name of a job to execute when the environment is about to be stopped."
-            },
-            "action": {
-              "enum": ["start", "prepare", "stop"],
-              "description": "Specifies what this job will do. 'start' (default) indicates the job will start the deployment. 'prepare' indicates this will not affect the deployment. 'stop' indicates this will stop the deployment."
-            },
-            "auto_stop_in": {
-              "type": "string",
-              "description": "The amount of time it should take before Gitlab will automatically stop the environment. Supports a wide variety of formats, e.g. '1 week', '3 mins 4 sec', '2 hrs 20 min', '2h20min', '6 mos 1 day', '47 yrs 6 mos and 4d', '3 weeks and 2 days'."
-            },
-            "kubernetes": {
+          "oneOf": [
+            { "type": "string" },
+            {
               "type": "object",
-              "description": "Used to configure the kubernetes deployment for this environment. This is currently not supported for kubernetes clusters that are managed by Gitlab.",
+              "additionalProperties": false,
               "properties": {
-                "namespace": {
+                "name": {
                   "type": "string",
-                  "description": "The kubernetes namespace where this environment should be deployed to.",
+                  "description": "The name of the environment, e.g. 'qa', 'staging', 'production'.",
                   "minLength": 1
+                },
+                "url": {
+                  "type": "string",
+                  "description": "When set, this will expose buttons in various places for the current environment in Gitlab, that will take you to the defined URL.",
+                  "format": "uri",
+                  "pattern": "^(https?://.+|\\$[A-Za-z]+)"
+                },
+                "on_stop": {
+                  "type": "string",
+                  "description": "The name of a job to execute when the environment is about to be stopped."
+                },
+                "action": {
+                  "enum": ["start", "prepare", "stop"],
+                  "description": "Specifies what this job will do. 'start' (default) indicates the job will start the deployment. 'prepare' indicates this will not affect the deployment. 'stop' indicates this will stop the deployment.",
+                  "default": "start"
+                },
+                "auto_stop_in": {
+                  "type": "string",
+                  "description": "The amount of time it should take before Gitlab will automatically stop the environment. Supports a wide variety of formats, e.g. '1 week', '3 mins 4 sec', '2 hrs 20 min', '2h20min', '6 mos 1 day', '47 yrs 6 mos and 4d', '3 weeks and 2 days'."
+                },
+                "kubernetes": {
+                  "type": "object",
+                  "description": "Used to configure the kubernetes deployment for this environment. This is currently not supported for kubernetes clusters that are managed by Gitlab.",
+                  "properties": {
+                    "namespace": {
+                      "type": "string",
+                      "description": "The kubernetes namespace where this environment should be deployed to.",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "deployment_tier": {
+                  "type": "string",
+                  "description": "Explicitly specifies the tier of the deployment environment if non-standard environment name is used.",
+                  "enum": [
+                    "production",
+                    "staging",
+                    "testing",
+                    "development",
+                    "other"
+                  ]
                 }
-              }
+              },
+              "required": ["name"]
             }
-          },
-          "required": ["name"]
+          ]
         },
         "release": {
           "type": "object",

--- a/src/test/gitlab-ci/environment.json
+++ b/src/test/gitlab-ci/environment.json
@@ -1,0 +1,75 @@
+{
+  "deploy to production 1": {
+    "stage": "deploy",
+    "script": "git push production HEAD: master",
+    "environment": "production"
+  },
+  "deploy to production 2": {
+    "stage": "deploy",
+    "script": "git push production HEAD:master",
+    "environment": {
+      "name": "production"
+    }
+  },
+  "deploy to production 3": {
+    "stage": "deploy",
+    "script": "git push production HEAD:master",
+    "environment": {
+      "name": "production",
+      "url": "https://prod.example.com"
+    }
+  },
+  "review_app 1": {
+    "stage": "deploy",
+    "script": "make deploy-app",
+    "environment": {
+      "name": "review/$CI_COMMIT_REF_NAME",
+      "url": "https://$CI_ENVIRONMENT_SLUG.example.com",
+      "on_stop": "stop_review_app"
+    }
+  },
+  "stop_review_app": {
+    "stage": "deploy",
+    "variables": {
+      "GIT_STRATEGY": "none"
+    },
+    "script": "make delete-app",
+    "when": "manual",
+    "environment": {
+      "name": "review/$CI_COMMIT_REF_NAME",
+      "action": "stop"
+    }
+  },
+  "review_app 2": {
+    "script": "deploy-review-app",
+    "environment": {
+      "name": "review/$CI_COMMIT_REF_NAME",
+      "auto_stop_in": "1 day"
+    }
+  },
+  "deploy 1": {
+    "stage": "deploy",
+    "script": "make deploy-app",
+    "environment": {
+      "name": "production",
+      "kubernetes": {
+        "namespace": "production"
+      }
+    }
+  },
+  "deploy 2": {
+    "script": "echo",
+    "environment": {
+      "name": "customer-portal",
+      "deployment_tier": "production"
+    }
+  },
+  "deploy as review app": {
+    "stage": "deploy",
+    "script": "make deploy",
+    "environment": {
+      "name": "review/$CI_COMMIT_REF_NAME",
+      "url": "https://$CI_ENVIRONMENT_SLUG.example.com/"
+    }
+  }
+}


### PR DESCRIPTION
## Job environment
1. Allow `#/definitions/job_template/environment` to be string.
    https://docs.gitlab.com/ee/ci/yaml/#environment
1. Add `deployment_tier` to `#/definitions/job_template/environment` also here #1539.
    https://docs.gitlab.com/ee/ci/yaml/#environmentdeployment_tier 
1. Add `default` value to `#/definitions/job_template/action`.
    https://docs.gitlab.com/ee/ci/yaml/#environmentaction.
1. Add test for environment.

## Others
I've found this because I've tried to use `environment` in `default`.
1. Disable `additionalProperties` for `#/properties/default`.
    https://docs.gitlab.com/ee/ci/yaml/#custom-default-keyword-values
1. Remove secrets from `#/properties/default`.
1. Add negative test for no additional properties.

