### PR TITLE
kustomization.yaml: recognize "secretGenerator[].options" and "configMapGenerator[].options"

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -50,6 +50,9 @@
         "namespace": {
           "description": "Namespace for the configmap, optional",
           "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/GeneratorOptions"
         }
       },
       "additionalProperties": false,
@@ -471,6 +474,9 @@
         "namespace": {
           "description": "Namespace for the secret, optional",
           "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/GeneratorOptions"
         },
         "type": {
           "description": "Type of the secret, optional",

--- a/src/test/kustomization/configMapGenerator.json
+++ b/src/test/kustomization/configMapGenerator.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "kustomize.config.k8s.io/v1beta1",
+  "kind": "Kustomization",
+  "generatorOptions": {
+    "labels": {
+      "fruit": "apple"
+    }
+  },
+  "configMapGenerator": [
+    {
+      "name": "my-java-server-props",
+      "behavior": "merge",
+      "files": [
+        "application.properties",
+        "more.properties"
+      ]
+    },
+    {
+      "name": "my-java-server-env-file-vars",
+      "envs": [
+        "my-server-env.properties",
+        "more-server-props.env"
+      ]
+    },
+    {
+      "name": "my-java-server-env-vars",
+      "literals": [
+        "JAVA_HOME=/opt/java/jdk",
+        "JAVA_TOOL_OPTIONS=-agentlib:hprof"
+      ],
+      "options": {
+        "disableNameSuffixHash": true,
+        "labels": {
+          "pet": "dog"
+        }
+      }
+    },
+    {
+      "name": "dashboards",
+      "files": [
+        "mydashboard.json"
+      ],
+      "options": {
+        "annotations": {
+          "dashboard": "1"
+        },
+        "labels": {
+          "app.kubernetes.io/name": "app1"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/kustomization/images.json
+++ b/src/test/kustomization/images.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "kustomize.config.k8s.io/v1beta1",
+  "kind": "Kustomization",
+  "images": [
+    {
+      "name": "postgres",
+      "newName": "my-registry/my-postgres",
+      "newTag": "v1"
+    },
+    {
+      "name": "nginx",
+      "newTag": "1.8.0"
+    },
+    {
+      "name": "my-demo-app",
+      "newName": "my-app"
+    },
+    {
+      "name": "alpine",
+      "digest": "sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3"
+    }
+  ],
+  "resources": [
+    "deployment.yaml"
+  ]
+}

--- a/src/test/kustomization/secretGenerator.json
+++ b/src/test/kustomization/secretGenerator.json
@@ -1,0 +1,45 @@
+{
+  "apiVersion": "kustomize.config.k8s.io/v1beta1",
+  "kind": "Kustomization",
+  "secretGenerator": [
+    {
+      "name": "app-tls",
+      "files": [
+        "secret/tls.cert",
+        "secret/tls.key"
+      ],
+      "type": "kubernetes.io/tls"
+    },
+    {
+      "name": "app-tls-namespaced",
+      "namespace": "apps",
+      "files": [
+        "tls.crt=catsecret/tls.cert",
+        "tls.key=secret/tls.key"
+      ],
+      "type": "kubernetes.io/tls"
+    },
+    {
+      "name": "env_file_secret",
+      "envs": [
+        "env.txt"
+      ],
+      "type": "Opaque"
+    },
+    {
+      "name": "secret-with-annotation",
+      "files": [
+        "app-config.yaml"
+      ],
+      "type": "Opaque",
+      "options": {
+        "annotations": {
+          "app_config": "true"
+        },
+        "labels": {
+          "app.kubernetes.io/name": "app2"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
close #1677