### PR TITLE
Add Symphony SWADL schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2537,6 +2537,15 @@
       "url": "https://json.schemastore.org/stylelintrc.json"
     },
     {
+      "name": "SWADL",
+      "description": "Symphony Workflow Automation Definition Language. See https://developers.symphony.com/",
+      "fileMatch": [
+        "*.swadl.yaml",
+        "*.swadl.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/SymphonyPlatformSolutions/symphony-wdk/master/workflow-language/src/main/resources/swadl-schema-1.0.json"
+    },
+    {
       "name": "Swagger API 2.0",
       "description": "Swagger API 2.0 schema",
       "fileMatch": [


### PR DESCRIPTION
SWADL stands for Symphony Workflow Automation Definition Language, a
YAML based language to write workflows for the Symphony Platform.

SWADL files are identified with the .swadl.yaml extension.

More information can be found on
https://github.com/SymphonyPlatformSolutions/symphony-wdk

No tests have been added as the schema is hosted on our Github repository (from what I read on previous PRs).
