### PR TITLE
Fix filenames of .stylelintrc

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2183,7 +2183,8 @@
       "description": "Configuration file for stylelint",
       "fileMatch": [
         ".stylelintrc",
-        "stylelintrc.json",
+        ".stylelintrc.yml",
+        ".stylelintrc.yaml",
         ".stylelintrc.json"
       ],
       "url": "https://json.schemastore.org/stylelintrc.json"


### PR DESCRIPTION
`.stylelintrc` files may use the `.yml` or `.yaml` extension, but they must start with a `.`.

See https://stylelint.io/user-guide/configure