### PR TITLE
update: CONTRIBUTING.md with info about EditorConfig

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,10 @@ A valid YAML file can be [translated to JSON](https://www.json2yaml.com/convert-
 
 If you wish to retain full control over your schema definition, simply register it in the [schema catalog](src/api/json/catalog.json) by providing a `url` pointing to the self-hosted schema file to the [entry](#catalog).
 
+### JSON formatter
+This project contain [.editorconfig](https://github.com/SchemaStore/schemastore/blob/master/.editorconfig) file.
+Please install the [EditorConfig](https://editorconfig.org) plugin for your IDE.
+
 ## CSS spec
 The CSS specification is divided into multiple XML documents
 > one for each CSS module as specified by the W3C.


### PR DESCRIPTION
This is related to issue #1652
I suspect that some IDE used for schemastore have not installed this [EditorConfig plugin](https://editorconfig.org)
This may explain why sometimes the indent is wrong.