### PR TITLE
feat: add schema for pull request labeler

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1908,6 +1908,14 @@
       "url": "https://json.schemastore.org/pubspec.json"
     },
     {
+      "name": "Pull Request Labeler",
+      "description": "A GitHub Action for automatically labelling pull requests",
+      "fileMatch": [
+        ".github/labeler.yml"
+      ],
+      "url": "https://json.schemastore.org/pull-request-labeler.json"
+    },
+    {
       "name": "pyrseas-0.8.json",
       "description": "Pyrseas database schema versioning for Postgres databases, v0.8",
       "fileMatch": [

--- a/src/schemas/json/pull-request-labeler.json
+++ b/src/schemas/json/pull-request-labeler.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "https://github.com/actions/labeler",
+  "title": "Pull Request Labeler",
+  "description": "A GitHub Action for automatically labelling pull requests.",
+  "type": "object",
+  "additionalProperties": {
+    "title": "Label",
+    "type": [
+      "string",
+      "array"
+    ],
+    "items": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "properties": {
+            "any": {
+              "title": "Any",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "all": {
+              "title": "All",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/pull-request-labeler/dockstarter.json
+++ b/src/test/pull-request-labeler/dockstarter.json
@@ -1,0 +1,30 @@
+{
+  "apps": [
+    "compose/*",
+    "compose/**/*"
+  ],
+  "ci": [
+    ".github/workflows/*"
+  ],
+  "core": [
+    "./*.sh",
+    "./**/*.sh",
+    ".scripts/*",
+    ".scripts/**/*"
+  ],
+  "docs": [
+    "./*.md",
+    "./**/*.md",
+    "./mkdocs.yml",
+    "docs/*",
+    "docs/**/*"
+  ],
+  "repo": [
+    "./*",
+    ".github/*",
+    ".github/**/*",
+    "!./*.md",
+    "!./*.sh",
+    "!.github/workflows/*"
+  ]
+}

--- a/src/test/pull-request-labeler/freecodecamp.json
+++ b/src/test/pull-request-labeler/freecodecamp.json
@@ -1,0 +1,33 @@
+{
+  "scope: docs": [
+    "docs/**/*"
+  ],
+  "scope: curriculum": [
+    "curriculum/challenges/**/*"
+  ],
+  "platform: client": [
+    "client/**/*"
+  ],
+  "platform: api": [
+    "api-server/**/*"
+  ],
+  "scope: tools/scripts": [
+    "cypress/**/*",
+    "tools/**/*",
+    ".github/**/*",
+    "utils/**/*"
+  ],
+  "scope: i18n": [
+    {
+      "any": [
+        "curriculum/challenges/**/*",
+        "!curriculum/challenges/english/**/*"
+      ]
+    },
+    "docs/i18n/**/*",
+    "client/i18n/**/*",
+    "config/crowdin/**/*",
+    "config/i18n/**/*",
+    "tools/crowdin/**/*"
+  ]
+}

--- a/src/test/pull-request-labeler/tidb.json
+++ b/src/test/pull-request-labeler/tidb.json
@@ -1,0 +1,45 @@
+{
+  "sig/execution": [
+    "distsql/*",
+    "executor/*",
+    "!executor/brie*",
+    "util/chunk/*",
+    "util/disk/*",
+    "util/execdetails/*",
+    "util/expensivequery/*",
+    "util/filesort/*",
+    "util/memory/*",
+    "util/sqlexec/*"
+  ],
+  "component/expression": [
+    "expression/*",
+    "types/*"
+  ],
+  "sig/planner": [
+    "planner/*",
+    "bindinfo/*",
+    "util/ranger/*",
+    "util/plancodec/*"
+  ],
+  "component/statistics": [
+    "statistics/*"
+  ],
+  "sig/sql-infra": [
+    "ddl/*",
+    "domain/*",
+    "infoschema/*",
+    "session/*",
+    "server/*",
+    "privilege/*",
+    "plugin/*",
+    "config/*",
+    "meta/*",
+    "owner/*"
+  ],
+  "component/config": [
+    "config/*"
+  ],
+  "sig/migrate": [
+    "executor/brie*"
+  ]
+}


### PR DESCRIPTION
Adds a JSON Schema for the [Pull Request Labeler](https://github.com/actions/labeler) (`.github/labeler.yml`) GitHub Action.

Test files were just taken from other popular repositories:
* https://github.com/freeCodeCamp/freeCodeCamp
* https://github.com/pingcap/tidb
* https://github.com/GhostWriters/DockSTARTer
