### PR TITLE
Added nuclei jsonschema to catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1877,6 +1877,14 @@
       "url": "https://json.schemastore.org/npmpackagejsonlintrc.json"
     },
     {
+      "name": "nuclei-template.yaml",
+      "description": "JSON schema for Nuclei Template YAML files.",
+      "url": "https://raw.githubusercontent.com/projectdiscovery/nuclei/master/nuclei-jsonschema.json",
+      "fileMatch": [
+        "**/nuclei-templates/**/*.yaml"
+      ]
+    },
+    {
       "name": "nuget-project.json",
       "description": "JSON schema for NuGet project.json files.",
       "url": "https://json.schemastore.org/nuget-project.json",


### PR DESCRIPTION
Nuclei is used to send requests across targets based on a template leading to zero false positives and providing fast scanning on a large number of hosts. All kinds of security checks can be modeled with Nuclei.

This PR adds a JSON schema that will validate Nuclei Templates written in YAML format. 