### PR TITLE
add codemagic.yaml json schema url

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -453,6 +453,15 @@
       "url": "https://json.schemastore.org/cloudify.json"
     },
     {
+        "name": "codemagic",
+        "description": "JSON schema for Codemagic CI/CD file configuration",
+        "fileMatch": [
+          "codemagic.yaml",
+          "codemagic.yml"
+        ],
+        "url": "https://static.codemagic.io/codemagic-schema.json"
+    },
+    {
       "name": "JSON schema for Codecov configuration files",
       "description": "Schema for codecov.yml files.",
       "fileMatch": [


### PR DESCRIPTION
Adding the JSON schema for `codemagic.yaml` configuration file for [Codemagic CI/CD](https://docs.codemagic.io/getting-started/yaml/)