### PR TITLE
feat: add minecraft data pack schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1582,6 +1582,94 @@
       "url": "https://json.schemastore.org/mimetypes.json"
     },
     {
+      "name": "Minecraft Data Pack Advancement",
+      "description": "Configuration file defining an advancement for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/advancements/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-advancement.json"
+    },
+    {
+      "name": "Minecraft Data Pack Biome",
+      "description": "Configuration file defining a biome for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/worldgen/biome/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-biome.json"
+    },
+    {
+      "name": "Minecraft Data Pack Configured Carver",
+      "description": "Configuration file defining a configured carver for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/worldgen/configured_carver/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-configured-carver.json"
+    },
+    {
+      "name": "Minecraft Data Pack Dimension Type",
+      "description": "Configuration file defining a dimension type for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/dimension_type/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-dimension-type.json"
+    },
+    {
+      "name": "Minecraft Data Pack Dimension",
+      "description": "Configuration file defining a dimension for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/dimension/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-dimension.json"
+    },
+    {
+      "name": "Minecraft Data Pack Item Modifier",
+      "description": "Configuration file defining an item modifier for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/item_modifiers/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-item-modifier.json"
+    },
+    {
+      "name": "Minecraft Data Pack Loot Table",
+      "description": "Configuration file defining a loot table for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/loot_tables/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-loot-table.json"
+    },
+    {
+      "name": "Minecraft Data Pack Metadata",
+      "description": "Configuration file defining the metadata of a data pack for Minecraft.",
+      "fileMatch": [
+        "**/pack.mcmeta"
+      ],
+      "url": "https://json.schemastore.org/minecraft-pack-mcmeta.json"
+    },
+    {
+      "name": "Minecraft Data Pack Predicate",
+      "description": "Configuration file defining a predicate for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/predicates/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-predicate.json"
+    },
+    {
+      "name": "Minecraft Data Pack Recipe",
+      "description": "Configuration file defining a recipe for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/recipes/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-recipe.json"
+    },
+    {
+      "name": "Minecraft Data Pack Template Pool",
+      "description": "Configuration file defining a template pool for a data pack for Minecraft.",
+      "fileMatch": [
+        "**/data/*/worldgen/template_pool/*.json"
+      ],
+      "url": "https://json.schemastore.org/minecraft-template-pool.json"
+    },
+    {
       "name": ".mocharc",
       "description": "JSON schema for MochaJS configuration files",
       "fileMatch": [

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Advancement/JSON_format",
+  "title": "Minecraft Data Pack Advancement",
+  "description": "Configuration file defining an advancement for a data pack for Minecraft.",
+  "type": "object",
+  "definitions": {
+    "jsonTextComponent": {
+      "$comment": "https://minecraft.fandom.com/wiki/Raw_JSON_text_format",
+      "type": [
+        "string",
+        "boolean",
+        "number",
+        "array",
+        "object"
+      ],
+      "properties": {
+        "extra": {
+          "title": "Extra",
+          "description": "A list of additional raw JSON text components to be displayed after this one.",
+          "type": "array",
+          "items": {
+            "description": "A child text component. Child text components inherit all formatting and interactivity from the parent component, unless they explicitly override them.",
+            "$ref": "#/definitions/jsonTextComponent"
+          }
+        },
+        "color": {
+          "title": "Color",
+          "description": "The color to render the content in.",
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": [
+                "black",
+                "dark_blue",
+                "dark_green",
+                "dark_aqua",
+                "dark_red",
+                "dark_purple",
+                "gold",
+                "gray",
+                "dark_gray",
+                "blue",
+                "green",
+                "aqua",
+                "red",
+                "light_purple",
+                "yellow",
+                "white",
+                "reset"
+              ]
+            },
+            {
+              "pattern": "#[A-F\\d]{6}"
+            }
+          ]
+        },
+        "font": {
+          "title": "Font",
+          "description": "The resource location of the font for this component in the resource pack within assets/<namespace>/font.",
+          "type": "string",
+          "default": "minecraft:default"
+        },
+        "bold": {
+          "title": "Bold",
+          "description": "Whether to render the content in bold.",
+          "type": "boolean"
+        },
+        "italic": {
+          "title": "Italic",
+          "description": "Whether to render the content in italics. Note that text that is italicized by default, such as custom item names, can be unitalicized by setting this to false.",
+          "type": "boolean"
+        },
+        "underlined": {
+          "title": "Underlined",
+          "description": "Whether to underline the content.",
+          "type": "boolean"
+        },
+        "strikethrough": {
+          "title": "Strikethrough",
+          "description": "Whether to strikethrough the content.",
+          "type": "boolean"
+        },
+        "obfuscated": {
+          "title": "Obfuscated",
+          "description": "Whether to render the content obfuscated.",
+          "type": "boolean"
+        },
+        "insertion": {
+          "title": "Insertions",
+          "description": "When the text is shift-clicked by a player, this string is inserted in their chat input. It does not overwrite any existing text the player was writing. This only works in chat messages.",
+          "type": "string"
+        },
+        "clickEvent": {
+          "title": "Click Event",
+          "description": "Allows for events to occur when the player clicks on text. Only work in chat messages and written books, unless specified otherwise.",
+          "type": "object",
+          "properties": {
+            "action": {
+              "title": "Action",
+              "description": "The action to perform when clicked.",
+              "type": "string",
+              "enum": [
+                "open_url",
+                "open_file",
+                "run_command",
+                "suggest_command",
+                "change_page",
+                "copy_to_clipboard"
+              ]
+            },
+            "value": {
+              "title": "Value",
+              "description": "The URL, file path, chat, command or book page used by the specified action.",
+              "type": "string"
+            }
+          }
+        },
+        "hoverEvent": {
+          "title": "Hover Event",
+          "description": "Allows for a tooltip to be displayed when the player hovers their mouse over text.",
+          "type": "object",
+          "properties": {
+            "action": {
+              "title": "Action",
+              "description": "The type of tooltip to show.",
+              "type": "string",
+              "enum": [
+                "show_text",
+                "show_item",
+                "show_entity"
+              ]
+            },
+            "value": {
+              "title": "Value",
+              "description": "The formatting and type of this tag varies depending on the action.",
+              "type": "string"
+            },
+            "contents": {
+              "title": "Contents",
+              "description": "The formatting of this tag varies depending on the action.",
+              "type": "object"
+            }
+          }
+        },
+        "text": {
+          "title": "Text",
+          "description": "A string containing plain text to display directly. Can also be a number or boolean that is displayed directly.",
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ]
+        },
+        "translate": {
+          "title": "Translate",
+          "description": "A translation identifier, corresponding to the identifiers found in loaded language files. Displayed as the corresponding text in the player's selected language. If no corresponding translation can be found, the identifier itself is used as the translated text.",
+          "type": "string"
+        },
+        "with": {
+          "title": "With",
+          "description": "A list of raw JSON text components to be inserted into slots in the translation text.",
+          "type": "array",
+          "items": {
+            "description": "A raw JSON text component. If no component is provided for a slot, the slot is displayed as no text.",
+            "$ref": "#/definitions/jsonTextComponent"
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "display": {
+      "title": "Display",
+      "description": "The display data.",
+      "type": "object",
+      "properties": {
+        "icon": {
+          "title": "Icon",
+          "description": "The data for the icon.",
+          "type": "object",
+          "properties": {
+            "item": {
+              "title": "Item",
+              "description": "The item ID.",
+              "type": "string"
+            },
+            "nbt": {
+              "title": "Named Binary Tag",
+              "description": "The Named Binary Tag (NBT) data of the item.",
+              "type": "string"
+            }
+          }
+        },
+        "title": {
+          "title": "Title",
+          "description": "The title for this advancement.",
+          "$ref": "#/definitions/jsonTextComponent"
+        },
+        "frame": {
+          "title": "Frame",
+          "description": "The type of frame for the icon.",
+          "type": "string",
+          "enum": [
+            "challenge",
+            "goal",
+            "task"
+          ],
+          "default": "task"
+        },
+        "background": {
+          "title": "Background",
+          "description": "The directory for the background to use in this advancement tab (used only for the root advancement).",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "The description of the advancement.",
+          "$ref": "#/definitions/jsonTextComponent"
+        },
+        "show_toast": {
+          "title": "Show Toast",
+          "description": "Whether or not to show the toast pop up after completing this advancement.",
+          "type": "boolean",
+          "default": true
+        },
+        "annouce_to_chat": {
+          "title": "Annouce to Chat",
+          "description": "Whether or not to announce in the chat when this advancement has been completed.",
+          "type": "boolean",
+          "default": true
+        },
+        "hidden": {
+          "title": "Hidden",
+          "description": "Whether or not to hide this advancement and all its children from the advancement screen until this advancement have been completed. Has no effect on root advancements themselves, but still affects all their children.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "parent": {
+      "title": "Parent",
+      "description": "The parent advancement directory of this advancement. If this field is absent, this advancement is a root advancement. Circular references cause a loading failure.",
+      "type": "string"
+    },
+    "criteria": {
+      "title": "Criteria",
+      "description": "The required criteria that have to be met.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "trigger": {
+            "title": "Trigger",
+            "description": "The trigger for this advancement; specifies what the game should check for the advancement.",
+            "type": "string"
+          },
+          "conditions": {
+            "title": "Conditions",
+            "description": "All the conditions that need to be met when the trigger gets activated.",
+            "type": "object"
+          }
+        }
+      }
+    },
+    "requirements": {
+      "title": "Requirements",
+      "description": "A list of requirements (all the <criteriaNames>). If all criteria are required, this may be omitted. With multiple criteria: requirements contains a list of lists with criteria (all criteria need to be mentioned). If all of the lists each have any criteria met, the advancement is complete. (basically AND grouping of OR groups)",
+      "type": "array",
+      "items": {
+        "type": [
+          "string",
+          "array"
+        ],
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "rewards": {
+      "title": "Rewards",
+      "description": "The rewards provided when this advancement is obtained.",
+      "type": "object",
+      "properties": {
+        "recipies": {
+          "title": "Recipies",
+          "description": "A list of recipes to unlock.",
+          "type": "array",
+          "items": {
+            "description": "A namespaced ID for a recipe.",
+            "type": "string"
+          }
+        },
+        "loot": {
+          "title": "Loot",
+          "description": "A list of loot tables to give to the player.",
+          "type": "array",
+          "items": {
+            "description": "A namespaced ID for a loot table.",
+            "type": "string"
+          }
+        },
+        "experience": {
+          "title": "Experience",
+          "description": "An amount of experience.",
+          "type": "integer"
+        },
+        "function": {
+          "title": "Function",
+          "description": "A function to run. Function tags are not allowed.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Biome/JSON_format",
+  "title": "Minecraft Data Pack Biome",
+  "description": "Configuration file defining a biome for a data pack for Minecraft.",
+  "type": "object",
+  "properties": {
+    "depth": {
+      "title": "Depth",
+      "description": "Used for terrain noise generation. Biomes with positive depth are considered land, biomes with negative depth are oceans.",
+      "type": "number"
+    },
+    "scale": {
+      "title": "Scale",
+      "description": "Used for terrain noise generation. Vertically stretches the terrain. Lower values produce flatter terrain.",
+      "type": "number"
+    },
+    "precipitation": {
+      "title": "Precipitation",
+      "description": "The type of precipitation found in this biome. If snow, rabbits spawning in this biome will be white or black-and-white.",
+      "type": "string",
+      "enum": [
+        "none",
+        "rain",
+        "snow"
+      ]
+    },
+    "category": {
+      "title": "Category",
+      "type": "string",
+      "enum": [
+        "none",
+        "taiga",
+        "extreme_hills",
+        "jungle",
+        "mesa",
+        "plains",
+        "savanna",
+        "icy",
+        "the_end",
+        "beach",
+        "forest",
+        "ocean",
+        "desert",
+        "river",
+        "swamp",
+        "mushroom",
+        "nether"
+      ]
+    },
+    "temperature": {
+      "title": "Temperature",
+      "description": "Controls gameplay features like grass and foliage color and whether snow golems take damage.",
+      "type": "number"
+    },
+    "temperature_modifier": {
+      "title": "Temperature Modifier",
+      "type": "string",
+      "enum": [
+        "none",
+        "frozen"
+      ]
+    },
+    "downfall": {
+      "title": "Downfall",
+      "description": "Controls grass and foliage color, a value above 0.85 also makes fire burn out faster.",
+      "type": "number"
+    },
+    "player_spawn_friendly": {
+      "title": "Player Spawn Friendly",
+      "type": "boolean"
+    },
+    "creature_spawn_friendly": {
+      "title": "Creature Spawn Friendly",
+      "description": "Spawns passive mobs as long as random value is less than this.",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "effects": {
+      "title": "Effects",
+      "description": "Ambient effects in this biome.",
+      "type": "object",
+      "properties": {
+        "fog_color": {
+          "title": "Fog Color",
+          "description": "Decimal value converted from Hex color to use for fog.",
+          "type": "integer"
+        },
+        "foliage_color": {
+          "title": "Foliage Color",
+          "description": "Decimal value converted from Hex color to use for tree leaves and vines. If not present, the value depends on humidity and temperature.",
+          "type": "integer"
+        },
+        "grass_color": {
+          "title": "Grass Color",
+          "description": "Decimal value converted from Hex color to use for grass blocks, grass, tall grass, ferns, tall ferns, and sugar cane. If not present, the value depends on humidity and temperature.",
+          "type": "integer"
+        },
+        "sky_color": {
+          "title": "Sky Color",
+          "description": "Decimal value converted from Hex color to use for the sky.",
+          "type": "integer"
+        },
+        "water_color": {
+          "title": "Water Color",
+          "description": "Decimal value converted from Hex color to use for water blocks and cauldrons.",
+          "type": "integer"
+        },
+        "water_fog_color": {
+          "title": "Water Fog Color",
+          "description": "Decimal value converted from Hex color to use for fog.",
+          "type": "integer"
+        },
+        "grass_color_modifier": {
+          "title": "Grass Color Modifier",
+          "type": "string",
+          "enum": [
+            "none",
+            "dark_forest",
+            "swamp"
+          ]
+        },
+        "particle": {
+          "title": "Particle",
+          "description": "The particle to use throughout this biome.",
+          "type": "object",
+          "properties": {
+            "probability": {
+              "title": "Probability",
+              "description": "Controls how often the particle spawns.",
+              "type": "number"
+            },
+            "options": {
+              "title": "Options",
+              "description": "Controls what particle to use.",
+              "type": "object"
+            }
+          }
+        },
+        "ambient_sound": {
+          "title": "Ambient Sound",
+          "description": "Sound event to use for ambient sound.",
+          "type": "string"
+        },
+        "mood_sound": {
+          "title": "Mood Sound",
+          "description": "Settings for mood sound.",
+          "type": "object",
+          "properties": {
+            "sound": {
+              "title": "Sound",
+              "description": "Sound event to use.",
+              "type": "string"
+            },
+            "tick_delay": {
+              "title": "Tick Delay",
+              "type": "integer"
+            },
+            "block_search_context": {
+              "title": "Block Search Context",
+              "description": "Determines the cubic range of possible positions to play the mood sound. The player is at the center of the cubic range, and the edge length is 2 * block_search_extent + 1.",
+              "type": "integer"
+            },
+            "offset": {
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        },
+        "additions_sound": {
+          "title": "Additions Sound",
+          "description": "Settings for additions sound.",
+          "type": "object",
+          "properties": {
+            "sound": {
+              "title": "Sound",
+              "description": "Sound event to use.",
+              "type": "string"
+            },
+            "tick_chance": {
+              "title": "Tick Chance",
+              "type": "integer"
+            }
+          }
+        },
+        "music": {
+          "title": "Music",
+          "description": "Specific music that should be played in the biome.",
+          "type": "object",
+          "properties": {
+            "sound": {
+              "title": "Sound",
+              "description": "Sound event to use.",
+              "type": "string"
+            },
+            "min_delay": {
+              "title": "Minimum Delay",
+              "type": "integer"
+            },
+            "max_delay": {
+              "title": "Max Delay",
+              "type": "integer"
+            },
+            "replace_current_music": {
+              "title": "Replace Current Music",
+              "description": "Whether or not to replace music which is already playing.",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "surface_builder": {
+      "title": "Surface Builder",
+      "description": "The namespaced id of the configured surface builder to use.",
+      "type": "string"
+    },
+    "carvers": {
+      "title": "Carvers",
+      "description": "The carvers to use.",
+      "type": "object",
+      "properties": {
+        "air": {
+          "title": "Air",
+          "description": "List of carvers used during the air generation step.",
+          "type": "array",
+          "items": {
+            "description": "The namespaced id of a configured carver.",
+            "type": "string"
+          }
+        },
+        "liquid": {
+          "title": "Liquids",
+          "description": "List of carvers used during the liquid generation step",
+          "type": "array",
+          "items": {
+            "description": "The namespaced id of a configured carver.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "features": {
+      "title": "Features",
+      "description": "A list of 10 lists of features. In vanilla, each of the 10 lists corresponds to a different type of feature: the feature lists are applied to each chunk in order from top to bottom. The index of the list which the feature is placed in is also used to generate part of the feature seed, so moving features to a different list definitely has some effect on generation. Each element of each list is a namespaced ID of a configured feature. Can be a empty list.",
+      "type": "array",
+      "items": {
+        "type": "array"
+      }
+    },
+    "starts": {
+      "title": "Starts",
+      "description": "The structures to generate in this biome.",
+      "type": "array",
+      "items": {
+        "description": "The namespaced ID of a configured structure feature.",
+        "type": "string"
+      }
+    },
+    "spawners": {
+      "title": "Spawners",
+      "description": "Entity spawning settings.",
+      "type": "object"
+    },
+    "spawn_costs": {
+      "title": "Spawn Costs",
+      "description": "List of entity IDs.",
+      "additionalProperties": {
+        "properties": {
+          "energy_budget": {
+            "title": "Energy Budget",
+            "type": "integer"
+          },
+          "charge": {
+            "title": "Charge",
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/minecraft-configured-carver.json
+++ b/src/schemas/json/minecraft-configured-carver.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Custom_world_generation#Carvers",
+  "title": "Minecraft Data Pack Configured Carver",
+  "description": "Configuration file defining a configured carver for a data pack for Minecraft.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "title": "Type",
+      "description": "The type of carver to use.",
+      "type": "string",
+      "enum": [
+        "minecraft:cave",
+        "cave",
+        "minecraft:nether_cave",
+        "nether_cave",
+        "minecraft:canyon",
+        "canyon",
+        "minecraft:underwater_canyon",
+        "underwater_canyon",
+        "minecraft:underwater_cave",
+        "underwater_cave"
+      ]
+    },
+    "config": {
+      "title": "Configuration",
+      "description": "Configuration values for the carver.",
+      "type": "object",
+      "properties": {
+        "probability": {
+          "title": "Probability",
+          "description": "The probability that each chunk attempts to generate this carver.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/minecraft-dimension-type.json
+++ b/src/schemas/json/minecraft-dimension-type.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Custom_dimension#Dimension_type",
+  "title": "Minecraft Data Pack Dimension Type",
+  "description": "Configuration file defining a dimension type for a data pack for Minecraft.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "title": "Name",
+      "description": "The resource location used for the dimension type.",
+      "type": "string"
+    },
+    "ultrawarm": {
+      "title": "Ultrawarm",
+      "description": "Whether the dimensions behaves like the nether (water evaporates and sponges dry) or not. Also lets stalactites drip lava and causes lava to spread faster and thinner.",
+      "type": "boolean"
+    },
+    "natural": {
+      "title": "Natural",
+      "description": "When true, nether portals can spawn zombified piglins. When false, compasses spin randomly, and using a bed to set the respawn point or sleep, is disabled.",
+      "type": "boolean"
+    },
+    "coordinate_scale": {
+      "title": "Coordinate Scale",
+      "description": "The multiplier applied to coordinates when traveling to the dimension.",
+      "type": "number"
+    },
+    "has_skylight": {
+      "title": "Has Skylight",
+      "description": "Whether the dimension has skylight access or not.",
+      "type": "boolean"
+    },
+    "has_ceiling": {
+      "title": "Has Ceiling",
+      "description": "Whether the dimension has a bedrock ceiling or not.",
+      "type": "boolean"
+    },
+    "ambient_light": {
+      "title": "Ambient Light",
+      "description": "How much light the dimension has.",
+      "type": "number",
+      "default": 0.5
+    },
+    "fixed_time": {
+      "title": "Fixed Time",
+      "description": "If this is set to a number, the time of the day is the specified value.",
+      "anyOf": [
+        {
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 24000
+        }
+      ]
+    },
+    "piglin_safe": {
+      "title": "Piglin Safe",
+      "description": "Whether piglins shake and transform to zombified piglins.",
+      "type": "boolean"
+    },
+    "bed_works": {
+      "title": "Bed Words",
+      "description": "When false, the bed blows up when trying to sleep.",
+      "type": "boolean"
+    },
+    "respawn_anchor_works": {
+      "title": "Respawn Anchor Works",
+      "description": "Whether players can charge and use respawn anchors.",
+      "type": "boolean"
+    },
+    "has_raids": {
+      "title": "Has Raids",
+      "description": "Whether players with the Bad Omen effect can cause a raid.",
+      "type": "boolean"
+    },
+    "logical_height": {
+      "title": "Logical Height",
+      "description": "The maximum height to which chorus fruits and nether portals can bring players within this dimension. This excludes portals that were already built above the limit as they still connect normally.",
+      "type": "integer"
+    },
+    "min_y": {
+      "title": "Minimum Y",
+      "description": "The minimum height in which blocks can exist within this dimension.",
+      "type": "integer",
+      "minimum": -2032,
+      "maximum": 2031,
+      "multipleOf": 16
+    },
+    "height": {
+      "title": "Height",
+      "description": "The total height in which blocks can exist within this dimension.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4096,
+      "multipleOf": 16
+    },
+    "infiniburn": {
+      "title": "Infiniburn",
+      "description": "A resource location defining what block tag to use for infiniburn.",
+      "type": "string"
+    },
+    "effects": {
+      "title": "Effects",
+      "description": "Determines the dimension effect used for this dimension.",
+      "type": "string",
+      "enum": [
+        "minecraft:overworld",
+        "minecraft:the_nether",
+        "minecraft:the_end"
+      ],
+      "default": "minecraft:overworld"
+    }
+  }
+}

--- a/src/schemas/json/minecraft-dimension.json
+++ b/src/schemas/json/minecraft-dimension.json
@@ -1,0 +1,534 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Custom_dimension#Dimension_syntax",
+  "title": "Minecraft Data Pack Dimension",
+  "description": "Configuration file defining a dimension for a data pack for Minecraft.",
+  "type": "object",
+  "definitions": {
+    "noise": {
+      "type": "object",
+      "properties": {
+        "firstOctave": {
+          "title": "First Octave",
+          "description": "The lower the value, the smoother the changes in altitude will be, making biome edges smoother.",
+          "type": "integer",
+          "default": -7
+        },
+        "amplitudes": {
+          "title": "Amplitudes",
+          "description": "A list of floats. Using more values allows for greater precision. Higher absolute values seem to make the altitude reach greater absolute values.",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "default": [1, 1]
+        }
+      }
+    },
+    "dimensionType": {
+      "$comment": "https://minecraft.fandom.com/wiki/Custom_dimension#Dimension_type",
+      "title": "Minecraft Data Pack Dimension Type",
+      "description": "Configuration file defining a dimension type for a data pack for Minecraft.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The resource location used for the dimension type.",
+          "type": "string"
+        },
+        "ultrawarm": {
+          "title": "Ultrawarm",
+          "description": "Whether the dimensions behaves like the nether (water evaporates and sponges dry) or not. Also lets stalactites drip lava and causes lava to spread faster and thinner.",
+          "type": "boolean"
+        },
+        "natural": {
+          "title": "Natural",
+          "description": "When true, nether portals can spawn zombified piglins. When false, compasses spin randomly, and using a bed to set the respawn point or sleep, is disabled.",
+          "type": "boolean"
+        },
+        "coordinate_scale": {
+          "title": "Coordinate Scale",
+          "description": "The multiplier applied to coordinates when traveling to the dimension.",
+          "type": "number"
+        },
+        "has_skylight": {
+          "title": "Has Skylight",
+          "description": "Whether the dimension has skylight access or not.",
+          "type": "boolean"
+        },
+        "has_ceiling": {
+          "title": "Has Ceiling",
+          "description": "Whether the dimension has a bedrock ceiling or not.",
+          "type": "boolean"
+        },
+        "ambient_light": {
+          "title": "Ambient Light",
+          "description": "How much light the dimension has.",
+          "type": "number",
+          "default": 0.5
+        },
+        "fixed_time": {
+          "title": "Fixed Time",
+          "description": "If this is set to a number, the time of the day is the specified value.",
+          "anyOf": [
+            {
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 24000
+            }
+          ]
+        },
+        "piglin_safe": {
+          "title": "Piglin Safe",
+          "description": "Whether piglins shake and transform to zombified piglins.",
+          "type": "boolean"
+        },
+        "bed_works": {
+          "title": "Bed Words",
+          "description": "When false, the bed blows up when trying to sleep.",
+          "type": "boolean"
+        },
+        "respawn_anchor_works": {
+          "title": "Respawn Anchor Works",
+          "description": "Whether players can charge and use respawn anchors.",
+          "type": "boolean"
+        },
+        "has_raids": {
+          "title": "Has Raids",
+          "description": "Whether players with the Bad Omen effect can cause a raid.",
+          "type": "boolean"
+        },
+        "logical_height": {
+          "title": "Logical Height",
+          "description": "The maximum height to which chorus fruits and nether portals can bring players within this dimension. This excludes portals that were already built above the limit as they still connect normally.",
+          "type": "integer"
+        },
+        "min_y": {
+          "title": "Minimum Y",
+          "description": "The minimum height in which blocks can exist within this dimension.",
+          "type": "integer",
+          "minimum": -2032,
+          "maximum": 2031,
+          "multipleOf": 16
+        },
+        "height": {
+          "title": "Height",
+          "description": "The total height in which blocks can exist within this dimension.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4096,
+          "multipleOf": 16
+        },
+        "infiniburn": {
+          "title": "Infiniburn",
+          "description": "A resource location defining what block tag to use for infiniburn.",
+          "type": "string"
+        },
+        "effects": {
+          "title": "Effects",
+          "description": "Determines the dimension effect used for this dimension.",
+          "type": "string",
+          "enum": [
+            "minecraft:overworld",
+            "minecraft:the_nether",
+            "minecraft:the_end"
+          ],
+          "default": "minecraft:overworld"
+        }
+      }
+    }
+  },
+  "properties": {
+    "type": {
+      "title": "Type",
+      "description": "The namespaced ID of the dimension type.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "minecraft:overworld",
+            "minecraft:overworld_caves",
+            "minecraft:the_nether",
+            "minecraft:the_end"
+          ]
+        },
+        {
+          "$ref": "#/definitions/dimensionType"
+        }
+      ]
+    },
+    "generator": {
+      "title": "Generator",
+      "description": "Generation settings used for that dimension.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "The ID of the generator.",
+          "type": "string",
+          "enum": [
+            "minecraft:flat",
+            "minecraft:noise",
+            "minecraft:debug"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:flat"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "settings": {
+                "title": "Settings",
+                "description": "Superflat settings.",
+                "type": "object",
+                "properties": {
+                  "layers": {
+                    "title": "Layers",
+                    "description": "Layer settings.",
+                    "type": "array",
+                    "items": {
+                      "description": "A superflat layer. The first entry is the bottom layer, the last entry is the top layer.",
+                      "type": "object",
+                      "properties": {
+                        "height": {
+                          "title": "Height",
+                          "description": "The number of blocks in the layer.",
+                          "type": "integer"
+                        },
+                        "block": {
+                          "title": "Block",
+                          "description": "The block the layer is made of.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "biome": {
+                    "title": "Biome",
+                    "description": "The single biome of the world.",
+                    "type": "string"
+                  },
+                  "lakes": {
+                    "title": "Lakes",
+                    "description": "Whether or not to generate lakes. If set to true, then water and lava lakes generate often even in biomes where lakes don't normally generate. Lava lakes generate surrounded by different types of stone and ores from the overworld.",
+                    "type": "boolean"
+                  },
+                  "features": {
+                    "title": "Features",
+                    "description": "Whether or not to generate biome-specific decorations like trees, grass, flowers, cacti, etc.",
+                    "type": "boolean"
+                  },
+                  "structures": {
+                    "title": "Structures",
+                    "description": "Structure settings.",
+                    "type": "object",
+                    "properties": {
+                      "stronghold": {
+                        "title": "Stronghold",
+                        "description": "Settings for how strongholds should be spawned.",
+                        "type": "object",
+                        "properties": {
+                          "distance": {
+                            "title": "Distance",
+                            "description": "Controls how far apart the strongholds are.",
+                            "type": "integer"
+                          },
+                          "count": {
+                            "title": "Count",
+                            "description": "How many strongholds to generate.",
+                            "type": "integer"
+                          },
+                          "spread": {
+                            "title": "Spread",
+                            "type": "integer"
+                          }
+                        }
+                      },
+                      "structures": {
+                        "title": "Structures",
+                        "description": "Map of structures to use in this dimension.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "spacing": {
+                              "title": "Spacing",
+                              "description": "Average distance between two structure placement attempts of this type in chunks.",
+                              "type": "integer"
+                            },
+                            "seperation": {
+                              "title": "Seperation",
+                              "description": "Minimum distance between two structures of this type in chunks; must be less than spacing.",
+                              "type": "integer"
+                            },
+                            "salt": {
+                              "title": "Salt",
+                              "description": "A number that assists in randomization.",
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:noise"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "seed": {
+                "title": "Seed",
+                "description": "The seed used to generate the dimension. In most cases, this is exactly the same as the world seed, but can be different and the dimension generated is based upon this seed and not the world seed.",
+                "type": "integer"
+              },
+              "settings": {
+                "title": "Settings",
+                "description": "The noise settings used in the terrain generator. Can be set to a string to use a preset defined in the worldgen/noise_settings folder with a list of customized options.",
+                "type": [
+                  "string",
+                  "object"
+                ]
+              },
+              "biome_source": {
+                "title": "Biome Source",
+                "description": "Settings dictating which biomes and biome shapes.",
+                "type": "object",
+                "properties": {
+                  "seed": {
+                    "title": "Seed",
+                    "description": "The seed used for biome generation.",
+                    "type": "integer"
+                  },
+                  "biomes": {
+                    "title": "Biomes",
+                    "description": "A list of biome IDs to generate.",
+                    "type": "array"
+                  },
+                  "type": {
+                    "title": "Type",
+                    "description": "The type of biome generation.",
+                    "type": "string",
+                    "allOf": [
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "minecraft:vanilla_layered"
+                            }
+                          }
+                        },
+                        "then": {
+                          "description": "Default and large biome generation used in the overworld.",
+                          "properties": {
+                            "large_biomes": {
+                              "title": "Large Biomes",
+                              "description": "Whether the biomes are large.",
+                              "type": "boolean"
+                            },
+                            "legacy_biome_init_layer": {
+                              "title": "Legacy Biome Init Layer",
+                              "description": "Whether the world was default_1_1.",
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "minecraft:fixed"
+                            }
+                          }
+                        },
+                        "then": {
+                          "description": "A single biome.",
+                          "properties": {
+                            "biome": {
+                              "title": "Biome",
+                              "description": "The single biome to generate.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "minecraft:checkerboard"
+                            }
+                          }
+                        },
+                        "then": {
+                          "description": "A biome generation in which biomes are square (or close to square) and repeat along the diagonals.",
+                          "properties": {
+                            "biomes": {
+                              "title": "Biomes",
+                              "description": "A list of biomes that repeat along the diagonals.",
+                              "type": "array"
+                            },
+                            "scale": {
+                              "title": "Scale",
+                              "description": "Determines the size of the squares on an exponential scale.",
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 62
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "minecraft:multi_noise"
+                            }
+                          }
+                        },
+                        "then": {
+                          "description": "3D biome generation used in the nether.",
+                          "properties": {
+                            "altitude_noise": {
+                              "title": "Altitude Noise",
+                              "description": "How the altitude parameter is spread in the world.",
+                              "$ref": "#/definitions/noise"
+                            },
+                            "weirdness_noise": {
+                              "title": "Weirdness Noise",
+                              "description": "Similar to altitude_noise for the weirdness parameter.",
+                              "$ref": "#/definitions/noise"
+                            },
+                            "temperature_noise": {
+                              "title": "Temperature Noise",
+                              "description": "Similar to altitude_noise for the temperature parameter.",
+                              "$ref": "#/definitions/noise"
+                            },
+                            "humidity_noise": {
+                              "title": "Humidity Noise",
+                              "description": "Similar to altitude_noise for the humidity parameter.",
+                              "$ref": "#/definitions/noise"
+                            }
+                          },
+                          "anyOf": [
+                            {
+                              "properties": {
+                                "preset": {
+                                  "title": "Preset",
+                                  "description": "A preset of the set of biomes to be used.",
+                                  "type": "string",
+                                  "enum": [
+                                    "minecraft:nether"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "biomes": {
+                                  "title": "Biomes",
+                                  "description": "A list of biomes, including their likelihood.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "description": "A biome and its properties.",
+                                    "properties": {
+                                      "biome": {
+                                        "title": "Biome",
+                                        "description": "The biome.",
+                                        "type": "string"
+                                      },
+                                      "parameters": {
+                                        "title": "Parameters",
+                                        "description": "Represent optimal conditions for where the biome should be placed. These values do not affect the generation of terrain within biomes; they affect where the game chooses to place biomes.",
+                                        "type": "object",
+                                        "properties": {
+                                          "altitude": {
+                                            "title": "Altitude",
+                                            "description": "Used to place similar biomes near each other.",
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                          },
+                                          "weirdness": {
+                                            "title": "Weirdness",
+                                            "description": "Defines how weird the biome is going to appear next to other biomes.",
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                          },
+                                          "offset": {
+                                            "title": "Offset",
+                                            "description": " Similar to the other parameters but offset is 0 everywhere, thus setting this parameter nearer to 0 gives the biome a greater edge over others, all else being equal.",
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                          },
+                                          "temperature": {
+                                            "title": "Temperature",
+                                            "description": "Used to place similar biomes near each other. This is NOT the same as the temperature value listed on Biome, it does NOT affect rain/snow or the color of leaves and grass.",
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                          },
+                                          "humidity": {
+                                            "title": "Humidity",
+                                            "description": "Used to place similar biomes near each other.",
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "minecraft:the_end"
+                            }
+                          }
+                        },
+                        "then": {
+                          "description": "Biome generation used in the end with biome minecraft:the_end in the center and other end biomes around."
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/schemas/json/minecraft-item-modifier.json
+++ b/src/schemas/json/minecraft-item-modifier.json
@@ -1,0 +1,1041 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Item_modifier#JSON_structure",
+  "title": "Minecraft Data Pack Item Modifier",
+  "description": "Configuration file defining an item modifier for a data pack for Minecraft.",
+  "type": "array",
+  "definitions": {
+    "slotEnum": {
+      "enum": [
+        "mainhand",
+        "offhand",
+        "feet",
+        "legs",
+        "chest",
+        "head"
+      ]
+    },
+    "numberProvider": {
+      "$comment": "https://minecraft.fandom.com/wiki/Loot_table#Number_Providers",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "The number provider type.",
+          "type": "string",
+          "enum": [
+            "minecraft:constant",
+            "minecraft:uniform",
+            "minecraft:binomial",
+            "minecraft:score"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:constant"
+              }
+            }
+          },
+          "then": {
+            "description": "A constant value.",
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The exact value.",
+                "type": "number"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:uniform"
+              }
+            }
+          },
+          "then": {
+            "description": "A random number following a uniform distribution between two values (inclusive).",
+            "properties": {
+              "min": {
+                "title": "Minimum",
+                "description": "The minimum value.",
+                "type": [
+                  "number",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              },
+              "max": {
+                "title": "Max",
+                "description": "The maximum value.",
+                "type": [
+                  "number",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:binomial"
+              }
+            }
+          },
+          "then": {
+            "description": "A random number following a binomial distribution.",
+            "properties": {
+              "n": {
+                "title": "n",
+                "description": "The amount of trials.",
+                "type": [
+                  "integer",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              },
+              "p": {
+                "title": "p",
+                "description": "The probability of success on an individual trial.",
+                "$ref": "#/definitions/numberProvider"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:score"
+              }
+            }
+          },
+          "then": {
+            "description": "A scoreboard value.",
+            "properties": {
+              "target": {
+                "title": "Target",
+                "description": "Scoreboard name provider.",
+                "type": [
+                  "string",
+                  "object"
+                ],
+                "enum": [
+                  "this",
+                  "killer",
+                  "direct_killer",
+                  "player_killer"
+                ],
+                "properties": {
+                  "type": {
+                    "title": "Type",
+                    "description": "Resource location.",
+                    "type": "string",
+                    "enum": [
+                      "fixed",
+                      "context"
+                    ]
+                  }
+                },
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "fixed"
+                        }
+                      }
+                    },
+                    "then": {
+                      "properties": {
+                        "name": {
+                          "title": "Name",
+                          "description": "A UUID or player name.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "context"
+                        }
+                      }
+                    },
+                    "then": {
+                      "properties": {
+                        "target": {
+                          "title": "Target",
+                          "type": "string",
+                          "enum": [
+                            "this",
+                            "killer",
+                            "direct_killer",
+                            "player_killer"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "score": {
+                "title": "Score",
+                "description": "The scoreboard objective.",
+                "type": "string"
+              },
+              "scale": {
+                "title": "Scale",
+                "description": "Scale to multiply the score before returning it.",
+                "type": "number"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "items": {
+    "properties": {
+      "function": {
+        "title": "Function",
+        "description": "Namespaced ID of the function to apply.",
+        "type": "string",
+        "enum": [
+          "minecraft:apply_bonus",
+          "minecraft:copy_name",
+          "minecraft:copy_nbt",
+          "minecraft:copy_state",
+          "minecraft:enchant_randomly",
+          "minecraft:enchant_with_levels",
+          "minecraft:exploration_map",
+          "minecraft:explosion_decay",
+          "minecraft:furnace_smelt",
+          "minecraft:fill_player_head",
+          "minecraft:limit_count",
+          "minecraft:looting_enchant",
+          "minecraft:set_attributes",
+          "minecraft:set_banner_pattern",
+          "minecraft:set_contents",
+          "minecraft:set_count",
+          "minecraft:set_damage",
+          "minecraft:set_enchantments",
+          "minecraft:set_loot_table",
+          "minecraft:set_lore",
+          "minecraft:set_name",
+          "minecraft:set_nbt",
+          "minecraft:set_stew_effect"
+        ]
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:apply_bonus"
+            }
+          }
+        },
+        "then": {
+          "description": "Applies a predefined bonus formula.",
+          "type": "object",
+          "properties": {
+            "enchantment": {
+              "title": "Enchantment",
+              "description": "Enchantment ID used for level calculation.",
+              "type": "string"
+            },
+            "formula": {
+              "title": "Forumla",
+              "type": "string",
+              "enum": [
+                "binomial_with_bonus_count",
+                "uniform_bonus_count",
+                "ore_drops"
+              ]
+            },
+            "parameters": {
+              "title": "Parameters",
+              "description": "Values required for the formula.",
+              "type": "object",
+              "properties": {
+                "extra": {
+                  "title": "Extra",
+                  "description": "For formula 'binomial_with_bonus_count', the extra value.",
+                  "type": "integer"
+                },
+                "probability": {
+                  "title": "Probability",
+                  "description": "For formula 'binomial_with_bonus_count', the probability.",
+                  "type": "number"
+                },
+                "bonusMultiplier": {
+                  "title": "Bonus Multiplier",
+                  "description": "For formula 'uniform_bonus_count', the bonus multiplier.",
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:copy_name"
+            }
+          }
+        },
+        "then": {
+          "description": "For loot table type 'block', copies a block entity's CustomName tag into the item's display.",
+          "type": "object",
+          "properties": {
+            "source": {
+              "title": "Source",
+              "type": "string",
+              "enum": [
+                "block_entity"
+              ],
+              "default": "block_entity"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:copy_nbt"
+            }
+          }
+        },
+        "then": {
+          "description": "Copies NBT to the item.",
+          "type": "object",
+          "properties": {
+            "source": {
+              "title": "Source",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "block_entity",
+                    "this",
+                    "killer",
+                    "killer_player"
+                  ]
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "title": "Type",
+                      "description": "NBT provider type.",
+                      "type": "string",
+                      "enum": [
+                        "minecraft:context",
+                        "minecraft:storage"
+                      ]
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "if": {
+                        "properties": {
+                          "type": {
+                            "const": "minecraft:context"
+                          }
+                        }
+                      },
+                      "then": {
+                        "properties": {
+                          "target": {
+                            "title": "Target",
+                            "description": "Same as source above.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "if": {
+                        "properties": {
+                          "type": {
+                            "const": "minecraft:storage"
+                          }
+                        }
+                      },
+                      "then": {
+                        "properties": {
+                          "target": {
+                            "title": "Source",
+                            "description": "A resource location specifying the storage ID.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "ops": {
+              "title": "Operations",
+              "description": "A list of copy operations.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "title": "Source",
+                    "description": "The NBT path to copy from.",
+                    "type": "string"
+                  },
+                  "target": {
+                    "title": "Target",
+                    "description": "The NBT path to copy to, starting from the item's tag tag.",
+                    "type": "string"
+                  },
+                  "op": {
+                    "title": "Operation",
+                    "description": "Can be replace to replace any existing contents of the target, append to append to a list, or merge to merge into a compound tag.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:copy_state"
+            }
+          }
+        },
+        "then": {
+          "description": "Copies state properties from dropped block to the item's BlockStateTag tag.",
+          "properties": {
+            "block": {
+              "title": "Block",
+              "description": "A block ID. Function fails if the block doesn't match.",
+              "type": "string"
+            },
+            "properties": {
+              "title": "Properties",
+              "description": "A list of property names to copy.",
+              "type": "array",
+              "items": {
+                "title": "Property",
+                "description": "A block state name to copy.",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:enchant_randomly"
+            }
+          }
+        },
+        "then": {
+          "description": "Enchants the item with one randomly-selected enchantment. The level of the enchantment, if applicable, is random.",
+          "properties": {
+            "enchantments": {
+              "title": "Enchantments",
+              "description": "List of enchantment IDs to choose from.",
+              "type": "array"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:enchant_with_levels"
+            }
+          }
+        },
+        "then": {
+          "description": "Enchants the item, with the specified enchantment level (roughly equivalent to using an enchantment table at that level).",
+          "properties": {
+            "treasure": {
+              "title": "Treasure",
+              "description": "Determines whether treasure enchantments are allowed on this item.",
+              "type": "boolean"
+            },
+            "levels": {
+              "title": "Levels",
+              "description": "Specifies the exact enchantment level to use.",
+              "type": [
+                "integer",
+                "object"
+              ],
+              "$ref": "#/definitions/numberProvider"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:exploration_map"
+            }
+          }
+        },
+        "then": {
+          "description": "Converts an empty map into an explorer map leading to a nearby generated structure.",
+          "properties": {
+            "destination": {
+              "title": "Destination",
+              "description": "The type of generated structure to locate. Accepts any of the StructureTypes used by the /locate command (case insensitive).",
+              "type": "string"
+            },
+            "decoration": {
+              "title": "Decoration",
+              "description": "The icon used to mark the destination on the map. Accepts any of the map icon text IDs (case insensitive).",
+              "type": "string"
+            },
+            "zoom": {
+              "title": "Zoom",
+              "description": "The zoom level of the resulting map.",
+              "type": "integer",
+              "default": 2
+            },
+            "search_radius": {
+              "title": "Search Radius",
+              "description": "The size, in chunks, of the area to search for structures. The area checked is square, not circular.",
+              "type": "integer",
+              "default": 50
+            },
+            "skip_existing_chunks": {
+              "title": "Skip Existing Chunks",
+              "description": "Don't search in chunks that have already been generated.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:explosion_decay"
+            }
+          }
+        },
+        "then": {
+          "description": "For loot tables of type 'block', removes some items from a stack, if there was an explosion. Each item has a chance of 1/explosion radius to be lost."
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:furnace_smelt"
+            }
+          }
+        },
+        "then": {
+          "description": "Smelts the item as it would be in a furnace. Used in combination with the entity_properties condition to cook food from animals on death."
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:fill_player_head"
+            }
+          }
+        },
+        "then": {
+          "description": "Adds required item tags of a player head.",
+          "properties": {
+            "entity": {
+              "title": "Entity",
+              "description": "Specifies an entity to be used for the player head.",
+              "type": "string"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:limit_count"
+            }
+          }
+        },
+        "then": {
+          "description": "Limits the count of every item stack.",
+          "properties": {
+            "limit": {
+              "title": "Limit",
+              "description": "Specifies the exact limit to use.",
+              "type": [
+                "integer",
+                "object"
+              ],
+              "$ref": "#/definitions/numberProvider",
+              "properties": {
+                "min": {
+                  "title": "Minimum",
+                  "description": "Minimum limit to use.",
+                  "type": [
+                    "integer",
+                    "object"
+                  ],
+                  "$ref": "#/definitions/numberProvider"
+                },
+                "max": {
+                  "title": "Max",
+                  "description": "Max limit to use.",
+                  "type": [
+                    "integer",
+                    "object"
+                  ],
+                  "$ref": "#/definitions/numberProvider"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:looting_enchant"
+            }
+          }
+        },
+        "then": {
+          "description": "Adjusts the stack size based on the level of the Looting enchantment on the killer entity.",
+          "properties": {
+            "count": {
+              "title": "Count",
+              "description": "Specifies the number of additional items per level of looting.",
+              "type": [
+                "integer",
+                "object"
+              ],
+              "$ref": "#/definitions/numberProvider"
+            },
+            "limit": {
+              "title": "Limit",
+              "description": "Specifies the maximum amount of items in the stack after the looting calculation. If the value is 0, no limit is applied.",
+              "type": "integer"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_attributes"
+            }
+          }
+        },
+        "then": {
+          "description": "Add attribute modifiers to the item.",
+          "properties": {
+            "modifiers": {
+              "title": "Modifiers",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "properties": {
+                    "name": {
+                      "title": "Name",
+                      "description": "Name of the modifer.",
+                      "type": "string"
+                    },
+                    "attribute": {
+                      "title": "Attribute",
+                      "description": "The name of the attribute this modifer is to act upon.",
+                      "type": "string"
+                    },
+                    "operation": {
+                      "title": "Operation",
+                      "type": "string",
+                      "enum": [
+                        "addition",
+                        "multiply_base",
+                        "multiply_total"
+                      ]
+                    },
+                    "amount": {
+                      "title": "Amount",
+                      "description": "Specifies the amount of the modifier.",
+                      "type": [
+                        "number",
+                        "object"
+                      ],
+                      "$ref": "#/definitions/numberProvider"
+                    },
+                    "id": {
+                      "title": "ID",
+                      "description": "UUID of the modifier following.",
+                      "type": "string"
+                    },
+                    "slot": {
+                      "title": "Slot",
+                      "description": "Slots the item must be in for the modifier to take effect.",
+                      "type": [
+                        "string",
+                        "array"
+                      ],
+                      "$ref": "#/definitions/slotEnum",
+                      "items": {
+                        "type": "string",
+                        "$ref": "#/definitions/slotEnum"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_banner_pattern"
+            }
+          }
+        },
+        "then": {
+          "description": "Sets tags needed for banner patterns.",
+          "properties": {
+            "patterns": {
+              "title": "Patterns",
+              "description": "List of patterns.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "pattern": {
+                      "title": "Pattern",
+                      "description": "The pattern type.",
+                      "type": "string"
+                    },
+                    "color": {
+                      "title": "Color",
+                      "description": "The color for this pattern.",
+                      "type": "string",
+                      "enum": [
+                        "white",
+                        "orange",
+                        "magenta",
+                        "light_blue",
+                        "yellow",
+                        "lime",
+                        "pink",
+                        "gray",
+                        "light_gray",
+                        "cyan",
+                        "purple",
+                        "blue",
+                        "brown",
+                        "green",
+                        "red",
+                        "black"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "append": {
+              "title": "Append",
+              "description": "If true, new patterns will be appended to existing ones.",
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_contents"
+            }
+          }
+        },
+        "then": {
+          "description": "For loot tables of type 'block', sets the contents of a container block item to a list of entries.",
+          "properties": {
+            "entries": {
+              "title": "Entries",
+              "description": "The entries to use as contents.",
+              "type": "array"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_count"
+            }
+          }
+        },
+        "then": {
+          "description": "Sets the stack size.",
+          "properties": {
+            "count": {
+              "title": "Count",
+              "description": "Specifies the stack size to set.",
+              "type": [
+                "integer",
+                "object"
+              ],
+              "$ref": "#/definitions/numberProvider"
+            },
+            "add": {
+              "title": "Add",
+              "description": "If true, change will be relative to the current count.",
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_damage"
+            }
+          }
+        },
+        "then": {
+          "description": "Sets the item's damage value (durability) for tools.",
+          "properties": {
+            "damage": {
+              "title": "Damage",
+              "description": "Specifies the damage fraction to set (1.0 is undamaged, 0.0 is zero durability left).",
+              "type": [
+                "number",
+                "object"
+              ],
+              "$ref": "#/definitions/numberProvider"
+            },
+            "add": {
+              "title": "Add",
+              "description": "If true, change will be relative to current damage.",
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_enchantments"
+            }
+          }
+        },
+        "then": {
+          "description": "Sets the item's enchantments.",
+          "properties": {
+            "enchantments": {
+              "title": "Enchantments",
+              "description": "Enchantments to add.",
+              "type": "object",
+              "additionalProperties": {
+                "description": "Key name is the enchantment ID.",
+                "type": [
+                  "integer",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              }
+            },
+            "add": {
+              "title": "Add",
+              "description": "If true, change will be relative to current level.",
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_loot_table"
+            }
+          }
+        },
+        "then": {
+          "description": "Sets the loot table for a container (chest etc.).",
+          "properties": {
+            "name": {
+              "title": "Name",
+              "description": "Specifies the resource location of the loot table to be used.",
+              "type": "string"
+            },
+            "seed": {
+              "title": "Seed",
+              "description": "Specifies the loot table seed. If absent or set to 0, a random seed will be used.",
+              "type": "integer"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_lore"
+            }
+          }
+        },
+        "then": {
+          "description": "Adds lore to the item.",
+          "properties": {
+            "lore": {
+              "title": "Lore",
+              "description": "List of JSON text components. Each list entry represents one line of the lore. Advanced components are resolved only if entity successfully targets an entity.",
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "entity": {
+              "title": "Entity",
+              "description": "Specifies the entity to act as the source @s in the JSON text component.",
+              "type": "string"
+            },
+            "replace": {
+              "title": "Replace",
+              "description": "If true, replaces all existing lines of lore, if false appends the list.",
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_name"
+            }
+          }
+        },
+        "then": {
+          "description": "Adds display name of the item.",
+          "properties": {
+            "name": {
+              "title": "Name",
+              "description": "A JSON text component name, allowing color, translations, etc. Advanced components are resolved only if entity successfully targets an entity.",
+              "type": [
+                "array",
+                "object",
+                "string"
+              ]
+            },
+            "entity": {
+              "title": "Entity",
+              "description": "Specifies an entity to act as source @s in the JSON text component.",
+              "type": "string"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_nbt"
+            }
+          }
+        },
+        "then": {
+          "description": "Adds NBT data to the item.",
+          "properties": {
+            "tag": {
+              "title": "Tag",
+              "description": "Tag string to add, similar to those used by commands. Note that the first bracket is required and quotation marks need to be escaped using a backslash (\\).",
+              "type": "string"
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "function": {
+              "const": "minecraft:set_stew_effect"
+            }
+          }
+        },
+        "then": {
+          "description": "Sets the status effects for suspicious stew.",
+          "properties": {
+            "effects": {
+              "title": "Effects",
+              "description": "The effects to apply.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "title": "Type",
+                      "description": "The effect ID.",
+                      "type": "string"
+                    },
+                    "duration": {
+                      "title": "Duration",
+                      "description": "The duration of the effect.",
+                      "type": [
+                        "integer",
+                        "object"
+                      ],
+                      "$ref": "#/definitions/numberProvider"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/schemas/json/minecraft-loot-table.json
+++ b/src/schemas/json/minecraft-loot-table.json
@@ -1,0 +1,449 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Loot_table",
+  "title": "Minecraft Data Pack Loot Table",
+  "description": "Configuration file defining a loot table for a data pack for Minecraft.",
+  "definitions": {
+    "numberProvider": {
+      "$comment": "https://minecraft.fandom.com/wiki/Loot_table#Number_Providers",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "The number provider type.",
+          "type": "string",
+          "enum": [
+            "minecraft:constant",
+            "minecraft:uniform",
+            "minecraft:binomial",
+            "minecraft:score"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:constant"
+              }
+            }
+          },
+          "then": {
+            "description": "A constant value.",
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The exact value.",
+                "type": "number"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:uniform"
+              }
+            }
+          },
+          "then": {
+            "description": "A random number following a uniform distribution between two values (inclusive).",
+            "properties": {
+              "min": {
+                "title": "Minimum",
+                "description": "The minimum value.",
+                "type": [
+                  "number",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              },
+              "max": {
+                "title": "Max",
+                "description": "The maximum value.",
+                "type": [
+                  "number",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:binomial"
+              }
+            }
+          },
+          "then": {
+            "description": "A random number following a binomial distribution.",
+            "properties": {
+              "n": {
+                "title": "n",
+                "description": "The amount of trials.",
+                "type": [
+                  "integer",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              },
+              "p": {
+                "title": "p",
+                "description": "The probability of success on an individual trial.",
+                "$ref": "#/definitions/numberProvider"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:score"
+              }
+            }
+          },
+          "then": {
+            "description": "A scoreboard value.",
+            "properties": {
+              "target": {
+                "title": "Target",
+                "description": "Scoreboard name provider.",
+                "type": [
+                  "string",
+                  "object"
+                ],
+                "enum": [
+                  "this",
+                  "killer",
+                  "direct_killer",
+                  "player_killer"
+                ],
+                "properties": {
+                  "type": {
+                    "title": "Type",
+                    "description": "Resource location.",
+                    "type": "string",
+                    "enum": [
+                      "fixed",
+                      "context"
+                    ]
+                  }
+                },
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "fixed"
+                        }
+                      }
+                    },
+                    "then": {
+                      "properties": {
+                        "name": {
+                          "title": "Name",
+                          "description": "A UUID or player name.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "context"
+                        }
+                      }
+                    },
+                    "then": {
+                      "properties": {
+                        "target": {
+                          "title": "Target",
+                          "type": "string",
+                          "enum": [
+                            "this",
+                            "killer",
+                            "direct_killer",
+                            "player_killer"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "score": {
+                "title": "Score",
+                "description": "The scoreboard objective.",
+                "type": "string"
+              },
+              "scale": {
+                "title": "Scale",
+                "description": "Scale to multiply the score before returning it.",
+                "type": "number"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "properties": {
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "enum": [
+        "minecraft:empty",
+        "empty",
+        "minecraft:entity",
+        "entity",
+        "minecraft:block",
+        "block",
+        "minecraft:chest",
+        "chest",
+        "minecraft:fishing",
+        "fishing",
+        "minecraft:gift",
+        "gift",
+        "minecraft:advancement_reward",
+        "advancement_reward",
+        "minecraft:barter",
+        "barter",
+        "minecraft:command",
+        "command",
+        "minecraft:selector",
+        "selector",
+        "minecraft:advancement_entity",
+        "advancement_entity",
+        "minecraft:generic",
+        "generic"
+      ]
+    },
+    "functions": {
+      "title": "Functions",
+      "description": " Applies functions to all item stacks produced by this table. Functions are applied in order, so for example looting_enchant must be after set_count to work correctly.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": {
+          "description": "A function.",
+          "type": "object",
+          "properties": {
+            "function": {
+              "title": "Function",
+              "description": "Namespaced ID of the function to apply.",
+              "type": "string"
+            },
+            "conditions": {
+              "title": "Conditions",
+              "description": "Determines conditions for this function to be applied. If multiple conditions are specified, all must pass.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "description": "A function.",
+                  "type": "object",
+                  "properties": {
+                    "condition": {
+                      "title": "Condition",
+                      "description": "Namespaced ID of condition.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "pools": {
+      "title": "Pools",
+      "description": "A list of all pools for this loot table. Each pool used generates items from its list of items based on the number of rolls. Pools are applied in order.",
+      "type": "array",
+      "items": {
+        "description": "A pool.",
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "title": "Conditions",
+            "description": "Determines conditions for this pool to be used. If multiple conditions are specified, all must pass.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "description": "A condition.",
+                "properties": {
+                  "condition": {
+                    "title": "Condition",
+                    "description": "Namespaced ID of condition.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "functions": {
+            "title": "Functions",
+            "description": "Applies functions to all item stacks produced by this pool. Functions are applied in order, so for example looting_enchant must be after set_count to work correctly.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "description": "A function.",
+                "properties": {
+                  "function": {
+                    "title": "Function",
+                    "description": "Namespaced ID of the function to apply.",
+                    "type": "string"
+                  },
+                  "conditions": {
+                    "title": "Conditions",
+                    "description": "Determines conditions for this function to be applied. If multiple conditions are specified, all must pass.",
+                    "type": "array",
+                    "items": {
+                      "description": "A condition.",
+                      "type": "object",
+                      "properties": {
+                        "condition": {
+                          "title": "Condition",
+                          "description": "Namespaced ID of condition.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "rolls": {
+            "title": "Rolls",
+            "description": "Specifies the number of rolls on the pool.",
+            "type": [
+              "integer",
+              "object"
+            ],
+            "$ref": "#/definitions/numberProvider"
+          },
+          "bonus_rolls": {
+            "title": "Bonus Rolls",
+            "description": "Specifies the number of bonus rolls on the pool per point of luck. Rounded down after multiplying.",
+            "type": [
+              "number",
+              "object"
+            ],
+            "$ref": "#/definitions/numberProvider"
+          },
+          "entries": {
+            "title": "Entries",
+            "description": "A list of all things that can be produced by this pool. One entry is chosen per roll as a weighted random selection from all entries without failing conditions.",
+            "type": "array",
+            "items": {
+              "description": "An entry.",
+              "type": "object",
+              "properties": {
+                "conditions": {
+                  "title": "Conditions",
+                  "description": "Determines conditions for this entry to be used. If multiple conditions are specified, all must pass.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "description": "A condition.",
+                      "properties": {
+                        "condition": {
+                          "title": "Condition",
+                          "description": "Namespaced ID of condition.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "functions": {
+                  "title": "Functions",
+                  "description": "Applies functions to the item stack or item stacks being produced. Functions are applied in order, so for example looting_enchant must be after set_count to work correctly.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "description": "A function.",
+                      "properties": {
+                        "function": {
+                          "title": "Function",
+                          "description": "Namespaced ID of the function to apply.",
+                          "type": "string"
+                        },
+                        "conditions": {
+                          "title": "Conditions",
+                          "description": "Determines conditions for this function to be applied. If multiple conditions are specified, all must pass.",
+                          "type": "array",
+                          "items": {
+                            "description": "A condition.",
+                            "type": "object",
+                            "properties": {
+                              "condition": {
+                                "title": "Condition",
+                                "description": "Namespaced ID of condition.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": {
+                  "title": "Type",
+                  "description": "Namespaced ID type of entry.",
+                  "type": "string",
+                  "enum": [
+                    "minecraft:item",
+                    "minecraft:tag",
+                    "minecraft:loot_table",
+                    "minecraft:group",
+                    "minecraft:alternatives",
+                    "minecraft:sequence",
+                    "minecraft:dynamic",
+                    "minecraft:empty"
+                  ]
+                },
+                "name": {
+                  "title": "Name",
+                  "type": "string"
+                },
+                "children": {
+                  "title": "Children",
+                  "type": "array"
+                },
+                "expand": {
+                  "title": "Expand",
+                  "description": "For type 'tag', if set to true, it chooses one item of the tag, each with the same weight and quality. If false, it generates one of each of the items in the tag.",
+                  "type": "boolean"
+                },
+                "weight": {
+                  "title": "Weight",
+                  "description": "Determines how often this entry is chosen out of all the entries in the pool. Entries with higher weights are used more often (chance is this entry's weight⁄total of all considered entries' weights).",
+                  "type": "integer"
+                },
+                "quality": {
+                  "title": "Quality",
+                  "description": "Modifies the entry's weight based on the killing/opening/fishing player's luck attribute. Formula is floor( weight + (quality * generic.luck)).",
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Data_Pack",
+  "title": "Minecraft Data Pack Metadata",
+  "description": "Configuration file defining the metadata of a data pack for Minecraft.",
+  "type": "object",
+  "properties": {
+    "pack": {
+      "title": "Pack",
+      "type": "object",
+      "properties": {
+        "pack_format": {
+          "title": "Pack Format",
+          "type": "number"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/minecraft-predicate.json
+++ b/src/schemas/json/minecraft-predicate.json
@@ -1,0 +1,1300 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Predicate",
+  "title": "Minecraft Data Pack Predicate",
+  "description": "Configuration file defining a predicate for a data pack for Minecraft.",
+  "type": "object",
+  "definitions": {
+    "numberRange": {
+      "type": "object",
+      "properties": {
+        "max": {
+          "title": "Max",
+          "description": "The max value.",
+          "type": "number"
+        },
+        "min": {
+          "title": "Minimum",
+          "description": "The minimum value.",
+          "type": "number"
+        }
+      }
+    },
+    "integerRange": {
+      "properties": {
+        "max": {
+          "title": "Max",
+          "description": "The max value.",
+          "type": [
+            "integer",
+            "object"
+          ],
+          "$ref": "#/definitions/numberProvider"
+        },
+        "min": {
+          "title": "Minimum",
+          "description": "The minimum value.",
+          "type": [
+            "integer",
+            "object"
+          ],
+          "$ref": "#/definitions/numberProvider"
+        }
+      }
+    },
+    "numberProvider": {
+      "$comment": "https://minecraft.fandom.com/wiki/Loot_table#Number_Providers",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "The number provider type.",
+          "type": "string",
+          "enum": [
+            "minecraft:constant",
+            "minecraft:uniform",
+            "minecraft:binomial",
+            "minecraft:score"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:constant"
+              }
+            }
+          },
+          "then": {
+            "description": "A constant value.",
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The exact value.",
+                "type": "number"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:uniform"
+              }
+            }
+          },
+          "then": {
+            "description": "A random number following a uniform distribution between two values (inclusive).",
+            "properties": {
+              "min": {
+                "title": "Minimum",
+                "description": "The minimum value.",
+                "type": [
+                  "number",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              },
+              "max": {
+                "title": "Max",
+                "description": "The maximum value.",
+                "type": [
+                  "number",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:binomial"
+              }
+            }
+          },
+          "then": {
+            "description": "A random number following a binomial distribution.",
+            "properties": {
+              "n": {
+                "title": "n",
+                "description": "The amount of trials.",
+                "type": [
+                  "integer",
+                  "object"
+                ],
+                "$ref": "#/definitions/numberProvider"
+              },
+              "p": {
+                "title": "p",
+                "description": "The probability of success on an individual trial.",
+                "$ref": "#/definitions/numberProvider"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "minecraft:score"
+              }
+            }
+          },
+          "then": {
+            "description": "A scoreboard value.",
+            "properties": {
+              "target": {
+                "title": "Target",
+                "description": "Scoreboard name provider.",
+                "type": [
+                  "string",
+                  "object"
+                ],
+                "enum": [
+                  "this",
+                  "killer",
+                  "direct_killer",
+                  "player_killer"
+                ],
+                "properties": {
+                  "type": {
+                    "title": "Type",
+                    "description": "Resource location.",
+                    "type": "string",
+                    "enum": [
+                      "fixed",
+                      "context"
+                    ]
+                  }
+                },
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "fixed"
+                        }
+                      }
+                    },
+                    "then": {
+                      "properties": {
+                        "name": {
+                          "title": "Name",
+                          "description": "A UUID or player name.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "type": {
+                          "const": "context"
+                        }
+                      }
+                    },
+                    "then": {
+                      "properties": {
+                        "target": {
+                          "title": "Target",
+                          "type": "string",
+                          "enum": [
+                            "this",
+                            "killer",
+                            "direct_killer",
+                            "player_killer"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "score": {
+                "title": "Score",
+                "description": "The scoreboard objective.",
+                "type": "string"
+              },
+              "scale": {
+                "title": "Scale",
+                "description": "Scale to multiply the score before returning it.",
+                "type": "number"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "enchantments": {
+      "type": "array",
+      "items": {
+        "title": "Enchantment",
+        "type": "object",
+        "properties": {
+          "enchantment": {
+            "title": "Enchantment",
+            "description": "An enchantment ID.",
+            "type": "string"
+          },
+          "levels": {
+            "title": "Levels",
+            "description": "The level of the enchantment.",
+            "type": [
+              "integer",
+              "object"
+            ],
+            "$ref": "#/definitions/integerRange"
+          }
+        }
+      }
+    },
+    "tagsCommonToAllDamageTypes": {
+      "type": "object",
+      "properties": {
+        "bypasses_armor": {
+          "title": "Bypasses Armor",
+          "description": "Checks if the damage bypassed the armor of the player (suffocation damage predominantly).",
+          "type": "boolean"
+        },
+        "bypasses_invulnerability": {
+          "title": "Bypasses Invulnerability",
+          "description": "Checks if the damage bypassed the invulnerability status of the player (void or /kill damage).",
+          "type": "boolean"
+        },
+        "bypasses_magic": {
+          "title": "Bypasses Magic",
+          "description": "Checks if the damage was caused by starvation.",
+          "type": "boolean"
+        },
+        "direct_entity": {
+          "title": "Direct Entity",
+          "description": "The entity that was the direct cause of the damage.",
+          "type": "object"
+        },
+        "is_explosion": {
+          "title": "Is Explosion",
+          "description": "Checks if the damage originated from an explosion.",
+          "type": "boolean"
+        },
+        "is_fire": {
+          "title": "Is Fire",
+          "description": "Checks if the damage originated from fire.",
+          "type": "boolean"
+        },
+        "is_magic": {
+          "title": "Is Magic",
+          "description": "Checks if the damage originated from magic.",
+          "type": "boolean"
+        },
+        "is_projectile": {
+          "title": "Is Projectile",
+          "description": "Checks if the damage originated from a projectile.",
+          "type": "boolean"
+        },
+        "is_lightning": {
+          "title": "Is Lightning",
+          "description": "Checks if the damage originated from lightning.",
+          "type": "boolean"
+        },
+        "source_entity": {
+          "title": "Source Entity",
+          "description": "Checks the entity that was the source of the damage (for example: The skeleton that shot the arrow).",
+          "$ref": "#/definitions/tagsCommonToAllEntities"
+        }
+      }
+    },
+    "tagsCommonToAllItems": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Count",
+          "description": "The amount of the item.",
+          "type": [
+            "integer",
+            "object"
+          ],
+          "$ref": "#/definitions/integerRange"
+        },
+        "durability": {
+          "title": "Durability",
+          "description": "The durability of the item.",
+          "type": [
+            "integer",
+            "object"
+          ],
+          "$ref": "#/definitions/integerRange"
+        },
+        "enchantments": {
+          "title": "Enchantments",
+          "description": "List of enchantments.",
+          "$ref": "#/definitions/enchantments"
+        },
+        "stored_enchantments": {
+          "title": "Stored Enchantments",
+          "description": "List of stored enchantments.",
+          "$ref": "#/definitions/enchantments"
+        },
+        "items": {
+          "title": "Items",
+          "description": "List of item IDs.",
+          "type": "array"
+        },
+        "nbt": {
+          "title": "NBT",
+          "description": "An NBT string.",
+          "type": "string"
+        },
+        "potion": {
+          "title": "Potion",
+          "description": "A brewed potion ID.",
+          "type": "string"
+        },
+        "tag": {
+          "title": "Tag",
+          "description": "An item data pack tag.",
+          "type": "string"
+        }
+      }
+    },
+    "tagsCommonToAllLocations": {
+      "type": "object",
+      "properties": {
+        "biome": {
+          "title": "Biome",
+          "description": "The biome the entity is currently in.",
+          "type": "string",
+          "enum": [
+            "badlands",
+            "badlands_plateau",
+            "beach",
+            "birch_forest",
+            "birch_forest_hills",
+            "cold_ocean",
+            "dark_forest",
+            "dark_forest_hills",
+            "deep_cold_ocean",
+            "deep_frozen_ocean",
+            "deep_lukewarm_ocean",
+            "deep_ocean",
+            "deep_warm_ocean",
+            "desert",
+            "desert_hills",
+            "desert_lakes",
+            "end_barrens",
+            "end_highlands",
+            "end_midlands",
+            "eroded_badlands",
+            "flower_forest",
+            "forest",
+            "frozen_ocean",
+            "frozen_river",
+            "giant_spruce_taiga",
+            "giant_spruce_taiga_hills",
+            "giant_tree_taiga",
+            "giant_tree_taiga_hills",
+            "gravelly_mountains",
+            "ice_spikes",
+            "jungle",
+            "jungle_edge",
+            "jungle_hills",
+            "lukewarm_ocean",
+            "modified_badlands_plateau",
+            "modified_gravelly_mountains",
+            "modified_jungle",
+            "modified_jungle_edge",
+            "modified_wooded_badlands_plateau",
+            "mountain_edge",
+            "mountains",
+            "mushroom_field_shore",
+            "mushroom_fields",
+            "nether",
+            "ocean",
+            "plains",
+            "river",
+            "savanna",
+            "savanna_plateau",
+            "shattered_savanna",
+            "shattered_savanna_plateau",
+            "small_end_islands",
+            "snowy_beach",
+            "snowy_mountains",
+            "snowy_taiga",
+            "snowy_taiga_hills",
+            "snowy_taiga_mountains",
+            "snowy_tundra",
+            "stone_shore",
+            "sunflower_plains",
+            "swamp",
+            "swamp_hills",
+            "taiga",
+            "taiga_hills",
+            "taiga_mountains",
+            "tall_birch_forest",
+            "tall_birch_hills",
+            "the_end",
+            "the_void",
+            "warm_ocean",
+            "wooded_badlands_plateau",
+            "wooded_hills",
+            "wooded_mountains"
+          ]
+        },
+        "block": {
+          "title": "Block",
+          "description": "The block at the location.",
+          "type": "object",
+          "properties": {
+            "blocks": {
+              "title": "Blocks",
+              "description": "A list of block IDs.",
+              "type": "array"
+            },
+            "tag": {
+              "title": "Tag",
+              "description": "The block tag.",
+              "type": "string"
+            },
+            "nbt": {
+              "title": "NBT",
+              "description": "The block NBT.",
+              "type": "string"
+            },
+            "state": {
+              "title": "State",
+              "description": "A map of block property names to values. Test will fail if the block doesn't match.",
+              "type": "object",
+              "properties": {
+                "key": {
+                  "title": "Key",
+                  "description": "Block property key and value pair.",
+                  "type": [
+                    "boolean",
+                    "integer",
+                    "string",
+                    "object"
+                  ],
+                  "$ref": "#/definitions/integerRange"
+                }
+              }
+            }
+          }
+        },
+        "dimension": {
+          "title": "Dimension",
+          "description": "The dimension the entity is currently in.",
+          "type": "string"
+        },
+        "feature": {
+          "title": "Feature",
+          "description": "Name of a structure.",
+          "type": "string",
+          "enum": [
+            "buried_treasure",
+            "desert_pyramid",
+            "endcity",
+            "fortress",
+            "igloo",
+            "jungle_pyramid",
+            "mansion",
+            "mineshaft",
+            "monument",
+            "ocean_ruin",
+            "pillager_outpost",
+            "shipwreck",
+            "stronghold",
+            "swamp_hut",
+            "village"
+          ]
+        },
+        "fluid": {
+          "title": "Fluid",
+          "description": "The fluid at the location.",
+          "type": "object",
+          "properties": {
+            "fluid": {
+              "title": "Fluid",
+              "description": "The fluid ID.",
+              "type": "string"
+            },
+            "tag": {
+              "title": "Tag",
+              "description": "The fluid tag.",
+              "type": "string"
+            },
+            "state": {
+              "title": "State",
+              "description": "A map of fluid property names to values. Test will fail if the fluid doesn't match.",
+              "type": [
+                "boolean",
+                "integer",
+                "string",
+                "object"
+              ],
+              "$ref": "#/definitions/integerRange"
+            }
+          }
+        },
+        "light": {
+          "title": "Light",
+          "description": "The light at the location.",
+          "type": "object",
+          "properties": {
+            "light": {
+              "title": "Light",
+              "description": "The light Level of visible light. Calculated using: (max(sky-darkening,block)).",
+              "type": [
+                "integer",
+                "object"
+              ],
+              "$ref": "#/definitions/integerRange"
+            }
+          }
+        },
+        "position": {
+          "title": "Position",
+          "type": "object",
+          "properties": {
+            "x": {
+              "title": "X",
+              "description": "The X position.",
+              "$ref": "#/definitions/numberRange"
+            },
+            "y": {
+              "title": "Y",
+              "description": "The Y position.",
+              "$ref": "#/definitions/numberRange"
+            },
+            "z": {
+              "title": "Z",
+              "description": "The Z position.",
+              "$ref": "#/definitions/numberRange"
+            }
+          }
+        },
+        "smokey": {
+          "title": "Smokey",
+          "description": "True if the block is closely above a campfire or soul campfire.",
+          "type": "boolean"
+        }
+      }
+    },
+    "tagsCommonToAllEntities": {
+      "type": "object",
+      "properties": {
+        "distance": {
+          "title": "Distance",
+          "type": "object",
+          "properties": {
+            "absolute": {
+              "title": "Absolute",
+              "$ref": "#/definitions/numberRange"
+            },
+            "horizontal": {
+              "title": "Horizontal",
+              "$ref": "#/definitions/numberRange"
+            },
+            "x": {
+              "title": "X",
+              "$ref": "#/definitions/numberRange"
+            },
+            "y": {
+              "title": "Y",
+              "$ref": "#/definitions/numberRange"
+            },
+            "z": {
+              "title": "Z",
+              "$ref": "#/definitions/numberRange"
+            }
+          }
+        },
+        "effects": {
+          "title": "Effects",
+          "description": "A map of status effects.",
+          "additionalProperties": {
+            "title": "Effect",
+            "description": "A status effect with the key name being the status effect name.",
+            "type": "object",
+            "properties": {
+              "ambient": {
+                "title": "Ambient",
+                "description": "Whether the effect is from a beacon.",
+                "type": "boolean"
+              },
+              "amplifier": {
+                "title": "Amplifier",
+                "description": "The effect amplifier.",
+                "type": [
+                  "integer",
+                  "object"
+                ],
+                "$ref": "#/definitions/integerRange"
+              },
+              "duration": {
+                "title": "Duration",
+                "description": "The effect duration in ticks.",
+                "type": [
+                  "integer",
+                  "object"
+                ],
+                "$ref": "#/definitions/integerRange"
+              },
+              "visible": {
+                "title": "Visible",
+                "description": "Whether the effect has visible particles.",
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "equipment": {
+          "title": "Equipment",
+          "type": "object",
+          "properties": {
+            "mainhand": {
+              "title": "Mainhand",
+              "$ref": "#/definitions/tagsCommonToAllItems"
+            },
+            "offhand": {
+              "title": "Offhand",
+              "$ref": "#/definitions/tagsCommonToAllItems"
+            },
+            "head": {
+              "title": "Head",
+              "$ref": "#/definitions/tagsCommonToAllItems"
+            },
+            "chest": {
+              "title": "Chest",
+              "$ref": "#/definitions/tagsCommonToAllItems"
+            },
+            "legs": {
+              "title": "Legs",
+              "$ref": "#/definitions/tagsCommonToAllItems"
+            },
+            "feet": {
+              "title": "Feet",
+              "$ref": "#/definitions/tagsCommonToAllItems"
+            }
+          }
+        },
+        "flags": {
+          "title": "Flags",
+          "description": "Predicate Flags to be checked.",
+          "type": "object",
+          "properties": {
+            "is_on_fire": {
+              "title": "Is on Fire",
+              "description": "Test whether the entity is or is not on fire."
+            },
+            "is_sneaking": {
+              "title": "Is Sneaking",
+              "description": "Test whether the entity is or is not sneaking.",
+              "type": "boolean"
+            },
+            "is_sprinting": {
+              "title": "Is Sprinting",
+              "description": "Test whether the entity is or is not sprinting.",
+              "type": "boolean"
+            },
+            "is_swimming": {
+              "title": "Is Swimming",
+              "description": "Test whether the entity is or is not swimming.",
+              "type": "boolean"
+            },
+            "is_baby": {
+              "title": "Is Baby",
+              "description": "Test whether the entity is or is not a baby variant.",
+              "type": "boolean"
+            }
+          }
+        },
+        "lightning_bolt": {
+          "title": "Lightning Bolt",
+          "description": "Lightning bolt properties to be checked. Fails when entity is not a lightning bolt.",
+          "type": "object",
+          "properties": {
+            "blocks_set_on_fire": {
+              "title": "Blocks Set on Fire",
+              "description": "Number of blocks set on fire by this lightning bolt.",
+              "type": "integer"
+            },
+            "entity_struck": {
+              "title": "Entity Struck",
+              "description": "Entity properties of entities struck by this lightning bolt. If present, this tag must match one or more entities.",
+              "$ref": "#/definitions/tagsCommonToAllEntities"
+            }
+          }
+        },
+        "location": {
+          "title": "Location",
+          "$ref": "#/definitions/tagsCommonToAllLocations"
+        },
+        "nbt": {
+          "title": "NBT",
+          "description": "An NBT string.",
+          "type": "string"
+        },
+        "passenger": {
+          "title": "Passanger",
+          "description": "The entity directly riding this entity.",
+          "$ref": "#/definitions/tagsCommonToAllEntities"
+        },
+        "player": {
+          "title": "Player",
+          "description": "Player properties to be checked. Fails when entity is not a player.",
+          "type": "object",
+          "properties": {
+            "looking_at": {
+              "title": "Looking At",
+              "description": "The entity that the player is looking at, as long as it is visible and within a radius of 100 blocks.",
+              "$ref": "#/definitions/tagsCommonToAllEntities"
+            },
+            "advancements": {
+              "title": "Advancements",
+              "description": "A map of advancements to check.",
+              "type": "object",
+              "additionalProperties": {
+                "description": "An advancement ID.",
+                "type": [
+                  "boolean",
+                  "object"
+                ],
+                "additionalProperties": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "gamemode": {
+              "title": "Game Mode",
+              "description": "The game mode of the player.",
+              "type": "string",
+              "enum": [
+                "survival",
+                "adventure",
+                "creative",
+                "spectator"
+              ]
+            },
+            "level": {
+              "title": "Level",
+              "description": "The level of the player.",
+              "type": [
+                "integer",
+                "object"
+              ],
+              "$ref": "#/definitions/integerRange"
+            },
+            "recipes": {
+              "title": "Recipies",
+              "description": "A map of recipies to check.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "boolean"
+              }
+            },
+            "stats": {
+              "title": "Stats",
+              "description": "List of statistics to match.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "title": "Type",
+                    "description": "The statistic base.",
+                    "type": "string",
+                    "enum": [
+                      "minecraft:custom",
+                      "minecraft:crafted",
+                      "minecraft:used",
+                      "minecraft:broken",
+                      "minecraft:mined",
+                      "minecraft:killed",
+                      "minecraft:picked_up",
+                      "minecraft:dropped",
+                      "minecraft:killed_by"
+                    ]
+                  },
+                  "stat": {
+                    "title": "Stat",
+                    "description": "The statistic ID. Mostly mimics the criteria used for defining scoreboard objectives.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Value",
+                    "description": "The value of the statistic.",
+                    "type": [
+                      "integer",
+                      "object"
+                    ],
+                    "$ref": "#/definitions/integerRange"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "stepping_on": {
+          "title": "Stepping On",
+          "description": "Location predicate for the block the entity is standing on.",
+          "$ref": "#/definitions/tagsCommonToAllLocations"
+        },
+        "team": {
+          "title": "Team",
+          "description": "The team the entity belongs to.",
+          "type": "string"
+        },
+        "type": {
+          "title": "Type",
+          "description": "An entity ID.",
+          "type": "string"
+        },
+        "targeted_entity": {
+          "title": "Targeted Entity",
+          "description": "The entity which this entity is targeting for attacks.",
+          "$ref": "#/definitions/tagsCommonToAllEntities"
+        },
+        "vehicle": {
+          "title": "Vehicle",
+          "description": " The vehicle that the entity is riding on.",
+          "$ref": "#/definitions/tagsCommonToAllEntities"
+        }
+      }
+    }
+  },
+  "properties": {
+    "conditions": {
+      "title": "Conditions",
+      "description": "The condition's ID.",
+      "type": "string",
+      "enum": [
+        "minecraft:alternative",
+        "minecraft:block_state_property",
+        "minecraft:damage_source_properties",
+        "minecraft:entity_properties",
+        "minecraft:entity_scores",
+        "minecraft:inverted",
+        "minecraft:killed_by_player",
+        "minecraft:location_check",
+        "minecraft:match_tool",
+        "minecraft:random_chance",
+        "minecraft:random_chance_with_looting",
+        "minecraft:reference",
+        "minecraft:survives_explosion",
+        "minecraft:table_bonus",
+        "minecraft:time_check",
+        "minecraft:weather_check",
+        "minecraft:value_check"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:alternative"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "terms": {
+            "title": "Terms",
+            "description": "A list of conditions to join using 'or'.",
+            "type": "object"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:block_state_property"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "block": {
+            "title": "Block",
+            "description": "A block ID.",
+            "type": "string"
+          },
+          "properties": {
+            "title": "Properties",
+            "description": "A map of block property names to values.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:damage_source_properties"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "predicate": {
+            "title": "Predicate",
+            "description": "Predicate applied to the damage source.",
+            "$ref": "#/definitions/tagsCommonToAllDamageTypes"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:entity_properties"
+          }
+        }
+      },
+      "then": {
+        "description": "Test properties of an entity.",
+        "properties": {
+          "entity": {
+            "title": "Entity",
+            "description": "Specifies the entity to check for the condition.",
+            "type": "string",
+            "enum": [
+              "this",
+              "killer",
+              "killer_player"
+            ]
+          },
+          "predicate": {
+            "title": "Predicate",
+            "description": "Predicate applied to entity.",
+            "$ref": "#/definitions/tagsCommonToAllEntities"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:entity_scores"
+          }
+        }
+      },
+      "then": {
+        "description": "Test the scoreboard scores of an entity.",
+        "properties": {
+          "entity": {
+            "title": "Entity",
+            "description": "Specifies the entity to check for the condition.",
+            "type": "string",
+            "enum": [
+              "this",
+              "killer",
+              "killer_player"
+            ]
+          },
+          "scores": {
+            "title": "Scores",
+            "description": "Scores to check. All specified scores must pass for the condition to pass.",
+            "type": "object",
+            "additionalProperties": {
+              "type": [
+                "integer",
+                "object"
+              ],
+              "$ref": "#/definitions/integerRange"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:inverted"
+          }
+        }
+      },
+      "then": {
+        "description": "Inverts condition from parameter term.",
+        "properties": {
+          "term": {
+            "title": "Term",
+            "description": "The condition to be negated.",
+            "type": "object"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:killed_by_player"
+          }
+        }
+      },
+      "then": {
+        "description": "Test if a killer_player entity is available.",
+        "properties": {
+          "inverse": {
+            "title": "Inverse",
+            "description": "If true, the condition passes if killer_player is not available.",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:location_check"
+          }
+        }
+      },
+      "then": {
+        "description": "Checks if the current location matches.",
+        "properties": {
+          "offsetX": {
+            "title": "Offset X",
+            "description": "Offsets to location.",
+            "type": "integer"
+          },
+          "offsetY": {
+            "title": "Offset Y",
+            "description": "Offsets to location.",
+            "type": "integer"
+          },
+          "offsetZ": {
+            "title": "Offset Z",
+            "description": "Offsets to location.",
+            "type": "integer"
+          },
+          "predicate": {
+            "title": "Predicate",
+            "description": "Predicate applied to location.",
+            "$ref": "#/definitions/tagsCommonToAllLocations"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:match_tool"
+          }
+        }
+      },
+      "then": {
+        "description": "Checks tool.",
+        "properties": {
+          "predicate": {
+            "title": "Predicate",
+            "description": "Predicate applied to item.",
+            "$ref": "#/definitions/tagsCommonToAllItems"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:random_chance"
+          }
+        }
+      },
+      "then": {
+        "description": "Test if a random number 0.0–1.0 is less than a specified value.",
+        "properties": {
+          "chance": {
+            "title": "Chance",
+            "description": "Success rate.",
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:random_chance_with_looting"
+          }
+        }
+      },
+      "then": {
+        "description": "Test if a random number 0.0–1.0 is less than a specified value, affected by the level of Looting on the killer entity.",
+        "properties": {
+          "chance": {
+            "title": "Chance",
+            "description": "Base success rate.",
+            "type": "number"
+          },
+          "looting_multiplier": {
+            "title": "Looting Multiplier",
+            "description": "Looting adjustment to the base success rate. Formula is chance + (looting_level * looting_multiplier).",
+            "type": "number"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:reference"
+          }
+        }
+      },
+      "then": {
+        "description": "Test if another referred condition (predicate) passes.",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "description": "The namespaced ID of the condition (predicate) referred to. A cyclic reference causes a parsing failure.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:survives_explosion"
+          }
+        }
+      },
+      "then": {
+        "description": "Returns true with 1/explosion radius probability."
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:table_bonus"
+          }
+        }
+      },
+      "then": {
+        "description": "Passes with probability picked from table, indexed by enchantment level.",
+        "properties": {
+          "enchantment": {
+            "title": "Enchantment",
+            "description": "Id of enchantment.",
+            "type": "integer"
+          },
+          "chances": {
+            "title": "Chances",
+            "description": "List of probabilities for enchantment level, indexed from 0.",
+            "type": "array"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:time_check"
+          }
+        }
+      },
+      "then": {
+        "description": "Checks the current time.",
+        "properties": {
+          "value": {
+            "title": "Value",
+            "description": "The time value in ticks.",
+              "type": [
+                "integer",
+                "object"
+              ],
+              "$ref": "#/definitions/integerRange"
+          },
+          "period": {
+            "title": "Period",
+            "description": "Time gets modulo-divided by this value (for example, if set to 24000, value operates on a time period of daytime ticks just like /time query daytime).",
+            "type": "integer"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:weather_check"
+          }
+        }
+      },
+      "then": {
+        "description": "Checks for a current weather state.",
+        "properties": {
+          "raining": {
+            "title": "Raining",
+            "description": "If true, the condition evaluates to true only if it's raining or thundering.",
+            "type": "boolean"
+          },
+          "thundering": {
+            "title": "Thundering",
+            "description": "If true, the condition evaluates to true only if it's thundering.",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "conditions": {
+            "const": "minecraft:value_check"
+          }
+        }
+      },
+      "then": {
+        "description": "Checks for range of value.",
+        "properties": {
+          "value": {
+            "title": "Value",
+            "description": "The value to test.",
+            "type": [
+              "integer",
+              "object"
+            ],
+            "$ref": "#/definitions/numberProvider"
+          },
+          "range": {
+            "title": "Range",
+            "description": "If true, the condition evaluates to true only if it's thundering.",
+            "type": [
+              "integer",
+              "object"
+            ],
+            "$ref": "#/definitions/integerRange"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/schemas/json/minecraft-recipe.json
+++ b/src/schemas/json/minecraft-recipe.json
@@ -1,0 +1,370 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Recipe#JSON_format",
+  "title": "Minecraft Data Pack Recipe",
+  "description": "Configuration file defining a recipe for a data pack for Minecraft.",
+  "type": "object",
+  "definitions": {
+    "item": {
+      "type": "object",
+      "properties": {
+        "item": {
+          "title": "Item",
+          "description": "An item ID.",
+          "type": "string"
+        },
+        "tag": {
+          "title": "Tag",
+          "description": "An item tag.",
+          "type": "string"
+        }
+      }
+    },
+    "ingredient": {
+      "title": "Ingredient",
+      "description": "An acceptable ingredient.",
+      "type": "object",
+      "$ref": "#/definitions/item"
+    },
+    "tagsCommonToAllRecipes": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "A namespaced ID indicating the type of serializer of the recipe.",
+          "type": "string"
+        },
+        "group": {
+          "title": "Group",
+          "description": "A string identifier. Used to group multiple recipes together in the recipe book.",
+          "type": "string"
+        }
+      }
+    },
+    "tagsCommonToAllCookingRecipes": {
+      "type": "object",
+      "properties": {
+        "ingredient": {
+          "title": "Ingredients",
+          "description": "The ingredients.",
+          "type": [
+            "object",
+            "array"
+          ],
+          "$ref": "#/definitions/ingredient",
+          "items": {
+            "$ref": "#/definitions/ingredient"
+          }
+        },
+        "result": {
+          "title": "Result",
+          "description": "An item ID. The output item of the recipe.",
+          "type": "string"
+        },
+        "experience": {
+          "title": "Experience",
+          "description": "The output experience of the recipe.",
+          "type": "number"
+        },
+        "cookingtime": {
+          "title": "Cooking Time",
+          "description": "The cook time of the recipe in ticks.",
+          "type": "integer"
+        }
+      }
+    },
+    "result": {
+      "title": "Result",
+      "description": "The output item of the recipe.",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Count",
+          "description": "The amount of the item.",
+          "type": "integer",
+          "default": 1
+        },
+        "item": {
+          "title": "Item",
+          "description": "An item ID.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+    "type": {
+      "title": "Type",
+      "description": "The type of recipe.",
+      "type": "string",
+      "enum": [
+        "minecraft:blasting",
+        "minecraft:campfire_cooking",
+        "minecraft:crafting_shaped",
+        "minecraft:crafting_shapeless",
+        "minecraft:smelting",
+        "minecraft:smithing",
+        "minecraft:smoking",
+        "minecraft:stonecutting"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "minecraft:blasting"
+          }
+        }
+      },
+      "then": {
+        "description": "Represents a recipe in a blast furnace.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/tagsCommonToAllRecipes"
+          },
+          {
+            "$ref": "#/definitions/tagsCommonToAllCookingRecipes"
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "minecraft:campfire_cooking"
+          }
+        }
+      },
+      "then": {
+        "description": "Represents a recipe in a campfire.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/tagsCommonToAllRecipes"
+          },
+          {
+            "$ref": "#/definitions/tagsCommonToAllCookingRecipes"
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "minecraft:crafting_shaped"
+          }
+        }
+      },
+      "then": {
+        "description": "Represents a shaped crafting recipe in a crafting table.",
+        "properties": {
+          "pattern": {
+            "title": "Pattern",
+            "description": "A list of single-character keys used to describe a pattern for shaped crafting.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 3
+            },
+            "maxItems": 3
+          },
+          "key": {
+            "title": "Key",
+            "description": "All keys used for this shaped crafting recipe.",
+            "additionalProperties": {
+              "type": [
+                "object",
+                "array"
+              ],
+              "description": "The ingredient corresponding to this key.",
+              "properties": {
+                "item": {
+                  "title": "Item",
+                  "description": "An item ID.",
+                  "type": "string"
+                },
+                "tag": {
+                  "title": "Tag",
+                  "description": "An item tag.",
+                  "type": "string"
+                }
+              },
+              "items": {
+                "properties": {
+                  "item": {
+                    "title": "Item",
+                    "description": "An item ID.",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "title": "Tag",
+                    "description": "An item tag.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "result": {
+            "$ref": "#/definitions/result"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "minecraft:crafting_shapeless"
+          }
+        }
+      },
+      "then": {
+        "description": "Represents a shapeless crafting recipe in a crafting table.",
+        "$ref": "#/definitions/tagsCommonToAllRecipes",
+        "properties": {
+          "ingredients": {
+            "title": "Ingredients",
+            "description": "A list of entries for this shapeless crafting recipe.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "title": "Ingredient",
+                  "description": "An entry made of a single ingredient.",
+                  "type": "object",
+                  "$ref": "#/definitions/ingredient"
+                },
+                {
+                  "title": "Ingredient",
+                  "description": "An entry made of a list of acceptable ingredients.",
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 9,
+                  "items": {
+                    "$ref": "#/definitions/ingredient"
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "$ref": "#/definitions/result"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "minecraft:smelting"
+          }
+        }
+      },
+      "then": {
+        "description": "Represents a recipe in a furnace.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/tagsCommonToAllRecipes"
+          },
+          {
+            "$ref": "#/definitions/tagsCommonToAllCookingRecipes"
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "minecraft:smithing"
+          }
+        }
+      },
+      "then": {
+        "description": "Represents a recipe in a smithing table.",
+        "$ref": "#/definitions/tagsCommonToAllRecipes",
+        "properties": {
+          "base": {
+            "title": "Base",
+            "description": "Ingredient specifying an item to be upgraded.",
+            "$ref": "#/definitions/item"
+          },
+          "addition": {
+            "title": "Addition",
+            "$ref": "#/definitions/item"
+          },
+          "result": {
+            "title": "Result",
+            "type": "object"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "minecraft:smoking"
+          }
+        }
+      },
+      "then": {
+        "description": "Represents a recipe in a smoker.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/tagsCommonToAllRecipes"
+          },
+          {
+            "$ref": "#/definitions/tagsCommonToAllCookingRecipes"
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "minecraft:stonecutting"
+          }
+        }
+      },
+      "then": {
+        "description": "Represents a recipe in a stonecutter.",
+        "$ref": "#/definitions/tagsCommonToAllRecipes",
+        "oneOf": [
+          {
+            "title": "Ingredient",
+            "description": "The ingredient for the recipe.",
+            "$ref": "#/definitions/item"
+          },
+          {
+            "title": "Ingredient",
+            "description": "The list of ingredients for the recipe.",
+            "type": "array",
+            "items": {
+              "title": "Ingredient",
+              "$ref": "#/definitions/item"
+            }
+          }
+        ],
+        "properties": {
+          "result": {
+            "title": "Result",
+            "description": "An item ID. The output item of the recipe.",
+            "type": "string"
+          },
+          "count": {
+            "title": "Count",
+            "description": "The amount of the output item.",
+            "type": "integer"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/schemas/json/minecraft-template-pool.json
+++ b/src/schemas/json/minecraft-template-pool.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://minecraft.fandom.com/wiki/Custom_world_generation#Jigsaw_pools",
+  "title": "Minecraft Data Pack Template Pool",
+  "description": "Configuration file defining a template pool for a data pack for Minecraft.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "title": "Name",
+      "description": "The namespaced ID of the pool.",
+      "type": "string"
+    },
+    "fallback": {
+      "title": "Fallback",
+      "description": "Can set to another template pool, which generates when the original pool cannot generate at the end of all layers.",
+      "type": "string"
+    },
+    "elements": {
+      "title": "Elements",
+      "description": "A list of structures to choose from.",
+      "type": "array",
+      "items": {
+        "title": "Element",
+        "type": "object",
+        "properties": {
+          "weight": {
+            "title": "Weight",
+            "description": "How likely this element is to be chosen when using this pool.",
+            "type": "integer"
+          },
+          "element": {
+            "title": "Element",
+            "description": "The properties of this element.",
+            "type": "object",
+            "properties": {
+              "element_type": {
+                "title": "Element Type",
+                "type": "string",
+                "enum": [
+                  "minecraft:empty_pool_element",
+                  "minecraft:feature_pool_element",
+                  "minecraft:list_pool_element",
+                  "minecraft:legacy_single_pool_element",
+                  "minecraft:single_pool_element"
+                ]
+              },
+              "feature": {
+                "title": "Feature",
+                "description": "The namespaced id of the feature.",
+                "type": "string"
+              },
+              "location": {
+                "title": "Location",
+                "description": "The namespaced id of the structure to place.",
+                "type": "string"
+              },
+              "projection": {
+                "title": "Projection",
+                "type": "string",
+                "enum": [
+                  "rigid",
+                  "terrain_matching"
+                ]
+              },
+              "processors": {
+                "title": "Processors",
+                "description": "The namespaced ID of a processor if this is a string.",
+                "type": [
+                  "string",
+                  "object"
+                ],
+                "properties": {
+                  "processors": {
+                    "title": "Processors",
+                    "description": "A list of processors to use.",
+                    "type": "array",
+                    "items": {
+                      "title": "Processor",
+                      "type": "object",
+                      "properties": {
+                        "processor_type": {
+                          "title": "Processor Type",
+                          "description": "The namespaced id of the processor to use.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "elements": {
+                "title": "Elements",
+                "description": "A list of structures to choose from.",
+                "type": "array",
+                "items": {
+                  "title": "Element",
+                  "type": "object",
+                  "properties": {
+                    "weight": {
+
+                    },
+                    "location": {
+                      "title": "Location",
+                      "description": "The namespaced id of the structure to place.",
+                      "type": "string"
+                    },
+                    "projection": {
+                      "title": "Projection",
+                      "type": "string",
+                      "enum": [
+                        "rigid",
+                        "terrain_matching"
+                      ]
+                    },
+                    "element_type": {
+                      "title": "Element Type",
+                      "type": "string",
+                      "enum": [
+                        "minecraft:empty_pool_element",
+                        "minecraft:list_pool_element",
+                        "minecraft:legacy_single_pool_element",
+                        "minecraft:single_pool_element"
+                      ]
+                    },
+                    "processors": {
+                      "title": "Processors",
+                      "description": "The namespaced ID of a processor if this is a string.",
+                      "type": [
+                        "string",
+                        "object"
+                      ],
+                      "properties": {
+                        "processors": {
+                          "title": "Processors",
+                          "description": "A list of processors to use.",
+                          "type": "array",
+                          "items": {
+                            "title": "Processor",
+                            "type": "object",
+                            "properties": {
+                              "processor_type": {
+                                "title": "Processor Type",
+                                "description": "The namespaced id of the processor to use.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/minecraft-advancement/arbalistic.json
+++ b/src/test/minecraft-advancement/arbalistic.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:adventure/ol_betsy",
+  "display": {
+    "icon": {
+      "item": "minecraft:crossbow",
+      "nbt": "{Damage:0}"
+    },
+    "title": {
+      "translate": "advancements.adventure.arbalistic.title"
+    },
+    "description": {
+      "translate": "advancements.adventure.arbalistic.description"
+    },
+    "frame": "challenge",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": true
+  },
+  "rewards": {
+    "experience": 85
+  },
+  "criteria": {
+    "arbalistic": {
+      "trigger": "minecraft:killed_by_crossbow",
+      "conditions": {
+        "unique_entity_types": 5
+      }
+    }
+  },
+  "requirements": [
+    [
+      "arbalistic"
+    ]
+  ]
+}

--- a/src/test/minecraft-advancement/elytra.json
+++ b/src/test/minecraft-advancement/elytra.json
@@ -1,0 +1,38 @@
+{
+  "parent": "minecraft:end/find_end_city",
+  "display": {
+    "icon": {
+      "item": "minecraft:elytra",
+      "nbt": "{Damage:0}"
+    },
+    "title": {
+      "translate": "advancements.end.elytra.title"
+    },
+    "description": {
+      "translate": "advancements.end.elytra.description"
+    },
+    "frame": "goal",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "criteria": {
+    "elytra": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:elytra"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "elytra"
+    ]
+  ]
+}

--- a/src/test/minecraft-biome/dreadlands.json
+++ b/src/test/minecraft-biome/dreadlands.json
@@ -1,0 +1,43 @@
+{
+  "surface_builder": "minecraft:grass",
+  "depth": 0.125,
+  "scale": 0.05,
+  "temperature": 1,
+  "downfall": 0.5,
+  "precipitation": "none",
+  "temperature_modifier": "none",
+  "category": "forest",
+  "player_spawn_friendly": false,
+  "creature_spawn_probability": 1,
+  "effects": {
+    "sky_color": 5046276,
+    "fog_color": 2171169,
+    "water_color": 12713984,
+    "water_fog_color": 3343621,
+    "grass_color": 13697024,
+    "foliage_color": 12386304
+  },
+  "starts": [],
+  "spawners": {
+    "monster": [
+      {
+        "type": "minecraft:husk",
+        "weight": 1,
+        "minCount": 0,
+        "maxCount": 300
+      }
+    ]
+  },
+  "spawn_costs": {},
+  "carvers": {
+    "air": [
+      "minecraft:cave"
+    ]
+  },
+  "features": [
+    [
+      "minecraft:trees_shattered_savanna",
+      "patch_grass_forest"
+    ]
+  ]
+}

--- a/src/test/minecraft-configured-carver/cave-carver.json
+++ b/src/test/minecraft-configured-carver/cave-carver.json
@@ -1,0 +1,57 @@
+{
+  "config": {
+    "horizontal_radius_factor": {
+      "type": "minecraft:uniform",
+      "value": {
+        "base": 0.25,
+        "spread": 0.125
+      }
+    },
+    "vertical_radius_default_factor": 0.300,
+    "vertical_radius_center_factor": 10.0,
+    "vertical_rotation": {
+      "type": "minecraft:uniform",
+      "value": {
+        "base": -0.125,
+        "spread": 0.25
+      }
+    },
+    "thickness": {
+      "type": "minecraft:uniform",
+      "value": {
+        "base": 0.0,
+        "spread": 2.0
+      }
+    },
+    "width_smoothness": 60,
+    "top_inclusive": {
+      "absolute": 80
+    },
+    "y_scale": {
+      "base": 200,
+      "spread": 2500
+    },
+    "distanceFactor": {
+      "type": "minecraft:uniform",
+      "value": {
+        "base": 0.5,
+        "spread": 0.50
+      }
+    },
+    "probability": 0.005,
+    "debug_settings": {
+      "air_state": {
+        "Properties": {
+          "powered": "false",
+          "facing": "north",
+          "face": "wall"
+        },
+        "Name": "minecraft:oak_button"
+      }
+    },
+    "bottom_inclusive": {
+      "absolute": -62
+    }
+  },
+  "type": "minecraft:cave"
+}

--- a/src/test/minecraft-dimension-type/overworld_caves.json
+++ b/src/test/minecraft-dimension-type/overworld_caves.json
@@ -1,0 +1,17 @@
+{
+  "logical_height": 384,
+  "infiniburn": "minecraft:infiniburn_overworld",
+  "effects": "minecraft:overworld",
+  "ambient_light": 0.0,
+  "respawn_anchor_works": false,
+  "has_raids": true,
+  "min_y": -64,
+  "height": 384,
+  "natural": true,
+  "coordinate_scale": 1.0,
+  "piglin_safe": false,
+  "bed_works": true,
+  "has_skylight": true,
+  "has_ceiling": true,
+  "ultrawarm": false
+}

--- a/src/test/minecraft-dimension/thedrealands.json
+++ b/src/test/minecraft-dimension/thedrealands.json
@@ -1,0 +1,90 @@
+{
+  "type": {
+    "name": "minecraft:dreadlands",
+    "ultrawarm": true,
+    "natural": false,
+    "piglin_safe": true,
+    "respawn_anchor_works": true,
+    "bed_works": false,
+    "has_raids": false,
+    "has_skylight": true,
+    "has_ceiling": false,
+    "coordinate_scale": 1,
+    "ambient_light": 0.1,
+    "logical_height": 256,
+    "fixed_time": 18000,
+    "effects": "minecraft:overworld",
+    "infiniburn": "minecraft:infiniburn_overworld",
+    "min_y": 0,
+    "height": 256
+  },
+  "generator": {
+    "type": "minecraft:noise",
+    "seed": -44018477,
+    "settings": "minecraft:floating_islands",
+    "biome_source": {
+      "type": "minecraft:multi_noise",
+      "seed": -44018477,
+      "altitude_noise": {
+        "firstOctave": -7,
+        "amplitudes": [
+          1,
+          1
+        ]
+      },
+      "temperature_noise": {
+        "firstOctave": -7,
+        "amplitudes": [
+          1,
+          1
+        ]
+      },
+      "humidity_noise": {
+        "firstOctave": -7,
+        "amplitudes": [
+          1,
+          1
+        ]
+      },
+      "weirdness_noise": {
+        "firstOctave": -7,
+        "amplitudes": [
+          1,
+          1
+        ]
+      },
+      "biomes": [
+        {
+          "biome": "minecraft:crimson_forest",
+          "parameters": {
+            "altitude": -1,
+            "temperature": 1,
+            "humidity": 0.5,
+            "weirdness": 0,
+            "offset": 0
+          }
+        },
+        {
+          "biome": "minecraft:dreadlands",
+          "parameters": {
+            "altitude": 1,
+            "temperature": 1,
+            "humidity": 0.5,
+            "weirdness": 0,
+            "offset": 0
+          }
+        },
+        {
+          "biome": "minecraft:bloodydreadlands",
+          "parameters": {
+            "altitude": 0,
+            "temperature": 1,
+            "humidity": 0.5,
+            "weirdness": 0,
+            "offset": 0
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/minecraft-item-modifier/edit-durability.json
+++ b/src/test/minecraft-item-modifier/edit-durability.json
@@ -1,0 +1,16 @@
+[
+  {
+    "function": "minecraft:copy_nbt",
+    "source": {
+      "type": "minecraft:storage",
+      "source": "treecapitator:storage"
+    },
+    "ops": [
+      {
+        "source": "temp",
+        "target": "Damage",
+        "op": "replace"
+      }
+    ]
+  }
+]

--- a/src/test/minecraft-loot-table/bastion-bridge.json
+++ b/src/test/minecraft-loot-table/bastion-bridge.json
@@ -1,0 +1,302 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1.0,
+              "add": false
+            }
+          ],
+          "name": "minecraft:lodestone"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "type": "minecraft:uniform",
+        "min": 1.0,
+        "max": 2.0
+      },
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_damage",
+              "damage": {
+                "type": "minecraft:uniform",
+                "min": 0.1,
+                "max": 0.5
+              },
+              "add": false
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:crossbow"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 10.0,
+                "max": 28.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:spectral_arrow"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 8.0,
+                "max": 12.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:gilded_blackstone"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 3.0,
+                "max": 8.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:crying_obsidian"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1.0,
+              "add": false
+            }
+          ],
+          "name": "minecraft:gold_block"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 4.0,
+                "max": 9.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:gold_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 4.0,
+                "max": 9.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1.0,
+              "add": false
+            }
+          ],
+          "name": "minecraft:golden_sword"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1.0,
+              "add": false
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:golden_chestplate"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1.0,
+              "add": false
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:golden_helmet"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1.0,
+              "add": false
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:golden_leggings"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1.0,
+              "add": false
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:golden_boots"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1.0,
+              "add": false
+            },
+            {
+              "function": "minecraft:enchant_randomly"
+            }
+          ],
+          "name": "minecraft:golden_axe"
+        }
+      ]
+    },
+    {
+      "rolls": {
+        "type": "minecraft:uniform",
+        "min": 2.0,
+        "max": 4.0
+      },
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1.0,
+                "max": 6.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:string"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1.0,
+                "max": 3.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:leather"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 5.0,
+                "max": 17.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:arrow"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 2.0,
+                "max": 6.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:iron_nugget"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 2.0,
+                "max": 6.0
+              },
+              "add": false
+            }
+          ],
+          "name": "minecraft:gold_nugget"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/minecraft-pack-mcmeta/default.json
+++ b/src/test/minecraft-pack-mcmeta/default.json
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 7,
+    "description": "The default data for Minecraft"
+  }
+}

--- a/src/test/minecraft-predicate/is-sneaking.json
+++ b/src/test/minecraft-predicate/is-sneaking.json
@@ -1,0 +1,9 @@
+{
+  "condition": "minecraft:entity_properties",
+  "predicate": {
+    "flags": {
+      "is_sneaking": true
+    }
+  },
+  "entity": "this"
+}

--- a/src/test/minecraft-recipe/anvil.json
+++ b/src/test/minecraft-recipe/anvil.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "III",
+    " i ",
+    "iii"
+  ],
+  "key": {
+    "I": {
+      "item": "minecraft:iron_block"
+    },
+    "i": {
+      "item": "minecraft:iron_ingot"
+    }
+  },
+  "result": {
+    "item": "minecraft:anvil"
+  }
+}

--- a/src/test/minecraft-template-pool/template.json
+++ b/src/test/minecraft-template-pool/template.json
@@ -1,0 +1,24 @@
+{
+  "name": "NAMESPACE:TEMPLATEPOOL",
+  "fallback": "minecraft:empty",
+  "elements": [
+    {
+      "weight": 50,
+      "element": {
+        "location": "minecraft:STRUCTURENAME",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    },
+    {
+      "weight": 70,
+      "element": {
+        "location": "minecraft:STRUCTURENAME2",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds JSON Schema for data pack files for Minecraft.

There might be more, however this PR is large enough as it is.
I may do more in future in a separate pull request, or cover resource packs as well.

* [Minecraft Data Pack Advancement](https://minecraft.fandom.com/wiki/Advancement/JSON_format)
* [Minecraft Data Pack Biome](https://minecraft.fandom.com/wiki/Biome/JSON_format)
* [Minecraft Data Pack Configured Carver](https://minecraft.fandom.com/wiki/Custom_world_generation#Carvers)
* [Minecraft Data Pack Dimension Type](https://minecraft.fandom.com/wiki/Custom_dimension#Dimension_type)
* [Minecraft Data Pack Dimension](https://minecraft.fandom.com/wiki/Custom_dimension#Dimension_syntax)
* [Minecraft Data Pack Item Modifier](https://minecraft.fandom.com/wiki/Item_modifier#JSON_structure)
* [Minecraft Data Pack Loot Table](https://minecraft.fandom.com/wiki/Loot_table)
* [Minecraft Data Pack Metadata](https://minecraft.fandom.com/wiki/Data_Pack)
* [Minecraft Data Pack Predicate](https://minecraft.fandom.com/wiki/Predicate)
* [Minecraft Data Pack Recipe](https://minecraft.fandom.com/wiki/Recipe#JSON_format)
* [Minecraft Data Pack Template Pool](https://minecraft.fandom.com/wiki/Custom_world_generation#Jigsaw_pools)

#### Related Issues
* Closes https://github.com/SchemaStore/schemastore/pull/972

Edit: I guess because I added the "Closes" in an edit rather than the initial PR, it's not actually going to close it. 🤔 