### PR TITLE
Corrected values for modules-download-mode:

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -333,8 +333,8 @@
         "modules-download-mode": {
           "description": "Option to pass to \"go list -mod={option}\".\nSee \"go help modules\" for more information.",
           "enum": [
+            "mod",
             "readonly",
-            "release",
             "vendor"
           ]
         },


### PR DESCRIPTION
`release` is not (no longer?) an option, whereas `mod` is (and was missing). Please see: https://golang.org/ref/mod#build-commands - the `-mod` flag.