### PR TITLE
Adds `converted_to_draft` for `github-workflow.json`

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -764,6 +764,7 @@
                       "closed",
                       "reopened",
                       "synchronize",
+                      "converted_to_draft",
                       "ready_for_review",
                       "locked",
                       "unlocked",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Just adding the missing enum value to make my IDE happy. 😂 

https://github.com/github/docs/issues/7975
