### PR TITLE
Add JSON schemas for Helm charts

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -438,6 +438,22 @@
       "url": "https://raw.githubusercontent.com/cityjson/specs/1.0.1/schemas/cityjson.min.schema.json"
     },
     {
+      "name": "Helm Chart.yaml",
+      "description": "The Chart.yaml file is required for a chart.",
+      "fileMatch": [
+        "Chart.yaml"
+      ],
+      "url": "https://json.schemastore.org/chart.json"
+    },
+    {
+      "name": "Helm Chart.lock",
+      "description": "The Chart.lock file locks dependencies from Chart.yaml",
+      "fileMatch": [
+        "Chart.lock"
+      ],
+      "url": "https://json.schemastore.org/chart-lock.json"
+    },
+    {
       "name": "CircleCI config.yml",
       "description": "Schema for CircleCI 2.0 config files",
       "fileMatch": [

--- a/src/schemas/json/chart-lock.json
+++ b/src/schemas/json/chart-lock.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Helm Chart.lock",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["generated", "digest", "dependencies"],
+  "properties": {
+    "generated": {
+      "description": "Generated is the date the lock file was last generated.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "digest": {
+      "description": "Digest is a hash of the dependencies in Chart.yaml.",
+      "type": "string"
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "In Helm, one chart may depend on any number of other charts. These dependencies can be dynamically linked using the dependencies field in Chart.yaml or brought in to the charts/ directory and managed manually.\nThe charts required by the current chart are defined as a list in the dependencies field.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "version", "repository"],
+        "properties": {
+          "name": {
+            "description": "The name of the chart",
+            "type": "string"
+          },
+          "version": {
+            "description": "The version of the chart",
+            "type": "string"
+          },
+          "repository": {
+            "description": "The repository URL or alias",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/chart.json
+++ b/src/schemas/json/chart.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Helm Chart.yaml",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "name", "version"],
+  "properties": {
+    "apiVersion": {
+      "description": "The apiVersion field should be v2 for Helm charts that require at least Helm 3. Charts supporting previous Helm versions have an apiVersion set to v1 and are still installable by Helm 3.",
+      "enum": ["v1", "v2"]
+    },
+    "name": {
+      "description": "The name of the chart",
+      "type": "string"
+    },
+    "version": {
+      "description": "A SemVer 2 version",
+      "type": "string"
+    },
+    "kubeVersion": {
+      "description": "The optional kubeVersion field can define semver constraints on supported Kubernetes versions. Helm will validate the version constraints when installing the chart and fail if the cluster runs an unsupported Kubernetes version.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A single-sentence description of this project",
+      "type": "string"
+    },
+    "type": {
+      "description": "The type of the chart",
+      "default": "application",
+      "enum": ["application", "library"]
+    },
+    "keywords": {
+      "type": "array",
+      "description": "A list of keywords about this project",
+      "items": {
+        "type": "string"
+      }
+    },
+    "home": {
+      "description": "The URL of this projects home page",
+      "type": "string",
+      "format": "uri"
+    },
+    "sources": {
+      "type": "array",
+      "description": "A list of URLs to source code for this project",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "In Helm, one chart may depend on any number of other charts. These dependencies can be dynamically linked using the dependencies field in Chart.yaml or brought in to the charts/ directory and managed manually.\nThe charts required by the current chart are defined as a list in the dependencies field.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "version"],
+        "properties": {
+          "name": {
+            "description": "The name of the chart",
+            "type": "string"
+          },
+          "version": {
+            "description": "The version of the chart",
+            "type": "string"
+          },
+          "repository": {
+            "description": "The repository URL or alias",
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "string",
+                "pattern": "^@"
+              }
+            ]
+          },
+          "condition": {
+            "description": "A yaml path that resolves to a boolean, used for enabling/disabling charts",
+            "type": "string"
+          },
+          "tags": {
+            "description": "Tags can be used to group charts for enabling/disabling together",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "import-values": {
+            "description": "ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "alias": {
+            "description": "Alias to be used for the chart. Useful when you have to add the same chart multiple times",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "maintainers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "description": "The maintainers name",
+            "type": "string"
+          },
+          "email": {
+            "description": "The maintainers email",
+            "type": "string",
+            "format": "email"
+          },
+          "url": {
+            "description": "A URL for the maintainer",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "icon": {
+      "description": "A URL to an SVG or PNG image to be used as an icon",
+      "type": "string",
+      "format": "uri"
+    },
+    "appVersion": {
+      "description": "Note that the appVersion field is not related to the version field. It is a way of specifying the version of the application. For example, the drupal chart may have an appVersion: \"8.2.1\", indicating that the version of Drupal included in the chart (by default) is 8.2.1. This field is informational, and has no impact on chart version calculations. Wrapping the version in quotes is highly recommended. It forces the YAML parser to treat the version number as a string. Leaving it unquoted can lead to parsing issues in some cases. For example, YAML interprets 1.0 as a floating point value, and a git commit SHA like 1234e10 as scientific notation.",
+      "type": "string"
+    },
+    "deprecated": {
+      "description": "When managing charts in a Chart Repository, it is sometimes necessary to deprecate a chart. The optional deprecated field in Chart.yaml can be used to mark a chart as deprecated. If the latest version of a chart in the repository is marked as deprecated, then the chart as a whole is considered to be deprecated. The chart name can be later reused by publishing a newer version that is not marked as deprecated.",
+      "type": "boolean"
+    },
+    "annotations": {
+      "description": "A list of annotations keyed by name",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {
+        "artifacthub.io/changes": {
+          "description": "This annotation is used to provide some details about the changes introduced by a given chart version. Artifact Hub can generate and display a ChangeLog based on the entries in the changes field in all your chart versions.\nThis annotation can be provided using two different formats: using a plain list of strings with the description of the change or using a list of objects with some extra structured information (see example below). Please feel free to use the one that better suits your needs. The UI experience will be slightly different depending on the choice. When using the list of objects option the valid supported kinds are added, changed, deprecated, removed, fixed and security.",
+          "type": "string"
+        },
+        "artifacthub.io/containsSecurityUpdates": {
+          "description": "Use this annotation to indicate that this chart version contains security updates. When a package release contains security updates, a special message will be displayed in the Artifact Hub UI as well as in the new release email notification.",
+          "enum": ["true", "false"]
+        },
+        "artifacthub.io/crds": {
+          "description": "By default, Artifact Hub will try to extract the containers images used by Helm charts from the manifests generated from a dry-run install using the default values. If you prefer, you can also provide a list of containers images manually by using this annotation.\nContainers images will be scanned for security vulnerabilities. The security report generated will be available in the package detail view. It is possible to whitelist images so that they are not scanned by setting the whitelisted flag to true.",
+          "type": "string"
+        },
+        "artifacthub.io/images": {
+          "description": "This annotation can be used to list the operator’s CRDs. They will be visible in the package’s detail view as cards.",
+          "type": "string"
+        },
+        "artifacthub.io/crdsExamples": {
+          "description": "Use this annotation to provide a list of example CRs for the operator’s CRDs. Each of the examples can be opened from the corresponding CRD card in the package’s detail view.",
+          "type": "string"
+        },
+        "artifacthub.io/license": {
+          "description": "Use this annotation to indicate the chart’s license. By default, Artifact Hub tries to read the chart’s license from the LICENSE file in the chart, but it’s possible to override or provide it with this annotation. It must be a valid SPDX identifier.",
+          "type": "string"
+        },
+        "artifacthub.io/links": {
+          "description": "This annotation allows including named links, which will be rendered nicely in Artifact Hub. You can use this annotation to include links not included previously in the Chart.yaml file, or you can use it to name links already present (in the sources section, for example).",
+          "type": "string"
+        },
+        "artifacthub.io/maintainers": {
+          "description": "This annotation can be used if you want to display a different name for a given user in Artifact Hub than the one used in the Chart.yaml file. If the email used matches, the name used in the annotations entry will be displayed in Artifact Hub. It’s also possible to include maintainers that should only be listed in Artifact Hub by adding additional entries.",
+          "type": "string"
+        },
+        "artifacthub.io/operator": {
+          "description": "Use this annotation to indicate that your chart represents an operator. Artifact Hub at the moment also considers your chart to represent an operator if the word operator appears in the chart name.",
+          "enum": ["true", "false"]
+        },
+        "artifacthub.io/operatorCapabilities": {
+          "description": "Use this annotation to indicate the capabilities of the operator your chart provides. It must be one of the following options: Basic Install, Seamless Upgrades, Full Lifecycle, Deep Insights or Auto Pilot. For more information please see the capability level diagram.",
+          "enum": [
+            "Basic Install",
+            "Seamless Upgrades",
+            "Full Lifecycle",
+            "Deep Insights",
+            "Auto Pilot"
+          ]
+        },
+        "artifacthub.io/prerelease": {
+          "description": "Use this annotation to indicate that this chart version is a pre-release. This status will be displayed in the UI’s package view, as well as in new releases notifications emails.",
+          "enum": ["true", "false"]
+        },
+        "artifacthub.io/recommendations": {
+          "description": "This annotation allows recommending other related packages. Recommended packages will be featured in the package detail view in Artifact Hub.",
+          "type": "string"
+        },
+        "artifacthub.io/signKey": {
+          "description": "This annotation can be used to provide some information about the key used to sign a given chart version. This information will be displayed on the Artifact Hub UI, making it easier for users to get the information they need to verify the integrity and origin of your chart. The url field indicates where users can find the public key and it is mandatory when a sign key entry is provided.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/test/chart-lock/chart.lock.json
+++ b/src/test/chart-lock/chart.lock.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": [
+    {
+      "name": "postgresql",
+      "repository": "https://charts.bitnami.com/bitnami",
+      "version": "10.5.0"
+    }
+  ],
+  "digest": "sha256:34c95197cd12ff7e4a0d638c521a2313b1f5551edc6f690614de11886605b38b",
+  "generated": "2021-06-15T09:16:47.765072012+02:00"
+}

--- a/src/test/chart/full.json
+++ b/src/test/chart/full.json
@@ -1,0 +1,48 @@
+{
+  "apiVersion": "v1",
+  "name": "hello-chart",
+  "version": "1.2.3",
+  "kubeVersion": ">=1.20",
+  "description": "A single-sentence description of this project",
+  "type": "library",
+  "keywords": ["keyword"],
+  "home": "https://helm.sh/docs/topics/charts/",
+  "sources": ["https://example.com/charts.git"],
+  "dependencies": [
+    {
+      "name": "world",
+      "version": "4.5.6",
+      "repository": "https://example.com/charts",
+      "condition": "subchart1.enabled",
+      "tags": ["tag"],
+      "import-values": ["world"],
+      "alias": "welt"
+    }
+  ],
+  "maintainers": [
+    {
+      "name": "Me",
+      "email": "me@example.com",
+      "url": "https://example.com/me"
+    }
+  ],
+  "icon": "https://example.com/icon.png",
+  "appVersion": "123",
+  "deprecated": false,
+  "annotations": {
+    "example": "A list of annotations keyed by name (optional).",
+    "artifacthub.io/changes": "- kind: added\n  description: Cool feature\n  links:\n    - name: Github Issue\n      url: https://github.com/issue-url\n    - name: Github PR\n      url: https://github.com/pr-url\n- kind: fixed\n  description: Minor bug\n  links:\n    - name: Github Issue\n      url: https://github.com/issue-url\n",
+    "artifacthub.io/containsSecurityUpdates": "true",
+    "artifacthub.io/images": "- name: img1\n  image: repo/img1:1.0.0\n- name: img2\n  image: repo/img2:2.0.0\n  whitelisted: true\n",
+    "artifacthub.io/crds": "- kind: MyKind\n  version: v1\n  name: mykind\n  displayName: My Kind\n  description: Some nice description\n",
+    "artifacthub.io/crdsExamples": "- apiVersion: v1\n  kind: MyKind\n  metadata:\n    name: mykind\n  spec:\n    replicas: 1\n",
+    "artifacthub.io/license": "Apache-2.0",
+    "artifacthub.io/links": "- name: link1\n  url: https://link1.url\n- name: link2\n  url: https://link2.url\n",
+    "artifacthub.io/maintainers": "- name: user1\n  email: user1@email.com\n- name: user2\n  email: user2@email.com\n",
+    "artifacthub.io/operator": "true",
+    "artifacthub.io/operatorCapabilities": "Basic Install",
+    "artifacthub.io/prerelease": "false",
+    "artifacthub.io/recommendations": "- url: https://artifacthub.io/packages/helm/artifact-hub/artifact-hub\n- url: https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack\n",
+    "artifacthub.io/signKey": "fingerprint: C874011F0AB405110D02105534365D9472D7468F\nurl: https://keybase.io/hashicorp/pgp_keys.asc\n"
+  }
+}

--- a/src/test/chart/minimal.json
+++ b/src/test/chart/minimal.json
@@ -1,0 +1,5 @@
+{
+  "apiVersion": "v2",
+  "name": "hello-chart",
+  "version": "1.2.3"
+}


### PR DESCRIPTION
The JSON schema for `Chart.yaml` is based on https://helm.sh/docs/topics/charts/#the-chartyaml-file

Additional annotations from Artifact Hub are supported which are documented on https://artifacthub.io/docs/topics/annotations/helm/.

The JSON schema for the `Chart.lock` file is based on https://github.com/helm/helm/blob/a499b4b179307c267bdf3ec49b880e3dbd2a5591/pkg/chart/dependency.go#L72, but only a subset of dependencies is written to file, as can be seen for example in https://github.com/bitnami/charts/blob/master/bitnami/postgresql/Chart.lock