### PR TITLE
Edit to Schema.org - Thing: Enable https for defining @context

### DIFF
--- a/src/schemas/json/schema-org-thing.json
+++ b/src/schemas/json/schema-org-thing.json
@@ -13,8 +13,8 @@
     "@context": {
       "type": "string",
       "format": "regex",
-      "pattern": "http://schema.org",
-      "description": "override the @context property to ensure the schema.org URI is used"
+      "pattern": "(http|https)://schema.org",
+      "description": "Override the @context property to ensure the schema.org URI is used. Both http and https are supported."
     },
     "additionalType": {
       "type": "string",


### PR DESCRIPTION
Modifying an existing JSON schema: [Schema.org - Thing](https://github.com/SchemaStore/schemastore/blob/44606df9684428727666ff4d94781faf2f630bf2/src/schemas/json/schema-org-thing.json)

### Motivation
Main motivation for the change is that the "official" example at https://schema.org/Thing#eg-0246 uses https, and therefore does not follow the current "Schema.org - Thing" JSON schema.

### Versioning
I did not create a new version of the schema because for the above reason, I consider this edit to be a bug fix rather than a new version of the schema. However, I'm not sure about the exact versioning conventions for this project, so feel free to correct me if needed.

### Description of changes

After the change, "Schema.org - Thing" supports both http and https protocols thanks to a redefined regex pattern. Previously only http was supported.

Regex pattern "(http|https)://schema.org" is used instead of the shorter "https?://schema.org" to provide more intuitive guidance in editors.


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
