### PR TITLE
Fix GitHub Workflow MacOS runners

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1178,7 +1178,7 @@
                   "type": "string",
                   "enum": [
                     "macos-10.15",
-                    "macos-11.0",
+                    "macos-11",
                     "macos-latest",
                     "self-hosted",
                     "ubuntu-16.04",

--- a/src/test/github-workflow/runs-on.json
+++ b/src/test/github-workflow/runs-on.json
@@ -52,6 +52,14 @@
         }
       ]
     },
+    "macos-11": {
+      "runs-on": "macos-11",
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    },
     "windows": {
       "runs-on": "windows-latest",
       "steps": [


### PR DESCRIPTION
Hello 👋 

Coming from [this issue](https://github.com/Expensify/App/pull/4339), I discovered that the `github-workflows` schema is not entirely correct. It previously referenced as "runs-on" attribute which includes `macos-11.0`. However, that runner is [not supported by GitHub](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), as evidenced by [this failed GitHub Workflow run](https://github.com/Expensify/App/actions/runs/1083795283).

This PR corrects the runner's specification to `macos-11`, which is included in the GitHub documentation and works, as evidenced by [this successful workflow run](https://github.com/Expensify/App/runs/3206159867?check_suite_focus=true)
