### PR TITLE
Add Appsemble app-definition.json to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -90,6 +90,14 @@
       "url": "https://json.schemastore.org/apple-app-site-association.json"
     },
     {
+      "name": "app-definition.yaml",
+      "description": "Appsemble app definition",
+      "fileMatch": [
+        "app-definition.yaml"
+      ],
+      "url": "https://appsemble.app/api.json#/components/schemas/AppDefinition"
+    },
+    {
       "name": "appsscript.json",
       "description": "Google Apps Script manifest file",
       "fileMatch": [


### PR DESCRIPTION
I work for Appsemble.

Appsemble allows to create apps using low-code app definitions based on a YAML file named `app.yaml`. For example [this app definition](https://gitlab.com/appsemble/appsemble/blob/main/apps/holidays/app.yaml) yields [this app](https://holidays.appsemble.appsemble.app/).

Because we’re interested in having schema validation in editors, I’m adding this to the SchemaStore catalog. Appsemble provides its own JSON schema through an OpenAPI document.

We understand a file named `app.yaml` is too generic for SchemaStore. In fact, I know of other tools using this filename myself. We’re in the process of renaming this to `app-definition.yaml`.