### PR TITLE
Add `expo` versions 41 and 42

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -984,12 +984,14 @@
       "fileMatch": [
         "app.json"
       ],
-      "url": "https://json.schemastore.org/expo-40.0.0.json",
+      "url": "https://json.schemastore.org/expo-41.0.0.json",
       "versions": {
         "37.0.0": "https://json.schemastore.org/expo-37.0.0.json",
         "38.0.0": "https://json.schemastore.org/expo-38.0.0.json",
         "39.0.0": "https://json.schemastore.org/expo-39.0.0.json",
-        "40.0.0": "https://json.schemastore.org/expo-40.0.0.json"
+        "40.0.0": "https://json.schemastore.org/expo-40.0.0.json",
+        "41.0.0": "https://json.schemastore.org/expo-41.0.0.json",
+        "42.0.0": "https://json.schemastore.org/expo-42.0.0.json"
       }
     },
     {

--- a/src/schemas/json/expo-41.0.0.json
+++ b/src/schemas/json/expo-41.0.0.json
@@ -1,0 +1,1821 @@
+{
+  "title": "JSON schema for Expo SDK 41 app manifest",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "expo"
+  ],
+  "properties": {
+    "expo": {
+      "definitions": {
+        "Android": {
+          "description": "Configuration that is specific to the Android platform.",
+          "type": "object",
+          "properties": {
+            "enableDangerousExperimentalLeanBuilds": {
+              "description": "@deprecated Use EAS Build or compile locally instead. If set to true, APK will contain only unimodules that are explicitly added in package.json and their dependencies",
+              "type": "boolean"
+            },
+            "publishManifestPath": {
+              "description": "The manifest for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "package": {
+              "description": "The package name for your Android standalone app. You make it up, but it needs to be unique on the Play Store. See [this StackOverflow question](http://stackoverflow.com/questions/6273892/android-package-name-convention).",
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)+$"
+            },
+            "versionCode": {
+              "description": "Version number required by Google Play. Increment by one for each release. Must be a positive integer. [Learn more](https://developer.android.com/studio/publish/versioning.html)",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2100000000
+            },
+            "backgroundColor": {
+              "description": "The background color for your Android app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "useNextNotificationsApi": {
+              "description": "A Boolean value that indicates whether the app should use the new notifications API.",
+              "type": "boolean"
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` key. We recommend that you use a 1024x1024 png file (transparency is recommended for the Google Play Store). This icon will appear on the home screen and within the Expo app.",
+              "type": "string"
+            },
+            "adaptiveIcon": {
+              "description": "Settings for an Adaptive Launcher Icon on Android. [Learn more](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive)",
+              "type": "object",
+              "properties": {
+                "foregroundImage": {
+                  "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` and the `android.icon` keys. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive). This icon will appear on the home screen.",
+                  "type": "string"
+                },
+                "backgroundImage": {
+                  "description": "Local path or remote URL to a background image for your app's Adaptive Icon on Android. If specified, this overrides the `backgroundColor` key. Must have the same dimensions as  foregroundImage`, and has no effect if `foregroundImage` is not specified. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive).",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to use as the background for your app's Adaptive Icon on Android. Defaults to white, `#FFFFFF`. Has no effect if `foregroundImage` is not specified.",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "playStoreUrl": {
+              "description": "URL to your app on the Google Play Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://play\\.google\\.com/",
+              "type": [
+                "string"
+              ]
+            },
+            "permissions": {
+              "description": "List of permissions used by the standalone app. \n\n To use ONLY the following minimum necessary permissions and none of the extras supported by Expo in a default managed app, set `permissions` to `[]`. The minimum necessary permissions do not require a Privacy Policy when uploading to Google Play Store and are: \n• receive data from Internet \n• view network connections \n• full network access \n• change your audio settings \n• prevent device from sleeping \n\n To use ALL permissions supported by Expo by default, do not specify the `permissions` key. \n\n  To use the minimum necessary permissions ALONG with certain additional permissions, specify those extras in `permissions`, e.g.\n\n `[ \"CAMERA\", \"ACCESS_FINE_LOCATION\" ]`.\n\n  You can specify the following permissions depending on what you need:\n\n- `ACCESS_COARSE_LOCATION`\n- `ACCESS_FINE_LOCATION`\n- `ACCESS_BACKGROUND_LOCATION`\n- `CAMERA`\n- `RECORD_AUDIO`\n- `READ_CONTACTS`\n- `WRITE_CONTACTS`\n- `READ_CALENDAR`\n- `WRITE_CALENDAR`\n- `READ_EXTERNAL_STORAGE`\n- `WRITE_EXTERNAL_STORAGE`\n- `USE_FINGERPRINT`\n- `USE_BIOMETRIC`\n- `WRITE_SETTINGS`\n- `VIBRATE`\n- `READ_PHONE_STATE`\n- `com.anddoes.launcher.permission.UPDATE_COUNT`\n- `com.android.launcher.permission.INSTALL_SHORTCUT`\n- `com.google.android.c2dm.permission.RECEIVE`\n- `com.google.android.gms.permission.ACTIVITY_RECOGNITION`\n- `com.google.android.providers.gsf.permission.READ_GSERVICES`\n- `com.htc.launcher.permission.READ_SETTINGS`\n- `com.htc.launcher.permission.UPDATE_SHORTCUT`\n- `com.majeur.launcher.permission.UPDATE_BADGE`\n- `com.sec.android.provider.badge.permission.READ`\n- `com.sec.android.provider.badge.permission.WRITE`\n- `com.sonyericsson.home.permission.BROADCAST_BADGE`\n",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase. Including this key automatically enables FCM in your standalone app.",
+              "type": "string"
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMaps": {
+                  "description": "[Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Google Maps Android SDK API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean"
+                },
+                "googleSignIn": {
+                  "description": "@deprecated Use `googleServicesFile` instead. [Google Sign-In Android SDK](https://developers.google.com/identity/sign-in/android/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "The Android API key. Can be found in the credentials section of the developer console or in `google-services.json`.",
+                      "type": "string"
+                    },
+                    "certificateHash": {
+                      "description": "The SHA-1 hash of the signing certificate used to build the APK without any separator (`:`). Can be found in `google-services.json`. https://developers.google.com/android/guides/client-auth",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for managed and standalone Android apps.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain",
+                    "native"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "mdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Natural sized image (baseline)`",
+                  "type": "string"
+                },
+                "hdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 1.5x`",
+                  "type": "string"
+                },
+                "xhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 2x`",
+                  "type": "string"
+                },
+                "xxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 3x`",
+                  "type": "string"
+                },
+                "xxxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 4x`",
+                  "type": "string"
+                }
+              }
+            },
+            "intentFilters": {
+              "description": "Configuration for setting an array of custom intent filters in Android manifest. [Learn more](https://developer.android.com/guide/components/intents-filters)",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "autoVerify": {
+                    "description": "You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](developer.android.com/training/app-links)",
+                    "type": "boolean"
+                  },
+                  "action": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "description": "the scheme of the URL, e.g. `https`",
+                            "type": "string"
+                          },
+                          "host": {
+                            "description": "the hostname, e.g. `myapp.io`",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "the port, e.g. `3000`",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+                            "type": "string"
+                          },
+                          "pathPattern": {
+                            "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+                            "type": "string"
+                          },
+                          "pathPrefix": {
+                            "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "description": "a MIME type for URLs that should be matched by the filter",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": [
+                          "array"
+                        ],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheme": {
+                              "description": "the scheme of the URL, e.g. `https`",
+                              "type": "string"
+                            },
+                            "host": {
+                              "description": "the hostname, e.g. `myapp.io`",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "the port, e.g. `3000`",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+                              "type": "string"
+                            },
+                            "pathPattern": {
+                              "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+                              "type": "string"
+                            },
+                            "pathPrefix": {
+                              "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                              "type": "string"
+                            },
+                            "mimeType": {
+                              "description": "a MIME type for URLs that should be matched by the filter",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    ]
+                  },
+                  "category": {
+                    "anyOf": [
+                      {
+                        "type": [
+                          "string"
+                        ]
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "action"
+                ]
+              }
+            },
+            "allowBackup": {
+              "description": "Allows your user's app data to be automatically backed up to their Google Drive. If this is set to false, no backup or restore of the application will ever be performed (this is useful if your app deals with sensitive information). Defaults to the Android default, which is `true`.",
+              "type": "boolean"
+            },
+            "softwareKeyboardLayoutMode": {
+              "description": "Determines how the software keyboard will impact the layout of your application. This maps to the `android:windowSoftInputMode` property. Defaults to `resize`. Valid values: `resize`, `pan`.",
+              "enum": [
+                "resize",
+                "pan"
+              ],
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "AndroidIntentFiltersData": {
+          "type": "object",
+          "properties": {
+            "scheme": {
+              "description": "the scheme of the URL, e.g. `https`",
+              "type": "string"
+            },
+            "host": {
+              "description": "the hostname, e.g. `myapp.io`",
+              "type": "string"
+            },
+            "port": {
+              "description": "the port, e.g. `3000`",
+              "type": "string"
+            },
+            "path": {
+              "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+              "type": "string"
+            },
+            "pathPattern": {
+              "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+              "type": "string"
+            },
+            "pathPrefix": {
+              "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+              "type": "string"
+            },
+            "mimeType": {
+              "description": "a MIME type for URLs that should be matched by the filter",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "IOS": {
+          "description": "Configuration that is specific to the iOS platform.",
+          "type": "object",
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "bundleIdentifier": {
+              "description": "The bundle identifier for your iOS standalone app. You make it up, but it needs to be unique on the App Store. See [this StackOverflow question](http://stackoverflow.com/questions/11347470/what-does-bundle-identifier-mean-in-the-ios-project).",
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9.-]+$"
+            },
+            "buildNumber": {
+              "description": "Build number for your iOS standalone app. Corresponds to `CFBundleVersion` and must match Apple's [specified format](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364). (Note: Transporter will pull the value for `Version Number` from `expo.version` and NOT from `expo.ios.buildNumber`.)",
+              "type": "string",
+              "pattern": "^[A-Za-z0-9.]+$"
+            },
+            "backgroundColor": {
+              "description": "The background color for your iOS app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on iOS. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency. \n\n Expo will generate the other required sizes. This icon will appear on the home screen and within the Expo app.",
+              "type": "string"
+            },
+            "merchantId": {
+              "description": "Merchant ID for use with Apple Pay in your standalone app.",
+              "type": "string"
+            },
+            "appStoreUrl": {
+              "description": "URL to your app on the Apple App Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://(itunes|apps)\\.apple\\.com/.*?\\d+",
+              "type": [
+                "string"
+              ]
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "usesNonExemptEncryption": {
+                  "description": "Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.",
+                  "type": "boolean"
+                },
+                "googleMapsApiKey": {
+                  "description": "[Google Maps iOS SDK](https://developers.google.com/maps/documentation/ios-sdk/start) key for your standalone app.",
+                  "type": "string"
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean"
+                },
+                "googleSignIn": {
+                  "description": "[Google Sign-In iOS SDK](https://developers.google.com/identity/sign-in/ios/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "reservedClientId": {
+                      "description": "The reserved client ID URL scheme. Can be found in `GoogleService-Info.plist`.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "isRemoteJSEnabled": {
+              "description": "@deprecated Use `updates.enabled` instead.",
+              "type": "boolean"
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.",
+              "type": "string"
+            },
+            "loadJSInBackgroundExperimental": {
+              "description": "@deprecated Use `updates` key with `fallbackToCacheTimeout: 0` instead.",
+              "type": "boolean"
+            },
+            "supportsTablet": {
+              "description": "Whether your standalone iOS app supports tablet screen sizes. Defaults to `false`.",
+              "type": "boolean"
+            },
+            "isTabletOnly": {
+              "description": "If true, indicates that your standalone iOS app does not support handsets, and only supports tablets.",
+              "type": "boolean"
+            },
+            "requireFullScreen": {
+              "description": "If true, indicates that your standalone iOS app does not support Slide Over and Split View on iPad. Defaults to `true` currently, but will change to `false` in a future SDK version.",
+              "type": "boolean"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "infoPlist": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "entitlements": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native *.entitlements (plist). Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "associatedDomains": {
+              "description": "An array that contains Associated Domains for the standalone app. See [Apple's docs for config](https://developer.apple.com/documentation/safariservices/supporting_associated_domains). ",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "usesIcloudStorage": {
+              "description": "A boolean indicating if the app uses iCloud Storage for `DocumentPicker`. See `DocumentPicker` docs for details.",
+              "type": "boolean"
+            },
+            "usesAppleSignIn": {
+              "description": "A boolean indicating if the app uses Apple Sign-In. See `AppleAuthentication` docs for details.",
+              "type": "boolean"
+            },
+            "accessesContactNotes": {
+              "description": "A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.",
+              "type": "boolean"
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for standalone iOS apps.",
+              "type": "object",
+              "properties": {
+                "xib": {
+                  "description": "@deprecated Apple has deprecated `.xib` splash screens in favor of `.storyboard` files. Local path to a XIB file as the loading screen. It overrides other loading screen options. Note: This will only be used in the standalone app (i.e., after you build the app). It will not be used in the Expo Go.",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "tabletImage": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "Splash": {
+          "description": "Configuration for loading and splash screen for standalone apps.",
+          "type": "object",
+          "properties": {
+            "backgroundColor": {
+              "description": "Color to fill the loading screen background",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "resizeMode": {
+              "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+              "enum": [
+                "cover",
+                "contain"
+              ],
+              "type": "string"
+            },
+            "image": {
+              "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+              "type": "string"
+            }
+          }
+        },
+        "PublishHook": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "file": {
+              "type": "string"
+            },
+            "config": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {}
+            }
+          }
+        },
+        "Web": {
+          "description": "Configuration that is specific to the web platform.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "favicon": {
+              "description": "Relative path of an image to use for your app's favicon.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Defines the title of the document, defaults to the outer level name",
+              "type": "string"
+            },
+            "shortName": {
+              "description": "A short version of the app's name, 12 characters or fewer. Used in app launcher and new tab pages. Maps to `short_name` in the PWA manifest.json. Defaults to the `name` property.",
+              "type": "string"
+            },
+            "lang": {
+              "description": "Specifies the primary language for the values in the name and short_name members. This value is a string containing a single language tag.",
+              "type": "string"
+            },
+            "scope": {
+              "description": "Defines the navigation scope of this website's context. This restricts what web pages can be viewed while the manifest is applied. If the user navigates outside the scope, it returns to a normal web page inside a browser tab/window. If the scope is a relative URL, the base URL will be the URL of the manifest.",
+              "type": "string"
+            },
+            "themeColor": {
+              "description": "Defines the color of the Android tool bar, and may be reflected in the app's preview in task switchers.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "description": {
+              "description": "Provides a general description of what the pinned website does.",
+              "type": "string"
+            },
+            "dir": {
+              "description": "Specifies the primary text direction for the name, short_name, and description members. Together with the lang member, it helps the correct display of right-to-left languages.",
+              "enum": [
+                "auto",
+                "ltr",
+                "rtl"
+              ],
+              "type": "string"
+            },
+            "display": {
+              "description": "Defines the developers’ preferred display mode for the website.",
+              "enum": [
+                "fullscreen",
+                "standalone",
+                "minimal-ui",
+                "browser"
+              ],
+              "type": "string"
+            },
+            "startUrl": {
+              "description": "The URL that loads when a user launches the application (e.g., when added to home screen), typically the index. Note: This has to be a relative URL, relative to the manifest URL.",
+              "type": "string"
+            },
+            "orientation": {
+              "description": "Defines the default orientation for all the website's top level browsing contexts.",
+              "enum": [
+                "any",
+                "natural",
+                "landscape",
+                "landscape-primary",
+                "landscape-secondary",
+                "portrait",
+                "portrait-primary",
+                "portrait-secondary"
+              ],
+              "type": "string"
+            },
+            "backgroundColor": {
+              "description": "Defines the expected “background color” for the website. This value repeats what is already available in the site’s CSS, but can be used by browsers to draw the background color of a shortcut when the manifest is available before the stylesheet has loaded. This creates a smooth transition between launching the web application and loading the site's content.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "barStyle": {
+              "description": "If content is set to default, the status bar appears normal. If set to black, the status bar has a black background. If set to black-translucent, the status bar is black and translucent. If set to default or black, the web content is displayed below the status bar. If set to black-translucent, the web content is displayed on the entire screen, partially obscured by the status bar.",
+              "enum": [
+                "default",
+                "black",
+                "black-translucent"
+              ],
+              "type": "string"
+            },
+            "preferRelatedApplications": {
+              "description": "Hints for the user agent to indicate to the user that the specified native applications (defined in expo.ios and expo.android) are recommended over the website.",
+              "type": "boolean"
+            },
+            "dangerous": {
+              "description": "Experimental features. These will break without deprecation notice.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "splash": {
+              "description": "Configuration for PWA splash screens.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "description": "Firebase web configuration. Used by the expo-firebase packages on both web and native. [Learn more](https://firebase.google.com/docs/reference/js/firebase.html#initializeapp)",
+              "type": "object",
+              "properties": {
+                "firebase": {
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "type": "string"
+                    },
+                    "authDomain": {
+                      "type": "string"
+                    },
+                    "databaseURL": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "storageBucket": {
+                      "type": "string"
+                    },
+                    "messagingSenderId": {
+                      "type": "string"
+                    },
+                    "appId": {
+                      "type": "string"
+                    },
+                    "measurementId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of your app as it appears both within Expo Go and on your home screen as a standalone app.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A short description of what your app is and why it is great.",
+          "type": "string"
+        },
+        "slug": {
+          "description": "The friendly URL name for publishing. For example, `myAppName` will refer to the `expo.io/@project-owner/myAppName` project.",
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_\\-]+$"
+        },
+        "owner": {
+          "description": "The Expo account name of the team owner, only applicable if you are enrolled in the EAS Priority Plan. If not provided, defaults to the username of the current user.",
+          "type": "string",
+          "minLength": 1
+        },
+        "currentFullName": {
+          "description": "The auto generated Expo account name and slug used for display purposes. Formatted like `@username/slug`. When unauthenticated, the username is `@anonymous`. For published projects, this value may change when a project is transferred between accounts or renamed.",
+          "type": "string"
+        },
+        "originalFullName": {
+          "description": "The auto generated Expo account name and slug used for services like Notifications and AuthSession proxy. Formatted like `@username/slug`. When unauthenticated, the username is `@anonymous`. For published projects, this value will not change when a project is transferred between accounts or renamed.",
+          "type": "string"
+        },
+        "privacy": {
+          "description": "Defaults to `unlisted`. `unlisted` hides the project from search results. `hidden` restricts access to the project page to only the owner and other users that have been granted access. Valid values: `public`, `unlisted`, `hidden`.",
+          "enum": [
+            "public",
+            "unlisted",
+            "hidden"
+          ],
+          "type": "string"
+        },
+        "sdkVersion": {
+          "description": "The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.",
+          "type": "string",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+)|(UNVERSIONED)$"
+        },
+        "runtimeVersion": {
+          "description": "**Note: Don't use this property unless you are sure what you're doing** \n\nThe runtime version associated with this manifest for bare workflow projects. If provided, this must match the version set in Expo.plist or AndroidManifest.xml.",
+          "type": "string",
+          "pattern": "^[0-9\\.]+$"
+        },
+        "version": {
+          "description": "Your app version. In addition to this field, you'll also use `ios.buildNumber` and `android.versionCode` — read more about how to version your app [here](https://docs.expo.io/distribution/app-stores/#versioning-your-app). On iOS this corresponds to `CFBundleShortVersionString`, and on Android, this corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).",
+          "type": "string"
+        },
+        "platforms": {
+          "description": "Platforms that your project explicitly supports. If not specified, it defaults to `[\"ios\", \"android\"]`.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "android",
+              "ios",
+              "web"
+            ]
+          }
+        },
+        "githubUrl": {
+          "description": "If you would like to share the source code of your app on Github, enter the URL for the repository here and it will be linked to from your Expo project page.",
+          "pattern": "^https://github\\.com/",
+          "type": [
+            "string"
+          ]
+        },
+        "orientation": {
+          "description": "Locks your app to a specific orientation with portrait or landscape. Defaults to no lock. Valid values: `default`, `portrait`, `landscape`",
+          "enum": [
+            "default",
+            "portrait",
+            "landscape"
+          ],
+          "type": "string"
+        },
+        "userInterfaceStyle": {
+          "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+          "type": "string",
+          "enum": [
+            "light",
+            "dark",
+            "automatic"
+          ]
+        },
+        "backgroundColor": {
+          "description": "The background color for your app, behind any of your React views. This is also known as the root view background color.",
+          "type": "string",
+          "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+        },
+        "primaryColor": {
+          "description": "On Android, this will determine the color of your app in the multitasker. Currently this is not used on iOS, but it may be used for other purposes in the future.",
+          "type": "string",
+          "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+        },
+        "icon": {
+          "description": "Local path or remote URL to an image to use for your app's icon. We recommend that you use a 1024x1024 png file. This icon will appear on the home screen and within the Expo app.",
+          "type": "string"
+        },
+        "notification": {
+          "description": "Configuration for remote (push) notifications.",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "description": "(Android only) Local path or remote URL to an image to use as the icon for push notifications. 96x96 png grayscale with transparency. We recommend following [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles). If not provided, defaults to your app icon.",
+              "type": "string"
+            },
+            "color": {
+              "description": "(Android only) Tint color for the push notification image when it appears in the notification tray. Defaults to `#ffffff`",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "iosDisplayInForeground": {
+              "description": "Whether or not to display notifications when the app is in the foreground on iOS. `_displayInForeground` option in the individual push notification message overrides this option. [Learn more.](https://docs.expo.io/push-notifications/receiving-notifications/#foreground-notification-behavior) Defaults to `false`.",
+              "type": "boolean"
+            },
+            "androidMode": {
+              "description": "Show each push notification individually (`default`) or collapse into one (`collapse`).",
+              "enum": [
+                "default",
+                "collapse"
+              ],
+              "type": "string"
+            },
+            "androidCollapsedTitle": {
+              "description": "If `androidMode` is set to `collapse`, this title is used for the collapsed notification message. For example, `'#{unread_notifications} new interactions'`.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "appKey": {
+          "description": "By default, Expo looks for the application registered with the AppRegistry as `main`. If you would like to change this, you can specify the name in this property.",
+          "type": "string"
+        },
+        "androidStatusBarColor": {
+          "description": "@deprecated Use `androidStatusBar` instead.",
+          "type": "string",
+          "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+        },
+        "androidStatusBar": {
+          "description": "Configuration for the status bar on Android. For more details please navigate to [Configuring StatusBar](https://docs.expo.io/guides/configuring-statusbar/).",
+          "type": "object",
+          "properties": {
+            "barStyle": {
+              "description": "Configures the status bar icons to have a light or dark color. Valid values: `light-content`, `dark-content`. Defaults to `dark-content`",
+              "type": "string",
+              "enum": [
+                "light-content",
+                "dark-content"
+              ]
+            },
+            "backgroundColor": {
+              "description": "Specifies the background color of the status bar. Defaults to `#00000000` (transparent) for `dark-content` bar style and `#00000088` (semi-transparent black) for `light-content` bar style",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "hidden": {
+              "description": "Instructs the system whether the status bar should be visible or not. Defaults to `false`",
+              "type": "boolean"
+            },
+            "translucent": {
+              "description": "Sets `android:windowTranslucentStatus` in `styles.xml`. When false, the system status bar pushes the content of your app down (similar to `position: relative`). When true, the status bar floats above the content in your app (similar to `position: absolute`). Defaults to `true` to match the iOS status bar behavior (which can only float above content).",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "androidNavigationBar": {
+          "description": "Configuration for the bottom navigation bar on Android.",
+          "type": "object",
+          "properties": {
+            "visible": {
+              "description": "Determines how and when the navigation bar is shown. [Learn more](https://developer.android.com/training/system-ui/immersive). Valid values: `leanback`, `immersive`, `sticky-immersive` \n\n `leanback` results in the navigation bar being hidden until the first touch gesture is registered. \n\n `immersive` results in the navigation bar being hidden until the user swipes up from the edge where the navigation bar is hidden. \n\n `sticky-immersive` is identical to `'immersive'` except that the navigation bar will be semi-transparent and will be hidden again after a short period of time",
+              "type": "string",
+              "enum": [
+                "leanback",
+                "immersive",
+                "sticky-immersive"
+              ]
+            },
+            "barStyle": {
+              "description": "Configure the navigation bar icons to have a light or dark color. Supported on Android Oreo and newer. Valid values: `'light-content'`, `'dark-content'`",
+              "type": "string",
+              "enum": [
+                "light-content",
+                "dark-content"
+              ]
+            },
+            "backgroundColor": {
+              "description": "Specifies the background color of the navigation bar.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            }
+          },
+          "additionalProperties": false
+        },
+        "developmentClient": {
+          "description": "Settings that apply specifically to running this app in a development client",
+          "type": "object",
+          "properties": {
+            "silentLaunch": {
+              "description": "If true, the app will launch in a development client with no additional dialogs or progress indicators, just like in a standalone app.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "scheme": {
+          "description": "**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped.",
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9+.-]*$"
+        },
+        "entryPoint": {
+          "description": "The relative path to your main JavaScript file.",
+          "type": "string"
+        },
+        "extra": {
+          "description": "Any extra fields you want to pass to your experience. Values are accessible via `Expo.Constants.manifest.extra` ([Learn more](https://docs.expo.io/versions/latest/sdk/constants/#constantsmanifest))",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "packagerOpts": {
+          "description": "@deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.io/guides/customizing-metro/)",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "updates": {
+          "description": "Configuration for how and when the app should request OTA JavaScript updates",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "If set to false, your standalone app will never download any code, and will only use code bundled locally on the device. In that case, all updates to your app must be submitted through Apple review. Defaults to true. (Note: This will not work out of the box with ExpoKit projects)",
+              "type": "boolean"
+            },
+            "checkAutomatically": {
+              "description": "By default, Expo will check for updates every time the app is loaded. Set this to `ON_ERROR_RECOVERY` to disable automatic checking unless recovering from an error. Must be one of `ON_LOAD` or `ON_ERROR_RECOVERY`",
+              "enum": [
+                "ON_ERROR_RECOVERY",
+                "ON_LOAD"
+              ],
+              "type": "string"
+            },
+            "fallbackToCacheTimeout": {
+              "description": "How long (in ms) to allow for fetching OTA updates before falling back to a cached version of the app. Defaults to 0. Must be between 0 and 300000 (5 minutes).",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 300000
+            }
+          },
+          "additionalProperties": false
+        },
+        "locales": {
+          "description": "Provide overrides by locale for System Dialog prompts like Permissions Boxes",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": {
+            "type": [
+              "string",
+              "object"
+            ]
+          }
+        },
+        "facebookAppId": {
+          "description": "Used for all Facebook libraries. Set up your Facebook App ID at https://developers.facebook.com.",
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "facebookAutoInitEnabled": {
+          "description": "Whether the Facebook SDK should be initialized automatically. The default in Expo (Client and in standalone apps) is `false`.",
+          "type": "boolean"
+        },
+        "facebookAutoLogAppEventsEnabled": {
+          "description": "Whether the Facebook SDK log app events automatically. If you don't set this property, Facebook's default will be used. (Applicable only to standalone apps.) Note: The Facebook SDK must be initialized for app events to work. You may autoinitialize Facebook SDK by setting `facebookAutoInitEnabled` to `true`",
+          "type": "boolean"
+        },
+        "facebookAdvertiserIDCollectionEnabled": {
+          "description": "Whether the Facebook SDK should collect advertiser ID properties, like the Apple IDFA and Android Advertising ID, automatically. If you don't set this property, Facebook's default policy will be used. (Applicable only to standalone apps.)",
+          "type": "boolean"
+        },
+        "facebookDisplayName": {
+          "description": "Used for native Facebook login.",
+          "type": "string"
+        },
+        "facebookScheme": {
+          "description": "Used for Facebook native login. Starts with 'fb' and followed by a string of digits, like 'fb1234567890'. You can find your scheme [here](https://developers.facebook.com/docs/facebook-login/ios)in the 'Configuring Your info.plist' section (only applicable to standalone apps and custom Expo Go apps).",
+          "type": "string",
+          "pattern": "^fb[0-9]+[A-Za-z]*$"
+        },
+        "isDetached": {
+          "description": "Is app detached",
+          "type": "boolean"
+        },
+        "detach": {
+          "description": "Extra fields needed by detached apps",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "assetBundlePatterns": {
+          "description": "An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.io/guides/offline-support/)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "plugins": {
+          "description": "Config plugins for adding extra functionality to your project. [Learn more](https://docs.expo.io/guides/config-plugins/).",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": [
+                  "string"
+                ]
+              },
+              {
+                "type": "array",
+                "items": [
+                  {
+                    "type": [
+                      "string"
+                    ]
+                  },
+                  {}
+                ],
+                "additionalItems": false
+              }
+            ]
+          }
+        },
+        "splash": {
+          "description": "Configuration for loading and splash screen for standalone apps.",
+          "type": "object",
+          "properties": {
+            "backgroundColor": {
+              "description": "Color to fill the loading screen background",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "resizeMode": {
+              "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+              "enum": [
+                "cover",
+                "contain"
+              ],
+              "type": "string"
+            },
+            "image": {
+              "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+              "type": "string"
+            }
+          }
+        },
+        "ios": {
+          "description": "Configuration that is specific to the iOS platform.",
+          "type": "object",
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "bundleIdentifier": {
+              "description": "The bundle identifier for your iOS standalone app. You make it up, but it needs to be unique on the App Store. See [this StackOverflow question](http://stackoverflow.com/questions/11347470/what-does-bundle-identifier-mean-in-the-ios-project).",
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9.-]+$"
+            },
+            "buildNumber": {
+              "description": "Build number for your iOS standalone app. Corresponds to `CFBundleVersion` and must match Apple's [specified format](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364). (Note: Transporter will pull the value for `Version Number` from `expo.version` and NOT from `expo.ios.buildNumber`.)",
+              "type": "string",
+              "pattern": "^[A-Za-z0-9\\.]+$"
+            },
+            "backgroundColor": {
+              "description": "The background color for your iOS app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on iOS. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency. \n\n Expo will generate the other required sizes. This icon will appear on the home screen and within the Expo app.",
+              "type": "string"
+            },
+            "merchantId": {
+              "description": "Merchant ID for use with Apple Pay in your standalone app.",
+              "type": "string"
+            },
+            "appStoreUrl": {
+              "description": "URL to your app on the Apple App Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://(itunes|apps)\\.apple\\.com/.*?\\d+",
+              "type": [
+                "string"
+              ]
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "usesNonExemptEncryption": {
+                  "description": "Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.",
+                  "type": "boolean"
+                },
+                "googleMapsApiKey": {
+                  "description": "[Google Maps iOS SDK](https://developers.google.com/maps/documentation/ios-sdk/start) key for your standalone app.",
+                  "type": "string"
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean"
+                },
+                "googleSignIn": {
+                  "description": "[Google Sign-In iOS SDK](https://developers.google.com/identity/sign-in/ios/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "reservedClientId": {
+                      "description": "The reserved client ID URL scheme. Can be found in `GoogleService-Info.plist`.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "isRemoteJSEnabled": {
+              "description": "@deprecated Use `updates.enabled` instead.",
+              "type": "boolean"
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.",
+              "type": "string"
+            },
+            "loadJSInBackgroundExperimental": {
+              "description": "@deprecated Use `updates` key with `fallbackToCacheTimeout: 0` instead.",
+              "type": "boolean"
+            },
+            "supportsTablet": {
+              "description": "Whether your standalone iOS app supports tablet screen sizes. Defaults to `false`.",
+              "type": "boolean"
+            },
+            "isTabletOnly": {
+              "description": "If true, indicates that your standalone iOS app does not support handsets, and only supports tablets.",
+              "type": "boolean"
+            },
+            "requireFullScreen": {
+              "description": "If true, indicates that your standalone iOS app does not support Slide Over and Split View on iPad. Defaults to `true` currently, but will change to `false` in a future SDK version.",
+              "type": "boolean"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "infoPlist": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "entitlements": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native *.entitlements (plist). Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "associatedDomains": {
+              "description": "An array that contains Associated Domains for the standalone app. See [Apple's docs for config](https://developer.apple.com/documentation/safariservices/supporting_associated_domains). ",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "usesIcloudStorage": {
+              "description": "A boolean indicating if the app uses iCloud Storage for `DocumentPicker`. See `DocumentPicker` docs for details.",
+              "type": "boolean"
+            },
+            "usesAppleSignIn": {
+              "description": "A boolean indicating if the app uses Apple Sign-In. See `AppleAuthentication` docs for details.",
+              "type": "boolean"
+            },
+            "accessesContactNotes": {
+              "description": "A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.",
+              "type": "boolean"
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for standalone iOS apps.",
+              "type": "object",
+              "properties": {
+                "xib": {
+                  "description": "@deprecated Apple has deprecated `.xib` splash screens in favor of `.storyboard` files. Local path to a XIB file as the loading screen. It overrides other loading screen options. Note: This will only be used in the standalone app (i.e., after you build the app). It will not be used in the Expo Go.",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "tabletImage": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "android": {
+          "description": "Configuration that is specific to the Android platform.",
+          "type": "object",
+          "properties": {
+            "enableDangerousExperimentalLeanBuilds": {
+              "description": "@deprecated Use EAS Build or compile locally instead. If set to true, APK will contain only unimodules that are explicitly added in package.json and their dependencies",
+              "type": "boolean"
+            },
+            "publishManifestPath": {
+              "description": "The manifest for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "package": {
+              "description": "The package name for your Android standalone app. You make it up, but it needs to be unique on the Play Store. See [this StackOverflow question](http://stackoverflow.com/questions/6273892/android-package-name-convention).",
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)+$"
+            },
+            "versionCode": {
+              "description": "Version number required by Google Play. Increment by one for each release. Must be a positive integer. [Learn more](https://developer.android.com/studio/publish/versioning.html)",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2100000000
+            },
+            "backgroundColor": {
+              "description": "The background color for your Android app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "useNextNotificationsApi": {
+              "description": "A Boolean value that indicates whether the app should use the new notifications API.",
+              "type": "boolean"
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` key. We recommend that you use a 1024x1024 png file (transparency is recommended for the Google Play Store). This icon will appear on the home screen and within the Expo app.",
+              "type": "string"
+            },
+            "adaptiveIcon": {
+              "description": "Settings for an Adaptive Launcher Icon on Android. [Learn more](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive)",
+              "type": "object",
+              "properties": {
+                "foregroundImage": {
+                  "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` and the `android.icon` keys. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive). This icon will appear on the home screen.",
+                  "type": "string"
+                },
+                "backgroundImage": {
+                  "description": "Local path or remote URL to a background image for your app's Adaptive Icon on Android. If specified, this overrides the `backgroundColor` key. Must have the same dimensions as  foregroundImage`, and has no effect if `foregroundImage` is not specified. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive).",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to use as the background for your app's Adaptive Icon on Android. Defaults to white, `#FFFFFF`. Has no effect if `foregroundImage` is not specified.",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "playStoreUrl": {
+              "description": "URL to your app on the Google Play Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://play\\.google\\.com/",
+              "type": [
+                "string"
+              ]
+            },
+            "permissions": {
+              "description": "List of permissions used by the standalone app. \n\n To use ONLY the following minimum necessary permissions and none of the extras supported by Expo in a default managed app, set `permissions` to `[]`. The minimum necessary permissions do not require a Privacy Policy when uploading to Google Play Store and are: \n• receive data from Internet \n• view network connections \n• full network access \n• change your audio settings \n• prevent device from sleeping \n\n To use ALL permissions supported by Expo by default, do not specify the `permissions` key. \n\n  To use the minimum necessary permissions ALONG with certain additional permissions, specify those extras in `permissions`, e.g.\n\n `[ \"CAMERA\", \"ACCESS_FINE_LOCATION\" ]`.\n\n  You can specify the following permissions depending on what you need:\n\n- `ACCESS_COARSE_LOCATION`\n- `ACCESS_FINE_LOCATION`\n- `ACCESS_BACKGROUND_LOCATION`\n- `CAMERA`\n- `RECORD_AUDIO`\n- `READ_CONTACTS`\n- `WRITE_CONTACTS`\n- `READ_CALENDAR`\n- `WRITE_CALENDAR`\n- `READ_EXTERNAL_STORAGE`\n- `WRITE_EXTERNAL_STORAGE`\n- `USE_FINGERPRINT`\n- `USE_BIOMETRIC`\n- `WRITE_SETTINGS`\n- `VIBRATE`\n- `READ_PHONE_STATE`\n- `com.anddoes.launcher.permission.UPDATE_COUNT`\n- `com.android.launcher.permission.INSTALL_SHORTCUT`\n- `com.google.android.c2dm.permission.RECEIVE`\n- `com.google.android.gms.permission.ACTIVITY_RECOGNITION`\n- `com.google.android.providers.gsf.permission.READ_GSERVICES`\n- `com.htc.launcher.permission.READ_SETTINGS`\n- `com.htc.launcher.permission.UPDATE_SHORTCUT`\n- `com.majeur.launcher.permission.UPDATE_BADGE`\n- `com.sec.android.provider.badge.permission.READ`\n- `com.sec.android.provider.badge.permission.WRITE`\n- `com.sonyericsson.home.permission.BROADCAST_BADGE`\n",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase. Including this key automatically enables FCM in your standalone app.",
+              "type": "string"
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMaps": {
+                  "description": "[Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Google Maps Android SDK API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean"
+                },
+                "googleSignIn": {
+                  "description": "@deprecated Use `googleServicesFile` instead. [Google Sign-In Android SDK](https://developers.google.com/identity/sign-in/android/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "The Android API key. Can be found in the credentials section of the developer console or in `google-services.json`.",
+                      "type": "string"
+                    },
+                    "certificateHash": {
+                      "description": "The SHA-1 hash of the signing certificate used to build the APK without any separator (`:`). Can be found in `google-services.json`. https://developers.google.com/android/guides/client-auth",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for managed and standalone Android apps.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain",
+                    "native"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "mdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Natural sized image (baseline)`",
+                  "type": "string"
+                },
+                "hdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 1.5x`",
+                  "type": "string"
+                },
+                "xhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 2x`",
+                  "type": "string"
+                },
+                "xxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 3x`",
+                  "type": "string"
+                },
+                "xxxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 4x`",
+                  "type": "string"
+                }
+              }
+            },
+            "intentFilters": {
+              "description": "Configuration for setting an array of custom intent filters in Android manifest. [Learn more](https://developer.android.com/guide/components/intents-filters)",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "autoVerify": {
+                    "description": "You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](developer.android.com/training/app-links)",
+                    "type": "boolean"
+                  },
+                  "action": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "description": "the scheme of the URL, e.g. `https`",
+                            "type": "string"
+                          },
+                          "host": {
+                            "description": "the hostname, e.g. `myapp.io`",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "the port, e.g. `3000`",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+                            "type": "string"
+                          },
+                          "pathPattern": {
+                            "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+                            "type": "string"
+                          },
+                          "pathPrefix": {
+                            "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "description": "a MIME type for URLs that should be matched by the filter",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": [
+                          "array"
+                        ],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheme": {
+                              "description": "the scheme of the URL, e.g. `https`",
+                              "type": "string"
+                            },
+                            "host": {
+                              "description": "the hostname, e.g. `myapp.io`",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "the port, e.g. `3000`",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+                              "type": "string"
+                            },
+                            "pathPattern": {
+                              "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+                              "type": "string"
+                            },
+                            "pathPrefix": {
+                              "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                              "type": "string"
+                            },
+                            "mimeType": {
+                              "description": "a MIME type for URLs that should be matched by the filter",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    ]
+                  },
+                  "category": {
+                    "anyOf": [
+                      {
+                        "type": [
+                          "string"
+                        ]
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "action"
+                ]
+              }
+            },
+            "allowBackup": {
+              "description": "Allows your user's app data to be automatically backed up to their Google Drive. If this is set to false, no backup or restore of the application will ever be performed (this is useful if your app deals with sensitive information). Defaults to the Android default, which is `true`.",
+              "type": "boolean"
+            },
+            "softwareKeyboardLayoutMode": {
+              "description": "Determines how the software keyboard will impact the layout of your application. This maps to the `android:windowSoftInputMode` property. Defaults to `resize`. Valid values: `resize`, `pan`.",
+              "enum": [
+                "resize",
+                "pan"
+              ],
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "web": {
+          "description": "Configuration that is specific to the web platform.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "favicon": {
+              "description": "Relative path of an image to use for your app's favicon.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Defines the title of the document, defaults to the outer level name",
+              "type": "string"
+            },
+            "shortName": {
+              "description": "A short version of the app's name, 12 characters or fewer. Used in app launcher and new tab pages. Maps to `short_name` in the PWA manifest.json. Defaults to the `name` property.",
+              "type": "string"
+            },
+            "lang": {
+              "description": "Specifies the primary language for the values in the name and short_name members. This value is a string containing a single language tag.",
+              "type": "string"
+            },
+            "scope": {
+              "description": "Defines the navigation scope of this website's context. This restricts what web pages can be viewed while the manifest is applied. If the user navigates outside the scope, it returns to a normal web page inside a browser tab/window. If the scope is a relative URL, the base URL will be the URL of the manifest.",
+              "type": "string"
+            },
+            "themeColor": {
+              "description": "Defines the color of the Android tool bar, and may be reflected in the app's preview in task switchers.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "description": {
+              "description": "Provides a general description of what the pinned website does.",
+              "type": "string"
+            },
+            "dir": {
+              "description": "Specifies the primary text direction for the name, short_name, and description members. Together with the lang member, it helps the correct display of right-to-left languages.",
+              "enum": [
+                "auto",
+                "ltr",
+                "rtl"
+              ],
+              "type": "string"
+            },
+            "display": {
+              "description": "Defines the developers’ preferred display mode for the website.",
+              "enum": [
+                "fullscreen",
+                "standalone",
+                "minimal-ui",
+                "browser"
+              ],
+              "type": "string"
+            },
+            "startUrl": {
+              "description": "The URL that loads when a user launches the application (e.g., when added to home screen), typically the index. Note: This has to be a relative URL, relative to the manifest URL.",
+              "type": "string"
+            },
+            "orientation": {
+              "description": "Defines the default orientation for all the website's top level browsing contexts.",
+              "enum": [
+                "any",
+                "natural",
+                "landscape",
+                "landscape-primary",
+                "landscape-secondary",
+                "portrait",
+                "portrait-primary",
+                "portrait-secondary"
+              ],
+              "type": "string"
+            },
+            "backgroundColor": {
+              "description": "Defines the expected “background color” for the website. This value repeats what is already available in the site’s CSS, but can be used by browsers to draw the background color of a shortcut when the manifest is available before the stylesheet has loaded. This creates a smooth transition between launching the web application and loading the site's content.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "barStyle": {
+              "description": "If content is set to default, the status bar appears normal. If set to black, the status bar has a black background. If set to black-translucent, the status bar is black and translucent. If set to default or black, the web content is displayed below the status bar. If set to black-translucent, the web content is displayed on the entire screen, partially obscured by the status bar.",
+              "enum": [
+                "default",
+                "black",
+                "black-translucent"
+              ],
+              "type": "string"
+            },
+            "preferRelatedApplications": {
+              "description": "Hints for the user agent to indicate to the user that the specified native applications (defined in expo.ios and expo.android) are recommended over the website.",
+              "type": "boolean"
+            },
+            "dangerous": {
+              "description": "Experimental features. These will break without deprecation notice.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "splash": {
+              "description": "Configuration for PWA splash screens.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "description": "Firebase web configuration. Used by the expo-firebase packages on both web and native. [Learn more](https://firebase.google.com/docs/reference/js/firebase.html#initializeapp)",
+              "type": "object",
+              "properties": {
+                "firebase": {
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "type": "string"
+                    },
+                    "authDomain": {
+                      "type": "string"
+                    },
+                    "databaseURL": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "storageBucket": {
+                      "type": "string"
+                    },
+                    "messagingSenderId": {
+                      "type": "string"
+                    },
+                    "appId": {
+                      "type": "string"
+                    },
+                    "measurementId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "hooks": {
+          "description": "Configuration for scripts to run to hook into the publish process",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "postPublish": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {}
+                  }
+                }
+              }
+            },
+            "postExport": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "experiments": {
+          "description": "Enable experimental features that may be unstable, unsupported, or removed without deprecation notices.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "turboModules": {
+              "description": "Enables Turbo Modules, which are a type of native modules that use a different way of communicating between JS and platform code. When installing a Turbo Module you will need to enable this experimental option (the library still needs to be a part of Expo SDK already, like react-native-reanimated v2). Turbo Modules do not support remote debugging and enabling this option will disable remote debugging.",
+              "type": "boolean"
+            }
+          }
+        },
+        "_internal": {
+          "description": "Internal properties for developer tools",
+          "type": "object",
+          "properties": {
+            "pluginHistory": {
+              "description": "List of plugins already run on the config",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "slug"
+      ]
+    }
+  }
+}

--- a/src/schemas/json/expo-42.0.0.json
+++ b/src/schemas/json/expo-42.0.0.json
@@ -1,0 +1,1812 @@
+{
+  "title": "JSON schema for Expo SDK 41 app manifest",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "expo"
+  ],
+  "properties": {
+    "expo": {
+      "definitions": {
+        "Android": {
+          "description": "Configuration that is specific to the Android platform.",
+          "type": "object",
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "package": {
+              "description": "The package name for your Android standalone app. You make it up, but it needs to be unique on the Play Store. See [this StackOverflow question](http://stackoverflow.com/questions/6273892/android-package-name-convention).",
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)+$"
+            },
+            "versionCode": {
+              "description": "Version number required by Google Play. Increment by one for each release. Must be a positive integer. [Learn more](https://developer.android.com/studio/publish/versioning.html)",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2100000000
+            },
+            "backgroundColor": {
+              "description": "The background color for your Android app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "useNextNotificationsApi": {
+              "description": "@deprecated A Boolean value that indicates whether the app should use the new notifications API.",
+              "type": "boolean"
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` key. We recommend that you use a 1024x1024 png file (transparency is recommended for the Google Play Store). This icon will appear on the home screen and within the Expo app.",
+              "type": "string"
+            },
+            "adaptiveIcon": {
+              "description": "Settings for an Adaptive Launcher Icon on Android. [Learn more](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive)",
+              "type": "object",
+              "properties": {
+                "foregroundImage": {
+                  "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` and the `android.icon` keys. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive). This icon will appear on the home screen.",
+                  "type": "string"
+                },
+                "backgroundImage": {
+                  "description": "Local path or remote URL to a background image for your app's Adaptive Icon on Android. If specified, this overrides the `backgroundColor` key. Must have the same dimensions as  foregroundImage`, and has no effect if `foregroundImage` is not specified. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive).",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to use as the background for your app's Adaptive Icon on Android. Defaults to white, `#FFFFFF`. Has no effect if `foregroundImage` is not specified.",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "playStoreUrl": {
+              "description": "URL to your app on the Google Play Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://play\\.google\\.com/",
+              "type": [
+                "string"
+              ]
+            },
+            "permissions": {
+              "description": "List of permissions used by the standalone app. \n\n To use ONLY the following minimum necessary permissions and none of the extras supported by Expo in a default managed app, set `permissions` to `[]`. The minimum necessary permissions do not require a Privacy Policy when uploading to Google Play Store and are: \n• receive data from Internet \n• view network connections \n• full network access \n• change your audio settings \n• prevent device from sleeping \n\n To use ALL permissions supported by Expo by default, do not specify the `permissions` key. \n\n  To use the minimum necessary permissions ALONG with certain additional permissions, specify those extras in `permissions`, e.g.\n\n `[ \"CAMERA\", \"ACCESS_FINE_LOCATION\" ]`.\n\n  You can specify the following permissions depending on what you need:\n\n- `ACCESS_COARSE_LOCATION`\n- `ACCESS_FINE_LOCATION`\n- `ACCESS_BACKGROUND_LOCATION`\n- `CAMERA`\n- `RECORD_AUDIO`\n- `READ_CONTACTS`\n- `WRITE_CONTACTS`\n- `READ_CALENDAR`\n- `WRITE_CALENDAR`\n- `READ_EXTERNAL_STORAGE`\n- `WRITE_EXTERNAL_STORAGE`\n- `USE_FINGERPRINT`\n- `USE_BIOMETRIC`\n- `WRITE_SETTINGS`\n- `VIBRATE`\n- `READ_PHONE_STATE`\n- `com.anddoes.launcher.permission.UPDATE_COUNT`\n- `com.android.launcher.permission.INSTALL_SHORTCUT`\n- `com.google.android.c2dm.permission.RECEIVE`\n- `com.google.android.gms.permission.ACTIVITY_RECOGNITION`\n- `com.google.android.providers.gsf.permission.READ_GSERVICES`\n- `com.htc.launcher.permission.READ_SETTINGS`\n- `com.htc.launcher.permission.UPDATE_SHORTCUT`\n- `com.majeur.launcher.permission.UPDATE_BADGE`\n- `com.sec.android.provider.badge.permission.READ`\n- `com.sec.android.provider.badge.permission.WRITE`\n- `com.sonyericsson.home.permission.BROADCAST_BADGE`\n",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase. Including this key automatically enables FCM in your standalone app.",
+              "type": "string"
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMaps": {
+                  "description": "[Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Google Maps Android SDK API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean"
+                },
+                "googleSignIn": {
+                  "description": "@deprecated Use `googleServicesFile` instead. [Google Sign-In Android SDK](https://developers.google.com/identity/sign-in/android/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "The Android API key. Can be found in the credentials section of the developer console or in `google-services.json`.",
+                      "type": "string"
+                    },
+                    "certificateHash": {
+                      "description": "The SHA-1 hash of the signing certificate used to build the APK without any separator (`:`). Can be found in `google-services.json`. https://developers.google.com/android/guides/client-auth",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for managed and standalone Android apps.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain",
+                    "native"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "mdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Natural sized image (baseline)`",
+                  "type": "string"
+                },
+                "hdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 1.5x`",
+                  "type": "string"
+                },
+                "xhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 2x`",
+                  "type": "string"
+                },
+                "xxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 3x`",
+                  "type": "string"
+                },
+                "xxxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 4x`",
+                  "type": "string"
+                }
+              }
+            },
+            "intentFilters": {
+              "description": "Configuration for setting an array of custom intent filters in Android manifest. [Learn more](https://developer.android.com/guide/components/intents-filters)",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "autoVerify": {
+                    "description": "You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](developer.android.com/training/app-links)",
+                    "type": "boolean"
+                  },
+                  "action": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "description": "the scheme of the URL, e.g. `https`",
+                            "type": "string"
+                          },
+                          "host": {
+                            "description": "the hostname, e.g. `myapp.io`",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "the port, e.g. `3000`",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+                            "type": "string"
+                          },
+                          "pathPattern": {
+                            "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+                            "type": "string"
+                          },
+                          "pathPrefix": {
+                            "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "description": "a MIME type for URLs that should be matched by the filter",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": [
+                          "array"
+                        ],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheme": {
+                              "description": "the scheme of the URL, e.g. `https`",
+                              "type": "string"
+                            },
+                            "host": {
+                              "description": "the hostname, e.g. `myapp.io`",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "the port, e.g. `3000`",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+                              "type": "string"
+                            },
+                            "pathPattern": {
+                              "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+                              "type": "string"
+                            },
+                            "pathPrefix": {
+                              "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                              "type": "string"
+                            },
+                            "mimeType": {
+                              "description": "a MIME type for URLs that should be matched by the filter",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    ]
+                  },
+                  "category": {
+                    "anyOf": [
+                      {
+                        "type": [
+                          "string"
+                        ]
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "action"
+                ]
+              }
+            },
+            "allowBackup": {
+              "description": "Allows your user's app data to be automatically backed up to their Google Drive. If this is set to false, no backup or restore of the application will ever be performed (this is useful if your app deals with sensitive information). Defaults to the Android default, which is `true`.",
+              "type": "boolean"
+            },
+            "softwareKeyboardLayoutMode": {
+              "description": "Determines how the software keyboard will impact the layout of your application. This maps to the `android:windowSoftInputMode` property. Defaults to `resize`. Valid values: `resize`, `pan`.",
+              "enum": [
+                "resize",
+                "pan"
+              ],
+              "type": "string"
+            },
+            "jsEngine": {
+              "description": "Specifies the JavaScript engine. Supported only on EAS Build. Defaults to `jsc`. Valid values: `hermes`, `jsc`.",
+              "type": "string",
+              "enum": [
+                "hermes",
+                "jsc"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "AndroidIntentFiltersData": {
+          "type": "object",
+          "properties": {
+            "scheme": {
+              "description": "the scheme of the URL, e.g. `https`",
+              "type": "string"
+            },
+            "host": {
+              "description": "the hostname, e.g. `myapp.io`",
+              "type": "string"
+            },
+            "port": {
+              "description": "the port, e.g. `3000`",
+              "type": "string"
+            },
+            "path": {
+              "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+              "type": "string"
+            },
+            "pathPattern": {
+              "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+              "type": "string"
+            },
+            "pathPrefix": {
+              "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+              "type": "string"
+            },
+            "mimeType": {
+              "description": "a MIME type for URLs that should be matched by the filter",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "IOS": {
+          "description": "Configuration that is specific to the iOS platform.",
+          "type": "object",
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "bundleIdentifier": {
+              "description": "The bundle identifier for your iOS standalone app. You make it up, but it needs to be unique on the App Store. See [this StackOverflow question](http://stackoverflow.com/questions/11347470/what-does-bundle-identifier-mean-in-the-ios-project).",
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9.-]+$"
+            },
+            "buildNumber": {
+              "description": "Build number for your iOS standalone app. Corresponds to `CFBundleVersion` and must match Apple's [specified format](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364). (Note: Transporter will pull the value for `Version Number` from `expo.version` and NOT from `expo.ios.buildNumber`.)",
+              "type": "string",
+              "pattern": "^[A-Za-z0-9\\.]+$"
+            },
+            "backgroundColor": {
+              "description": "The background color for your iOS app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on iOS. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency. \n\n Expo will generate the other required sizes. This icon will appear on the home screen and within the Expo app.",
+              "type": "string"
+            },
+            "merchantId": {
+              "description": "Merchant ID for use with Apple Pay in your standalone app.",
+              "type": "string"
+            },
+            "appStoreUrl": {
+              "description": "URL to your app on the Apple App Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://(itunes|apps)\\.apple\\.com/.*?\\d+",
+              "type": [
+                "string"
+              ]
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "usesNonExemptEncryption": {
+                  "description": "Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.",
+                  "type": "boolean"
+                },
+                "googleMapsApiKey": {
+                  "description": "[Google Maps iOS SDK](https://developers.google.com/maps/documentation/ios-sdk/start) key for your standalone app.",
+                  "type": "string"
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean"
+                },
+                "googleSignIn": {
+                  "description": "[Google Sign-In iOS SDK](https://developers.google.com/identity/sign-in/ios/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "reservedClientId": {
+                      "description": "The reserved client ID URL scheme. Can be found in `GoogleService-Info.plist`.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.",
+              "type": "string"
+            },
+            "supportsTablet": {
+              "description": "Whether your standalone iOS app supports tablet screen sizes. Defaults to `false`.",
+              "type": "boolean"
+            },
+            "isTabletOnly": {
+              "description": "If true, indicates that your standalone iOS app does not support handsets, and only supports tablets.",
+              "type": "boolean"
+            },
+            "requireFullScreen": {
+              "description": "If true, indicates that your standalone iOS app does not support Slide Over and Split View on iPad. Defaults to `true` currently, but will change to `false` in a future SDK version.",
+              "type": "boolean"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "infoPlist": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "entitlements": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native *.entitlements (plist). Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "associatedDomains": {
+              "description": "An array that contains Associated Domains for the standalone app. [Learn more](https://developer.apple.com/documentation/safariservices/supporting_associated_domains).",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "usesIcloudStorage": {
+              "description": "A boolean indicating if the app uses iCloud Storage for `DocumentPicker`. See `DocumentPicker` docs for details.",
+              "type": "boolean"
+            },
+            "usesAppleSignIn": {
+              "description": "A boolean indicating if the app uses Apple Sign-In. See `AppleAuthentication` docs for details.",
+              "type": "boolean"
+            },
+            "accessesContactNotes": {
+              "description": "A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.",
+              "type": "boolean"
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for standalone iOS apps.",
+              "type": "object",
+              "properties": {
+                "xib": {
+                  "description": "@deprecated Apple has deprecated `.xib` splash screens in favor of `.storyboard` files. Local path to a XIB file as the loading screen. It overrides other loading screen options. Note: This will only be used in the standalone app (i.e., after you build the app). It will not be used in the Expo Go.",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "tabletImage": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "Splash": {
+          "description": "Configuration for loading and splash screen for standalone apps.",
+          "type": "object",
+          "properties": {
+            "backgroundColor": {
+              "description": "Color to fill the loading screen background",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "resizeMode": {
+              "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+              "enum": [
+                "cover",
+                "contain"
+              ],
+              "type": "string"
+            },
+            "image": {
+              "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+              "type": "string"
+            }
+          }
+        },
+        "PublishHook": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "file": {
+              "type": "string"
+            },
+            "config": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {}
+            }
+          }
+        },
+        "Web": {
+          "description": "Configuration that is specific to the web platform.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "favicon": {
+              "description": "Relative path of an image to use for your app's favicon.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Defines the title of the document, defaults to the outer level name",
+              "type": "string"
+            },
+            "shortName": {
+              "description": "A short version of the app's name, 12 characters or fewer. Used in app launcher and new tab pages. Maps to `short_name` in the PWA manifest.json. Defaults to the `name` property.",
+              "type": "string"
+            },
+            "lang": {
+              "description": "Specifies the primary language for the values in the name and short_name members. This value is a string containing a single language tag.",
+              "type": "string"
+            },
+            "scope": {
+              "description": "Defines the navigation scope of this website's context. This restricts what web pages can be viewed while the manifest is applied. If the user navigates outside the scope, it returns to a normal web page inside a browser tab/window. If the scope is a relative URL, the base URL will be the URL of the manifest.",
+              "type": "string"
+            },
+            "themeColor": {
+              "description": "Defines the color of the Android tool bar, and may be reflected in the app's preview in task switchers.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "description": {
+              "description": "Provides a general description of what the pinned website does.",
+              "type": "string"
+            },
+            "dir": {
+              "description": "Specifies the primary text direction for the name, short_name, and description members. Together with the lang member, it helps the correct display of right-to-left languages.",
+              "enum": [
+                "auto",
+                "ltr",
+                "rtl"
+              ],
+              "type": "string"
+            },
+            "display": {
+              "description": "Defines the developers’ preferred display mode for the website.",
+              "enum": [
+                "fullscreen",
+                "standalone",
+                "minimal-ui",
+                "browser"
+              ],
+              "type": "string"
+            },
+            "startUrl": {
+              "description": "The URL that loads when a user launches the application (e.g., when added to home screen), typically the index. Note: This has to be a relative URL, relative to the manifest URL.",
+              "type": "string"
+            },
+            "orientation": {
+              "description": "Defines the default orientation for all the website's top level browsing contexts.",
+              "enum": [
+                "any",
+                "natural",
+                "landscape",
+                "landscape-primary",
+                "landscape-secondary",
+                "portrait",
+                "portrait-primary",
+                "portrait-secondary"
+              ],
+              "type": "string"
+            },
+            "backgroundColor": {
+              "description": "Defines the expected “background color” for the website. This value repeats what is already available in the site’s CSS, but can be used by browsers to draw the background color of a shortcut when the manifest is available before the stylesheet has loaded. This creates a smooth transition between launching the web application and loading the site's content.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "barStyle": {
+              "description": "If content is set to default, the status bar appears normal. If set to black, the status bar has a black background. If set to black-translucent, the status bar is black and translucent. If set to default or black, the web content is displayed below the status bar. If set to black-translucent, the web content is displayed on the entire screen, partially obscured by the status bar.",
+              "enum": [
+                "default",
+                "black",
+                "black-translucent"
+              ],
+              "type": "string"
+            },
+            "preferRelatedApplications": {
+              "description": "Hints for the user agent to indicate to the user that the specified native applications (defined in expo.ios and expo.android) are recommended over the website.",
+              "type": "boolean"
+            },
+            "dangerous": {
+              "description": "Experimental features. These will break without deprecation notice.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "splash": {
+              "description": "Configuration for PWA splash screens.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "description": "Firebase web configuration. Used by the expo-firebase packages on both web and native. [Learn more](https://firebase.google.com/docs/reference/js/firebase.html#initializeapp)",
+              "type": "object",
+              "properties": {
+                "firebase": {
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "type": "string"
+                    },
+                    "authDomain": {
+                      "type": "string"
+                    },
+                    "databaseURL": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "storageBucket": {
+                      "type": "string"
+                    },
+                    "messagingSenderId": {
+                      "type": "string"
+                    },
+                    "appId": {
+                      "type": "string"
+                    },
+                    "measurementId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of your app as it appears both within Expo Go and on your home screen as a standalone app.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A short description of what your app is and why it is great.",
+          "type": "string"
+        },
+        "slug": {
+          "description": "The friendly URL name for publishing. For example, `myAppName` will refer to the `expo.io/@project-owner/myAppName` project.",
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_\\-]+$"
+        },
+        "owner": {
+          "description": "The Expo account name of the team owner, only applicable if you are enrolled in the EAS Priority Plan. If not provided, defaults to the username of the current user.",
+          "type": "string",
+          "minLength": 1
+        },
+        "currentFullName": {
+          "description": "The auto generated Expo account name and slug used for display purposes. Formatted like `@username/slug`. When unauthenticated, the username is `@anonymous`. For published projects, this value may change when a project is transferred between accounts or renamed.",
+          "type": "string"
+        },
+        "originalFullName": {
+          "description": "The auto generated Expo account name and slug used for services like Notifications and AuthSession proxy. Formatted like `@username/slug`. When unauthenticated, the username is `@anonymous`. For published projects, this value will not change when a project is transferred between accounts or renamed.",
+          "type": "string"
+        },
+        "privacy": {
+          "description": "Defaults to `unlisted`. `unlisted` hides the project from search results. `hidden` restricts access to the project page to only the owner and other users that have been granted access. Valid values: `public`, `unlisted`, `hidden`.",
+          "enum": [
+            "public",
+            "unlisted",
+            "hidden"
+          ],
+          "type": "string"
+        },
+        "sdkVersion": {
+          "description": "The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.",
+          "type": "string",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+)|(UNVERSIONED)$"
+        },
+        "runtimeVersion": {
+          "description": "**Note: Don't use this property unless you are sure what you're doing** \n\nThe runtime version associated with this manifest for bare workflow projects. If provided, this must match the version set in Expo.plist or AndroidManifest.xml.",
+          "type": "string",
+          "pattern": "^[0-9.]+$"
+        },
+        "version": {
+          "description": "Your app version. In addition to this field, you'll also use `ios.buildNumber` and `android.versionCode` — read more about how to version your app [here](https://docs.expo.io/distribution/app-stores/#versioning-your-app). On iOS this corresponds to `CFBundleShortVersionString`, and on Android, this corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).",
+          "type": "string"
+        },
+        "platforms": {
+          "description": "Platforms that your project explicitly supports. If not specified, it defaults to `[\"ios\", \"android\"]`.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "android",
+              "ios",
+              "web"
+            ]
+          }
+        },
+        "githubUrl": {
+          "description": "If you would like to share the source code of your app on Github, enter the URL for the repository here and it will be linked to from your Expo project page.",
+          "pattern": "^https://github\\.com/",
+          "type": [
+            "string"
+          ]
+        },
+        "orientation": {
+          "description": "Locks your app to a specific orientation with portrait or landscape. Defaults to no lock. Valid values: `default`, `portrait`, `landscape`",
+          "enum": [
+            "default",
+            "portrait",
+            "landscape"
+          ],
+          "type": "string"
+        },
+        "userInterfaceStyle": {
+          "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+          "type": "string",
+          "enum": [
+            "light",
+            "dark",
+            "automatic"
+          ]
+        },
+        "backgroundColor": {
+          "description": "The background color for your app, behind any of your React views. This is also known as the root view background color.",
+          "type": "string",
+          "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+        },
+        "primaryColor": {
+          "description": "On Android, this will determine the color of your app in the multitasker. Currently this is not used on iOS, but it may be used for other purposes in the future.",
+          "type": "string",
+          "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+        },
+        "icon": {
+          "description": "Local path or remote URL to an image to use for your app's icon. We recommend that you use a 1024x1024 png file. This icon will appear on the home screen and within the Expo app.",
+          "type": "string"
+        },
+        "notification": {
+          "description": "Configuration for remote (push) notifications.",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "description": "(Android only) Local path or remote URL to an image to use as the icon for push notifications. 96x96 png grayscale with transparency. We recommend following [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles). If not provided, defaults to your app icon.",
+              "type": "string"
+            },
+            "color": {
+              "description": "(Android only) Tint color for the push notification image when it appears in the notification tray. Defaults to `#ffffff`",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "iosDisplayInForeground": {
+              "description": "Whether or not to display notifications when the app is in the foreground on iOS. `_displayInForeground` option in the individual push notification message overrides this option. [Learn more.](https://docs.expo.io/push-notifications/receiving-notifications/#foreground-notification-behavior) Defaults to `false`.",
+              "type": "boolean"
+            },
+            "androidMode": {
+              "description": "Show each push notification individually (`default`) or collapse into one (`collapse`).",
+              "enum": [
+                "default",
+                "collapse"
+              ],
+              "type": "string"
+            },
+            "androidCollapsedTitle": {
+              "description": "If `androidMode` is set to `collapse`, this title is used for the collapsed notification message. For example, `'#{unread_notifications} new interactions'`.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "appKey": {
+          "description": "By default, Expo looks for the application registered with the AppRegistry as `main`. If you would like to change this, you can specify the name in this property.",
+          "type": "string"
+        },
+        "androidStatusBar": {
+          "description": "Configuration for the status bar on Android. For more details please navigate to [Configuring StatusBar](https://docs.expo.io/guides/configuring-statusbar/).",
+          "type": "object",
+          "properties": {
+            "barStyle": {
+              "description": "Configures the status bar icons to have a light or dark color. Valid values: `light-content`, `dark-content`. Defaults to `dark-content`",
+              "type": "string",
+              "enum": [
+                "light-content",
+                "dark-content"
+              ]
+            },
+            "backgroundColor": {
+              "description": "Specifies the background color of the status bar. Defaults to `#00000000` (transparent) for `dark-content` bar style and `#00000088` (semi-transparent black) for `light-content` bar style",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "hidden": {
+              "description": "Instructs the system whether the status bar should be visible or not. Defaults to `false`",
+              "type": "boolean"
+            },
+            "translucent": {
+              "description": "Sets `android:windowTranslucentStatus` in `styles.xml`. When false, the system status bar pushes the content of your app down (similar to `position: relative`). When true, the status bar floats above the content in your app (similar to `position: absolute`). Defaults to `true` to match the iOS status bar behavior (which can only float above content).",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "androidNavigationBar": {
+          "description": "Configuration for the bottom navigation bar on Android.",
+          "type": "object",
+          "properties": {
+            "visible": {
+              "description": "Determines how and when the navigation bar is shown. [Learn more](https://developer.android.com/training/system-ui/immersive). Valid values: `leanback`, `immersive`, `sticky-immersive` \n\n `leanback` results in the navigation bar being hidden until the first touch gesture is registered. \n\n `immersive` results in the navigation bar being hidden until the user swipes up from the edge where the navigation bar is hidden. \n\n `sticky-immersive` is identical to `'immersive'` except that the navigation bar will be semi-transparent and will be hidden again after a short period of time",
+              "type": "string",
+              "enum": [
+                "leanback",
+                "immersive",
+                "sticky-immersive"
+              ]
+            },
+            "barStyle": {
+              "description": "Configure the navigation bar icons to have a light or dark color. Supported on Android Oreo and newer. Valid values: `'light-content'`, `'dark-content'`",
+              "type": "string",
+              "enum": [
+                "light-content",
+                "dark-content"
+              ]
+            },
+            "backgroundColor": {
+              "description": "Specifies the background color of the navigation bar.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            }
+          },
+          "additionalProperties": false
+        },
+        "developmentClient": {
+          "description": "Settings that apply specifically to running this app in a development client",
+          "type": "object",
+          "properties": {
+            "silentLaunch": {
+              "description": "If true, the app will launch in a development client with no additional dialogs or progress indicators, just like in a standalone app.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "scheme": {
+          "description": "**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped.",
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9+.-]*$"
+        },
+        "entryPoint": {
+          "description": "The relative path to your main JavaScript file.",
+          "type": "string"
+        },
+        "extra": {
+          "description": "Any extra fields you want to pass to your experience. Values are accessible via `Expo.Constants.manifest.extra` ([Learn more](https://docs.expo.io/versions/latest/sdk/constants/#constantsmanifest))",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "packagerOpts": {
+          "description": "@deprecated Use a `metro.config.js` file instead. [Learn more](https://docs.expo.io/guides/customizing-metro/)",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "updates": {
+          "description": "Configuration for how and when the app should request OTA JavaScript updates",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "If set to false, your standalone app will never download any code, and will only use code bundled locally on the device. In that case, all updates to your app must be submitted through app store review. Defaults to true. (Note: This will not work out of the box with ExpoKit projects)",
+              "type": "boolean"
+            },
+            "checkAutomatically": {
+              "description": "By default, Expo will check for updates every time the app is loaded. Set this to `ON_ERROR_RECOVERY` to disable automatic checking unless recovering from an error. Must be one of `ON_LOAD` or `ON_ERROR_RECOVERY`",
+              "enum": [
+                "ON_ERROR_RECOVERY",
+                "ON_LOAD"
+              ],
+              "type": "string"
+            },
+            "fallbackToCacheTimeout": {
+              "description": "How long (in ms) to allow for fetching OTA updates before falling back to a cached version of the app. Defaults to 0. Must be between 0 and 300000 (5 minutes).",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 300000
+            },
+            "url": {
+              "description": "URL from which expo-updates will fetch update manifests",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "locales": {
+          "description": "Provide overrides by locale for System Dialog prompts like Permissions Boxes",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": {
+            "type": [
+              "string",
+              "object"
+            ]
+          }
+        },
+        "facebookAppId": {
+          "description": "Used for all Facebook libraries. Set up your Facebook App ID at https://developers.facebook.com.",
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "facebookAutoInitEnabled": {
+          "description": "Whether the Facebook SDK should be initialized automatically. The default in Expo (Client and in standalone apps) is `false`.",
+          "type": "boolean"
+        },
+        "facebookAutoLogAppEventsEnabled": {
+          "description": "Whether the Facebook SDK log app events automatically. If you don't set this property, Facebook's default will be used. (Applicable only to standalone apps.) Note: The Facebook SDK must be initialized for app events to work. You may autoinitialize Facebook SDK by setting `facebookAutoInitEnabled` to `true`",
+          "type": "boolean"
+        },
+        "facebookAdvertiserIDCollectionEnabled": {
+          "description": "Whether the Facebook SDK should collect advertiser ID properties, like the Apple IDFA and Android Advertising ID, automatically. If you don't set this property, Facebook's default policy will be used. (Applicable only to standalone apps.)",
+          "type": "boolean"
+        },
+        "facebookDisplayName": {
+          "description": "Used for native Facebook login.",
+          "type": "string"
+        },
+        "facebookScheme": {
+          "description": "Used for Facebook native login. Starts with 'fb' and followed by a string of digits, like 'fb1234567890'. You can find your scheme [here](https://developers.facebook.com/docs/facebook-login/ios)in the 'Configuring Your info.plist' section (only applicable to standalone apps and custom Expo Go apps).",
+          "type": "string",
+          "pattern": "^fb[0-9]+[A-Za-z]*$"
+        },
+        "isDetached": {
+          "description": "Is app detached",
+          "type": "boolean"
+        },
+        "detach": {
+          "description": "Extra fields needed by detached apps",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "assetBundlePatterns": {
+          "description": "An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.io/guides/offline-support/)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "plugins": {
+          "description": "Config plugins for adding extra functionality to your project. [Learn more](https://docs.expo.io/guides/config-plugins/).",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": [
+                  "string"
+                ]
+              },
+              {
+                "type": "array",
+                "items": [
+                  {
+                    "type": [
+                      "string"
+                    ]
+                  },
+                  {}
+                ],
+                "additionalItems": false
+              }
+            ]
+          }
+        },
+        "splash": {
+          "description": "Configuration for loading and splash screen for standalone apps.",
+          "type": "object",
+          "properties": {
+            "backgroundColor": {
+              "description": "Color to fill the loading screen background",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "resizeMode": {
+              "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+              "enum": [
+                "cover",
+                "contain"
+              ],
+              "type": "string"
+            },
+            "image": {
+              "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+              "type": "string"
+            }
+          }
+        },
+        "ios": {
+          "description": "Configuration that is specific to the iOS platform.",
+          "type": "object",
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "bundleIdentifier": {
+              "description": "The bundle identifier for your iOS standalone app. You make it up, but it needs to be unique on the App Store. See [this StackOverflow question](http://stackoverflow.com/questions/11347470/what-does-bundle-identifier-mean-in-the-ios-project).",
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9.-]+$"
+            },
+            "buildNumber": {
+              "description": "Build number for your iOS standalone app. Corresponds to `CFBundleVersion` and must match Apple's [specified format](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364). (Note: Transporter will pull the value for `Version Number` from `expo.version` and NOT from `expo.ios.buildNumber`.)",
+              "type": "string",
+              "pattern": "^[A-Za-z0-9\\.]+$"
+            },
+            "backgroundColor": {
+              "description": "The background color for your iOS app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on iOS. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency. \n\n Expo will generate the other required sizes. This icon will appear on the home screen and within the Expo app.",
+              "type": "string"
+            },
+            "merchantId": {
+              "description": "Merchant ID for use with Apple Pay in your standalone app.",
+              "type": "string"
+            },
+            "appStoreUrl": {
+              "description": "URL to your app on the Apple App Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://(itunes|apps)\\.apple\\.com/.*?\\d+",
+              "type": [
+                "string"
+              ]
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "usesNonExemptEncryption": {
+                  "description": "Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.",
+                  "type": "boolean"
+                },
+                "googleMapsApiKey": {
+                  "description": "[Google Maps iOS SDK](https://developers.google.com/maps/documentation/ios-sdk/start) key for your standalone app.",
+                  "type": "string"
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean"
+                },
+                "googleSignIn": {
+                  "description": "[Google Sign-In iOS SDK](https://developers.google.com/identity/sign-in/ios/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "reservedClientId": {
+                      "description": "The reserved client ID URL scheme. Can be found in `GoogleService-Info.plist`.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.",
+              "type": "string"
+            },
+            "supportsTablet": {
+              "description": "Whether your standalone iOS app supports tablet screen sizes. Defaults to `false`.",
+              "type": "boolean"
+            },
+            "isTabletOnly": {
+              "description": "If true, indicates that your standalone iOS app does not support handsets, and only supports tablets.",
+              "type": "boolean"
+            },
+            "requireFullScreen": {
+              "description": "If true, indicates that your standalone iOS app does not support Slide Over and Split View on iPad. Defaults to `true` currently, but will change to `false` in a future SDK version.",
+              "type": "boolean"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "infoPlist": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "entitlements": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native *.entitlements (plist). Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "associatedDomains": {
+              "description": "An array that contains Associated Domains for the standalone app. [Learn more](https://developer.apple.com/documentation/safariservices/supporting_associated_domains).",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "usesIcloudStorage": {
+              "description": "A boolean indicating if the app uses iCloud Storage for `DocumentPicker`. See `DocumentPicker` docs for details.",
+              "type": "boolean"
+            },
+            "usesAppleSignIn": {
+              "description": "A boolean indicating if the app uses Apple Sign-In. See `AppleAuthentication` docs for details.",
+              "type": "boolean"
+            },
+            "accessesContactNotes": {
+              "description": "A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.",
+              "type": "boolean"
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for standalone iOS apps.",
+              "type": "object",
+              "properties": {
+                "xib": {
+                  "description": "@deprecated Apple has deprecated `.xib` splash screens in favor of `.storyboard` files. Local path to a XIB file as the loading screen. It overrides other loading screen options. Note: This will only be used in the standalone app (i.e., after you build the app). It will not be used in the Expo Go.",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "tabletImage": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "android": {
+          "description": "Configuration that is specific to the Android platform.",
+          "type": "object",
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "package": {
+              "description": "The package name for your Android standalone app. You make it up, but it needs to be unique on the Play Store. See [this StackOverflow question](http://stackoverflow.com/questions/6273892/android-package-name-convention).",
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)+$"
+            },
+            "versionCode": {
+              "description": "Version number required by Google Play. Increment by one for each release. Must be a positive integer. [Learn more](https://developer.android.com/studio/publish/versioning.html)",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2100000000
+            },
+            "backgroundColor": {
+              "description": "The background color for your Android app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": [
+                "light",
+                "dark",
+                "automatic"
+              ]
+            },
+            "useNextNotificationsApi": {
+              "description": "@deprecated A Boolean value that indicates whether the app should use the new notifications API.",
+              "type": "boolean"
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` key. We recommend that you use a 1024x1024 png file (transparency is recommended for the Google Play Store). This icon will appear on the home screen and within the Expo app.",
+              "type": "string"
+            },
+            "adaptiveIcon": {
+              "description": "Settings for an Adaptive Launcher Icon on Android. [Learn more](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive)",
+              "type": "object",
+              "properties": {
+                "foregroundImage": {
+                  "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` and the `android.icon` keys. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive). This icon will appear on the home screen.",
+                  "type": "string"
+                },
+                "backgroundImage": {
+                  "description": "Local path or remote URL to a background image for your app's Adaptive Icon on Android. If specified, this overrides the `backgroundColor` key. Must have the same dimensions as  foregroundImage`, and has no effect if `foregroundImage` is not specified. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive).",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to use as the background for your app's Adaptive Icon on Android. Defaults to white, `#FFFFFF`. Has no effect if `foregroundImage` is not specified.",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "playStoreUrl": {
+              "description": "URL to your app on the Google Play Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://play\\.google\\.com/",
+              "type": [
+                "string"
+              ]
+            },
+            "permissions": {
+              "description": "List of permissions used by the standalone app. \n\n To use ONLY the following minimum necessary permissions and none of the extras supported by Expo in a default managed app, set `permissions` to `[]`. The minimum necessary permissions do not require a Privacy Policy when uploading to Google Play Store and are: \n• receive data from Internet \n• view network connections \n• full network access \n• change your audio settings \n• prevent device from sleeping \n\n To use ALL permissions supported by Expo by default, do not specify the `permissions` key. \n\n  To use the minimum necessary permissions ALONG with certain additional permissions, specify those extras in `permissions`, e.g.\n\n `[ \"CAMERA\", \"ACCESS_FINE_LOCATION\" ]`.\n\n  You can specify the following permissions depending on what you need:\n\n- `ACCESS_COARSE_LOCATION`\n- `ACCESS_FINE_LOCATION`\n- `ACCESS_BACKGROUND_LOCATION`\n- `CAMERA`\n- `RECORD_AUDIO`\n- `READ_CONTACTS`\n- `WRITE_CONTACTS`\n- `READ_CALENDAR`\n- `WRITE_CALENDAR`\n- `READ_EXTERNAL_STORAGE`\n- `WRITE_EXTERNAL_STORAGE`\n- `USE_FINGERPRINT`\n- `USE_BIOMETRIC`\n- `WRITE_SETTINGS`\n- `VIBRATE`\n- `READ_PHONE_STATE`\n- `com.anddoes.launcher.permission.UPDATE_COUNT`\n- `com.android.launcher.permission.INSTALL_SHORTCUT`\n- `com.google.android.c2dm.permission.RECEIVE`\n- `com.google.android.gms.permission.ACTIVITY_RECOGNITION`\n- `com.google.android.providers.gsf.permission.READ_GSERVICES`\n- `com.htc.launcher.permission.READ_SETTINGS`\n- `com.htc.launcher.permission.UPDATE_SHORTCUT`\n- `com.majeur.launcher.permission.UPDATE_BADGE`\n- `com.sec.android.provider.badge.permission.READ`\n- `com.sec.android.provider.badge.permission.WRITE`\n- `com.sonyericsson.home.permission.BROADCAST_BADGE`\n",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase. Including this key automatically enables FCM in your standalone app.",
+              "type": "string"
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMaps": {
+                  "description": "[Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Google Maps Android SDK API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean"
+                },
+                "googleSignIn": {
+                  "description": "@deprecated Use `googleServicesFile` instead. [Google Sign-In Android SDK](https://developers.google.com/identity/sign-in/android/start-integrating) keys for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "The Android API key. Can be found in the credentials section of the developer console or in `google-services.json`.",
+                      "type": "string"
+                    },
+                    "certificateHash": {
+                      "description": "The SHA-1 hash of the signing certificate used to build the APK without any separator (`:`). Can be found in `google-services.json`. https://developers.google.com/android/guides/client-auth",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for managed and standalone Android apps.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain",
+                    "native"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "mdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Natural sized image (baseline)`",
+                  "type": "string"
+                },
+                "hdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 1.5x`",
+                  "type": "string"
+                },
+                "xhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 2x`",
+                  "type": "string"
+                },
+                "xxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 3x`",
+                  "type": "string"
+                },
+                "xxxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 4x`",
+                  "type": "string"
+                }
+              }
+            },
+            "intentFilters": {
+              "description": "Configuration for setting an array of custom intent filters in Android manifest. [Learn more](https://developer.android.com/guide/components/intents-filters)",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "autoVerify": {
+                    "description": "You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](developer.android.com/training/app-links)",
+                    "type": "boolean"
+                  },
+                  "action": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "description": "the scheme of the URL, e.g. `https`",
+                            "type": "string"
+                          },
+                          "host": {
+                            "description": "the hostname, e.g. `myapp.io`",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "the port, e.g. `3000`",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+                            "type": "string"
+                          },
+                          "pathPattern": {
+                            "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+                            "type": "string"
+                          },
+                          "pathPrefix": {
+                            "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "description": "a MIME type for URLs that should be matched by the filter",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": [
+                          "array"
+                        ],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheme": {
+                              "description": "the scheme of the URL, e.g. `https`",
+                              "type": "string"
+                            },
+                            "host": {
+                              "description": "the hostname, e.g. `myapp.io`",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "the port, e.g. `3000`",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "an exact path for URLs that should be matched by the filter, e.g. `/records`",
+                              "type": "string"
+                            },
+                            "pathPattern": {
+                              "description": " a regex for paths that should be matched by the filter, e.g. `.*`",
+                              "type": "string"
+                            },
+                            "pathPrefix": {
+                              "description": "a prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                              "type": "string"
+                            },
+                            "mimeType": {
+                              "description": "a MIME type for URLs that should be matched by the filter",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    ]
+                  },
+                  "category": {
+                    "anyOf": [
+                      {
+                        "type": [
+                          "string"
+                        ]
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "action"
+                ]
+              }
+            },
+            "allowBackup": {
+              "description": "Allows your user's app data to be automatically backed up to their Google Drive. If this is set to false, no backup or restore of the application will ever be performed (this is useful if your app deals with sensitive information). Defaults to the Android default, which is `true`.",
+              "type": "boolean"
+            },
+            "softwareKeyboardLayoutMode": {
+              "description": "Determines how the software keyboard will impact the layout of your application. This maps to the `android:windowSoftInputMode` property. Defaults to `resize`. Valid values: `resize`, `pan`.",
+              "enum": [
+                "resize",
+                "pan"
+              ],
+              "type": "string"
+            },
+            "jsEngine": {
+              "description": "Specifies the JavaScript engine. Supported only on EAS Build. Defaults to `jsc`. Valid values: `hermes`, `jsc`.",
+              "type": "string",
+              "enum": [
+                "hermes",
+                "jsc"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "web": {
+          "description": "Configuration that is specific to the web platform.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "favicon": {
+              "description": "Relative path of an image to use for your app's favicon.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Defines the title of the document, defaults to the outer level name",
+              "type": "string"
+            },
+            "shortName": {
+              "description": "A short version of the app's name, 12 characters or fewer. Used in app launcher and new tab pages. Maps to `short_name` in the PWA manifest.json. Defaults to the `name` property.",
+              "type": "string"
+            },
+            "lang": {
+              "description": "Specifies the primary language for the values in the name and short_name members. This value is a string containing a single language tag.",
+              "type": "string"
+            },
+            "scope": {
+              "description": "Defines the navigation scope of this website's context. This restricts what web pages can be viewed while the manifest is applied. If the user navigates outside the scope, it returns to a normal web page inside a browser tab/window. If the scope is a relative URL, the base URL will be the URL of the manifest.",
+              "type": "string"
+            },
+            "themeColor": {
+              "description": "Defines the color of the Android tool bar, and may be reflected in the app's preview in task switchers.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "description": {
+              "description": "Provides a general description of what the pinned website does.",
+              "type": "string"
+            },
+            "dir": {
+              "description": "Specifies the primary text direction for the name, short_name, and description members. Together with the lang member, it helps the correct display of right-to-left languages.",
+              "enum": [
+                "auto",
+                "ltr",
+                "rtl"
+              ],
+              "type": "string"
+            },
+            "display": {
+              "description": "Defines the developers’ preferred display mode for the website.",
+              "enum": [
+                "fullscreen",
+                "standalone",
+                "minimal-ui",
+                "browser"
+              ],
+              "type": "string"
+            },
+            "startUrl": {
+              "description": "The URL that loads when a user launches the application (e.g., when added to home screen), typically the index. Note: This has to be a relative URL, relative to the manifest URL.",
+              "type": "string"
+            },
+            "orientation": {
+              "description": "Defines the default orientation for all the website's top level browsing contexts.",
+              "enum": [
+                "any",
+                "natural",
+                "landscape",
+                "landscape-primary",
+                "landscape-secondary",
+                "portrait",
+                "portrait-primary",
+                "portrait-secondary"
+              ],
+              "type": "string"
+            },
+            "backgroundColor": {
+              "description": "Defines the expected “background color” for the website. This value repeats what is already available in the site’s CSS, but can be used by browsers to draw the background color of a shortcut when the manifest is available before the stylesheet has loaded. This creates a smooth transition between launching the web application and loading the site's content.",
+              "type": "string",
+              "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+            },
+            "barStyle": {
+              "description": "If content is set to default, the status bar appears normal. If set to black, the status bar has a black background. If set to black-translucent, the status bar is black and translucent. If set to default or black, the web content is displayed below the status bar. If set to black-translucent, the web content is displayed on the entire screen, partially obscured by the status bar.",
+              "enum": [
+                "default",
+                "black",
+                "black-translucent"
+              ],
+              "type": "string"
+            },
+            "preferRelatedApplications": {
+              "description": "Hints for the user agent to indicate to the user that the specified native applications (defined in expo.ios and expo.android) are recommended over the website.",
+              "type": "boolean"
+            },
+            "dangerous": {
+              "description": "Experimental features. These will break without deprecation notice.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "splash": {
+              "description": "Configuration for PWA splash screens.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": [
+                    "cover",
+                    "contain"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "description": "Firebase web configuration. Used by the expo-firebase packages on both web and native. [Learn more](https://firebase.google.com/docs/reference/js/firebase.html#initializeapp)",
+              "type": "object",
+              "properties": {
+                "firebase": {
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "type": "string"
+                    },
+                    "authDomain": {
+                      "type": "string"
+                    },
+                    "databaseURL": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "storageBucket": {
+                      "type": "string"
+                    },
+                    "messagingSenderId": {
+                      "type": "string"
+                    },
+                    "appId": {
+                      "type": "string"
+                    },
+                    "measurementId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "hooks": {
+          "description": "Configuration for scripts to run to hook into the publish process",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "postPublish": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {}
+                  }
+                }
+              }
+            },
+            "postExport": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "experiments": {
+          "description": "Enable experimental features that may be unstable, unsupported, or removed without deprecation notices.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "turboModules": {
+              "description": "Enables Turbo Modules, which are a type of native modules that use a different way of communicating between JS and platform code. When installing a Turbo Module you will need to enable this experimental option (the library still needs to be a part of Expo SDK already, like react-native-reanimated v2). Turbo Modules do not support remote debugging and enabling this option will disable remote debugging.",
+              "type": "boolean"
+            }
+          }
+        },
+        "_internal": {
+          "description": "Internal properties for developer tools",
+          "type": "object",
+          "properties": {
+            "pluginHistory": {
+              "description": "List of plugins already run on the config",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "slug"
+      ]
+    }
+  }
+}

--- a/src/test/expo-42.0.0/hotdog-app.json
+++ b/src/test/expo-42.0.0/hotdog-app.json
@@ -1,0 +1,67 @@
+{
+  "expo": {
+    "name": "Hotdog",
+    "slug": "not-hotdog",
+    "privacy": "hidden",
+    "platforms": [
+      "ios",
+      "android"
+    ],
+    "version": "1.2.3",
+    "orientation": "portrait",
+    "icon": "./assets/hotdog-not-hotdog.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "cover",
+      "backgroundColor": "#FFFFFF"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "com.hotdog.nothotdog",
+      "buildNumber": "1.2.3",
+      "requireFullScreen": false,
+      "config": {
+        "usesNonExemptEncryption": false
+      },
+      "backgroundColor": "#FFFFFF"
+    },
+    "android": {
+      "useNextNotificationsApi": true,
+      "package": "com.hotdog.nothotdog",
+      "versionCode": 9,
+      "permissions": [
+        "WAKE_LOCK",
+        "VIBRATE",
+        "LOCATION"
+      ],
+      "googleServicesFile": "./google-services.json",
+      "config": {
+        "googleMaps": {
+          "apiKey": "supercalifragilistic"
+        }
+      }
+    },
+    "notification": {
+      "iosDisplayInForeground": true,
+      "androidMode": "default"
+    },
+    "hooks": {
+      "postPublish": [
+        {
+          "file": "sentry-expo/upload-sourcemaps",
+          "config": {
+            "organization": "hotdog",
+            "project": "not-hotdog",
+            "authToken": "12345"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
schemas taken from https://expo.io/--/xdl-schema/42.0.0 with various tweaks along the way, removing invalid properties
and inlining some definitions.