### PR TITLE
Allow cache to be array in gitlab-ci.josn

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -591,6 +591,19 @@
       ]
     },
     "cache": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/cache_entry"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/cache_entry"
+          }
+        }
+      ]
+    },
+    "cache_entry": {
       "type": "object",
       "description": "Specify files or directories to cache between jobs. Can be set globally or per job.",
       "additionalProperties": false,

--- a/src/test/gitlab-ci/multiple-caches.json
+++ b/src/test/gitlab-ci/multiple-caches.json
@@ -1,0 +1,24 @@
+{
+  "test-job": {
+    "stage": "build",
+    "cache": [
+      {
+        "key": {
+          "files": ["Gemfile.lock"]
+        },
+        "paths": ["vendor/ruby"]
+      },
+      {
+        "key": {
+          "files": ["yarn.lock"]
+        },
+        "paths": [".yarn-cache/"]
+      }
+    ],
+    "script": [
+      "bundle install --path=vendor",
+      "yarn install --cache-folder .yarn-cache",
+      "echo Run tests..."
+    ]
+  }
+}


### PR DESCRIPTION
Related issue #1623

Tested with the [example in GitLab documentation](https://docs.gitlab.com/ee/ci/yaml/#multiple-caches)

```yaml
test-job:
  stage: build
  cache:
    - key:
        files:
          - Gemfile.lock
      paths:
        - vendor/ruby
    - key:
        files:
          - yarn.lock
      paths:
        - .yarn-cache/
  script:
    - bundle install --path=vendor
    - yarn install --cache-folder .yarn-cache
    - echo Run tests...
```