### PR TITLE
Fixed responseOverrides naming for Static Web Apps config

### DIFF
--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -602,7 +602,7 @@
             },
             "additionalProperties": false
         },
-        "responseErrorOverrides": {
+        "responseOverrides": {
             "type": "object",
             "description": "Custom error pages or redirects",
             "examples": [

--- a/src/test/staticwebapp.config/staticwebapp.config.json
+++ b/src/test/staticwebapp.config/staticwebapp.config.json
@@ -53,7 +53,7 @@
             "*.{txt}"
         ]
     },
-    "responseErrorOverrides": {
+    "responseOverrides": {
         "400": {
             "rewrite": "/custom_error.html",
             "statusCode": 201


### PR DESCRIPTION
Rename `responseErrorOverrides` to `responseOverrides`
https://docs.microsoft.com/en-us/azure/static-web-apps/configuration#response-overrides