### PR TITLE
[gitlab-ci] Update job retry errors definition

### DIFF
--- a/src/negative_test/gitlab-ci/retry_unknown_when.json
+++ b/src/negative_test/gitlab-ci/retry_unknown_when.json
@@ -1,0 +1,9 @@
+{
+  "gitlab-ci-retry-object-unknown-when": {
+    "stage": "test",
+    "script": "rspec",
+    "retry": {
+      "when": "gitlab-ci-retry-object-unknown-when"
+    }
+  }
+}

--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -771,36 +771,60 @@
     "retry_errors": {
       "oneOf": [
         {
-          "enum": ["always"],
+          "const": "always",
           "description": "Retry on any failure (default)."
         },
         {
-          "enum": ["unknown_failure"],
+          "const": "unknown_failure",
           "description": "Retry when the failure reason is unknown."
         },
         {
-          "enum": ["script_failure"],
+          "const": "script_failure",
           "description": "Retry when the script failed."
         },
         {
-          "enum": ["api_failure"],
+          "const": "api_failure",
           "description": "Retry on API failure."
         },
         {
-          "enum": ["stuck_or_timeout_failure"],
+          "const": "stuck_or_timeout_failure",
           "description": "Retry when the job got stuck or timed out."
         },
         {
-          "enum": ["runner_system_failure"],
-          "description": "Retry if there was a runner system failure (e.g. setting up the job failed)."
+          "const": "runner_system_failure",
+          "description": "Retry if there is a runner system failure (for example, job setup failed)."
         },
         {
-          "enum": ["missing_dependency_failure"],
-          "description": "Retry if a dependency was missing."
+          "const": "missing_dependency_failure",
+          "description": "Retry if a dependency is missing."
         },
         {
-          "enum": ["runner_unsupported"],
-          "description": "Retry if the runner was unsupported."
+          "const": "runner_unsupported",
+          "description": "Retry if the runner is unsupported."
+        },
+        {
+          "const": "stale_schedule",
+          "description": "Retry if a delayed job could not be executed."
+        },
+        {
+          "const": "job_execution_timeout",
+          "description": "Retry if the script exceeded the maximum execution time set for the job."
+        },
+        {
+          "const": "archived_failure",
+          "description": "Retry if the job is archived and can’t be run."
+        },
+        {
+          "const": "unmet_prerequisites",
+          "description": "Retry if the job failed to complete prerequisite tasks."
+        },
+        {
+          "const": "scheduler_failure",
+          "description": "Retry if the scheduler failed to assign the job to a runner."
+        },
+        {
+          "const": "data_integrity_failure",
+          "description": "Retry if there is a structural integrity problem detected."
         }
       ]
     },

--- a/src/test/gitlab-ci/retry.json
+++ b/src/test/gitlab-ci/retry.json
@@ -1,0 +1,61 @@
+{
+  "gitlab-ci-retry-int": {
+    "stage": "test",
+    "script": "rspec",
+    "retry": 2
+  },
+  "gitlab-ci-retry-object-no-max": {
+    "stage": "test",
+    "script": "rspec",
+    "retry": {
+      "when": "runner_system_failure"
+    }
+  },
+  "gitlab-ci-retry-object-single-when": {
+    "stage": "test",
+    "script": "rspec",
+    "retry": {
+      "max": 2,
+      "when": "runner_system_failure"
+    }
+  },
+  "gitlab-ci-retry-object-multiple-when": {
+    "stage": "test",
+    "script": "rspec",
+    "retry": {
+      "max": 2,
+      "when": ["runner_system_failure", "stuck_or_timeout_failure"]
+    }
+  },
+  "gitlab-ci-retry-object-multiple-when-dupes": {
+    "stage": "test",
+    "script": "rspec",
+    "retry": {
+      "max": 2,
+      "when": ["runner_system_failure", "runner_system_failure"]
+    }
+  },
+  "gitlab-ci-retry-object-all-when": {
+    "stage": "test",
+    "script": "rspec",
+    "retry": {
+      "max": 2,
+      "when": [
+        "always",
+        "unknown_failure",
+        "script_failure",
+        "api_failure",
+        "stuck_or_timeout_failure",
+        "runner_system_failure",
+        "missing_dependency_failure",
+        "runner_unsupported",
+        "stale_schedule",
+        "job_execution_timeout",
+        "archived_failure",
+        "unmet_prerequisites",
+        "scheduler_failure",
+        "data_integrity_failure"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Retry errors
Ref: #1568

1. Add new values to `#/definitions/retry_errors`.
      - `stale_schedule`
      - `job_execution_timeout`
      - `archived_failure`
      - `unmet_prerequisites`
      - `scheduler_failure`
      - `data_integrity_failure`
1. Replace single item `enum` with `const` in `#/definitions/retry_errors`.
1. Update `description` values from https://docs.gitlab.com/ee/ci/yaml/#retry.
1. Add tests for job retry settings.