### PR TITLE
Allow key: value requirements in Bamboo specs

### DIFF
--- a/src/schemas/json/bamboo-spec.json
+++ b/src/schemas/json/bamboo-spec.json
@@ -365,7 +365,19 @@
         "requirements": {
           "type": "array",
           "items": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "patternProperties": {
+                  ".": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
           }
         },
         "tasks": {

--- a/src/test/bamboo-spec/bamboo-spec-plan.json
+++ b/src/test/bamboo-spec/bamboo-spec-plan.json
@@ -188,7 +188,8 @@
       }
     ],
     "requirements": [
-      "hasDocker"
+      "hasDocker",
+      {"operating.system": "linux"}
     ],
     "docker": {
       "image": "ubuntu",


### PR DESCRIPTION
Bamboo spec job requirements can be specified as `key: value` not just `key`.

https://docs.atlassian.com/bamboo-specs-docs/7.0.1/specs.html?yaml#requirements