### PR TITLE
Make `version` optional for chart dependencies

### DIFF
--- a/src/schemas/json/chart.json
+++ b/src/schemas/json/chart.json
@@ -56,14 +56,14 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name", "version"],
+        "required": ["name"],
         "properties": {
           "name": {
             "description": "The name of the chart",
             "type": "string"
           },
           "version": {
-            "description": "The version of the chart",
+            "description": "The version of the chart. If not provided, the latest version will be used",
             "type": "string"
           },
           "repository": {


### PR DESCRIPTION
[Despite the documentation does not say that it's optional](https://helm.sh/docs/topics/charts/#the-chartyaml-file), in fact it is.

`helm` commands works properly when not supplying the version, and it is desired not to have `version` defined when retrieving charts from the local file system, such as:

```yaml
# Chart.yaml
dependencies:
  - name: chart-a
    repository: file://../chart-a
```

An alternative seems to use `nil` as value:

```yaml
# Chart.yaml
dependencies:
  - name: chart-a
    repository: file://../chart-a
    version: nil
```