### PR TITLE
Add library definition to bukkit-plugin schema

### DIFF
--- a/src/schemas/json/bukkit-plugin.json
+++ b/src/schemas/json/bukkit-plugin.json
@@ -173,6 +173,19 @@
       "description": "Gives the API version which this plugin is designed to support.",
       "type": [ "string", "number" ],
       "examples": [ "1.13", "1.14", "1.15", "1.16" ]
+    },
+    "libraries": {
+      "description": "A list of libraries the server should download and supply to the plugin when loading it.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "A single server provided library. This library can be used during runtime without being shaded into the plugin jar.",
+        "pattern": "([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)",
+        "examples": [
+          "org.xerial:sqlite-jdbc:3.34.0",
+          "com.google.dagger:dagger:2.36"
+        ]
+      }
     }
   }
 }

--- a/src/test/bukkit-plugin/bukkit-plugin-test.json
+++ b/src/test/bukkit-plugin/bukkit-plugin-test.json
@@ -7,6 +7,9 @@
   "website": "http://www.curse.com/server-mods/minecraft/myplugin",
   "main": "com.captaininflamo.bukkit.inferno.Inferno",
   "depend": ["NewFire", "FlameWire"],
+  "libraries": [
+    "com.squareup.okhttp3:okhttp:4.9.0"
+  ],
   "api-version": "1.13",
   "commands": {
     "flagrate": {


### PR DESCRIPTION
In a recent commit to the bukkit api, an automatic library framework was
introduced that allows plugins to specify libraries hosted on maven
central which will be downloaded automatically on server start.
This framework can decrease the plugin jar size by avoiding shading
external libraries and instead shifting this responsibility to the
server itself.

These libraries are defined in the bukkit plugin.yml file, which follows
the bukkit-plugin.json schema.

This commit hence adds the schema specifications for the library
declarations to the bukkit-plugin.json file.
The individual library strings follow the pattern used by the maven
artifact resolver's DefaultArtifact.java class to validate artifacts.

See also: https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/146a7e4bd764990c56bb326643e92eb69f24d27e
See also: https://github.com/apache/maven-resolver/blob/master/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java#L37