### PR TITLE
Allow custom parsers in prettierrc.json

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -126,7 +126,8 @@
             { "enum": ["glimmer"], "description": "Ember / Handlebars" },
             { "enum": ["html"], "description": "HTML" },
             { "enum": ["angular"], "description": "Angular" },
-            { "enum": ["lwc"], "description": "Lightning Web Components" }
+            { "enum": ["lwc"], "description": "Lightning Web Components" },
+            { "type": "string", "description": "Custom parser" }
           ]
         },
         "pluginSearchDirs": {

--- a/src/test/prettierrc/prettierrc.json
+++ b/src/test/prettierrc/prettierrc.json
@@ -1,0 +1,25 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "overrides": [
+    {
+      "files": ["*/*.type"],
+      "options": {
+        "parser": "custom"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The current schema for [Prettier](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/prettierrc.json) does not allow custom parsers as mentioned under https://prettier.io/docs/en/options.html#parser.

The main use case is for plugins which add their own parser.

This PR adds the option to have the parser option just as a simple string.

I also added a test file.