### PR TITLE
Add JSON schema for .appsemblerc.yaml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -98,6 +98,14 @@
       "url": "https://appsemble.app/api.json#/components/schemas/AppDefinition"
     },
     {
+      "name": ".appsemblerc.yaml",
+      "description": "Appsemble RC file",
+      "fileMatch": [
+        ".appsemblerc.yaml"
+      ],
+      "url": "https://json.schemastore.org/appsemblerc.json"
+    },
+    {
       "name": "appsscript.json",
       "description": "Google Apps Script manifest file",
       "fileMatch": [

--- a/src/schemas/json/appsemblerc.json
+++ b/src/schemas/json/appsemblerc.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": ".appsemblerc.yaml",
+  "description": "A .appsemblerc.yaml file may be used to configure either an app or a block.",
+  "type": "object",
+  "additionalProperties": false,
+
+  "properties": {
+    "name": {
+      "description": "The name of a block. By default the name in package.json is used.",
+      "type": "string",
+      "pattern": "^@([\\da-z](?:(?!.*--)[\\da-z-]*[\\da-z])?)/([\\da-z](?:(?!.*--)[\\da-z-]*[\\da-z])?)$"
+    },
+    "description": {
+      "description": "A short description of the block. By default the description in package.json is used.",
+      "maxLength": 160
+    },
+    "version": {
+      "description": "A semantic version of the block representation of the block version. By default the version in package.json is used."
+    },
+    "longDescription": {
+      "description": "The long description of the block. Markdown is supported. By default the content of README.md is used.",
+      "type": "string"
+    },
+    "layout": {
+      "description": "The type of layout to be used for the block.",
+      "enum": ["float", "grow", "hidden", "static", null],
+      "default": "static"
+    },
+    "output": {
+      "description": "Where to read build output from.",
+      "type": "string",
+      "default": "dist"
+    },
+    "webpack": {
+      "description": "The path to the webpack configuration file relative to the block project directory. By default a file named webpack.config.js is used, with a fallback to the webpack configuration from @appsemble/webpack-config.",
+      "type": "string"
+    },
+    "events": {
+      "type": "object",
+      "description": "An object describing the names of the events the block can listen and emit to. By default this is extracted from the block’s TypeScript module augmentations.",
+      "additionalProperties": false,
+      "properties": {
+        "listen": {
+          "description": "The events the block listens on.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "emit": {
+          "description": "The events the block may emit.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "actions": {
+      "description": "An object which describes the actions a block can trigger. This will be used to validate app definitions. By default this is extracted from the block’s TypeScript module augmentations.",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "parameters": {
+      "description": "A JSON schema which describes the block parameters. By default this is extracted from the block’s TypeScript module augmentations."
+    },
+
+
+    "iconBackground": {
+      "description": "The background color to use for maskable icons.",
+      "type":"string",
+      "pattern": "^#[a-zA-Z\\d]{6}$"
+    },
+    "context": {
+      "type": "object",
+      "description": "A context which can be specified using the --context command line parameter.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "remote": {
+            "description": "If remote is specified, this will override --remote passed by the command line.",
+            "type":"string",
+            "format": "uri",
+            "default": "https://appsemble.app"
+          },
+          "organization":{
+            "description": "If organization is specified, this will override --organization passed by the command line when creating an app.",
+            "type":"string",
+            "pattern": "^([\\da-z](?:(?!.*--)[\\da-z-]*[\\da-z])?)$",
+            "minLength": 1,
+            "maxLength": 30
+          },
+          "icon": {
+            "description": "A path to the app icon to use",
+            "type": "string",
+            "default": "icon.png"
+          },
+          "iconBackground": {
+            "description": "The background color to use for maskable icons.",
+            "type":"string",
+            "pattern": "^#[a-zA-Z\\d]{6}$"
+          },
+          "maskableIcon": {
+            "description": "A path to the maskable app icon to use",
+            "type": "string",
+            "default": "maskable-icon.png"
+          },
+          "id": {
+            "description": "If id is specified, this will override --id passed by the command line when updating an app.",
+            "type": "integer",
+            "minimum": 1
+          },
+          "private": {
+            "description": "If private is specified, this will override --private passed on the command line.",
+            "type": "boolean",
+            "default": true
+          },
+          "template": {
+            "description": "If template is specified, this will override --template passed on the command line.",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/appsemblerc/app.json
+++ b/src/test/appsemblerc/app.json
@@ -1,0 +1,15 @@
+{
+  "iconBackground": "#0f1e2d",
+  "context": {
+    "production":{
+      "remote": "https://appsemble.app",
+      "organization": "appsemble",
+      "icon": "icon.png",
+      "iconBackground": "#0f1e2d",
+      "maskableIcon": "maskable-icon.png",
+      "id": 1,
+      "private": true,
+      "template": false
+    }
+  }
+}

--- a/src/test/appsemblerc/block.json
+++ b/src/test/appsemblerc/block.json
@@ -1,0 +1,29 @@
+{
+  "name": "@appsemble/example",
+  "version": "1.2.3",
+  "description": "This is an example block.",
+  "longDescription": "This is a longer description of this example block." ,
+  "layout": "float",
+  "output": "build",
+  "webpack": "../webpack.config.js",
+  "events": {
+    "listen": {
+      "input": {
+        "description": "Use this to pass data into the block."
+      }
+    },
+    "emit": {
+      "input": {
+        "description": "Use this to use data output from the block."
+      }
+    }
+  },
+  "actions": {
+    "onClick": {
+      "description": "This event is dispatched when the button is clicked."
+    }
+  },
+  "parameters": {
+    "type": "object"
+  }
+}


### PR DESCRIPTION
Practical examples can be found for example [here](https://gitlab.com/appsemble/appsemble/-/blob/main/apps/person/.appsemblerc.yaml) and [here](https://gitlab.com/appsemble/appsemble/-/blob/main/blocks/action-button/.appsemblerc.yaml) and in similar places in the project file hierarchy.