### PR TITLE
Extended elmah.io configuration to appsettings.json

### DIFF
--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -85,6 +85,21 @@
                     "type": "string",
                     "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
                 },
+                "Application": {
+                    "description": "An application name to put on all error messages.",
+                    "type": "string"
+                },
+                "HandledStatusCodesToLog": {
+                    "description": "A list of HTTP status codes (besides 404) to log even though no exception is thrown.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "TreatLoggingAsBreadcrumbs": {
+                    "description": "Include log messages from Microsoft.Extensions.Logging as breadcrumbs.",
+                    "type": "boolean"
+                },
                 "HeartbeatId": {
                     "description": "The Id of the elmah.io heartbeat to notify.",
                     "type": "string",
@@ -332,6 +347,20 @@
                     }
                 },
                 "EventLog": {
+                    "properties": {
+                        "LogLevel": {
+                            "$ref": "#/definitions/logLevel"
+                        }
+                    }
+                },
+                "ElmahIo": {
+                    "properties": {
+                        "LogLevel": {
+                            "$ref": "#/definitions/logLevel"
+                        }
+                    }
+                },
+                "ElmahIoBreadcrumbs": {
                     "properties": {
                         "LogLevel": {
                             "$ref": "#/definitions/logLevel"

--- a/src/test/appsettings/elmahio.json
+++ b/src/test/appsettings/elmahio.json
@@ -1,0 +1,25 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    },
+    "ElmahIo": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "ElmahIoBreadcrumbs": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  },
+  "ElmahIo": {
+    "ApiKey": "5b2772f723be40c08976b34bbc45604f",
+    "LogId": "499221f0-dd36-4ae3-ace0-7736b88c8997",
+    "Application": "MyApp",
+    "HandledStatusCodesToLog": [ 400, 500 ],
+    "HeartbeatId": "0fd0cf5b22d54e35b2918dd661163ae6",
+    "TreatLoggingAsBreadcrumbs": false
+  }
+}


### PR DESCRIPTION
I have added the following missing app settings from the elmah.io config in `appsettings.json` files:

- `Application`
- `HandledStatusCodesToLog`
- `TreatLoggingAsBreadcrumbs`

I have also added elmah.io specific config for settings up elmah.io logging for Microsoft.Extensions.Logging like this:

```json
{
  "Logging": {
    "LogLevel": {
      "Default": "Debug"
    },
    "ElmahIo": {
      "LogLevel": {
        "Default": "Warning"
      }
    }
}
```

Finally, I have added a test file to verify a valid config file against the schema.