### PR TITLE
feat: add stale bot configuration schema

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-
 [*.json]
 indent_style = space
 indent_size = 2

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2129,6 +2129,14 @@
       "url": "https://schema.stackhead.io/stackhead/tag/v1/-/project-definition.schema.json"
     },
     {
+      "name": "Stale",
+      "description": "Configuration file for Stale for closing abandoned issues and pull requests. See https://probot.github.io/apps/stale/.",
+      "fileMatch": [
+        ".github/stale.yml"
+      ],
+      "url": "https://json.schemastore.org/stale.json"
+    },
+    {
       "name": "Stryker Mutator",
       "description": "Configuration file for Stryker Mutator, the mutation testing framework for JavaScript and friends. See https://stryker-mutator.io.",
       "fileMatch": [

--- a/src/schemas/json/stale.json
+++ b/src/schemas/json/stale.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "$comment": "https://probot.github.io/apps/stale/",
+  "description": "A GitHub app that closes abandoned issues and pull requests",
+  "type": "object",
+  "definitions": {
+    "configuration": {
+      "properties": {
+        "daysUntilStale": {
+          "title": "Days Until Stale",
+          "description": "Number of days of inactivity before an Issue or Pull Request becomes stale.",
+          "type": "number",
+          "default": 60
+        },
+        "daysUntilClose": {
+          "title": "Days Until Close",
+          "description": "Number of days of inactivity before an Issue or Pull Request with the stale label is closed.",
+          "type": [
+            "integer",
+            "boolean"
+          ],
+          "default": 7
+        },
+        "onlyLabels": {
+          "title": "Only Labels",
+          "description": "Only issues or pull requests with all of these labels are check if stale.",
+          "type": "array",
+          "items": {
+            "title": "Label",
+            "type": "string"
+          },
+          "default": []
+        },
+        "exemptLabels": {
+          "title": "Exempt Labels",
+          "description": "Issues or Pull Requests with these labels will never be considered stale.",
+          "type": "array",
+          "items": {
+            "title": "Label",
+            "type": "string"
+          },
+          "default": []
+        },
+        "exemptProjects": {
+          "title": "Exempt Projects",
+          "description": "Set to true to ignore issues in a milestone.",
+          "type": "boolean",
+          "default": false
+        },
+        "exemptAssignees": {
+          "title": "Exempt Assignees",
+          "description": "Set to true to ignore issues with an assignee.",
+          "type": "boolean",
+          "default": false
+        },
+        "staleLabel": {
+          "title": "Stale Label",
+          "description": "Label to use when marking as stale.",
+          "type": "string",
+          "default": "wontfix"
+        },
+        "markComment": {
+          "title": "Mark Comment",
+          "description": "Comment to post when marking as stale.",
+          "type": [
+            "string",
+            "boolean"
+          ],
+          "default": "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
+        },
+        "unmarkComment": {
+          "title": "Unmark Comment",
+          "description": "Comment to post when removing the stale label.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "closeComment": {
+          "title": "Closed Comment",
+          "description": "Comment to post when closing a stale issue or pull request.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "limitPerRun": {
+          "title": "Limit Per Run",
+          "description": "Limit the number of actions per hour.",
+          "type": "number",
+          "minimum": 1,
+          "maximum": 30,
+          "default": 30
+        },
+        "only": {
+          "title": "Only",
+          "description": "Limit to only issues or pulls requests.",
+          "enum": [
+            "issues",
+            "pulls"
+          ]
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/configuration",
+  "properties": {
+    "pulls": {
+      "title": "Pulls",
+      "description": "Specify configuration settings that are specific to pull requests.",
+      "$ref": "#/definitions/configuration"
+    },
+    "issues": {
+      "title": "Issues",
+      "description": "Specify configuration settings that are specific to issues.",
+      "$ref": "#/definitions/configuration"
+    }
+  }
+}

--- a/src/test/stale/go-ethereum.json
+++ b/src/test/stale/go-ethereum.json
@@ -1,0 +1,11 @@
+{
+   "daysUntilStale": 366,
+   "daysUntilClose": 42,
+   "exemptLabels": [
+      "pinned",
+      "security"
+   ],
+   "staleLabel": "status:inactive",
+   "markComment": "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.\n",
+   "closeComment": false
+}

--- a/src/test/stale/jellyfin.json
+++ b/src/test/stale/jellyfin.json
@@ -1,0 +1,17 @@
+{
+   "daysUntilStale": 120,
+   "daysUntilClose": 21,
+   "exemptLabels": [
+      "regression",
+      "security",
+      "dotnet-3.0-future",
+      "roadmap",
+      "future",
+      "feature",
+      "enhancement",
+      "confirmed"
+   ],
+   "staleLabel": "stale",
+   "markComment": "This issue has gone 120 days without comment. To avoid abandoned issues, it will be closed in 21 days if there are no new comments.\nIf you're the original submitter of this issue, please comment confirming if this issue still affects you in the latest release or nightlies, or close the issue if it has been fixed. If you're another user also affected by this bug, please comment confirming so. Either action will remove the stale label.\nThis bot exists to prevent issues from becoming stale and forgotten. Jellyfin is always moving forward, and bugs are often fixed as side effects of other changes. We therefore ask that bug report authors remain vigilant about their issues to ensure they are closed if fixed, or re-confirmed - perhaps with fresh logs or reproduction examples - regularly. If you have any questions you can reach us on [Matrix or Social Media](https://docs.jellyfin.org/general/getting-help.html).\n",
+   "closeComment": false
+}

--- a/src/test/stale/openai-gym.json
+++ b/src/test/stale/openai-gym.json
@@ -1,0 +1,19 @@
+{
+   "daysUntilStale": 60,
+   "daysUntilClose": 14,
+   "onlyLabels": [
+      "more-information-needed"
+   ],
+   "exemptLabels": [
+      "pinned",
+      "security",
+      "[Status] Maybe Later"
+   ],
+   "exemptProjects": true,
+   "exemptMilestones": true,
+   "exemptAssignees": true,
+   "staleLabel": "stale",
+   "markComment": "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.\n",
+   "limitPerRun": 30,
+   "only": "issues"
+}

--- a/src/test/stale/react.json
+++ b/src/test/stale/react.json
@@ -1,0 +1,22 @@
+{
+   "daysUntilStale": 90,
+   "daysUntilClose": 7,
+   "exemptLabels": [
+      "Partner",
+      "React Core Team",
+      "Resolution: Backlog",
+      "Type: Bug",
+      "Type: Discussion",
+      "Type: Needs Investigation",
+      "Type: Regression"
+   ],
+   "staleLabel": "Resolution: Stale",
+   "issues": {
+      "markComment": "This issue has been automatically marked as stale. **If this issue is still affecting you, please leave any comment** (for example, \"bump\"), and we'll keep it open. We are sorry that we haven't been able to prioritize it yet. If you have any new additional information, please include it with your comment!\n",
+      "closeComment": "Closing this issue after a prolonged period of inactivity. If this issue is still present in the latest release, please create a new issue with up-to-date information. Thank you!\n"
+   },
+   "pulls": {
+      "markComment": "This pull request has been automatically marked as stale. **If this pull request is still relevant, please leave any comment** (for example, \"bump\"), and we'll keep it open. We are sorry that we haven't been able to prioritize reviewing it yet. Your contribution is very much appreciated.\n",
+      "closeComment": "Closing this pull request after a prolonged period of inactivity. If this issue is still present in the latest release, please ask for this pull request to be reopened. Thank you!\n"
+   }
+}

--- a/src/test/stale/stale.json
+++ b/src/test/stale/stale.json
@@ -1,0 +1,3 @@
+{
+   "_extends": ".github"
+}

--- a/src/test/stale/tensorflow.json
+++ b/src/test/stale/tensorflow.json
@@ -1,0 +1,12 @@
+{
+   "daysUntilStale": 7,
+   "daysUntilClose": 7,
+   "onlyLabels": [
+      "stat:awaiting response"
+   ],
+   "markComment": "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you.\n",
+   "unmarkComment": false,
+   "closeComment": "Closing as stale. Please reopen if you'd like to work on this further.\n",
+   "limitPerRun": 30,
+   "only": "issues"
+}


### PR DESCRIPTION
Adds a JSON Schema for the [Stale](https://probot.github.io/apps/stale/) app on GitHub.

The tests are just `stale.yml` configurations from other popular repositories.