### PR TITLE
Fix 'key_value' property of ansible 'set_fact'

### DIFF
--- a/src/test/ansible-role-2.9/set_fact.json
+++ b/src/test/ansible-role-2.9/set_fact.json
@@ -1,0 +1,34 @@
+[
+  {
+      "name": "Setting host facts using complex arguments",
+      "set_fact": {
+          "one_fact": "something",
+          "other_fact": "{{ local_var * 2 }}",
+          "another_fact": "{{ some_registered_var.results | map(attribute='ansible_facts.some_fact') | list }}"
+      }
+  },
+  {
+      "name": "Setting facts so that they will be persisted in the fact cache",
+      "set_fact": {
+          "one_fact": "something",
+          "other_fact": "{{ local_var * 2 }}",
+          "cacheable": true
+      }
+  },
+  {
+      "name": "Setting host facts using structured arguments",
+      "set_fact": {
+          "a_boolean": true,
+          "a_number": 2,
+          "an_array": [
+              1,
+              2,
+              3
+          ],
+          "a_dict": {
+              "key1": "value1",
+              "key2": 1
+          }
+      }
+  }
+]


### PR DESCRIPTION
Fixes #1397
And therefore redhat-developer/vscode-yaml#340

`key_value` is documented as required but it as to be interpreted as it's description says: it takes any property but need at least 1.
`minProperty: 1` is not enough as `cacheable` may be catch by it, but didn't find better way to do it.