### PR TITLE
fix incorrect type in tsconfig.json

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -130,7 +130,7 @@
             },
             "synchronousWatchDirectory": {
               "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
-              "type": "string",
+              "type": "boolean",
               "markdownDescription": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.\n\nSee more: https://www.typescriptlang.org/tsconfig#synchronousWatchDirectory"
             },
             "excludeFiles": {


### PR DESCRIPTION
**Fixes:** [Incorrect warning for synchronousWatchDirectory in tsconfig editor. #45422](https://github.com/microsoft/TypeScript/issues/45422)

**Summary:** Change type of synchronousWatchDirectory from "string" to "boolean", that's it
