### PR TITLE
add: issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: "🐛 Bug report"
+description: Report errors or unexpected behavior
+labels:
+  - Issue-Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure to [search for existing issues](https://github.com/SchemaStore/schemastore/issues) before filing a new one!
+  - type: dropdown
+    attributes:
+      label: Area with issue?
+      multiple: false
+      options:
+        - JSON Schema
+        - Documentation
+        - Build server
+        - Web server
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: ✔️ Expected Behavior
+      placeholder: What were you expecting?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: ❌ Actual Behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: YAML or JSON file that does not work.
+      placeholder: |
+        This file is used to reproduce the problem.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: IDE or code editor.
+      description: Some issues are related to IDE or code editor.
+      multiple: false
+      options:
+        - Visual Studio Code
+        - Visual Studio
+        - IntelliJ and it's derivatives
+        - Other
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request_new_schema.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_new_schema.yml
@@ -1,0 +1,21 @@
+name: "⭐ Request (schema)"
+description: Request to add a new JSON schema.
+labels:
+  - Request-for-new-schema
+body:
+  - type: textarea
+    attributes:
+      label: Description of the JSON schema.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Supporting information.
+      placeholder: |
+        URL where you can find the schema documentation.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Please limit one request per issue.

--- a/.github/ISSUE_TEMPLATE/feature_request_website.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_website.yml
@@ -1,0 +1,14 @@
+name: "⭐ Request (feature)"
+description: Propose something new for the SchemaStore web site or build server.
+labels:
+  - Feature-for-website-or-build-server
+body:
+  - type: textarea
+    attributes:
+      label: Description of the feature / enhancement.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Please limit one request per issue.


### PR DESCRIPTION
SchemaStore is missing an issue template. This one is copy from [Microsoft/powertoys](https://github.com/microsoft/PowerToys/tree/master/.github/ISSUE_TEMPLATE) with some modification.

User can open 3 different types of problem reports. [See working example on my fork.](https://github.com/GerryFerdinandus/schemastore/issues/new/choose)

Note that I have not added 'question' selection or template.