### PR TITLE
fix: accept .resume.json and allow any directory

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2208,7 +2208,11 @@
       "description": "A JSON format to describe resumes",
       "fileMatch": [
         "**/resume.json",
-        "**/*.resume.json"
+        "**/*.resume.json",
+        "**/resume.yaml",
+        "**/*.resume.yaml",
+        "**/resume.yml",
+        "**/*.resume.yml"
       ],
       "url": "https://json.schemastore.org/resume.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2207,7 +2207,8 @@
       "name": "JSON Resume",
       "description": "A JSON format to describe resumes",
       "fileMatch": [
-        "resume.json"
+        "**/resume.json",
+        "**/*.resume.json"
       ],
       "url": "https://json.schemastore.org/resume.json"
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Based on the official repository for JSON Resume for Visual Studio Code, it accepts the following files:
* `resume.json`
* `*.resume.json`

And it allows those files to be in any directory, not just the project root.

This updates JSON Resume entry in the catalog to reflect those changes.