### PR TITLE
Add BigQuery table schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -291,6 +291,14 @@
       ]
     },
     {
+      "name": "bigquery-table",
+      "description": "BigQuery table schema",
+      "url": "https://json.schemastore.org/bigquery-table.json",
+      "fileMatch": [
+        "*.bigquery.json"
+      ]
+    },
+    {
       "name": "bitbucket-pipelines",
       "description": "Bitbucket Pipelines CI/CD manifest schema",
       "url": "https://bitbucket.org/atlassianlabs/atlascode/raw/main/resources/schemas/pipelines-schema.json",

--- a/src/schemas/json/bigquery-table.json
+++ b/src/schemas/json/bigquery-table.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/bigquery-table",
+  "title": "BigQuery table schema",
+  "description": "BigQuery lets you specify a table's schema when you load data into a table or when you create an empty table. A table schema is a JSON file.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "description": "A column in a BigQuery table",
+    "additionalProperties": false,
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string",
+        "enum": [ "INT64", "FLOAT64", "NUMERIC", "BIGNUMERIC", "BOOL", "STRING", "BYTES", "DATE", "DATETIME", "TIME", "TIMESTAMP", "STRUCT", "GEOGRAPHY" ]
+      },
+      "mode": {
+        "type": "string",
+        "enum": ["NULLABLE", "REQUIRED", "REPEATED"]
+      }
+    },
+    "required": ["name", "type"]
+  }
+}

--- a/src/test/bigquery-table/sample.bigquery.json
+++ b/src/test/bigquery-table/sample.bigquery.json
@@ -1,0 +1,18 @@
+[
+  {
+    "description": "Person name",
+    "mode": "REQUIRED",
+    "name": "full_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "team",
+    "type": "STRING"
+  },
+  {
+    "description": "High-score",
+    "name": "score",
+    "type": "BIGNUMERIC"
+  }
+]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

BigQuery is Google managed data warehouse solution. In BigQuery, as in traditional relational databases, tables can have a schema. This schema can be specified as a JSON file. Please see https://cloud.google.com/bigquery/docs/schemas for the schema details.

This PR adds a JSON schema that will validate BigQuery table schemas in JSON format.

