### PR TITLE
Add replicas field to kustomization.json

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -257,6 +257,13 @@
           },
           "type": "array"
         },
+        "replicas": {
+          "description": "Replicas is a list of (resource name, count) for changing number of replicas for a resources. It will match any group and kind that has a matching name and that is one of: Deployment, ReplicationController, Replicaset, Statefulset.",
+          "items": {
+            "$ref": "#/definitions/Replicas"
+          },
+          "type": "array"
+        },
         "resources": {
           "description": "Resources specifies relative paths to files holding YAML representations of kubernetes API objects. URLs and globs not supported.",
           "items": {
@@ -407,6 +414,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "Replicas": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "count": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "SecretArgs": {
       "description": "SecretArgs contains the metadata of how to generate a secret",


### PR DESCRIPTION
According to https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/replicas/ pull request adds support for "replicas" field.
#1361 