### PR TITLE
Correct type schema for GitHub Actions workflow's `/on/push`

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -881,7 +881,6 @@
                   "type": "array"
               }
               },
-              "type": "object",
               "additionalProperties": false
             },
             "registry_package": {

--- a/src/test/github-workflow/on-event_name-null.json
+++ b/src/test/github-workflow/on-event_name-null.json
@@ -1,0 +1,45 @@
+{
+  "name": "Test null values for /on/*",
+  "on": {
+    "check_run": null,
+    "check_suite": null,
+    "create": null,
+    "delete": null,
+    "deployment": null,
+    "deployment_status": null,
+    "fork": null,
+    "gollum": null,
+    "issue_comment": null,
+    "issues": null,
+    "label": null,
+    "member": null,
+    "milestone": null,
+    "page_build": null,
+    "project": null,
+    "project_card": null,
+    "project_column": null,
+    "public": null,
+    "pull_request": null,
+    "pull_request_review": null,
+    "pull_request_review_comment": null,
+    "pull_request_target": null,
+    "push": null,
+    "registry_package": null,
+    "release": null,
+    "status": null,
+    "watch": null,
+    "workflow_dispatch": null,
+    "workflow_run": null,
+    "repository_dispatch": null
+  },
+  "jobs": {
+    "foo": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "run": ""
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
A "type" schema was added (https://github.com/SchemaStore/schemastore/pull/1675) for the /on/push property of GitHub Actions workflow specifying that the type is "object", but a "null" type is also allowed. This is already defined via the property's referenced "#/definitions/ref" schema, but the newly added schema overrode that, causing spurious validation failures of valid workflows that used a null value for the property.

I added a test for use of null values in all /on/* properties that support it (only [the `schedule` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule) does not).

### References

- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-multiple-events-with-activity-types-or-configuration
- https://github.com/actions/starter-workflows/blob/27a54d9d4c8f0dd4949d40837df6f690442aae42/.github/workflows/validate-data.yaml#L4