### PR TITLE
Fix Snapcraft schema path

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2432,7 +2432,7 @@
         ".snapcraft.yaml",
         "snapcraft.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/snapcore/snapcraft/4.3/schema/snapcraft.json"
+      "url": "https://raw.githubusercontent.com/snapcore/snapcraft/master/schema/snapcraft.json"
     },
     {
       "name": "Solidarity",


### PR DESCRIPTION
The schema for Snapcraft `snapcraft.yaml` files had a hard-coded version that is very obsolete. This should point to `master` (or `5.0` if you can guarantee that you will update on Snapcraft version bumps, but the main branch is sufficient).

* Fix Snapcraft schema to point to upstream `master` branch.