### PR TITLE
github-workflow: add missing 'permissions' property

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1089,6 +1089,9 @@
                 }
               ]
             },
+            "permissions": {
+              "$ref": "#/definitions/permissions"
+            },
             "runs-on": {
               "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on",
               "description": "The type of machine to run the job on. The machine can be either a GitHub-hosted runner, or a self-hosted runner.",

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -151,7 +151,10 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": ["read-all", "write-all"]
+          "enum": [
+            "read-all",
+            "write-all"
+          ]
         },
         {
           "$ref": "#/definitions/permissions-event"
@@ -196,7 +199,11 @@
     },
     "permissions-level": {
       "type": "string",
-      "enum": ["read", "write", "none"]
+      "enum": [
+        "read",
+        "write",
+        "none"
+      ]
     },
     "env": {
       "type": "object",
@@ -1429,6 +1436,9 @@
       },
       "minProperties": 1,
       "additionalProperties": false
+    },
+    "permissions": {
+      "$ref": "#/definitions/permissions"
     }
   },
   "required": [

--- a/src/test/github-workflow/npm-publish.json
+++ b/src/test/github-workflow/npm-publish.json
@@ -7,6 +7,10 @@
             ]
         }
     },
+    "permissions": {
+        "contents": "read",
+        "pull-requests": "write"
+    },
     "jobs": {
         "build": {
             "runs-on": "ubuntu-latest",

--- a/src/test/github-workflow/npm-publish.json
+++ b/src/test/github-workflow/npm-publish.json
@@ -1,0 +1,86 @@
+{
+    "name": "Node.js Package",
+    "on": {
+        "release": {
+            "types": [
+                "created"
+            ]
+        }
+    },
+    "jobs": {
+        "build": {
+            "runs-on": "ubuntu-latest",
+            "steps": [
+                {
+                    "uses": "actions/checkout@v2"
+                },
+                {
+                    "uses": "actions/setup-node@v2",
+                    "with": {
+                        "node-version": 12
+                    }
+                },
+                {
+                    "run": "npm ci"
+                },
+                {
+                    "run": "npm test"
+                }
+            ]
+        },
+        "publish-npm": {
+            "needs": "build",
+            "runs-on": "ubuntu-latest",
+            "steps": [
+                {
+                    "uses": "actions/checkout@v2"
+                },
+                {
+                    "uses": "actions/setup-node@v2",
+                    "with": {
+                        "node-version": 12,
+                        "registry-url": "https://registry.npmjs.org/"
+                    }
+                },
+                {
+                    "run": "npm ci"
+                },
+                {
+                    "run": "npm publish",
+                    "env": {
+                        "NODE_AUTH_TOKEN": "${{secrets.npm_token}}"
+                    }
+                }
+            ]
+        },
+        "publish-gpr": {
+            "needs": "build",
+            "runs-on": "ubuntu-latest",
+            "permissions": {
+                "contents": "read",
+                "packages": "write"
+            },
+            "steps": [
+                {
+                    "uses": "actions/checkout@v2"
+                },
+                {
+                    "uses": "actions/setup-node@v2",
+                    "with": {
+                        "node-version": 12,
+                        "registry-url": "https://npm.pkg.github.com/"
+                    }
+                },
+                {
+                    "run": "npm ci"
+                },
+                {
+                    "run": "npm publish",
+                    "env": {
+                        "NODE_AUTH_TOKEN": "${{secrets.GITHUB_TOKEN}}"
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1610 - the `permissions` property vital for creating GitHub workflows for publishing packages was defined on the schema but missing from the list of allowed properties - the PR addresses that and adds a test file for Node.js package [publishing](https://docs.github.com/en/actions/guides/publishing-nodejs-packages) workflow.