### PR TITLE
fix: filematch for minecraft-loot-table

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1692,7 +1692,7 @@
       "name": "Minecraft Data Pack Loot Table",
       "description": "Configuration file defining a loot table for a data pack for Minecraft.",
       "fileMatch": [
-        "**/data/*/loot_tables/*.json"
+        "**/data/*/loot_tables/**/*.json"
       ],
       "url": "https://json.schemastore.org/minecraft-loot-table.json"
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

I'm hoping this is correct? 🤔 

It should match the following:
* `data/test/loot_tables/table.json`
* `data/test/loot_tables/blocks/table.json`

Just not 100% sure if `**/*.json` is what is required.

