### PR TITLE
feat(gitlab): trigger from another project

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -975,6 +975,11 @@
                 "include": {
                   "oneOf": [
                     {
+                      "description": "References a file from another project.",
+                      "type": "array",
+                      "items": { "$ref": "#/definitions/include_item" }
+                    },
+                    {
                       "description": "Relative path from local repository root (`/`) to the local YAML file to define the pipeline configuration.",
                       "type": "string",
                       "format": "uri-reference",


### PR DESCRIPTION
Support triggering child pipelines with files from another project.

See [Docs](https://docs.gitlab.com/ee/ci/yaml/#trigger-child-pipeline-with-files-from-another-project)

Signed-off-by: Peter Benjamin <petermbenjamin@gmail.com>