### PR TITLE
Update fabric.mod.json

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -307,6 +307,14 @@
       }
     },
     {
+      "fabric.mod.json": {
+        "unknownKeywords": [
+          "x-intellij-html-description",
+          "markdownDescription"
+        ]
+      }
+    },
+    {
       "feed.json": {
         "unknownKeywords": [
           "deprecated"

--- a/src/schemas/json/fabric.mod.json
+++ b/src/schemas/json/fabric.mod.json
@@ -13,7 +13,7 @@
 		},
 		"schemaVersion": {
 			"type": "integer",
-			"description": "The version of the mod.json file",
+			"description": "The version of the fabric.mod.json schema",
 			"const": 1
 		},
 		"environment": {
@@ -73,14 +73,14 @@
 				"oneOf": [
 					{
 						"type": "string",
-						"description": "Path to mixin file from root of the JAR"
+						"description": "Path to mixin file from the root of the JAR"
 					},
 					{
 						"type": "object",
 						"properties": {
 							"config": {
 								"type": "string",
-								"description": "Path to mixin file from root of the JAR"
+								"description": "Path to mixin file from the root of the JAR"
 							},
 							"environment": {
 								"$ref": "#/definitions/environment"
@@ -90,39 +90,43 @@
 				]
 			}
 		},
+		"accessWidener": {
+			"type": "string",
+			"description": "Path to an access widener definition file"
+		},
 		"depends": {
 			"type": "object",
 			"description": "id→versionRange map for dependencies. Failure to meet these causes a hard failure",
 			"additionalProperties": {
-				"$ref": "#/definitions/versionRange"
+				"$ref": "#/definitions/versionRanges"
 			}
 		},
 		"recommends": {
 			"type": "object",
 			"description": "id→versionRange map for dependencies. Failure to meet these causes a soft failure (warning)",
 			"additionalProperties": {
-				"$ref": "#/definitions/versionRange"
+				"$ref": "#/definitions/versionRanges"
 			}
 		},
 		"suggests": {
 			"type": "object",
 			"description": "id→versionRange map for dependencies. Are not matched and are mainly used as metadata",
 			"additionalProperties": {
-				"$ref": "#/definitions/versionRange"
+				"$ref": "#/definitions/versionRanges"
 			}
 		},
 		"conflicts": {
 			"type": "object",
 			"description": "id→versionRange map for dependencies. A successful match causes a soft failure (warning)",
 			"additionalProperties": {
-				"$ref": "#/definitions/versionRange"
+				"$ref": "#/definitions/versionRanges"
 			}
 		},
 		"breaks": {
 			"type": "object",
 			"description": "id→versionRange map for dependencies. A successful match causes a hard failure",
 			"additionalProperties": {
-				"$ref": "#/definitions/versionRange"
+				"$ref": "#/definitions/versionRanges"
 			}
 		},
 		"name": {
@@ -217,7 +221,7 @@
 				},
 				{
 					"type": "string",
-					"description": "The entrypoint functions or class"
+					"description": "The entrypoint function or class"
 				}
 			]
 		},
@@ -257,7 +261,7 @@
 				"client",
 				"server"
 			],
-			"description": "The environment where this is applied"
+			"description": "The environment where this mod will be loaded"
 		},
 		"nestedJar": {
 			"type": "object",
@@ -295,8 +299,24 @@
 				}
 			]
 		},
+		"versionRanges": {
+			"oneOf": [
+				{
+					"$ref": "#/definitions/versionRange"
+				},
+				{
+					"type": "array",
+					"description": "Multiple version ranges that are combined with an \"OR\" relationship - only one of the ranges needs to match",
+					"items": {
+						"$ref": "#/definitions/versionRange"
+					}
+				}
+			]
+		},
 		"versionRange": {
-			"type": "string"
+			"type": "string",
+			"description": "A version range that matches versions. The following variants are supported:\n\n- A single asterisk matches any version.\n- Ranges following NPM semver specification including >=, >, =, <, <=, X-ranges (1.x), tilde ranges (fixed minor) and caret ranges (fixed major).\n- Additionally exact string matches will always be performed.",
+			"x-intellij-html-description": "<p>A version range or an array of those that match versions. The following variants are supported:</p><ul><li><code>*</code> matches any version.</li><li>Ranges following <a href=\"https://docs.npmjs.com/about-semantic-versioning\">NPM semver specification</a>:<ul><li><code>&gt;=</code>, <code>&gt;</code>, <code>=</code>, <code>&lt;</code> and <code>&lt;</code></li><li>X-ranges to specify variable components, e.g. <code>1.x</code></li><li>tilde ranges that allow patch version changes, e.g. <code>~1.2.3</code></li><li>caret ranges that allow up to minor version changes, e.g. <code>^1.2.3</code></li></ul></li><li>Exact string matches are always performed as well.</li></ul><p>If an array of ranges is used, they're treated as in an \"OR\" relationship - only one of the ranges needs to match.</p>"
 		}
 	}
 }

--- a/src/schemas/json/fabric.mod.json
+++ b/src/schemas/json/fabric.mod.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"type": "object",
 	"properties": {
 		"id": {
@@ -316,7 +316,8 @@
 		"versionRange": {
 			"type": "string",
 			"description": "A version range that matches versions. The following variants are supported:\n\n- A single asterisk matches any version.\n- Ranges following NPM semver specification including >=, >, =, <, <=, X-ranges (1.x), tilde ranges (fixed minor) and caret ranges (fixed major).\n- Additionally exact string matches will always be performed.",
-			"x-intellij-html-description": "<p>A version range or an array of those that match versions. The following variants are supported:</p><ul><li><code>*</code> matches any version.</li><li>Ranges following <a href=\"https://docs.npmjs.com/about-semantic-versioning\">NPM semver specification</a>:<ul><li><code>&gt;=</code>, <code>&gt;</code>, <code>=</code>, <code>&lt;</code> and <code>&lt;</code></li><li>X-ranges to specify variable components, e.g. <code>1.x</code></li><li>tilde ranges that allow patch version changes, e.g. <code>~1.2.3</code></li><li>caret ranges that allow up to minor version changes, e.g. <code>^1.2.3</code></li></ul></li><li>Exact string matches are always performed as well.</li></ul><p>If an array of ranges is used, they're treated as in an \"OR\" relationship - only one of the ranges needs to match.</p>"
+			"x-intellij-html-description": "<p>A version range or an array of those that match versions. The following variants are supported:</p><ul><li><code>*</code> matches any version.</li><li>Ranges following <a href=\"https://docs.npmjs.com/about-semantic-versioning\">NPM semver specification</a>:<ul><li><code>&gt;=</code>, <code>&gt;</code>, <code>=</code>, <code>&lt;</code> and <code>&lt;</code></li><li>X-ranges to specify variable components, e.g. <code>1.x</code></li><li>tilde ranges that allow patch version changes, e.g. <code>~1.2.3</code></li><li>caret ranges that allow up to minor version changes, e.g. <code>^1.2.3</code></li></ul></li><li>Exact string matches are always performed as well.</li></ul><p>If an array of ranges is used, they're treated as in an \"OR\" relationship - only one of the ranges needs to match.</p>",
+			"markdownDescription": "A version range or an array of those that match versions. The following variants are supported:\n\n- `*` matches any version.\n- Ranges following [NPM semver specification](https://docs.npmjs.com/about-semantic-versioning):\n  - `>=`, `>`, `=`, `<` and `<=`\n  - X-ranges to specify variable components, e.g. `1.x`\n  - tilde ranges that allow patch version changes, e.g. `~1.2.3`\n  - caret ranges that allow up to minor version changes, e.g. `^1.2.3`\n- Exact string matches are always performed as well.\n\nIf an array of ranges is used, they're treated as in an \"OR\" relationship - only one of the ranges needs to match."
 		}
 	}
 }


### PR DESCRIPTION
- Add the new-ish `accessWidener` property
- Improve version ranges that wrongly couldn't be arrays before
- A longer and more helpful description for version ranges. This uses `x-intellij-html-description` and `markdownDescription`, and adjusts the `schema-validation.json` entry accordingly.
- Fix some wording in descriptions