### PR TITLE
github-workflow : add 'concurrency'

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -15,6 +15,25 @@
       "$ref": "#/definitions/globs",
       "description": "When using the push and pull_request events, you can configure a workflow to run on specific branches or tags. If you only define only tags or only branches, the workflow won't run for events affecting the undefined Git ref.\nThe branches, branches-ignore, tags, and tags-ignore keywords accept glob patterns that use the * and ** wildcard characters to match more than one branch or tag name. For more information, see https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet.\nThe patterns defined in branches and tags are evaluated against the Git ref's name. For example, defining the pattern mona/octocat in branches will match the refs/heads/mona/octocat Git ref. The pattern releases/** will match the refs/heads/releases/10 Git ref.\nYou can use two types of filters to prevent a workflow from running on pushes and pull requests to tags and branches:\n- branches or branches-ignore - You cannot use both the branches and branches-ignore filters for the same event in a workflow. Use the branches filter when you need to filter branches for positive matches and exclude branches. Use the branches-ignore filter when you only need to exclude branch names.\n- tags or tags-ignore - You cannot use both the tags and tags-ignore filters for the same event in a workflow. Use the tags filter when you need to filter tags for positive matches and exclude tags. Use the tags-ignore filter when you only need to exclude tag names.\nYou can exclude tags and branches using the ! character. The order that you define patterns matters.\n- A matching negative pattern (prefixed with !) after a positive match will exclude the Git ref.\n- A matching positive pattern after a negative match will include the Git ref again."
     },
+    "concurrency": {
+      "type": "object",
+      "properties": {
+        "group": {
+          "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run-1",
+          "description": "When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled.",
+          "type": "string"
+        },
+        "cancel-in-progress": {
+          "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run-1",
+          "description": "To cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "group"
+      ],
+      "additionalProperties": false
+    },
     "configuration": {
       "oneOf": [
         {
@@ -975,6 +994,18 @@
       "$ref": "#/definitions/defaults",
       "description": "A map of default settings that will apply to all jobs in the workflow."
     },
+    "concurrency": {
+      "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency",
+      "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/concurrency"
+        }
+      ]
+    },
     "jobs": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobs",
       "description": "A workflow run is made up of one or more jobs. Jobs run in parallel by default. To run jobs sequentially, you can define dependencies on other jobs using the jobs.<job_id>.needs keyword.\nEach job runs in a fresh instance of the virtual environment specified by runs-on.\nYou can run an unlimited number of jobs as long as you are within the workflow usage limits. For more information, see https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#usage-limits.",
@@ -1322,6 +1353,18 @@
               "additionalProperties": {
                 "$ref": "#/definitions/container"
               }
+            },
+            "concurrency": {
+              "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency",
+              "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/concurrency"
+                }
+              ]
             }
           },
           "required": [

--- a/src/test/github-workflow/concurrency.json
+++ b/src/test/github-workflow/concurrency.json
@@ -1,0 +1,20 @@
+{
+    "name": "Test concurrency",
+    "on": [
+      "push"
+    ],
+    "concurrency": "concurrency-${{ github.ref }}",
+    "jobs": {
+      "build": {
+        "runs-on": "ubuntu-latest",
+        "concurrency": "build-${{ github.ref }}"
+      },
+      "test": {
+        "runs-on": "ubuntu-latest",
+        "concurrency": {
+          "group": "test-${{ github.ref }}",
+          "cancel-in-progress": true
+        }
+      }
+    }
+  }


### PR DESCRIPTION
[github feature announcement](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/)
[github docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency)

This change adds support for `concurrency` in github workflows.

`concurrency: staging_environment`

```
concurrency: 
  group: staging
  cancel-in-progress: true
```

fixes : #1576