### PR TITLE
feat(gitlab-ci): Added 'needs.pipeline' to schema.

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -949,6 +949,22 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
+                  "pipeline": {
+                    "type": "string"
+                  },
+                  "job": {
+                    "type": "string"
+                  },
+                  "artifacts": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["job", "pipeline"]
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
                   "job": {
                     "type": "string"
                   },


### PR DESCRIPTION
Since GitLab 13.7, the 'needs' property accepts a new object: https://docs.gitlab.com/ee/ci/yaml/README.html#artifact-downloads-to-child-pipelines
The documentation is quite sparse on what other properties is accepted, but the CI Lint tool provided by GitLab fails to validate any other than the included properties.

This pull requests adds the new object in the schema.