### PR TITLE
Updated skaffold to v2beta20

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3404,7 +3404,7 @@
         "skaffold.yaml",
         "skaffold.yml"
       ],
-      "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta19.json",
+      "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta20.json",
       "versions": {
         "v1alpha1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha1.json",
         "v1alpha2": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha2.json",
@@ -3451,7 +3451,8 @@
         "v2beta16": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta16.json",
         "v2beta17": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta17.json",
         "v2beta18": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta18.json",
-        "v2beta19": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta19.json"
+        "v2beta19": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta19.json",
+        "v2beta20": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta20.json"
       }
     },
     {


### PR DESCRIPTION
Skaffold v1.29.0 comes with skaffold.yaml v2beta20:
https://github.com/GoogleContainerTools/skaffold/releases/tag/v1.29.0

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
