### PR TITLE
Fix composer version pattern

### DIFF
--- a/src/schemas/json/composer.json
+++ b/src/schemas/json/composer.json
@@ -42,7 +42,7 @@
         "version": {
             "type": "string",
             "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes.",
-            "pattern": "^v?\\d+(((\\.\\d+)?\\.\\d+)?\\.\\d+)?|^dev-"
+            "pattern": "^v?\\d+(((\\.\\d+)?\\.\\d+)?\\.\\d+)?(-dev|-patch|-p|-alpha|-a|-beta|-b|-RC)?$"
         },
         "time": {
             "type": "string",


### PR DESCRIPTION
According to https://getcomposer.org/doc/04-schema.md#version it should be:
This must follow the format of X.Y.Z or vX.Y.Z with an optional suffix of -dev, -patch (-p), -alpha (-a), -beta (-b) or -RC. The patch, alpha, beta and RC suffixes can also be followed by a number.