### PR TITLE
fix: [gitlab] allow_failure is missing "exit_codes"

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -517,11 +517,7 @@
           "variables": { "$ref": "#/definitions/variables" },
           "when": { "$ref": "#/definitions/when" },
           "start_in": { "$ref": "#/definitions/start_in" },
-          "allow_failure": {
-            "description": "Setting this option to true will allow the job to fail while still letting the pipeline pass.",
-            "type": "boolean",
-            "default": false
-          }
+          "allow_failure": { "$ref": "#/definitions/allow_failure" }
         }
       }
     },
@@ -560,6 +556,43 @@
       "type": "string",
       "description": "Used in conjunction with 'when: delayed' to set how long to delay before starting a job.",
       "minLength": 1
+    },
+    "allow_failure": {
+      "description": "Allow job to fail. A failed job does not cause the pipeline to fail.",
+      "oneOf": [
+        {
+          "description": "Setting this option to true will allow the job to fail while still letting the pipeline pass.",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "description": "Exit code that are not considered failure. The job fails for any other exit code.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["exit_codes"],
+          "properties": {
+            "exit_codes": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "description": "You can list which exit codes are not considered failures. The job fails for any other exit code.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["exit_codes"],
+          "properties": {
+            "exit_codes": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      ]
     },
     "when": {
       "description": "Describes the conditions for when to run the job. Defaults to 'on_success'.",
@@ -991,9 +1024,7 @@
           "$ref": "#/definitions/tags"
         },
         "allow_failure": {
-          "type": "boolean",
-          "description": "Setting this option to true will allow the job to fail while still letting the pipeline pass.",
-          "default": false
+          "$ref": "#/definitions/allow_failure"
         },
         "timeout": {
           "$ref": "#/definitions/timeout"

--- a/src/test/gitlab-ci/allow_failure.json
+++ b/src/test/gitlab-ci/allow_failure.json
@@ -1,0 +1,28 @@
+{
+  "job1": {
+    "stage": "test",
+    "script": [
+      "execute_script_that_will_fail"
+    ],
+    "allow_failure": true
+  },
+  "job2": {
+    "script": [
+      "exit 1"
+    ],
+    "allow_failure": {
+      "exit_codes": 137
+    }
+  },
+  "job3": {
+    "script": [
+      "exit 137"
+    ],
+    "allow_failure": {
+      "exit_codes": [
+        137,
+        255
+      ]
+    }
+  }
+}


### PR DESCRIPTION
fixed #1797