### PR TITLE
feat: add schema for global privacy control

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1076,6 +1076,14 @@
       }
     },
     {
+      "name": "Global Privacy Control",
+      "description": "Configuration for GPC, so a site can convey its support for the Global Privacy Control.",
+      "fileMatch": [
+        "**/.well-known/gpc.json"
+      ],
+      "url": "https://json.schemastore.org/gpc.json"
+    },
+    {
       "name": "geojson.json",
       "description": "GeoJSON format for representing geographic data.",
       "url": "https://json.schemastore.org/geojson.json"

--- a/src/schemas/json/gpc.json
+++ b/src/schemas/json/gpc.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "https://globalprivacycontrol.github.io/gpc-spec/",
+  "title": "Global Privacy Control",
+  "description": "Configuration for GPC, so a site can convey its support for the Global Privacy Control.",
+  "type": "object",
+  "properties": {
+    "gpc": {
+      "title": "Global Privacy Control",
+      "description": "Indicates that the server intends to abide by GPC requests.",
+      "type": "boolean"
+    },
+    "version": {
+      "title": "Version",
+      "type": "integer",
+      "default": 1
+    },
+    "lastUpdate": {
+      "title": "Last Update",
+      "description": "This indicates the time at which the statement of support was made, such that later changes to the meaning of the GPC standard should not affect the interpretation of the resource for legal purposes. If the member is not in a valid ISO 8601 format, the last update date and time is unknown.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "gpc"
+  ]
+}

--- a/src/test/gpc/from-reference-server.json
+++ b/src/test/gpc/from-reference-server.json
@@ -1,0 +1,4 @@
+{
+  "gpc": true,
+  "version": 1
+}

--- a/src/test/gpc/from-spec.json
+++ b/src/test/gpc/from-spec.json
@@ -1,0 +1,4 @@
+{
+  "gpc": true,
+  "lastUpdate": "1997-03-10"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Adds JSON Schema for [Global Privacy Control](https://globalprivacycontrol.github.io/gpc-spec/).