### PR TITLE
Fix identifier for lower_safe_namespace in the forms object of the .NET template files (template.json) schema

### DIFF
--- a/src/schemas/json/template.json
+++ b/src/schemas/json/template.json
@@ -815,7 +815,7 @@
             "description": "Converts the source value to a lowercase string suitable for a C# namespace",
             "properties": {
               "identifier": {
-                "enum": [ "safe_namespace" ]
+                "enum": [ "lower_safe_namespace" ]
               }
             }
           },


### PR DESCRIPTION
The identifier for the lower_safe_namespace value form is incorrect in the schema.  The identifier needs to be changed to `lower_safe_namespace` from `safe_namespace` so the description aligns with the identifier.