### PR TITLE
Adjust the `ecmaVersion` possible values for 7.30

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -505,9 +505,9 @@
           "$ref": "#/properties/ecmaFeatures"
         },
         "ecmaVersion": {
-          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018, 10, 2019, 11, 2020, 12, 2021 ],
-          "default": 11,
-          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11 (default) or 12 to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11) or 2021 (same as 12) to use the year-based naming."
+          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018, 10, 2019, 11, 2020, 12, 2021, "latest" ],
+          "default": "latest",
+          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11, 12 or latest (default) to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12) to use the year-based naming or latest to use always the latest supported ECMAScript version."
         },
         "sourceType": {
           "enum": [ "script", "module" ],

--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -506,8 +506,8 @@
         },
         "ecmaVersion": {
           "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018, 10, 2019, 11, 2020, 12, 2021, "latest" ],
-          "default": "latest",
-          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11, 12 or latest (default) to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12) to use the year-based naming or latest to use always the latest supported ECMAScript version."
+          "default": "11",
+          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11 (default), 12 or latest to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12) to use the year-based naming or latest to use always the latest supported ECMAScript version."
         },
         "sourceType": {
           "enum": [ "script", "module" ],


### PR DESCRIPTION
As of 7.30 `"ecmaVersion": "latest"` always enables the latest supported ECMAScript version in ESLint's default parser.

Please note that this feature applies only if you are using the default parser. If you're using a custom parser, refer to the parser's documentation for the list of available options.

Changelog:
* Added "ecmaVersion": "latest"`

Reference:
https://eslint.org/blog/2021/07/eslint-v7.30.0-released