### PR TITLE
Add docker service for appveyor.json schema

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -383,6 +383,7 @@
           "description": "Enable service required for build/tests",
           "items": {
             "enum": [
+              "docker",
               "iis",
               "mongodb",
               "msmq",


### PR DESCRIPTION
docker is a valid value according to the documentation
https://www.appveyor.com/docs/getting-started-with-appveyor-for-linux/#docker