### PR TITLE
Remove requested_action event type

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -438,15 +438,13 @@
                     "enum": [
                       "created",
                       "rerequested",
-                      "completed",
-                      "requested_action"
+                      "completed"
                     ]
                   },
                   "default": [
                     "created",
                     "rerequested",
-                    "completed",
-                    "requested_action"
+                    "completed"
                   ]
                 }
               }


### PR DESCRIPTION
This event type was never supported by GitHub Actions and is in the process of being removed from the docs https://github.com/github/docs/pull/6088.