### PR TITLE
add architect.yml schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -132,7 +132,7 @@
     },
     {
       "name": "architect.yml",
-      "description": "Architect.Yml Schema",
+      "description": "Architect.io Component Schema",
       "fileMatch": ["architect.yml", "architect.yaml"],
       "url": "https://raw.githubusercontent.com/architect-team/architect-cli/master/src/dependency-manager/schema/architect.schema.json"
     },


### PR DESCRIPTION
Hi-

The team at [Architect.io](https://www.architect.io/) is interested in adding our schema to SchemaStore.

Running into one issue though: we'd like to host our schema ourselves so that we can update/version the schema without having a PR-dependency on this repository. ie:

```
"$ref": "https://raw.githubusercontent.com/architect-team/architect-cli/master/src/dependency-manager/schema/architect.schema.json"
```

But when I do this, the `make` is failing with:

```
################ Error message
>> compile    | schemas/json/architect.json (draft-07)
>> Error: can't resolve reference https://raw.githubusercontent.com/architect-team/architect-cli/master/src/dependency-manager/schema/architect.schema.json from id #
##############################
```

I can resolve the URL just fine locally though. So is there some domain restriction for SchemaStore (ie. do all `$ref` urls need to refer to a file hosted by `json.schemastore.org`)?

If so, do you have any ideas for a pattern that we could use to accomplish our goal of hosting our own schema while adding a `$ref` to SchemaStore?

Any advice is much appreciated! Thanks for hosting and maintaining SchemaStore, very cool project!

Dan