### PR TITLE
chore: update license and add notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015-current Mads Kristensen
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+JSON Schema Store
+Copyright 2015-Current Mads Kristensen and Contributors


### PR DESCRIPTION
### License
* Rename `LICENSE.md` to just `LICENSE` as it's not Markdown. (Prevents editors from wrongfully trying to render it as Markdown.)
* Uses the licenses as it, the copyright information shouldn't be defined in the license, but in a NOTICE file.

> APPENDIX: **How to apply the Apache License to your work.**

This is an informational section on **how** to apply the license to particular files. It's not meant to be edited in the `LICENSE` directly. Otherwise, it'd be indicating that contributors should submit code with your name instead of theirs.

For example, if I create a new JS file here, as the copyright holder of the code, I'm meant to use `Copyright 2021 Seth Falco`, not `Copyright 2015-current Mads Kristensen`.

### Notice
* Move the generic copyright information for the project, you can add it to `NOTICE`.

> (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the **attribution notices contained within such NOTICE file**

You can see the LICENSE and NOTICE file completed this way on Apache's own projects:
* https://github.com/apache/flink
* https://github.com/apache/commons-beanutils

### Copyright Holders
* current -> Current
* Add "and Contributors"

As this repository doesn't have a [CLA (Contributor License Agreement)](https://en.wikipedia.org/wiki/Contributor_License_Agreement), all contributions made by individuals are under the copyright of those individuals, licensed under Apache-2.0, and should be attributed. (Note: you wouldn't see that in Apache's projects linked above because [they request developers sign a CLA](https://www.apache.org/licenses/contributor-agreements.html#clas).)

> If a project was started by a single author who later incorporated contributions by other authors, the primary author does not own sole copyright. For projects with lots of small contributions by many people, it would be unfeasible to list all actual authors in the copyright notice. Instead, it is common to list the group of authors as the copyright owner(s), or to explicitly list the primary authors and note that additional authors exist
> \- https://opensource.stackexchange.com/questions/5508/what-does-and-contributors-in-the-copyright-byline-imply

The following are some examples of large projects that mention other contributors in the copyright.

| Project | Copyright Line
|---|---
| [Spring Projects](https://github.com/spring-projects/) | Copyright 2002-2019 **the original author or authors**.
| [RxJava](https://github.com/ReactiveX/RxJava) | Copyright (c) 2016-present, **RxJava Contributors**.
| [Mockito](https://github.com/mockito/mockito) | Copyright (c) 2007 **Mockito contributors**
| [JUnit](https://github.com/junit-team/junit5) | Copyright 2015-2020 **the original author or authors**.

---

Sorry for the essay of a pull request description.
Just wanted to explain each change thoroughly.