### PR TITLE
feat: add schema for yamllint

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2888,6 +2888,16 @@
       "url": "https://uniswap.org/tokenlist.schema.json"
     },
     {
+      "name": "yamllint",
+      "description": "yamllint uses a set of rules to check source files for problems",
+      "fileMatch": [
+        "**/.yamllint",
+        "**/.yamllint.yaml",
+        "**/.yamllint.yml"
+      ],
+      "url": "https://json.schemastore.org/yamllint.json"
+    },
+    {
       "name": "Yippee-Ki-JSON configuration YML",
       "description": "Action and rule configuration descriptor for Yippee-Ki-JSON transformations.",
       "fileMatch": [

--- a/src/schemas/json/yamllint.json
+++ b/src/schemas/json/yamllint.json
@@ -1,0 +1,801 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "https://yamllint.readthedocs.io/en/stable/configuration.html",
+  "title": "yamllint",
+  "description": "yamllint uses a set of rules to check source files for problems.",
+  "type": "object",
+  "definitions": {
+    "toggle": {
+      "type": "string",
+      "enum": [
+        "enable",
+        "disable"
+      ]
+    },
+    "ignore": {
+      "properties": {
+        "ignore": {
+          "title": "Ignore",
+          "description": "Ignore files, so that the linter doesn't process them.",
+          "type": "string"
+        }
+      }
+    },
+    "allRules": {
+      "$ref": "#/definitions/ignore",
+      "properties": {
+        "level": {
+          "title": "Level",
+          "type": "string",
+          "default": "warning"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/ignore",
+  "properties": {
+    "extends": {
+      "title": "Extends",
+      "type": "string"
+    },
+    "yaml-files": {
+      "title": "YAML Files",
+      "type": "array",
+      "items": {
+        "title": "YAML File",
+        "type": "string"
+      },
+      "default": [
+        "*.yaml",
+        "*.yml",
+        ".yamllint"
+      ]
+    },
+    "locale": {
+      "title": "Locale",
+      "description": "This is passed to Python’s locale.setlocale.",
+      "type": "string"
+    },
+    "rules": {
+      "properties": {
+        "braces": {
+          "title": "Braces",
+          "description": "Use this rule to control the use of flow mappings or number of spaces inside braces ({ and }).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "forbid": {
+                  "title": "Forbid",
+                  "description": "Used to forbid the use of flow mappings which are denoted by surrounding braces ({ and }).",
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "non-empty"
+                      ]
+                    }
+                  ],
+                  "default": false
+                },
+                "min-spaces-inside": {
+                  "title": "Minimum Spaces Inside",
+                  "description": "Defines the minimal number of spaces required inside braces.",
+                  "type": "number",
+                  "default": 0
+                },
+                "max-spaces-inside": {
+                  "title": "Max Spaces Inside",
+                  "description": "Defines the maximal number of spaces allowed inside braces.",
+                  "type": "number",
+                  "default": 0
+                },
+                "min-spaces-inside-empty": {
+                  "title": "Minimum Spaces Inside Empty",
+                  "description": "Defines the minimal number of spaces required inside empty braces.",
+                  "type": "number",
+                  "default": -1
+                },
+                "max-spaces-inside-empty": {
+                  "title": "Max Spaces Inside Empty",
+                  "description": "Defines the maximal number of spaces allowed inside empty braces.",
+                  "type": "number",
+                  "default": -1
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "brackets": {
+          "title": "Brackets",
+          "description": "Use this rule to control the use of flow sequences or the number of spaces inside brackets ([ and ]).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "forbid": {
+                  "title": "Forbid",
+                  "description": "Used to forbid the use of flow sequences which are denoted by surrounding brackets ([ and ]).",
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "non-empty"
+                      ]
+                    }
+                  ],
+                  "default": false
+                },
+                "min-spaces-inside": {
+                  "title": "Minimum Spaces Inside",
+                  "description": "Defines the minimal number of spaces required inside brackets.",
+                  "type": "number",
+                  "default": 0
+                },
+                "max-spaces-inside": {
+                  "title": "Max Spaces Inside",
+                  "description": "Defines the maximal number of spaces allowed inside brackets.",
+                  "type": "number",
+                  "default": 0
+                },
+                "min-spaces-inside-empty": {
+                  "title": "Minimum Spaces Inside Empty",
+                  "description": "Defines the minimal number of spaces required inside empty brackets.",
+                  "type": "number",
+                  "default": -1
+                },
+                "max-spaces-inside-empty": {
+                  "title": "Max Spaces Inside Empty",
+                  "description": "Defines the maximal number of spaces allowed inside empty brackets.",
+                  "type": "number",
+                  "default": -1
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "colons": {
+          "title": "Colons",
+          "description": "Use this rule to control the number of spaces before and after colons (:).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "max-spaces-before": {
+                  "title": "Max Spaces Before",
+                  "description": "Defines the maximal number of spaces allowed before colons (use -1 to disable).",
+                  "type": "number",
+                  "default": 0
+                },
+                "max-spaces-after": {
+                  "title": "Max Spaces After",
+                  "description": "Defines the maximal number of spaces allowed after colons (use -1 to disable).",
+                  "type": "number",
+                  "default": 1
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "commas": {
+          "title": "Commas",
+          "description": "Use this rule to control the number of spaces before and after commas (,).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "max-spaces-before": {
+                  "title": "Max Spaces Before",
+                  "description": "Defines the maximal number of spaces allowed before commas (use -1 to disable).",
+                  "type": "number",
+                  "default": 0
+                },
+                "min-spaces-after": {
+                  "title": "Minimum Spaces After",
+                  "description": "Defines the minimal number of spaces required after commas.",
+                  "type": "number",
+                  "default": 1
+                },
+                "max-spaces-after": {
+                  "title": "Max Spaces After",
+                  "description": "Defines the maximal number of spaces allowed after commas (use -1 to disable).",
+                  "type": "number",
+                  "default": 1
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "comments": {
+          "title": "Comments",
+          "description": "Use this rule to control the position and formatting of comments.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "require-starting-space": {
+                  "title": "Require Starting Space",
+                  "description": "Require a space character right after the #.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "ignore-shebangs": {
+                  "title": "Ignore Shebangs",
+                  "description": "Ignore a shebang at the beginning of the file when require-starting-space is set.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "min-spaces-from-content": {
+                  "title": "Minimum Spaces from Content",
+                  "description": "Used to visually separate inline comments from content.",
+                  "type": "number",
+                  "default": 2
+                }
+              }
+            }
+          ],
+          "default": {
+            "level": "warning"
+          }
+        },
+        "comments-indentation": {
+          "title": "Comments Indentation",
+          "description": "Use this rule to force comments to be indented like content.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules"
+            }
+          ],
+          "default": {
+            "level": "warning"
+          }
+        },
+        "document-end": {
+          "title": "Document End",
+          "description": "Use this rule to require or forbid the use of document end marker (...).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "present": {
+                  "title": "Present",
+                  "description": "True when the document end marker is required, or to false when it is forbidden.",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ],
+          "default": "disable"
+        },
+        "document-start": {
+          "title": "Document Start",
+          "description": "Use this rule to require or forbid the use of document start marker (---).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "present": {
+                  "title": "Present",
+                  "description": "True when the document start marker is required, or to false when it is forbidden.",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ],
+          "default": {
+            "level": "warning"
+          }
+        },
+        "empty-lines": {
+          "title": "Empty Lines",
+          "description": "Use this rule to set a maximal number of allowed consecutive blank lines.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "max": {
+                  "title": "Max",
+                  "description": "Defines the maximal number of empty lines allowed in the document.",
+                  "type": "number",
+                  "default": 2
+                },
+                "max-start": {
+                  "title": "Max Start",
+                  "description": "Defines the maximal number of empty lines allowed at the beginning of the file.",
+                  "type": "number",
+                  "default": 0
+                },
+                "max-end": {
+                  "title": "Max End",
+                  "description": "",
+                  "type": "number",
+                  "default": 0
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "empty-values": {
+          "title": "Empty Values",
+          "description": "Use this rule to prevent nodes with empty content, that implicitly result in null values.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "forbid-in-block-mappings": {
+                  "title": "Forbid in Block Mappings",
+                  "description": "Prevent empty values in block mappings.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "forbid-in-flow-mappings": {
+                  "title": "Forbid in Flow Mappings",
+                  "description": "Prevent empty values in flow mappings.",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ],
+          "default": "disable"
+        },
+        "hyphens": {
+          "title": "Hyphens",
+          "description": "Use this rule to control the number of spaces after hyphens (-).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "max-spaces-after": {
+                  "title": "Max Spaces After",
+                  "description": "Defines the maximal number of spaces allowed after hyphens.",
+                  "type": "number",
+                  "default": 1
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "indentation": {
+          "title": "Indentation",
+          "description": "Use this rule to control the indentation.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "spaces": {
+                  "title": "Spaces",
+                  "description": "Defines the indentation width, in spaces.",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "consistent"
+                      ]
+                    }
+                  ],
+                  "default": "consistent"
+                },
+                "indent-sequence": {
+                  "title": "Indent Sequence",
+                  "description": "Defines whether block sequences should be indented or not (when in a mapping, this indentation is not mandatory – some people perceive the - as part of the indentation).",
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "whatever",
+                        "consistent"
+                      ]
+                    }
+                  ],
+                  "default": true
+                },
+                "check-multi-line-strings": {
+                  "title": "Check Multi Line Strings",
+                  "description": "Defines whether to lint indentation in multi-line strings.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "key-duplicates": {
+          "title": "Key Duplicates",
+          "description": "Use this rule to prevent multiple entries with the same key in mappings.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules"
+            }
+          ],
+          "default": "enable"
+        },
+        "key-ordering": {
+          "title": "Key Ordering",
+          "description": "Use this rule to enforce alphabetical ordering of keys in mappings.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules"
+            }
+          ],
+          "default": "disable"
+        },
+        "line-length": {
+          "title": "Line Length",
+          "description": "Use this rule to set a limit to lines length.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "max": {
+                  "title": "Max",
+                  "description": "Defines the maximal (inclusive) length of lines.",
+                  "type": "number",
+                  "default": 80
+                },
+                "allow-non-breakable-words": {
+                  "title": "Allow Non-Breakable Words",
+                  "description": "Used to allow non breakable words (without spaces inside) to overflow the limit.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "allow-non-breakable-inline-mappings": {
+                  "title": "Allow Non-Breakable Inline Mappings",
+                  "description": "Implies allow-non-breakable-words and extends it to also allow non-breakable words in inline mappings.",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "new-line-at-end-of-file": {
+          "title": "New Line at End of File",
+          "description": "Use this rule to require a new line character (\n) at the end of files.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules"
+            }
+          ],
+          "default": "enable"
+        },
+        "new-lines": {
+          "title": "New Lines",
+          "description": "Use this rule to force the type of new line characters.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "type": {
+                  "title": "Type",
+                  "description": "Unix to use UNIX-typed new line characters (\n), or dos to use DOS-typed new line characters (\r\n).",
+                  "type": "string",
+                  "enum": [
+                    "unix",
+                    "dos"
+                  ],
+                  "default": "unix"
+                }
+              }
+            }
+          ],
+          "default": "enable"
+        },
+        "octal-values": {
+          "title": "Octal Values",
+          "description": "Use this rule to prevent values with octal numbers.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "forbid-implicit-octal": {
+                  "title": "Forbid Implicit Octal",
+                  "description": "Prevent numbers starting with 0.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "forbid-explicit-octal": {
+                  "title": "Forbid Explicit Octal",
+                  "description": "Prevent numbers starting with 0o.",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ],
+          "default": "disable"
+        },
+        "quoted-strings": {
+          "title": "Quoted Strings",
+          "description": "Use this rule to forbid any string values that are not quoted, or to prevent quoted strings without needing it.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "quote-type": {
+                  "title": "Quote Type",
+                  "description": "Defines allowed quotes.",
+                  "type": "string",
+                  "enum": [
+                    "single",
+                    "double",
+                    "any"
+                  ],
+                  "default": "any"
+                },
+                "required": {
+                  "title": "Required",
+                  "description": "Defines whether using quotes in string values is required.",
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "only-when-needed"
+                      ]
+                    }
+                  ],
+                  "default": true
+                },
+                "extra-required": {
+                  "title": "Extra Required",
+                  "description": "List of PCRE regexes to force string values to be quoted, if they match any regex.",
+                  "type": "array",
+                  "items": {
+                    "title": "Pattern",
+                    "type": "string"
+                  },
+                  "default": []
+                },
+                "extra-allowed": {
+                  "title": "Extra Allowed",
+                  "description": "List of PCRE regexes to allow quoted string values, even if required: only-when-needed is set.",
+                  "type": "array",
+                  "items": {
+                    "title": "Pattern",
+                    "type": "string"
+                  },
+                  "default": []
+                }
+              }
+            }
+          ],
+          "default": "disable"
+        },
+        "trailing-spaces": {
+          "title": "Tailing Spaces",
+          "description": "Use this rule to forbid trailing spaces at the end of lines.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules"
+            }
+          ],
+          "default": "enable"
+        },
+        "truthy": {
+          "title": "Truthy",
+          "description": "Use this rule to forbid non-explictly typed truthy values other than allowed ones (by default: true and false), for example YES or off.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/toggle"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "$ref": "#/definitions/allRules",
+              "properties": {
+                "allowed-values": {
+                  "title": "Allowed Values",
+                  "description": "Defines the list of truthy values which will be ignored during linting.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "TRUE",
+                      "True",
+                      "true",
+                      "FALSE",
+                      "False",
+                      "false",
+                      "YES",
+                      "Yes",
+                      "yes",
+                      "NO",
+                      "No",
+                      "no",
+                      "ON",
+                      "On",
+                      "on",
+                      "OFF",
+                      "Off",
+                      "off"
+                    ]
+                  },
+                  "default": [
+                    "true",
+                    "false"
+                  ]
+                },
+                "check-keys": {
+                  "title": "Check Keys",
+                  "description": "Disables verification for keys in mappings.",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ],
+          "default": {
+            "level": "warning"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/yamllint/ansible-lint.json
+++ b/src/test/yamllint/ansible-lint.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "document-start": "disable",
+    "indentation": {
+      "level": "error",
+      "indent-sequences": "consistent"
+    }
+  },
+  "ignore": ".tox\nexamples/playbooks/example.yml\n"
+}

--- a/src/test/yamllint/apisix-dashboard.json
+++ b/src/test/yamllint/apisix-dashboard.json
@@ -1,0 +1,8 @@
+{
+  "extends": "default",
+  "rules": {
+    "document-start": false,
+    "line-length": false,
+    "truthy": false
+  }
+}

--- a/src/test/yamllint/buildx.json
+++ b/src/test/yamllint/buildx.json
@@ -1,0 +1,13 @@
+{
+  "ignore": "/vendor\n",
+  "extends": "default",
+  "yaml-files": [
+    "*.yaml",
+    "*.yml"
+  ],
+  "rules": {
+    "truthy": "disable",
+    "line-length": "disable",
+    "document-start": "disable"
+  }
+}

--- a/src/test/yamllint/coreruleset.json
+++ b/src/test/yamllint/coreruleset.json
@@ -1,0 +1,14 @@
+{
+  "extends": "default",
+  "rules": {
+    "line-length": {
+      "max": 1024,
+      "level": "warning",
+      "ignore": "tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920380.yaml\ntests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920390.yaml\ntests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941360.yaml\n"
+    },
+    "indentation": "disable",
+    "comments": {
+      "require-starting-space": false
+    }
+  }
+}

--- a/src/test/yamllint/jacket.json
+++ b/src/test/yamllint/jacket.json
@@ -1,0 +1,14 @@
+{
+  "extends": "default",
+  "rules": {
+    "document-start": {
+      "level": "error"
+    },
+    "line-length": "disable",
+    "key-duplicates": "disable",
+    "truthy": "disable",
+    "comments": {
+      "min-spaces-from-content": 1
+    }
+  }
+}

--- a/src/test/yamllint/tektoncd-catalog.json
+++ b/src/test/yamllint/tektoncd-catalog.json
@@ -1,0 +1,34 @@
+{
+  "ignore": "/vendor\n",
+  "rules": {
+    "braces": "enable",
+    "brackets": "enable",
+    "colons": "enable",
+    "commas": "enable",
+    "comments": {
+      "level": "warning"
+    },
+    "comments-indentation": {
+      "level": "warning"
+    },
+    "document-end": "disable",
+    "document-start": "disable",
+    "empty-lines": "enable",
+    "empty-values": "enable",
+    "hyphens": "enable",
+    "key-duplicates": "enable",
+    "key-ordering": "disable",
+    "line-length": "disable",
+    "new-line-at-end-of-file": "disable",
+    "new-lines": "enable",
+    "octal-values": "enable",
+    "quoted-strings": "disable",
+    "trailing-spaces": "enable",
+    "truthy": {
+      "level": "warning"
+    },
+    "indentation": {
+      "indent-sequences": "whatever"
+    }
+  }
+}

--- a/src/test/yamllint/weblate.json
+++ b/src/test/yamllint/weblate.json
@@ -1,0 +1,10 @@
+{
+  "extends": "default",
+  "rules": {
+    "line-length": {
+      "max": 500,
+      "level": "error"
+    },
+    "document-start": "disable"
+  }
+}


### PR DESCRIPTION
Adds a JSON Schema for [yamllint](https://yamllint.readthedocs.io/en/stable/configuration.html).
Probably one of the more painful ones I've written. ^-^'

Tests are taken from popular repositories:
* https://github.com/ansible-community/ansible-lint
* https://github.com/apache/apisix-dashboard
* https://github.com/docker/buildx
* https://github.com/coreruleset/coreruleset
* https://github.com/Jackett/Jackett
* https://github.com/tektoncd/catalog
* https://github.com/WeblateOrg/weblate