### PR TITLE
fix: missing run property introduced in v3.7.0 of taskfile

### DIFF
--- a/src/schemas/json/taskfile.json
+++ b/src/schemas/json/taskfile.json
@@ -90,6 +90,10 @@
         "tasks": {
           "description": "Defines your tasks",
           "$ref": "#/definitions/3/tasks"
+        },
+        "run": {
+          "description": "Default behavior when tasks are executed as part of deps or other cmds",
+          "$ref": "#/definitions/3/run"
         }
       },
       "additionalProperties": false,
@@ -155,6 +159,10 @@
           "label": {
             "type": "string",
             "description": "Override the task name print on summary, can be interpolated with variables"
+          },
+          "run": {
+            "description": "Controls whether or not this task runs when called by multiple deps or cmds.",
+            "$ref": "#/definitions/3/run"
           },
           "cmds": {
             "description": "A list of commands for this task",
@@ -336,6 +344,14 @@
             "type": "string"
           }
         }
+      },
+      "run": {
+        "type": "string",
+        "enum": [
+          "always",
+          "once",
+          "when_changed"
+        ]
       }
     }
   }


### PR DESCRIPTION
### If applied this pull request will ...
- see title

### Why are these changes needed ...
- Because the schema is missing a property introduced in v3.7.0 of task

### References
- https://github.com/go-task/task/releases/tag/v3.7.0
- https://taskfile.dev/#/usage?id=limiting-when-tasks-run
