### PR TITLE
Fix enum with custom values (must use anyOf instead of oneOf)

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -104,7 +104,7 @@
         },
         "parser": {
           "description": "Which parser to use.",
-          "oneOf": [
+          "anyOf": [
             { "enum": ["flow"], "description": "Flow" },
             { "enum": ["babel"], "description": "JavaScript" },
             { "enum": ["babel-flow"], "description": "Flow" },

--- a/src/test/prettierrc/prettierrc.json
+++ b/src/test/prettierrc/prettierrc.json
@@ -16,6 +16,12 @@
   "useTabs": false,
   "overrides": [
     {
+      "files": ["*/*.Rmd"],
+      "options": {
+        "parser": "markdown"
+      }
+    },
+    {
       "files": ["*/*.type"],
       "options": {
         "parser": "custom"


### PR DESCRIPTION
With oneOf, the parser property in prettierrc.json always fails  except for custom keys, because if one of the constants is given, two alternatives validate (the constant and the custom string alternative). With a custom string given, exactly one alternative validates (the custom string). In situations like this, anyOf can be used (one or more alternatives are allowed to validate at once).