### PR TITLE
Add GitHub Actions uses keyword

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -92,6 +92,11 @@
                   }
                 ]
               },
+              "uses": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsuses",
+                "description": "Selects an action to run as part of a step in your job.",
+                "type": "string"
+              },
               "name": {
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsname",
                 "description": "The name of the composite run step.",
@@ -116,9 +121,13 @@
                 "type": "string"
               }
             },
-            "required": [
-              "run",
-              "shell"
+            "oneOf": [
+              {
+                "required": ["run", "shell"]
+              },
+              {
+                "required": ["uses"]
+              }
             ],
             "additionalProperties": false
           }


### PR DESCRIPTION
Hello! GitHub recently added support for the `uses` keyword in their composite run steps actions. See [this issue](https://github.com/actions/runner/issues/646#issuecomment-903896111) and [updated documentation](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsuses).

I wasn't completely sure about the validation I added, but one of the following should be required:

- The `uses` field

OR

- Both the `run` field and the `shell` field