### PR TITLE
fix: `golangci-lint`

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -889,17 +889,20 @@
             },
             "packages-with-error-message": {
               "description": "Specify a mapping from packages to the error message to display.",
-              "type": "object",
-              "patternProperties": {
-                "^.*$": {
-                  "type": "string"
-                }
-              },
-              "examples": [
-                {
-                  "github.com/OpenPeeDeeP/depguards": "Please use \"github.com/OpenPeeDeeP/depguard\"."
-                }
-              ]
+              "type": "array",
+              "items": {
+                "type": "object",
+                "patternProperties": {
+                  "^.*$": {
+                    "type": "string"
+                  }
+                },
+                "examples": [
+                  {
+                    "github.com/OpenPeeDeeP/depguards": "Please use \"github.com/OpenPeeDeeP/depguard\"."
+                  }
+                ]
+              }
             }
           }
         },

--- a/src/test/golangci-lint/example-values.json
+++ b/src/test/golangci-lint/example-values.json
@@ -158,9 +158,11 @@
       "packages": [
         "github.com/sirupsen/logrus"
       ],
-      "packages-with-error-message": {
-        "github.com/sirupsen/logrus": "logging is allowed only by logutils.Log"
-      }
+      "packages-with-error-message": [
+        {
+          "github.com/sirupsen/logrus": "logging is allowed only by logutils.Log"
+        }
+      ]
     },
     "lll": {
       "line-length": 120,


### PR DESCRIPTION
Fixes schema for `golangci-lint`