### PR TITLE
Update tsconfig.json schema with new ts-node options from v10

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -871,7 +871,7 @@
     "tsNodeDefinition": {
       "properties": {
         "ts-node": {
-          "description": "ts-node options.  See also: https://github.com/TypeStrong/ts-node#configuration-options\n\nts-node offers TypeScript execution and REPL for node.js, with source map support.",
+          "description": "ts-node options.  See also: https://typestrong.org/ts-node/docs/configuration\n\nts-node offers TypeScript execution and REPL for node.js, with source map support.",
           "properties": {
             "compiler": {
               "default": "typescript",
@@ -880,7 +880,7 @@
             },
             "compilerHost": {
               "default": false,
-              "description": "Use TypeScript's compiler host API.",
+              "description": "Use TypeScript's compiler host API instead of the language service API.",
               "type": "boolean"
             },
             "compilerOptions": {
@@ -890,7 +890,7 @@
                   "$ref": "#/definitions/compilerOptionsDefinition/properties/compilerOptions"
                 }
               ],
-              "description": "JSON object to merge with compiler options.",
+              "description": "JSON object to merge with TypeScript `compilerOptions`.",
               "properties": {},
               "type": "object"
             },
@@ -901,25 +901,28 @@
             },
             "files": {
               "default": false,
-              "description": "Load files from `tsconfig.json` on startup.",
+              "description": "Load \"files\" and \"include\" from `tsconfig.json` on startup.\n\nDefault is to override `tsconfig.json` \"files\" and \"include\" to only include the entrypoint script.",
               "type": "boolean"
             },
             "ignore": {
-              "default": "/node_modules/",
-              "description": "Override the path patterns to skip compilation.",
+              "default": [
+                "(?:^|/)node_modules/"
+              ],
+              "description": "Paths which should not be compiled.\n\nEach string in the array is converted to a regular expression via `new RegExp()` and tested against source paths prior to compilation.\n\nSource paths are normalized to posix-style separators, relative to the directory containing `tsconfig.json` or to cwd if no `tsconfig.json` is loaded.\n\nDefault is to ignore all node_modules subdirectories.",
               "items": {
                 "type": "string"
               },
-              "type": "array",
-              "uniqueItems": true
+              "type": "array"
             },
             "ignoreDiagnostics": {
               "description": "Ignore TypeScript warnings by diagnostic code.",
               "items": {
-                "type": ["string", "number"]
+                "type": [
+                  "string",
+                  "number"
+                ]
               },
-              "type": "array",
-              "uniqueItems": true
+              "type": "array"
             },
             "logError": {
               "default": false,
@@ -928,7 +931,7 @@
             },
             "preferTsExts": {
               "default": false,
-              "description": "Re-order file extensions so that TypeScript imports are preferred.",
+              "description": "Re-order file extensions so that TypeScript imports are preferred.\n\nFor example, when both `index.js` and `index.ts` exist, enabling this option causes `require('./index')` to resolve to `index.ts` instead of `index.js`",
               "type": "boolean"
             },
             "pretty": {
@@ -937,27 +940,55 @@
               "type": "boolean"
             },
             "require": {
-              "description": "Modules to require, like node's `--require` flag.\n\nIf specified in tsconfig.json, the modules will be resolved relative to the tsconfig.json file.\n\nIf specified programmatically, each input string should be pre-resolved to an absolute path for\nbest results.",
+              "description": "Modules to require, like node's `--require` flag.\n\nIf specified in `tsconfig.json`, the modules will be resolved relative to the `tsconfig.json` file.\n\nIf specified programmatically, each input string should be pre-resolved to an absolute path for\nbest results.",
               "items": {
                 "type": "string"
               },
-              "type": "array",
-              "uniqueItems": true
-            },
-            "scope": {
-              "default": false,
-              "description": "Scope compiler to files within `cwd`.",
-              "type": "boolean"
+              "type": "array"
             },
             "skipIgnore": {
               "default": false,
-              "description": "Skip ignore check.",
+              "description": "Skip ignore check, so that compilation will be attempted for all files with matching extensions.",
               "type": "boolean"
             },
             "transpileOnly": {
               "default": false,
               "description": "Use TypeScript's faster `transpileModule`.",
               "type": "boolean"
+            },
+            "transpiler": {
+              "anyOf": [
+                {
+                  "additionalItems": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": true,
+                        "properties": {},
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": true,
+                      "properties": {},
+                      "type": "object"
+                    }
+                  ],
+                  "minItems": 2,
+                  "type": "array"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Specify a custom transpiler for use with transpileOnly"
             },
             "typeCheck": {
               "default": true,


### PR DESCRIPTION
ts-node v10 includes a few new options.
https://github.com/TypeStrong/ts-node/releases/tag/v10.0.0

This updates the schema based on the one generated from our sources.

https://unpkg.com/browse/ts-node@10.0.0/tsconfig.schemastore-schema.json