### PR TITLE
typo: reword contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ A valid YAML file can be [translated to JSON](https://www.json2yaml.com/convert-
 If you wish to retain full control over your schema definition, simply register it in the [schema catalog](src/api/json/catalog.json) by providing a `url` pointing to the self-hosted schema file to the [entry](#catalog).
 
 ### JSON formatter
-This project contain [.editorconfig](https://github.com/SchemaStore/schemastore/blob/master/.editorconfig) file.
-Please install the [EditorConfig](https://editorconfig.org) plugin for your IDE.
+This project contains an [`.editorconfig`](https://github.com/SchemaStore/schemastore/blob/master/.editorconfig) file.
+If your IDE or code editor doesn't natively support it, please install the [EditorConfig](https://editorconfig.org) plugin.
 
 ## CSS spec
 The CSS specification is divided into multiple XML documents


### PR DESCRIPTION
#### Typo
Rewords the first sentence, the original one was not grammatically correct.

* This project contain [.editorconfig](https://github.com/SchemaStore/schemastore/blob/master/.editorconfig) file.
* This project contains an [`.editorconfig`](https://github.com/SchemaStore/schemastore/blob/master/.editorconfig) file.

#### Some IDEs Support EditorConfig Natively
Makes the suggestion to install the plugin conditional. Many users don't actually have to install the plugin at all, so I think it's confusing to unconditionally instruct contributors to install a plugin they might not need.

On the side, it changes "IDE" to "IDE or code editor", as many people use a code editor like Visual Studio Code.

(This one is me nitpicking at the wording since I was fixing the typo anyway, feel free to drop opinions.)

#### Linked Issues
* Related To: https://github.com/SchemaStore/schemastore/pull/1687