### PR TITLE
adjust glob pattern for ioBroker JSON UI

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1241,9 +1241,9 @@
       "name": "ioBroker JSON UI",
       "description": "Schema for ioBroker JSON-based admin user interfaces - config, custom and tabs",
       "fileMatch": [
-        "*/admin/jsonConfig.json",
-        "*/admin/jsonCustom.json",
-        "*/admin/jsonTab.json"
+        "**/admin/jsonConfig.json",
+        "**/admin/jsonCustom.json",
+        "**/admin/jsonTab.json"
       ],
       "url": "https://raw.githubusercontent.com/ioBroker/adapter-react/master/schemas/jsonConfig.json"
     },


### PR DESCRIPTION
short question, will this also work for windows style paths or do I have to set the double backslashes explicitly?