### PR TITLE
add k3d remote json-schema (k3d repo link)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1367,6 +1367,22 @@
       "url": "https://json.schemastore.org/jsconfig.json"
     },
     {
+      "name": "k3d.yaml",
+      "description": "k3d configuration file",
+      "fileMatch": [
+          "k3d.yaml",
+          "k3d.yml",
+          ".k3d.yml",
+          ".k3d.yaml",
+          "*.k3d.yaml",
+          "*.k3d.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/v1alpha2/schema.json",
+      "versions": {
+        "v1alpha2": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/v1alpha2/schema.json"
+      }
+    },
+    {
       "name": "keto.yml",
       "description": "ORY Keto configuration file",
       "fileMatch": [


### PR DESCRIPTION
This PR adds the k3d config file Schema.
The JSON Schema is not (yet) directly included in the schemastore repository as it's still in Alpha.

Let me know, if you need anything else :+1: 