### PR TITLE
add: GitHub action to automatically close stale PR

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: "Close stale PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-pr-message: "This PR is stale because it has been open 60 days with no activity. Comment or this will be closed in 7 days."
+          close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ After adding schema files, register them in [schema catalog](src/api/json/catalo
 ```
 
 
-### Adding tests
+### Adding tests (for [local schemas](src/schemas/json) only)
 
 To make sure that files are validated against your schema correctly (we strongly suggest adding at least one before creating a pull request):
 


### PR DESCRIPTION
PR older than 60 days will get this message:
`This PR is stale because it has been open 60 days with no activity. Comment or this will be closed in 7 days.`

7 days later this PR will be closed with this message:
`This PR was closed because it has been stalled for 7 days with no activity.`

The issues will never stale or closed by this GitHub action.


Reason for this new rule
PR must be finish + merge.
PR are not for keeping it open for ever.
Hopefully this will prompt the submitter to finish the job.

Note:
Unable to test this action because I can not PR to my self.