### PR TITLE
feat(github-action): Add `with` keyword

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -97,6 +97,11 @@
                 "description": "Selects an action to run as part of a step in your job.",
                 "type": "string"
               },
+              "with": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepswith",
+                "description": "A map of the input parameters defined by the action. Each input parameter is a key/value pair. Input parameters are set as environment variables. The variable is prefixed with INPUT_ and converted to upper case.",
+                "type": "object"
+              },
               "name": {
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsname",
                 "description": "The name of the composite run step.",

--- a/src/test/github-action/composite-run-steps.json
+++ b/src/test/github-action/composite-run-steps.json
@@ -34,6 +34,13 @@
         "run": "echo $FOO",
         "shell": "bash --noprofile {0}",
         "working-directory": "$HOME"
+      },
+      {
+        "id": "pleasantries",
+        "uses": "action/checkout@v2",
+        "with": {
+          "ref": "main"
+        }
       }
     ]
   }


### PR DESCRIPTION
This is a follow-up to #1803 where `uses` was added. `with` is also allowed. I am not sure how to define the constraint where `with` can only be used when `uses` is defined.

See https://github.blog/changelog/2021-08-25-github-actions-reduce-duplication-with-action-composition/ for more information

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
