### PR TITLE
feat: add label-commeter-config.yml json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1438,6 +1438,14 @@
       "url": "https://json.schemastore.org/kustomization.json"
     },
     {
+      "name": "label-commenter-config.yml",
+      "description": "A JSON schema for the configuration of the Label Commenter GitHub Action",
+      "fileMatch": [
+        ".github/label-commenter-config.yml"
+      ],
+      "url": "https://json.schemastore.org/label-commenter-config.json"
+    },
+    {
       "name": "launchsettings.json",
       "description": "A JSON schema for the ASP.NET LaunchSettings.json files",
       "fileMatch": [

--- a/src/schemas/json/label-commenter-config.json
+++ b/src/schemas/json/label-commenter-config.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "$comment": "https://github.com/peaceiris/actions-label-commenter",
+  "description": "Configuration for Actions Label Commenter, for posting messages triggered by labels.",
+  "type": "object",
+  "definitions": {
+    "labelItem": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "title": "Body",
+          "type": "string"
+        },
+        "action": {
+          "title": "Action",
+          "type": "string"
+        },
+        "locking": {
+          "title": "Locking",
+          "enum": [
+            "lock",
+            "unlock"
+          ]
+        },
+        "lock_reason": {
+          "title": "Lock Reason",
+          "type": "string"
+        }
+      }
+    },
+    "labelFor": {
+      "type": "object",
+      "properties": {
+        "issue": {
+          "title": "Issue",
+          "$ref": "#/definitions/labelItem"
+        },
+        "pr": {
+          "title": "Pull Request",
+          "$ref": "#/definitions/labelItem"
+        }
+      }
+    },
+    "labelType": {
+      "type": "object",
+      "properties": {
+        "labeled": {
+          "title": "Labeled",
+          "$ref": "#/definitions/labelFor"
+        },
+        "unlabeled": {
+          "title": "Unlabeled",
+          "$ref": "#/definitions/labelFor"
+        }
+      }
+    }
+  },
+  "properties": {
+    "comment": {
+      "title": "Comment",
+      "type": "object",
+      "properties": {
+        "header": {
+          "title": "Header",
+          "type": "string"
+        },
+        "footer": {
+          "title": "Footer",
+          "type": "string"
+        }
+      }
+    },
+    "labels": {
+      "title": "Labels",
+      "type": "array",
+      "items": {
+        "title": "Label",
+        "$ref": "#/definitions/labelType",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/label-commenter-config/actions-label-commenter.json
+++ b/src/test/label-commenter-config/actions-label-commenter.json
@@ -1,0 +1,151 @@
+{
+    "comment": {
+        "header": "Hi, there.",
+        "footer": "---\n\n > This is an automated comment created by the [peaceiris/actions-label-commenter]. Responding to the bot or mentioning it won't have any effect.\n\n [peaceiris/actions-label-commenter]: https://github.com/peaceiris/actions-label-commenter "
+    },
+    "labels": [
+        {
+            "name": "invalid",
+            "labeled": {
+                "issue": {
+                    "body": "Please follow the issue templates.",
+                    "action": "close"
+                },
+                "pr": {
+                    "body": "Thank you @{{ pull_request.user.login }} for suggesting this. Please follow the pull request templates.",
+                    "action": "close"
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "Thank you for following the template. The repository owner will reply.",
+                    "action": "open"
+                }
+            }
+        },
+        {
+            "name": "forum",
+            "labeled": {
+                "issue": {
+                    "body": "Please ask questions about GitHub Actions at the following forum.\nhttps://github.community/c/github-actions\n",
+                    "action": "close"
+                }
+            }
+        },
+        {
+            "name": "wontfix",
+            "labeled": {
+                "issue": {
+                    "body": "This will not be worked on but we appreciate your contribution.",
+                    "action": "close"
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "This has become active again.",
+                    "action": "open"
+                }
+            }
+        },
+        {
+            "name": "duplicate",
+            "labeled": {
+                "issue": {
+                    "body": "This issue already exists.",
+                    "action": "close"
+                }
+            }
+        },
+        {
+            "name": "good first issue",
+            "labeled": {
+                "issue": {
+                    "body": "This issue is easy for contributing. Everyone can work on this."
+                }
+            }
+        },
+        {
+            "name": "proposal",
+            "labeled": {
+                "issue": {
+                    "body": "Thank you @{{ issue.user.login }} for suggesting this."
+                }
+            }
+        },
+        {
+            "name": "locked (spam)",
+            "labeled": {
+                "issue": {
+                    "body": "This issue has been **LOCKED** because of spam!\nPlease do not spam messages and/or issues on the issue tracker. You may get blocked from this repository for doing so.\n",
+                    "action": "close",
+                    "locking": "lock",
+                    "lock_reason": "spam"
+                },
+                "pr": {
+                    "body": "This pull-request has been **LOCKED** because of spam!\nPlease do not spam messages and/or pull-requests on this project. You may get blocked from this repository for doing so.\n",
+                    "action": "close",
+                    "locking": "lock",
+                    "lock_reason": "spam"
+                }
+            }
+        },
+        {
+            "name": "locked (heated)",
+            "labeled": {
+                "issue": {
+                    "body": "This issue has been **LOCKED** because of heated conversation!\nWe appreciate exciting conversations, as long as they won't become too aggressive and/or emotional.\n",
+                    "locking": "lock",
+                    "lock_reason": "too heated"
+                },
+                "pr": {
+                    "body": "This pull-request has been **LOCKED** because of heated conversation!\nWe appreciate exciting conversations, as long as they won't become too aggressive and/or emotional.\n",
+                    "locking": "lock",
+                    "lock_reason": "too heated"
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "This issue has been unlocked now.\n",
+                    "locking": "unlock"
+                },
+                "pr": {
+                    "body": "This pull-request has been unlocked now.\n",
+                    "locking": "unlock"
+                }
+            }
+        },
+        {
+            "name": "locked (off-topic)",
+            "labeled": {
+                "issue": {
+                    "body": "This issue has been **LOCKED** because of off-topic conversations!\nPlease use our other means of communication for casual chats.\n",
+                    "action": "close",
+                    "locking": "lock",
+                    "lock_reason": "off-topic"
+                }
+            }
+        },
+        {
+            "name": "locked (resolved)",
+            "labeled": {
+                "issue": {
+                    "body": "This issue has been **LOCKED** because of it being resolved!\nThe issue has been fixed and is therefore considered resolved.\nIf you still encounter this or it has changed, open a new issue instead of responding to solved ones.\n",
+                    "action": "close",
+                    "locking": "lock",
+                    "lock_reason": "resolved"
+                }
+            }
+        },
+        {
+            "name": "documentation",
+            "labeled": {
+                "issue": {
+                    "body": "Thank you for suggesting documentation improvement.\n"
+                },
+                "pr": {
+                    "body": "[The documentation label] was added.\n Thank you for suggesting documentation improvement. When you add a new section, do not forget to update the Table of Contents.\n ```sh\n npx doctoc --github README.md\n ```\n\n [The documentation label]: https://github.com/peaceiris/actions-label-commenter/issues?q=label%3Adocumentation\n "
+                }
+            }
+        }
+    ]
+}

--- a/src/test/label-commenter-config/placeholder-api.json
+++ b/src/test/label-commenter-config/placeholder-api.json
@@ -1,0 +1,97 @@
+{
+    "comment": {
+        "footer": "----\n\n > *This is an automated response created by a **GitHub Action***\n > *Mentioning the bot won't have any effect!* "
+    },
+    "labels": [
+        {
+            "name": "Type: Issue (Expansion)",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }},\n\nThe issue you encountered is caused by an Expansion and not PlaceholderAPI itself.\nThis issue-tracker is reserved for Bug reports and feature requests towards PlaceholderAPI.\n\nPlease report this issue to the Expansion's main issue-tracker.\nA list of known Expansion repositories and their issue trackers can be found [here](https://github.com/PlaceholderAPI/PlaceholderAPI/discussions/510#discussion-63812).",
+                    "action": "close"
+                }
+            }
+        },
+        {
+            "name": "Type: Duplicate",
+            "labeled": {
+                "issue": {
+                    "body": "Your issue is already known and a separate issue with the exact same report/feature request already exist.\n\nPlease comment on the already existing issue with your information instead of opening your own.",
+                    "action": "close"
+                }
+            }
+        },
+        {
+            "name": "Problem: More info required",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }},\n\nYour issue unfortunately lacks certain information that we require in order to help you with your issue.\nPlease make sure you provide the following information:\n\n- Currently used Versions of your server and PlaceholderAPI\n- Currently installed Expansions\n- Currently installed Plugins\n\nThe easiest way to provide those information is through the `/papi dumb` command which posts the required information to https://paste.helpch.at and gives a URL to share."
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "Thank you for providing additional information.\nWe will take a look at the issue you encounter and come back to you with a possible solution."
+                }
+            }
+        },
+        {
+            "name": "Type: Invalid",
+            "labeled": {
+                "issue": {
+                    "body": "Your issue has beeen marked as invalid.\nThis means that it either doesn't follow any provided template, or isn't related to PlaceholderAPI in any way.\n\nPlease make sure to use one of the issue templates and provide the requested information.\nCurrently available Templates are:\n\n- [Bug Report](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=bug_report.md)\n- [Feature Request](https://github.com/PlaceholderAPI/PlaceholderAPI/issues/new?template=feature_request.md)\n\nIf you want changes to be made towards the Wiki, would we encourage you to [Make a Pull request](https://github.com/PlaceholderAPI/PlaceholderAPI/pulls).  \nYou can find more information about this process on the [Wiki's Readme](https://github.com/PlaceholderAPI/PlaceholderAPI/blob/master/wiki/README.md).\n\nIt is recommended to [join our Discord Server](https://helpch.at/discord) as you often receive faster response compared to the issue tracker here.\nQuestions about PlaceholderAPI should be asked in our [Discussions](https://github.com/PlaceholderAPI/PlaceholderAPI/discussions).",
+                    "action": "close"
+                },
+                "pr": {
+                    "body": "Your Pull request has been marked as **invalid**.\nThis means that it doesn't follow our [Contributing Guidelines](https://github.com/PlaceholderAPI/PlaceholderAPI/blob/master/.github/CONTRIBUTING.md).\n\nHere is a small summary of what you should know:\n\n- Pull requests for PlaceholderAPI should target the `development` branch.\n- Pull requests for the Wiki should target the `docs/wiki` branch.\n\nDon't hesitate to ask us any questions.",
+                    "action": "close"
+                }
+            }
+        },
+        {
+            "name": "Target: Wiki",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }},\n\nThank you for reaching out to us about the wiki.\nWe would like to inform you, that you are now able to directly commit your changes to the wiki through a Pull request.\nWhen doing so, make sure you follow these steps:\n\n- The Pull request targets the [`docs/wiki`](https://github.com/PlaceholderAPI/PlaceholderAPI/tree/docs/wiki) branch of the Repository.\n- You only made changes to the files inside the [`wiki`](https://github.com/PlaceholderAPI/PlaceholderAPI/tree/docs/wiki/wiki) folder.\n- You followed the general Styling Guidelines mentioned in the wiki's [README](https://github.com/PlaceholderAPI/PlaceholderAPI/blob/docs/wiki/wiki/README.md) file.\n\nIf you have any questions about submitting a PR for the wiki or have any other questions don't hesitate to ask us about it."
+                }
+            }
+        },
+        {
+            "name": "Type: Not a bug",
+            "labeled": {
+                "issue": {
+                    "body": "The issue you encounter is not considered a bug and rather an intentional behaviour of PlaceholderAPI and/or one of its expansions.\nIf you still believe that it is a bug, provide more information and a maintainer of this repository may look at it more closely.\n\nBefore providing more info, always make sure to use the latest version of PlaceholderAPI, as the issue you encounter might already be fixed in a newer version.\nOptionally can you also try out [development builds](https://ci.extendedclip.com/job/PlaceholderAPI/) and see if the issue was fixed there.",
+                    "action": "close"
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "After further investigation is the issue you encounter indeed considered a bug and we will try to fix it as soon as possible.",
+                    "action": "open"
+                }
+            }
+        },
+        {
+            "name": "Status: Inactive",
+            "labeled": {
+                "issue": {
+                    "body": "The issue has been marked as **inactive** which means it didn't recieve any responses from the Author ({{ issue.user.login }}) for a long period of time.\nTo keep the issue-tracker clean and up to date do we close issues that haven't received any responses for a long time.\n\nIf you're the Author of this issue and the reported problem is still present, make sure to respond with additional info to this issue.\n**Do not create a new issue for the same problem!**",
+                    "action": "close"
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "The issue received a response from the Author who confirms this to still be prominent and has therefore been reopened.",
+                    "action": "open"
+                }
+            }
+        },
+        {
+            "name": "Type: Question",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }},\n\nThank you for reaching out to us for getting Support with PlaceholderAPI.\nWe would like to inform you, that we now have [Discussions](https://github.com/PlaceholderAPI/PlaceholderAPI/discussions) that you can use for asking questions.\nJust head over there and click the \"New discussion\" button to create a new post.\n\nRemember to first read the [READ ME](https://github.com/PlaceholderAPI/PlaceholderAPI/discussions/507) post to not face any issues.\n\nFor questions do we recommend to use the [(2) Support](https://github.com/PlaceholderAPI/PlaceholderAPI/discussions/categories/-2-support) category.\nYou can also use the Discussion to submit Feature requests (Feature requests through issues are still accepted tho)."
+                }
+            }
+        }
+    ]
+}

--- a/src/test/label-commenter-config/stellarium.json
+++ b/src/test/label-commenter-config/stellarium.json
@@ -1,0 +1,143 @@
+{
+    "labels": [
+        {
+            "name": "invalid",
+            "labeled": {
+                "issue": {
+                    "body": "This is not a bug! Or at least we just don't understand your problem (probably the log is not attached and hardware info is missing - so, please follow the issue templates).",
+                    "action": "close"
+                },
+                "pr": {
+                    "body": "Hello @{{ pull_request.user.login }}! Thank you for suggesting this, but please follow the pull request templates.",
+                    "action": "close"
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "Thank you for following the template. The repository owner will reply.",
+                    "action": "open"
+                }
+            }
+        },
+        {
+            "name": "duplicate",
+            "labeled": {
+                "issue": {
+                    "body": "This issue already exists.",
+                    "action": "close"
+                }
+            }
+        },
+        {
+            "name": "good first issue",
+            "labeled": {
+                "issue": {
+                    "body": "This issue is easy for contributing. Everyone can work on this."
+                }
+            }
+        },
+        {
+            "name": "incomplete",
+            "labeled": {
+                "issue": {
+                    "body": "The hardware info, steps of reproduction and log file are really important and help us resolve over 90% issues fast. Of course, in some specific cases we need more data, but we ask the required data separately..."
+                }
+            }
+        },
+        {
+            "name": "enhancement",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }}! Thank you for suggesting this enhancement."
+                },
+                "pr": {
+                    "body": "Hello @{{ pull_request.user.login }}! Thank you for this enhancement."
+                }
+            }
+        },
+        {
+            "name": "feature request",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }}! Thank you for suggesting this feature."
+                }
+            }
+        },
+        {
+            "name": "wishlist",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }}! Thank you for this suggestion."
+                }
+            }
+        },
+        {
+            "name": "confirmed",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }}! OK, developers can reproduce the issue. Thanks for the report!"
+                }
+            }
+        },
+        {
+            "name": "won't fix",
+            "labeled": {
+                "issue": {
+                    "body": "We have a reason not to do it at the moment, but maybe in future we will back to this proposal or someone can implement it and propose pull request with solution! Some reasons for it in the FAQ:\nhttps://github.com/Stellarium/stellarium/wiki/FAQ#Why_dont_you_implement\n",
+                    "action": "close"
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }}! This has become active again.",
+                    "action": "open"
+                }
+            }
+        },
+        {
+            "name": "FAQ",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }}! Please see FAQ in the wiki:\nhttps://github.com/Stellarium/stellarium/wiki/FAQ\n",
+                    "action": "close"
+                }
+            }
+        },
+        {
+            "name": "mobile",
+            "labeled": {
+                "issue": {
+                    "body": "This site actually does not discuss the Mobile version. Please use its own feedback system:\nhttps://www.stellarium-labs.com/support/\n",
+                    "action": "close"
+                }
+            }
+        },
+        {
+            "name": "translations",
+            "labeled": {
+                "issue": {
+                    "body": "Thank you @{{ issue.user.login }}! In future please use Transifex to fix and improve translations: \nhttps://www.transifex.com/stellarium/stellarium/dashboard/\n"
+                }
+            }
+        },
+        {
+            "name": "fix committed",
+            "labeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }}! Please check the fresh version (development snapshot) of Stellarium: \nhttps://github.com/Stellarium/stellarium-data/releases/tag/weekly-snapshot\n"
+                },
+                "pr": {
+                    "body": "Hello @{{ pull_request.user.login }}! Please check the fresh version (development snapshot) of Stellarium: \nhttps://github.com/Stellarium/stellarium-data/releases/tag/weekly-snapshot\n"
+                }
+            },
+            "unlabeled": {
+                "issue": {
+                    "body": "Hello @{{ issue.user.login }}! Please check the latest stable version of Stellarium: \nhttps://github.com/Stellarium/stellarium/releases/latest\n"
+                },
+                "pr": {
+                    "body": "Hello @{{ pull_request.user.login }}! Please check the latest stable version of Stellarium: \nhttps://github.com/Stellarium/stellarium/releases/latest\n"
+                }
+            }
+        }
+    ]
+}

--- a/src/test/label-commenter-config/yourls.json
+++ b/src/test/label-commenter-config/yourls.json
@@ -1,0 +1,13 @@
+{
+   "labels": [
+      {
+         "name": "missing template",
+         "labeled": {
+            "issue": {
+               "body": "Please follow the issue templates. Helping you on an issue without context is not possible.",
+               "action": "close"
+            }
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Adds a JSON Schema for the [Actions Label Commenter](https://github.com/peaceiris/actions-label-commenter) GitHub Action configuration.

The tests are just `label-commenter-config.yml` configurations from other popular repositories.