### PR TITLE
Update docfx.json

### DIFF
--- a/src/schemas/json/docfx.json
+++ b/src/schemas/json/docfx.json
@@ -161,6 +161,14 @@
           "type": "string",
           "description": "Defines the output folder of the generated metadata files."
         },
+        "disableGitFeatures": {
+          "type": "boolean",
+          "description": "If set to true, DocFX would not fetch Git related information for articles."
+        },
+        "disableDefaultFilter": {
+          "type": "boolean",
+          "description": "If set to true, disables default API visibility filter rule."
+        },
         "force": {
           "type": "boolean",
           "description": "If set to true, it would disable incremental build."


### PR DESCRIPTION
Add entries for disableGitFeatures and disableDefaultFilter.

There are probably more tags that aren't here, but these two are in the default configuration that's generated when you initialize a project, so they should definitely be here to stop the red squigglies!