### PR TITLE
Correct property/global property datatype

### DIFF
--- a/src/schemas/json/liquibase.json
+++ b/src/schemas/json/liquibase.json
@@ -553,8 +553,8 @@
                                         "default": ""
                                     },
                                     "global": {
-                                        "type": "string",
-                                        "default": ""
+                                        "type": "boolean",
+                                        "default": true
                                     },
                                     "target": {
                                         "type": "string",


### PR DESCRIPTION
Global datatype is boolean.
See https://docs.liquibase.com/concepts/basic/changelog-property-substitution.html

Default value not specified but it's true.