### PR TITLE
fix nest-cli error of $ref can not be resolved

### DIFF
--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -12,7 +12,7 @@
     "monorepo": {"type": "boolean", "default": false},
     "compilerOptions": {
       "allOf": [
-        {"$ref": "#CompilerOptions"},
+        {"$ref": "#/definitions/CompilerOptions"},
         {
           "properties": {
             "tsConfigPath": {"default": "tsconfig.build.json"},
@@ -24,16 +24,15 @@
         }
       ]
     },
-    "generateOptions": {"$ref": "#GenerateOptions", "default": {}},
+    "generateOptions": {"$ref": "#/definitions/GenerateOptions", "default": {}},
     "projects": {
       "type": "object",
-      "additionalProperties": {"$ref": "#ProjectConfiguration"},
+      "additionalProperties": {"$ref": "#/definitions/ProjectConfiguration"},
       "default": {}
     }
   },
   "definitions": {
     "CompilerOptions": {
-      "$id": "#CompilerOptions",
       "type": "object",
       "properties": {
         "tsConfigPath": {"type": "string"},
@@ -46,7 +45,6 @@
       "additionalProperties": false
     },
     "GenerateOptions": {
-      "$id": "#GenerateOptions",
       "type": "object",
       "properties": {
         "spec": {
@@ -57,14 +55,13 @@
       "additionalProperties": false
     },
     "ProjectConfiguration": {
-      "$id": "#ProjectConfiguration",
       "type": "object",
       "properties": {
         "type": {"type": "string"},
         "root": {"type": "string"},
         "entryFile": {"type": "string"},
         "sourceRoot": {"type": "string"},
-        "compilerOptions": {"$ref": "#CompilerOptions"}
+        "compilerOptions": {"$ref": "#/definitions/CompilerOptions"}
       },
       "additionalProperties": false
     }


### PR DESCRIPTION
The changes fix `$ref 'ProjectConfiguration' in 'https://json.schemastore.org/nest-cli' can not be resolved.` error.