### PR TITLE
Remove clientId and appId settings to match docs

### DIFF
--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -107,10 +107,6 @@
                                             "type": "string",
                                             "description": "The endpoint for the OpenID configuration of the AAD tenant"
                                         },
-                                        "clientId": {
-                                            "type": "string",
-                                            "description": "The client ID for the Azure AD app registration"
-                                        },
                                         "clientIdSettingName": {
                                             "type": "string",
                                             "description": "The name of the application setting containing the Application (client) ID for the Azure AD app registration"
@@ -159,10 +155,6 @@
                                         "clientSecretSettingName"
                                     ],
                                     "properties": {
-                                        "clientId": {
-                                            "type": "string",
-                                            "description": "The client ID"
-                                        },
                                         "clientIdSettingName": {
                                             "type": "string",
                                             "description": "The name of the application setting containing the Client ID"
@@ -211,10 +203,6 @@
                                         "appSecretSettingName"
                                     ],
                                     "properties": {
-                                        "appId": {
-                                            "type": "string",
-                                            "description": "The App ID"
-                                        },
                                         "appIdSettingName": {
                                             "type": "string",
                                             "description": "The name of the application setting containing the App ID"
@@ -263,10 +251,6 @@
                                         "clientSecretSettingName"
                                     ],
                                     "properties": {
-                                        "clientId": {
-                                            "type": "string",
-                                            "description": "The client ID"
-                                        },
                                         "clientIdSettingName": {
                                             "type": "string",
                                             "description": "The name of the application setting containing the Client ID"
@@ -315,10 +299,6 @@
                                         "clientSecretSettingName"
                                     ],
                                     "properties": {
-                                        "clientId": {
-                                            "type": "string",
-                                            "description": "The client ID"
-                                        },
                                         "clientIdSettingName": {
                                             "type": "string",
                                             "description": "The name of the application setting containing the Client ID"
@@ -367,10 +347,6 @@
                                         "consumerSecretSettingName"
                                     ],
                                     "properties": {
-                                        "consumerKey": {
-                                            "type": "string",
-                                            "description": "The Consumer Key"
-                                        },
                                         "consumerKeySettingName": {
                                             "type": "string",
                                             "description": "The name of the application setting containing the Consumer Key"
@@ -410,10 +386,6 @@
                                                 "openIdConnectConfiguration"
                                             ],
                                             "properties": {
-                                                "clientId": {
-                                                    "type": "string",
-                                                    "description": "The Client ID"
-                                                },
                                                 "clientIdSettingName": {
                                                     "type": "string",
                                                     "description": "The name of the application setting containing the Client ID"


### PR DESCRIPTION
Remove `clientId` and `appId` from schema to match [docs](https://docs.microsoft.com/en-us/azure/static-web-apps/authentication-custom?tabs=aad#configuration).