### PR TITLE
Update tsconfig.json schema with new ts-node options from v10.1.0 and v10.2.0

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -319,8 +319,7 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": ["crlf", "lf"
-                  ]
+                  "enum": ["crlf", "lf"]
                 },
                 {
                   "pattern": "^(CRLF|LF|crlf|lf)$"

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -180,10 +180,7 @@
             },
             "declarationDir": {
               "description": "Specify the output directory for generated declaration files.",
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
@@ -243,13 +240,7 @@
             },
             "jsx": {
               "description": "Specify what JSX code is generated.",
-              "enum": [
-                "preserve",
-                "react",
-                "react-jsx",
-                "react-jsxdev",
-                "react-native"
-              ]
+              "enum": ["preserve", "react", "react-jsx", "react-jsxdev", "react-native"]
             },
             "reactNamespace": {
               "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
@@ -314,10 +305,7 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [
-                    "Classic",
-                    "Node"
-                  ]
+                  "enum": ["Classic", "Node"]
                 },
                 {
                   "pattern": "^(([Nn]ode)|([Cc]lassic))$"
@@ -331,9 +319,7 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": [
-                    "crlf",
-                    "lf"
+                  "enum": ["crlf", "lf"
                   ]
                 },
                 {
@@ -844,11 +830,7 @@
             "importsNotUsedAsValues": {
               "description": "Specify emit/checking behavior for imports that are only used for types.",
               "default": "remove",
-              "enum": [
-                "remove",
-                "preserve",
-                "error"
-              ]
+              "enum": ["remove", "preserve", "error"]
             },
             "alwaysStrict": {
               "description": "Ensure 'use strict' is always emitted.",
@@ -1058,10 +1040,7 @@
             "ignoreDiagnostics": {
               "description": "Ignore TypeScript warnings by diagnostic code.",
               "items": {
-                "type": [
-                  "string",
-                  "number"
-                ]
+                "type": ["string", "number"]
               },
               "type": "array"
             },
@@ -1071,7 +1050,7 @@
               "type": "boolean"
             },
             "moduleTypes": {
-              "$ref": "#/definitions/Record<string,ModuleType>",
+              "type": "object",
               "description": "Override certain paths to be compiled and executed as CommonJS or ECMAScript modules.\nWhen overridden, the tsconfig \"module\" and package.json \"type\" fields are overridden.\nThis is useful because TypeScript files cannot use the .cjs nor .mjs file extensions;\nit achieves the same effect.\n\nEach key is a glob pattern following the same rules as tsconfig's \"include\" array.\nWhen multiple patterns match the same file, the last pattern takes precedence.\n\n`cjs` overrides matches files to compile and execute as CommonJS.\n`esm` overrides matches files to compile and execute as native ECMAScript modules.\n`package` overrides either of the above to default behavior, which obeys package.json \"type\" and\ntsconfig.json \"module\" options."
             },
             "preferTsExts": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -180,7 +180,10 @@
             },
             "declarationDir": {
               "description": "Specify the output directory for generated declaration files.",
-              "type": ["string", "null"],
+              "type": [
+                "string",
+                "null"
+              ],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
@@ -240,7 +243,13 @@
             },
             "jsx": {
               "description": "Specify what JSX code is generated.",
-              "enum": ["preserve", "react", "react-jsx", "react-jsxdev", "react-native"]
+              "enum": [
+                "preserve",
+                "react",
+                "react-jsx",
+                "react-jsxdev",
+                "react-native"
+              ]
             },
             "reactNamespace": {
               "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
@@ -305,7 +314,10 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": ["Classic", "Node"]
+                  "enum": [
+                    "Classic",
+                    "Node"
+                  ]
                 },
                 {
                   "pattern": "^(([Nn]ode)|([Cc]lassic))$"
@@ -319,7 +331,10 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": ["crlf", "lf"]
+                  "enum": [
+                    "crlf",
+                    "lf"
+                  ]
                 },
                 {
                   "pattern": "^(CRLF|LF|crlf|lf)$"
@@ -829,7 +844,11 @@
             "importsNotUsedAsValues": {
               "description": "Specify emit/checking behavior for imports that are only used for types.",
               "default": "remove",
-              "enum": ["remove", "preserve", "error"]
+              "enum": [
+                "remove",
+                "preserve",
+                "error"
+              ]
             },
             "alwaysStrict": {
               "description": "Ensure 'use strict' is always emitted.",
@@ -989,7 +1008,7 @@
     "tsNodeDefinition": {
       "properties": {
         "ts-node": {
-          "description": "ts-node options.  See also: https://github.com/TypeStrong/ts-node#configuration-options\n\nts-node offers TypeScript execution and REPL for node.js, with source map support.",
+          "description": "ts-node options.  See also: https://typestrong.org/ts-node/docs/configuration\n\nts-node offers TypeScript execution and REPL for node.js, with source map support.",
           "properties": {
             "compiler": {
               "default": "typescript",
@@ -1017,13 +1036,19 @@
               "description": "Emit output files into `.ts-node` directory.",
               "type": "boolean"
             },
+            "experimentalReplAwait": {
+              "description": "Allows the usage of top level await in REPL.\n\nUses node's implementation which accomplishes this with an AST syntax transformation.\n\nEnabled by default when tsconfig target is es2018 or above. Set to false to disable.\n\n**Note**: setting to `true` when tsconfig target is too low will throw an Error.  Leave as `undefined`\nto get default, automatic behavior.",
+              "type": "boolean"
+            },
             "files": {
               "default": false,
               "description": "Load \"files\" and \"include\" from `tsconfig.json` on startup.\n\nDefault is to override `tsconfig.json` \"files\" and \"include\" to only include the entrypoint script.",
               "type": "boolean"
             },
             "ignore": {
-              "default": ["(?:^|/)node_modules/"],
+              "default": [
+                "(?:^|/)node_modules/"
+              ],
               "description": "Paths which should not be compiled.\n\nEach string in the array is converted to a regular expression via `new RegExp()` and tested against source paths prior to compilation.\n\nSource paths are normalized to posix-style separators, relative to the directory containing `tsconfig.json` or to cwd if no `tsconfig.json` is loaded.\n\nDefault is to ignore all node_modules subdirectories.",
               "items": {
                 "type": "string"
@@ -1033,7 +1058,10 @@
             "ignoreDiagnostics": {
               "description": "Ignore TypeScript warnings by diagnostic code.",
               "items": {
-                "type": ["string", "number"]
+                "type": [
+                  "string",
+                  "number"
+                ]
               },
               "type": "array"
             },
@@ -1041,6 +1069,10 @@
               "default": false,
               "description": "Logs TypeScript errors to stderr instead of throwing exceptions.",
               "type": "boolean"
+            },
+            "moduleTypes": {
+              "$ref": "#/definitions/Record<string,ModuleType>",
+              "description": "Override certain paths to be compiled and executed as CommonJS or ECMAScript modules.\nWhen overridden, the tsconfig \"module\" and package.json \"type\" fields are overridden.\nThis is useful because TypeScript files cannot use the .cjs nor .mjs file extensions;\nit achieves the same effect.\n\nEach key is a glob pattern following the same rules as tsconfig's \"include\" array.\nWhen multiple patterns match the same file, the last pattern takes precedence.\n\n`cjs` overrides matches files to compile and execute as CommonJS.\n`esm` overrides matches files to compile and execute as native ECMAScript modules.\n`package` overrides either of the above to default behavior, which obeys package.json \"type\" and\ntsconfig.json \"module\" options."
             },
             "preferTsExts": {
               "default": false,
@@ -1058,6 +1090,15 @@
                 "type": "string"
               },
               "type": "array"
+            },
+            "scope": {
+              "default": false,
+              "description": "Scope compiler to files within `scopeDir`.",
+              "type": "boolean"
+            },
+            "scopeDir": {
+              "default": "First of: `tsconfig.json` \"rootDir\" if specified, directory containing `tsconfig.json`, or cwd if no `tsconfig.json` is loaded.",
+              "type": "string"
             },
             "skipIgnore": {
               "default": false,
@@ -1127,6 +1168,9 @@
     },
     {
       "$ref": "#/definitions/extendsDefinition"
+    },
+    {
+      "$ref": "#/definitions/tsNodeDefinition"
     },
     {
       "$ref": "#/definitions/watchOptionsDefinition"

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1146,13 +1146,13 @@
       "$ref": "#/definitions/extendsDefinition"
     },
     {
-      "$ref": "#/definitions/tsNodeDefinition"
-    },
-    {
       "$ref": "#/definitions/watchOptionsDefinition"
     },
     {
       "$ref": "#/definitions/buildOptionsDefinition"
+    },
+    {
+      "$ref": "#/definitions/tsNodeDefinition"
     },
     {
       "anyOf": [

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1027,9 +1027,7 @@
               "type": "boolean"
             },
             "ignore": {
-              "default": [
-                "(?:^|/)node_modules/"
-              ],
+              "default": ["(?:^|/)node_modules/"],
               "description": "Paths which should not be compiled.\n\nEach string in the array is converted to a regular expression via `new RegExp()` and tested against source paths prior to compilation.\n\nSource paths are normalized to posix-style separators, relative to the directory containing `tsconfig.json` or to cwd if no `tsconfig.json` is loaded.\n\nDefault is to ignore all node_modules subdirectories.",
               "items": {
                 "type": "string"
@@ -1155,9 +1153,6 @@
     },
     {
       "$ref": "#/definitions/buildOptionsDefinition"
-    },
-    {
-      "$ref": "#/definitions/tsNodeDefinition"
     },
     {
       "anyOf": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

ts-node v10.1.0 and v10.2.0 include a few new options.
https://github.com/TypeStrong/ts-node/releases/tag/v10.1.0
https://github.com/TypeStrong/ts-node/releases/tag/v10.2.0

This updates the schema based on the one generated from our sources.

https://unpkg.com/browse/ts-node@10.2.0/tsconfig.schemastore-schema.json