### PR TITLE
Remove invalid description for chart dependencies version

### DIFF
--- a/src/schemas/json/chart.json
+++ b/src/schemas/json/chart.json
@@ -63,7 +63,7 @@
             "type": "string"
           },
           "version": {
-            "description": "The version of the chart. If not provided, the latest version will be used",
+            "description": "The version of the chart",
             "type": "string"
           },
           "repository": {


### PR DESCRIPTION


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This extra description was added through #1815 but I realized at https://github.com/helm/helm/issues/10095 that it's not the case.

My bad for the mistake!

/cc @madskristensen