### PR TITLE
add glob pattern to architect filematch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -133,7 +133,7 @@
     {
       "name": "architect.yml",
       "description": "Architect.io Component Schema",
-      "fileMatch": ["architect.yml", "architect.yaml"],
+      "fileMatch": ["architect.yml", "architect.yaml", "*.architect.yml", "*.architect.yaml"],
       "url": "https://raw.githubusercontent.com/architect-team/architect-cli/master/src/dependency-manager/schema/architect.schema.json"
     },
     {


### PR DESCRIPTION
We've added a `*` pattern to match all files that end in `.architect.yml`.

Thanks!