### PR TITLE
Add schema for saucectl configuration files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3457,6 +3457,14 @@
         ".markdownlint.yml"
       ],
         "url": "https://json.schemastore.org/markdownlint.json"
+    },
+    {
+      "name": "SauceCTL Configuration",
+      "description": "JSON Schema for SauceCTL configuration files.",
+      "fileMatch": [
+        "**/.sauce/*.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/v1alpha/generated/saucectl.schema.json"
     }
   ]
 }


### PR DESCRIPTION
Add schema for configuration files as used by [saucectl](https://github.com/saucelabs/saucectl).
