### PR TITLE
typo: Remove duplicated `to the`.

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -73,7 +73,7 @@
         },
         "executablePath": {
           "type": "string",
-          "description": "An absolute or relative path to the to the executable.",
+          "description": "An absolute or relative path to the executable.",
           "default": ""
         },
         "workingDirectory": {


### PR DESCRIPTION
# Summary

This change fixes a typo where `to the` is repeated in the `description` for `executablePath`.