### PR TITLE
feat: add readthedocs schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1908,6 +1908,17 @@
       "url": "https://json.schemastore.org/pyrseas-0.8.json"
     },
     {
+      "name": "Read the Docs",
+      "description": "Read the Docs configuration file",
+      "fileMatch": [
+        "readthedocs.yml",
+        "readthedocs.yaml",
+        ".readthedocs.yml",
+        ".readthedocs.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/readthedocs/readthedocs.org/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.json"
+    },
+    {
       "name": "Red-DiscordBot Сog",
       "description": "Red-DiscordBot Сog metadata file",
       "fileMatch": [


### PR DESCRIPTION
Adds Read the Docs (`readthedocs.yml`) to the catalog. 