### PR TITLE
[gitlab-ci] Add inherit to gitlab-ci schema

### DIFF
--- a/src/negative_test/gitlab-ci/inherit_default_no additional_properties.json
+++ b/src/negative_test/gitlab-ci/inherit_default_no additional_properties.json
@@ -1,0 +1,8 @@
+{
+  "karma": {
+    "inherit": {
+      "default": ["secrets"]
+    },
+    "script": "karma"
+  }
+}

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -25,7 +25,6 @@
         "image": { "$ref": "#/definitions/image" },
         "interruptible": { "$ref": "#/definitions/interruptible" },
         "retry": { "$ref": "#/definitions/retry" },
-        "secrets": { "$ref": "#/definitions/secrets" },
         "services": { "$ref": "#/definitions/services" },
         "tags": { "$ref": "#/definitions/tags" },
         "timeout": { "$ref": "#/definitions/timeout" }
@@ -1172,6 +1171,51 @@
               "pattern": "\\S/\\S"
             }
           ]
+        },
+        "inherit": {
+          "type": "object",
+          "description": "Controls inheritance of globally-defined defaults and variables. Boolean values control inheritance of all default: or variables: keywords. To inherit only a subset of default: or variables: keywords, specify what you wish to inherit. Anything not listed is not inherited.",
+          "properties": {
+            "default": {
+              "description": "Whether to inherit all globally-defined defaults or not. Or subset of inherited defaults",
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "after_script",
+                      "artifacts",
+                      "before_script",
+                      "cache",
+                      "image",
+                      "interruptible",
+                      "retry",
+                      "services",
+                      "tags",
+                      "timeout"
+                    ]
+                  }
+                }
+              ]
+            },
+            "variables": {
+              "description": "Whether to inherit all globally-defined variables or not. Or subset of inherited variables",
+              "oneOf": [
+                { "type": "boolean" },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
         }
       },
       "oneOf": [

--- a/src/test/gitlab-ci/inherit.json
+++ b/src/test/gitlab-ci/inherit.json
@@ -1,0 +1,54 @@
+{
+  "default": {
+    "image": "ruby:2.4",
+    "before_script": ["echo Hello World"]
+  },
+  "variables": {
+    "DOMAIN": "example.com",
+    "WEBHOOK_URL": "https://my-webhook.example.com"
+  },
+  "rubocop": {
+    "inherit": {
+      "default": false,
+      "variables": false
+    },
+    "script": "bundle exec rubocop"
+  },
+  "rspec": {
+    "inherit": {
+      "default": ["image"],
+      "variables": ["WEBHOOK_URL"]
+    },
+    "script": "bundle exec rspec"
+  },
+  "capybara": {
+    "inherit": {
+      "variables": false
+    },
+    "script": "bundle exec capybara"
+  },
+  "karma": {
+    "inherit": {
+      "default": true,
+      "variables": ["DOMAIN"]
+    },
+    "script": "karma"
+  },
+  "inherit literally all": {
+    "inherit": {
+      "default": [
+        "after_script",
+        "artifacts",
+        "before_script",
+        "cache",
+        "image",
+        "interruptible",
+        "retry",
+        "services",
+        "tags",
+        "timeout"
+      ]
+    },
+    "script": "true"
+  }
+}


### PR DESCRIPTION
## Inherit
Ref: #1548 
1. Add `inherit` property to `#/definitions/job_template`
    https://docs.gitlab.com/ee/ci/yaml/#inherit
1. Add tests for inherit property
### Spec
- `inherit` can contain two properties `default` or `variables`.
- Each of properties can be either `boolean` or `array` `of strings`.
- Array items of `default` must be the same as properties of `#/properties/default`.
  **I'm not sure if we can check them**.
- Array items can be non unique.

## Others
1. Remove `secrets` property from `#/properties/default`