### PR TITLE
Add schema for Citation File Format

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3477,7 +3477,7 @@
     },
     {
       "name": "Citation File Format",
-      "description": "A file with citation metadata for software or datasets.",
+      "description": "A YAML file with citation metadata for software or datasets.",
       "fileMatch": [
         "CITATION.cff"
       ],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -667,6 +667,14 @@
       "url": "https://raw.githubusercontent.com/awslabs/goformation/v4.18.2/schema/sam.schema.json"
     },
     {
+      "name": "Citation File Format",
+      "description": "A YAML file with citation metadata for software or datasets.",
+      "fileMatch": [
+        "CITATION.cff"
+      ],
+      "url": "https://citation-file-format.github.io/1.2.0/schema.json"
+    },
+    {
       "name": "coffeelint.json",
       "description": "CoffeeLint configuration file",
       "fileMatch": [
@@ -3474,14 +3482,6 @@
         "**/.sauce/*.yml"
       ],
       "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/v1alpha/generated/saucectl.schema.json"
-    },
-    {
-      "name": "Citation File Format",
-      "description": "A YAML file with citation metadata for software or datasets.",
-      "fileMatch": [
-        "CITATION.cff"
-      ],
-      "url": "https://citation-file-format.github.io/1.2.0/schema.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3474,6 +3474,14 @@
         "**/.sauce/*.yml"
       ],
       "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/v1alpha/generated/saucectl.schema.json"
+    },
+    {
+      "name": "Citation File Format",
+      "description": "A file with citation metadata for software or datasets.",
+      "fileMatch": [
+        "CITATION.cff"
+      ],
+      "url": "https://citation-file-format.github.io/1.2.0/schema.json"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

As per https://github.com/citation-file-format/citation-file-format/issues/264, this PR adds an entry for the Citation File Format schema to Schemastore. 

Thanks for a great project, and let me know if you need anything else.
I would've liked to add tests, but wasn't sure how to do this with a self-hosted remote schema.
