### PR TITLE
github-workflow: Add mising pull_request_target types

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -916,11 +916,14 @@
                       "closed",
                       "reopened",
                       "synchronize",
+                      "converted_to_draft",
                       "ready_for_review",
                       "locked",
                       "unlocked",
                       "review_requested",
-                      "review_request_removed"
+                      "review_request_removed",
+                      "auto_merge_enabled",
+                      "auto_merge_disabled"
                     ]
                   },
                   "default": [


### PR DESCRIPTION
Closes #1835 

Adds the three missing types for the [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) workflow trigger.
