### PR TITLE
adds hosted Portman schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1843,6 +1843,15 @@
       "url": "https://json.schemastore.org/pocketmine-plugin.json"
     },
     {
+      "name": "portman.json",
+      "description": "JSON schema for Portman's configuration file",
+      "fileMatch": [
+        "portman-config.json",
+        "portman.json"
+      ],
+      "url": "https://raw.githubusercontent.com/apideck-libraries/portman/main/src/utils/portman-config-schema.json"
+    },
+    {
       "name": "PostCSS .prettierrc",
       "description": "PostCSS configuration file",
       "fileMatch": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
