### PR TITLE
add kustomization components support

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -264,6 +264,13 @@
           },
           "type": "array"
         },
+        "components": {
+          "description": "Components are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file of Kind Component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "secretGenerator": {
           "description": "SecretGenerator is a list of secrets to generate from local data (one secret per list item)",
           "items": {


### PR DESCRIPTION
Adds support for the recently added components field https://kubectl.docs.kubernetes.io/guides/config_management/components/.

Closes #1509;