### PR TITLE
appsscript: add missing 'sheets' resource for the 'addOns' property

### DIFF
--- a/src/schemas/json/appsscript.json
+++ b/src/schemas/json/appsscript.json
@@ -146,7 +146,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "format": "hostname"
+        "format": "uri"
       }
     },
     "urlFetchWhitelist": {
@@ -307,7 +307,7 @@
             "logoUrl": {
               "description": "The logo URL.",
               "type": "string",
-              "format": "hostname"
+              "format": "uri"
             },
             "layoutProperties": {
               "description": "Layout properties.",

--- a/src/schemas/json/appsscript.json
+++ b/src/schemas/json/appsscript.json
@@ -1,7 +1,23 @@
 {
   "title": "JSON schema for Google Apps Script manifest files",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "definitions": {
+    "homepageTrigger": {
+      "type": "object",
+      "description": "The Google Workspace add-on manifest configuration for homepage triggers.",
+      "properties": {
+        "enabled": {
+          "description": "Whether or not homepage (non-contextual) cards are enabled in Calendar. Defaults to true.",
+          "type": "boolean"
+        },
+        "runFunction": {
+          "description": "The name of the function to run when this trigger fires. You must implement this function in your add-on project. This function must build and return an array of Card objects.",
+          "type": "string"
+        }
+      }
+    }
+  },
   "properties": {
     "runtimeVersion": {
       "description": "Version of the server to use when executing this project.",
@@ -357,7 +373,10 @@
               "type": "boolean"
             }
           },
-          "required":["logoUrl", "name"]
+          "required": [
+            "logoUrl",
+            "name"
+          ]
         },
         "gmail": {
           "description": "Gmail add-on metadata.",
@@ -446,6 +465,25 @@
               ]
             }
           }
+        },
+        "sheets": {
+          "description": "Configurations for the Google Workspace Add-on's appearance and behavior within the Sheets host application.",
+          "type": "object",
+          "properties": {
+            "homepageTrigger": {
+              "$ref": "#/definitions/homepageTrigger"
+            },
+            "onFileScopeGrantedTrigger": {
+              "type": "object",
+              "description": "A configuration for a contextual trigger that fires when the add-on presents the request file scope dialog.",
+              "properties": {
+                "runFunction": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
         }
       }
     }

--- a/src/test/appsscript/appsscript.json
+++ b/src/test/appsscript/appsscript.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "../../schemas/json/appsscript.json",
+    "timeZone": "America/New_York",
+    "dependencies": {
+        "enabledAdvancedServices": [
+            {
+                "serviceId": "sheets",
+                "userSymbol": "Sheets",
+                "version": "v4"
+            }
+        ]
+    },
+    "exceptionLogging": "STACKDRIVER",
+    "runtimeVersion": "V8",
+    "oauthScopes": [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/userinfo.profile"
+    ],
+    "webapp": {
+        "executeAs": "USER_DEPLOYING",
+        "access": "ANYONE_ANONYMOUS"
+    },
+    "addOns": {
+        "common": {
+            "name": "My Awesome Addon",
+            "logoUrl": "https://www.gstatic.com/images/icons/material/system/2x/fact_check_black_24dp.png",
+            "layoutProperties": {
+                "primaryColor": "#0277bd",
+                "secondaryColor": "#c0c0c0"
+            }
+        },
+        "sheets": {
+            "homepageTrigger": {
+                "enabled": true,
+                "runFunction": "buildHomepage"
+            },
+            "onFileScopeGrantedTrigger": {
+                "runFunction": "onFileScope"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a missing `sheets` resource to the `addOns` property as specified by [the official docs](https://developers.google.com/apps-script/manifest/addons#AddOns.FIELDS.sheets). 
The manifest file now also has a corresponding test file (changes are covered).

The PR also replaces the `hostname` format to `uri` in 2 array properties that use it because it caused *valid* JSON files to fail tests (see the `oauthScopes` property in particular).