### PR TITLE
Update prettierrc for 2.4

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -19,6 +19,11 @@
             }
           ]
         },
+        "bracketSameLine": {
+          "description": "Put > of opening tags on the last line instead of on a new line.",
+          "default": false,
+          "type": "boolean"
+        },
         "bracketSpacing": {
           "description": "Print spaces between brackets.",
           "default": true,
@@ -89,11 +94,6 @@
         },
         "insertPragma": {
           "description": "Insert @format pragma into file's first docblock comment.",
-          "default": false,
-          "type": "boolean"
-        },
-        "jsxBracketSameLine": {
-          "description": "Put > on the last line instead of at a new line.",
           "default": false,
           "type": "boolean"
         },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Update `.prettierrc` schema for [Prettier 2.4](https://prettier.io/blog/2021/09/09/2.4.0.html)