### PR TITLE
Update hayson schema from bitbucket to github

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1184,7 +1184,7 @@
         "*.hayson.yaml",
         "*.hayson.yml"
       ],
-      "url": "https://bitbucket.org/finproducts/hayson/raw/master/hayson-json-schema.json"
+      "url": "https://raw.githubusercontent.com/j2inn/hayson/master/hayson-json-schema.json"
     },
     {
       "name": "host.json",


### PR DESCRIPTION
I've moved hayson from bitbucket to github. I've updated the link accordingly.