### PR TITLE
github-workflow: support expressions in jobs.<job_id>.strategy.matrix.*

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1258,12 +1258,19 @@
                     }
                   },
                   "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/configuration"
-                    },
-                    "minItems": 1,
-                    "additionalItems": false
+                    "oneOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/configuration"
+                        },
+                        "minItems": 1,
+                        "additionalItems": false
+                      },
+                      {
+                        "$ref": "#/definitions/expressionSyntax"
+                      }
+                    ]
                   },
                   "minProperties": 1
                 },

--- a/src/test/github-workflow/matrix_from_json.json
+++ b/src/test/github-workflow/matrix_from_json.json
@@ -28,6 +28,19 @@
           "run": "npm test"
         }
       ]
+    },
+    "array-is-expression": {
+      "runs-on": "ubuntu-latest",
+      "strategy": {
+        "matrix": {
+          "foo": "${{fromJSON('[\"bar\",\"baz\"]')}}"
+        }
+      },
+      "steps": [
+        {
+          "run": "echo ${{ matrix.foo }}"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
In GitHub Actions workflows, the [`jobs.<job_id>.strategy.matrix.*` array](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) may be defined in the form of an expression. Previously, this was not permitted by the schema.

I have added a test for this use case.

Minimal demonstration workflow for use case, which is also used as the job in the added test:
```yaml
on: push
jobs:
  job:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        foo: ${{fromJSON('["bar","baz"]')}}
    steps:
      - run: echo ${{matrix.foo}}
```
This will generate two jobs: "job (bar)" and "job (baz)".