### PR TITLE
Update composer.json version regexp

### DIFF
--- a/src/schemas/json/composer.json
+++ b/src/schemas/json/composer.json
@@ -42,7 +42,7 @@
         "version": {
             "type": "string",
             "description": "Package version, see https://getcomposer.org/doc/04-schema.md#version for more info on valid schemes.",
-            "pattern": "^v?\\d+(((\\.\\d+)?\\.\\d+)?\\.\\d+)?(-dev|-patch|-p|-alpha|-a|-beta|-b|-RC)?$"
+            "pattern": "^v?\\d+(((\\.\\d+)?\\.\\d+)?\\.\\d+)?(-dev|((-patch|-p|-alpha|-a|-beta|-b|-RC)(\\d+)?))?$"
         },
         "time": {
             "type": "string",


### PR DESCRIPTION
This regexp allows a number after the suffixes that are supposed to allow them, as stated here https://getcomposer.org/doc/04-schema.md#version

`^v?\d+(((\.\d+)?\.\d+)?\.\d+)?(-dev|((-patch|-p|-alpha|-a|-beta|-b|-RC)(\d+)?))?$`

See https://regexr.com/5rt9b for tests regarding the addition