### PR TITLE
[CircleCI] Add support for docker version 20.10.6

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -593,6 +593,7 @@
             "version": {
               "description": "If your build requires a specific docker image, you can set it as an image attribute",
               "enum": [
+                "20.10.6",
                 "20.10.2",
                 "19.03.14",
                 "19.03.13",


### PR DESCRIPTION
See https://circleci.com/docs/2.0/building-docker-images/#docker-version for a list of the supported values