### PR TITLE
add fulibWorkflows schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3529,6 +3529,14 @@
         "**/.sauce/*.yml"
       ],
       "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/v1alpha/generated/saucectl.schema.json"
+    },
+    {
+      "name": "fulibWorkflows",
+      "description": "JSON Schema for fulib Workflow files.",
+      "fileMatch": [
+        "*.es.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/fujaba/fulibWorkflows/main/schema/fulibWorklows.schema.json"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a new entry to the catalog.json referencing a JSON Schema for [fulibWorkflows ](https://github.com/fujaba/fulibWorkflows) generation files.

FulibWorkflows is still in a very early stage of development. The first goal of fulibWorkflows is to help the requirements engineering progress via event storming methods. Post Its which would normally be created for events are written in a .es.yaml file. From there a html view can be generated, the next step is to generate a prototype from the es.yaml file.
To help write the generation yaml file a json schema is extremly hepful in taking the first step to a proper auto completion.