### PR TITLE
feat: add schema for first-timers-bot

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1046,6 +1046,14 @@
       "url": "https://ffizer.github.io/ffizer/ffizer.schema.json"
     },
     {
+      "name": "first-timers-bot",
+      "description": "A bot that helps onboarding new open-source contributors.",
+      "fileMatch": [
+        ".github/first-timers.yml"
+      ],
+      "url": "https://json.schemastore.org/first-timers.json"
+    },
+    {
       "name": "Foundry VTT - Manifest",
       "description": "JSON schema for Foundry VTT system.json and module.json files.",
       "fileMatch": [

--- a/src/schemas/json/first-timers.json
+++ b/src/schemas/json/first-timers.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "https://github.com/hoodiehq/first-timers-bot",
+  "title": "first-timers-bot",
+  "description": "A bot that helps onboarding new open-source contributors.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "labels": {
+      "title": "Labels",
+      "description": "Sets the labels if \"first-timers-only\" is not what you are looking for.",
+      "type": "array",
+      "items": {
+        "title": "Label",
+        "type": "string"
+      }
+    },
+    "template": {
+      "title": "Template",
+      "description": "The path to your template, relative from the repository root.",
+      "type": "string"
+    },
+    "repository": {
+      "title": "Repository",
+      "description": "Specify a different repository than where the problem is. The bot must be installed on the configured repository.",
+      "type": "string"
+    }
+  }
+}

--- a/src/test/first-timers/first-timers-bot.json
+++ b/src/test/first-timers/first-timers-bot.json
@@ -1,0 +1,8 @@
+{
+  "repository": "camp",
+  "labels": [
+      "first-timers-only",
+      "available"
+  ],
+  "template": ".github/FIRST_TIMERS_ISSUE_TEMPLATE.md"
+}

--- a/src/test/first-timers/jekyll.json
+++ b/src/test/first-timers/jekyll.json
@@ -1,0 +1,9 @@
+{
+  "repository": "jekyll",
+  "labels": [
+      "good first issue",
+      "help-wanted",
+      "first-time-only"
+  ],
+  "template": ".github/first-timers-issue-template.md"
+}


### PR DESCRIPTION
Adds JSON Schema for [first-timers-bot](https://github.com/hoodiehq/first-timers-bot/).

Tests files are taken from other projects:
* [hoodiehq/first-timers-bot](https://github.com/hoodiehq/first-timers-bot)
* [jekyll/jekyll](https://github.com/jekyll/jekyll)