### PR TITLE
Add OpenAPI schema 3.0.x alongside 3.1

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1650,7 +1650,11 @@
         "openapi.yml",
         "openapi.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json"
+      "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json",
+      "versions": {
+        "3.0": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json",
+        "3.1": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json"
+      }
     },
     {
       "name": "openfin.json",


### PR DESCRIPTION
I've followed the format used elsewhere in the file, e.g. for Ansible Role.  Resolves #1591 