### PR TITLE
add: actions/labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,49 @@
+# Asp.Net files must not be updated.
+WARNING_AspNetFiles:
+  - "src/bin/**/*"
+  - "src/css/**/*"
+  - "src/img/**/*"
+  - "src/js/**/*"
+  - "**/*.sln"
+  - "**/*.cshtml"
+  - "**/*.config"
+  - "**/*.webinfo"
+  - "**/*.ico"
+  - "**/*.txt"
+
+# code change
+gruntfile.js:
+  - "src/Gruntfile.js"
+
+# possible code change
+GitHub_ci_folder:
+  - ".github/**/*"
+
+# possible code change
+makefile:
+  - "Makefile"
+
+# possible code change
+NodeJs:
+  - "src/package.json"
+  - "src/package-lock.json"
+
+# possible URL change
+doc_md:
+  - "**/*.md"
+
+# formatting change
+editorconfig:
+  - ".editorconfig"
+
+# lint change
+eslintrcjson:
+  - "src/.eslintrc.json"
+
+# Do not add "api", "schema" and "test" directories.
+# Those are the usual commit. No need for extra attention.
+# src/api/**/*
+# src/schema/*
+# src/test/**/*
+# src/negative_test/**/*
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
The reason for automatically adding a label to PR is to mark if some non-schema/non-test files have been updated.
Some files may be an [accidental change.](https://github.com/SchemaStore/schemastore/pull/1523#issuecomment-804242535)

The usual PR for schema/test will not shown as label.

.github/labeler.yml define which label will be shown.

Note: I am unable to test the working of it. Because i can not create PR to myself.
It is possible to create draft-pr to test this functionality.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
