### PR TITLE
Add schema for WordPress theme.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2572,6 +2572,14 @@
       "url": "https://json.schemastore.org/templatesources.json"
     },
     {
+      "name": "theme.json v1",
+      "description": "WordPress block theme global settings and styles configuration file version 1",
+      "fileMatch": [
+        "theme.json"
+      ],
+      "url": "https://json.schemastore.org/theme-v1.json"
+    },
+    {
       "name": "tmLanguage",
       "description": "Language grammar description files in Textmate and compatible editors",
       "fileMatch": [

--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -226,8 +226,22 @@
     },
     "settingsPropertiesComplete": {
       "type": "object",
-      "$ref": "#/definitions/settingsProperties",
-      "additionalProperties": false
+      "allOf": [
+        {
+          "$ref": "#/definitions/settingsProperties"
+        },
+        {
+          "properties": {
+            "border": {},
+            "color": {},
+            "layout": {},
+            "spacing": {},
+            "typography": {},
+            "custom": {}
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "settingsBlocksPropertiesComplete": {
       "type": "object",
@@ -586,8 +600,20 @@
     },
     "stylesPropertiesComplete": {
       "type": "object",
-      "$ref": "#/definitions/stylesProperties",
-      "additionalProperties": false
+      "allOf": [
+        {
+          "$ref": "#/definitions/stylesProperties"
+        },
+        {
+          "properties": {
+            "border": {},
+            "color": {},
+            "spacing": {},
+            "typography": {}
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "stylesElementsPropertiesComplete": {
       "type": "object",

--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -1,0 +1,973 @@
+{
+  "title": "JSON schema for WordPress block theme global settings and styles",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "//": {
+      "explainer": "https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/",
+      "reference": "https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/"
+    },
+    "settingsProperties": {
+      "properties": {
+        "border": {
+          "type": "object",
+          "properties": {
+            "customColor": {
+              "type": "boolean"
+            },
+            "customRadius": {
+              "type": "boolean"
+            },
+            "customStyle": {
+              "type": "boolean"
+            },
+            "customWidth": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "color": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "boolean"
+            },
+            "custom": {
+              "type": "boolean"
+            },
+            "customDuotone": {
+              "type": "boolean"
+            },
+            "customGradient": {
+              "type": "boolean"
+            },
+            "duotone": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "colors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["name", "slug", "colors"],
+                "additionalProperties": false
+              }
+            },
+            "gradients": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "gradient": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name", "slug", "gradient"],
+                "additionalProperties": false
+              }
+            },
+            "link": {
+              "type": "boolean"
+            },
+            "palette": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "color": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name", "slug", "color"],
+                "additionalProperties": false
+              }
+            },
+            "text": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "layout": {
+          "type": "object",
+          "properties": {
+            "contentSize": {
+              "type": "string"
+            },
+            "wideSize": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "spacing": {
+          "type": "object",
+          "properties": {
+            "blockGap": {
+              "oneOf": [{ "type": "number" }, { "type": "null" }]
+            },
+            "customMargin": {
+              "type": "boolean"
+            },
+            "customPadding": {
+              "type": "boolean"
+            },
+            "units": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "typography": {
+          "type": "object",
+          "properties": {
+            "customFontSize": {
+              "type": "boolean"
+            },
+            "customFontStyle": {
+              "type": "boolean"
+            },
+            "customFontWeight": {
+              "type": "boolean"
+            },
+            "customLetterSpacing": {
+              "type": "boolean"
+            },
+            "customLineHeight": {
+              "type": "boolean"
+            },
+            "customTextDecorations": {
+              "type": "boolean"
+            },
+            "customTextTransforms": {
+              "type": "boolean"
+            },
+            "dropCap": {
+              "type": "boolean"
+            },
+            "fontSizes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "slug": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "fontFamilies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "fontFamily": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "custom": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "$ref": "#/definitions/settingsProperties/properties/custom"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "settingsPropertiesComplete": {
+      "type": "object",
+      "$ref": "#/definitions/settingsProperties",
+      "additionalProperties": false
+    },
+    "settingsBlocksPropertiesComplete": {
+      "type": "object",
+      "properties": {
+        "core/archives": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/audio": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/block": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/button": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/buttons": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/calendar": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/categories": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/code": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/column": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/columns": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/cover": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/embed": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/file": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/freeform": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/gallery": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/group": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/heading": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/home-link": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/html": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/image": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/latest-comments": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/latest-posts": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/list": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/loginout": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/media-text": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/missing": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/more": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/navigation": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/navigation-link": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/nextpage": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/page-list": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/paragraph": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-author": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-comment": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-comment-author": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-comment-content": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-comment-date": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-comments": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-comments-count": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-comments-form": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-comments-link": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-content": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-date": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-excerpt": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-featured-image": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-navigation-link": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-template": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-terms": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/post-title": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/preformatted": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/pullquote": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/query": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/query-pagination": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/query-pagination-next": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/query-pagination-numbers": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/query-pagination-previous": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/query-title": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/quote": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/rss": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/search": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/separator": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/shortcode": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/site-logo": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/site-tagline": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/site-title": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/social-link": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/social-links": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/spacer": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/table": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/table-of-contents": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/tag-cloud": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/template-part": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/term-description": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/text-columns": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/verse": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/video": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/widget-area": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/legacy-widget": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        },
+        "core/widget-group": {
+          "$ref": "#/definitions/settingsPropertiesComplete"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stylesProperties": {
+      "properties": {
+        "border": {
+          "type": "object",
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "radius": {
+              "type": "string"
+            },
+            "style": {
+              "type": "string"
+            },
+            "width": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "color": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "string"
+            },
+            "gradient": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "spacing": {
+          "type": "object",
+          "properties": {
+            "blockGap": {
+              "type": "string"
+            },
+            "margin": {
+              "type": "object",
+              "properties": {
+                "top": {
+                  "type": "string"
+                },
+                "right": {
+                  "type": "string"
+                },
+                "bottom": {
+                  "type": "string"
+                },
+                "left": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "padding": {
+              "type": "object",
+              "properties": {
+                "top": {
+                  "type": "string"
+                },
+                "right": {
+                  "type": "string"
+                },
+                "bottom": {
+                  "type": "string"
+                },
+                "left": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "typography": {
+          "type": "object",
+          "properties": {
+            "fontFamily": {
+              "type": "string"
+            },
+            "fontSize": {
+              "type": "string"
+            },
+            "fontStyle": {
+              "type": "string"
+            },
+            "fontWeight": {
+              "type": "string"
+            },
+            "letterSpacing": {
+              "type": "string"
+            },
+            "lineHeight": {
+              "type": "string"
+            },
+            "textDecoration": {
+              "type": "string"
+            },
+            "textTransform": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "stylesPropertiesComplete": {
+      "type": "object",
+      "$ref": "#/definitions/stylesProperties",
+      "additionalProperties": false
+    },
+    "stylesElementsPropertiesComplete": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "$ref": "#/definitions/stylesPropertiesComplete"
+        },
+        "h1": {
+          "$ref": "#/definitions/stylesPropertiesComplete"
+        },
+        "h2": {
+          "$ref": "#/definitions/stylesPropertiesComplete"
+        },
+        "h3": {
+          "$ref": "#/definitions/stylesPropertiesComplete"
+        },
+        "h4": {
+          "$ref": "#/definitions/stylesPropertiesComplete"
+        },
+        "h5": {
+          "$ref": "#/definitions/stylesPropertiesComplete"
+        },
+        "h6": {
+          "$ref": "#/definitions/stylesPropertiesComplete"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stylesBlocksPropertiesComplete": {
+      "type": "object",
+      "properties": {
+        "core/archives": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/audio": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/block": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/button": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/buttons": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/calendar": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/categories": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/code": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/column": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/columns": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/cover": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/embed": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/file": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/freeform": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/gallery": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/group": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/heading": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/home-link": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/html": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/image": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/latest-comments": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/latest-posts": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/list": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/loginout": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/media-text": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/missing": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/more": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/navigation": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/navigation-link": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/nextpage": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/page-list": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/paragraph": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-author": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-comment": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-comment-author": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-comment-content": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-comment-date": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-comments": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-comments-count": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-comments-form": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-comments-link": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-content": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-date": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-excerpt": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-featured-image": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-navigation-link": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-template": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-terms": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/post-title": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/preformatted": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/pullquote": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/query": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/query-pagination": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/query-pagination-next": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/query-pagination-numbers": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/query-pagination-previous": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/query-title": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/quote": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/rss": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/search": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/separator": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/shortcode": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/site-logo": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/site-tagline": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/site-title": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/social-link": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/social-links": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/spacer": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/table": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/table-of-contents": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/tag-cloud": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/template-part": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/term-description": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/text-columns": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/verse": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/video": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/widget-area": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/legacy-widget": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        },
+        "core/widget-group": {
+          "$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stylesPropertiesAndElementsComplete": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/stylesProperties"
+        },
+        {
+          "properties": {
+            "color": {},
+            "spacing": {},
+            "typography": {},
+            "elements": {
+              "$ref": "#/definitions/stylesElementsPropertiesComplete"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "version": {
+      "type": "integer",
+      "enum": [1]
+    },
+    "settings": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/settingsProperties"
+        },
+        {
+          "properties": {
+            "color": {},
+            "layout": {},
+            "spacing": {},
+            "typography": {},
+            "border": {},
+            "custom": {},
+            "blocks": {
+              "$ref": "#/definitions/settingsBlocksPropertiesComplete"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "styles": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/stylesProperties"
+        },
+        {
+          "properties": {
+            "color": {},
+            "spacing": {},
+            "typography": {},
+            "elements": {
+              "$ref": "#/definitions/stylesElementsPropertiesComplete"
+            },
+            "blocks": {
+              "$ref": "#/definitions/stylesBlocksPropertiesComplete"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "customTemplates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "postTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "templateParts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "area": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/theme-v1/core.json
+++ b/src/test/theme-v1/core.json
@@ -1,0 +1,246 @@
+{
+  "version": 1,
+  "settings": {
+    "color": {
+      "background": true,
+      "palette": [
+        {
+          "name": "Black",
+          "slug": "black",
+          "color": "#000000"
+        },
+        {
+          "name": "Cyan bluish gray",
+          "slug": "cyan-bluish-gray",
+          "color": "#abb8c3"
+        },
+        {
+          "name": "White",
+          "slug": "white",
+          "color": "#ffffff"
+        },
+        {
+          "name": "Pale pink",
+          "slug": "pale-pink",
+          "color": "#f78da7"
+        },
+        {
+          "name": "Vivid red",
+          "slug": "vivid-red",
+          "color": "#cf2e2e"
+        },
+        {
+          "name": "Luminous vivid orange",
+          "slug": "luminous-vivid-orange",
+          "color": "#ff6900"
+        },
+        {
+          "name": "Luminous vivid amber",
+          "slug": "luminous-vivid-amber",
+          "color": "#fcb900"
+        },
+        {
+          "name": "Light green cyan",
+          "slug": "light-green-cyan",
+          "color": "#7bdcb5"
+        },
+        {
+          "name": "Vivid green cyan",
+          "slug": "vivid-green-cyan",
+          "color": "#00d084"
+        },
+        {
+          "name": "Pale cyan blue",
+          "slug": "pale-cyan-blue",
+          "color": "#8ed1fc"
+        },
+        {
+          "name": "Vivid cyan blue",
+          "slug": "vivid-cyan-blue",
+          "color": "#0693e3"
+        },
+        {
+          "name": "Vivid purple",
+          "slug": "vivid-purple",
+          "color": "#9b51e0"
+        }
+      ],
+      "gradients": [
+        {
+          "name": "Vivid cyan blue to vivid purple",
+          "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
+          "slug": "vivid-cyan-blue-to-vivid-purple"
+        },
+        {
+          "name": "Light green cyan to vivid green cyan",
+          "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
+          "slug": "light-green-cyan-to-vivid-green-cyan"
+        },
+        {
+          "name": "Luminous vivid amber to luminous vivid orange",
+          "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
+          "slug": "luminous-vivid-amber-to-luminous-vivid-orange"
+        },
+        {
+          "name": "Luminous vivid orange to vivid red",
+          "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
+          "slug": "luminous-vivid-orange-to-vivid-red"
+        },
+        {
+          "name": "Very light gray to cyan bluish gray",
+          "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
+          "slug": "very-light-gray-to-cyan-bluish-gray"
+        },
+        {
+          "name": "Cool to warm spectrum",
+          "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
+          "slug": "cool-to-warm-spectrum"
+        },
+        {
+          "name": "Blush light purple",
+          "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
+          "slug": "blush-light-purple"
+        },
+        {
+          "name": "Blush bordeaux",
+          "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
+          "slug": "blush-bordeaux"
+        },
+        {
+          "name": "Luminous dusk",
+          "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
+          "slug": "luminous-dusk"
+        },
+        {
+          "name": "Pale ocean",
+          "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
+          "slug": "pale-ocean"
+        },
+        {
+          "name": "Electric grass",
+          "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
+          "slug": "electric-grass"
+        },
+        {
+          "name": "Midnight",
+          "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
+          "slug": "midnight"
+        }
+      ],
+      "duotone": [
+        {
+          "name": "Dark grayscale",
+          "colors": ["#000000", "#7f7f7f"],
+          "slug": "dark-grayscale"
+        },
+        {
+          "name": "Grayscale",
+          "colors": ["#000000", "#ffffff"],
+          "slug": "grayscale"
+        },
+        {
+          "name": "Purple and yellow",
+          "colors": ["#8c00b7", "#fcff41"],
+          "slug": "purple-yellow"
+        },
+        {
+          "name": "Blue and red",
+          "colors": ["#000097", "#ff4747"],
+          "slug": "blue-red"
+        },
+        {
+          "name": "Midnight",
+          "colors": ["#000000", "#00a5ff"],
+          "slug": "midnight"
+        },
+        {
+          "name": "Magenta and yellow",
+          "colors": ["#c7005a", "#fff278"],
+          "slug": "magenta-yellow"
+        },
+        {
+          "name": "Purple and green",
+          "colors": ["#a60072", "#67ff66"],
+          "slug": "purple-green"
+        },
+        {
+          "name": "Blue and orange",
+          "colors": ["#1900d8", "#ffa96b"],
+          "slug": "blue-orange"
+        }
+      ],
+      "custom": true,
+      "customDuotone": true,
+      "customGradient": true,
+      "link": false,
+      "text": true
+    },
+    "typography": {
+      "dropCap": true,
+      "customFontSize": true,
+      "customLineHeight": false,
+      "customFontStyle": true,
+      "customFontWeight": true,
+      "customTextTransforms": true,
+      "customTextDecorations": true,
+      "customLetterSpacing": true,
+      "fontSizes": [
+        {
+          "name": "Small",
+          "slug": "small",
+          "size": "13px"
+        },
+        {
+          "name": "Normal",
+          "slug": "normal",
+          "size": "16px"
+        },
+        {
+          "name": "Medium",
+          "slug": "medium",
+          "size": "20px"
+        },
+        {
+          "name": "Large",
+          "slug": "large",
+          "size": "36px"
+        },
+        {
+          "name": "Huge",
+          "slug": "huge",
+          "size": "42px"
+        }
+      ]
+    },
+    "spacing": {
+      "blockGap": null,
+      "customMargin": false,
+      "customPadding": false,
+      "units": ["px", "em", "rem", "vh", "vw", "%"]
+    },
+    "border": {
+      "customColor": false,
+      "customRadius": false,
+      "customStyle": false,
+      "customWidth": false
+    },
+    "blocks": {
+      "core/button": {
+        "border": {
+          "customRadius": true
+        }
+      },
+      "core/pullquote": {
+        "border": {
+          "customColor": true,
+          "customRadius": true,
+          "customStyle": true,
+          "customWidth": true
+        }
+      }
+    }
+  },
+  "styles": {
+    "spacing": { "blockGap": "24px" }
+  }
+}

--- a/src/test/theme-v1/theme.json
+++ b/src/test/theme-v1/theme.json
@@ -1,0 +1,305 @@
+{
+  "version": 1,
+  "settings": {
+    "color": {
+      "custom": true,
+      "customDuotone": true,
+      "customGradient": true,
+      "duotone": [
+        {
+          "colors": ["#000", "#FFF"],
+          "slug": "black-and-white",
+          "name": "Black and White"
+        }
+      ],
+      "gradients": [
+        {
+          "slug": "blush-bordeaux",
+          "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
+          "name": "Blush bordeaux"
+        },
+        {
+          "slug": "blush-light-purple",
+          "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
+          "name": "Blush light purple"
+        }
+      ],
+      "link": true,
+      "palette": [
+        {
+          "name": "White",
+          "slug": "white",
+          "color": "#fff"
+        },
+        {
+          "name": "WordPress blue",
+          "slug": "blue",
+          "color": "#0073AA"
+        },
+        {
+          "slug": "dark-grey",
+          "color": "#23282D",
+          "name": "Dark grey"
+        },
+        {
+          "slug": "green",
+          "color": "#00FF00",
+          "name": "Green"
+        },
+        {
+          "slug": "blue",
+          "color": "#0000FF",
+          "name": "Blue"
+        }
+      ]
+    },
+    "layout": {
+      "contentSize": "840px",
+      "wideSize": "1100px"
+    },
+    "spacing": {
+      "customMargin": true,
+      "customPadding": true,
+      "units": ["px", "em", "rem", "vh", "vw"]
+    },
+    "typography": {
+      "customFontSize": true,
+      "customLineHeight": true,
+      "dropCap": true,
+      "fontFamilies": [
+        {
+          "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell, \"Helvetica Neue\",sans-serif",
+          "slug": "system-font",
+          "name": "System Font"
+        },
+        {
+          "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
+          "slug": "helvetica-arial",
+          "name": "Helvetica or Arial"
+        }
+      ],
+      "fontSizes": [
+        {
+          "slug": "normal",
+          "size": "20px",
+          "name": "normal"
+        },
+        {
+          "slug": "extra-small",
+          "size": "16px",
+          "name": "Extra small"
+        },
+        {
+          "slug": "large",
+          "size": "24px",
+          "name": "Large"
+        }
+      ]
+    },
+    "border": {
+      "customColor": true,
+      "customRadius": true,
+      "customStyle": true,
+      "customWidth": true
+    },
+    "custom": {
+      "baseFont": 16,
+      "lineHeight": {
+        "small": 1.2,
+        "medium": 1.4,
+        "large": 1.8,
+        "body": 1.7
+      },
+      "font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif"
+    },
+    "blocks": {
+      "core/paragraph": {
+        "color": {
+          "custom": true
+        },
+        "custom": {},
+        "layout": {},
+        "spacing": {}
+      },
+      "core/heading": {
+        "color": {
+          "palette": [
+            {
+              "slug": "white",
+              "color": "#fff",
+              "name": "White"
+            },
+            {
+              "slug": "medium-blue",
+              "color": "#00A0D2",
+              "name": "Medium blue"
+            }
+          ]
+        }
+      },
+      "core/group": {
+        "color": {
+          "palette": [
+            {
+              "slug": "black",
+              "color": "#000000",
+              "name": "Black"
+            },
+            {
+              "slug": "white",
+              "color": "#FFF",
+              "name": "White"
+            }
+          ]
+        },
+        "custom": {
+          "baseFont": 32
+        }
+      },
+      "core/button": {
+        "border": {
+          "customRadius": false
+        }
+      }
+    }
+  },
+  "styles": {
+    "color": {
+      "background": "var(--wp--preset--color--white)",
+      "gradient": "value",
+      "text": "var(--wp--preset--color--primary)"
+    },
+    "spacing": {
+      "margin": {
+        "top": "value",
+        "right": "value",
+        "bottom": "value",
+        "left": "value"
+      },
+      "padding": {
+        "top": "value",
+        "right": "value",
+        "bottom": "value",
+        "left": "value"
+      }
+    },
+    "typography": {
+      "fontSize": "var(--wp--preset--font-size--normal)",
+      "lineHeight": "value"
+    },
+    "elements": {
+      "link": {
+        "color": {
+          "text": "var(--wp--preset--color--dark-grey)"
+        },
+        "spacing": {},
+        "typography": {}
+      },
+      "h1": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--huge)"
+        }
+      },
+      "h2": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--big)"
+        },
+        "color": {
+          "text": "var(--wp--preset--color--medium-blue)"
+        }
+      },
+      "h3": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--medium)"
+        }
+      },
+      "h4": {},
+      "h5": {},
+      "h6": {}
+    },
+    "blocks": {
+      "core/group": {
+        "color": {
+          "text": "var(--wp--preset--color--tertiary)"
+        },
+        "spacing": {},
+        "typography": {},
+        "elements": {
+          "link": {},
+          "h1": {},
+          "h2": {
+            "typography": {
+              "fontSize": "var(--wp--preset--font-size--small)"
+            }
+          },
+          "h3": {
+            "typography": {
+              "fontSize": "var(--wp--preset--font-size--smaller)"
+            }
+          },
+          "h4": {},
+          "h5": {},
+          "h6": {}
+        }
+      },
+      "core/paragraph": {
+        "color": {
+          "text": "var(--wp--preset--color--secondary)"
+        },
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--normal)"
+        }
+      },
+      "core/post-excerpt": {
+        "elements": {
+          "link": {
+            "color": {
+              "text": "var(--wp--preset--color--white)",
+              "background": "var(--wp--preset--color--blue)"
+            },
+            "spacing": {
+              "padding": {
+                "top": "1em",
+                "right": "1em",
+                "bottom": "1em",
+                "left": "1em"
+              }
+            }
+          }
+        }
+      },
+      "core/post-terms": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--extra-small)"
+        }
+      },
+      "core/post-title": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--large)"
+        }
+      }
+    }
+  },
+  "customTemplates": [
+    {
+      "name": "page-home",
+      "title": "Page without title",
+      "postTypes": ["page", "post", "my-cpt"]
+    },
+    {
+      "name": "page-contact",
+      "title": "Contact",
+      "postTypes": ["page"]
+    }
+  ],
+  "templateParts": [
+    {
+      "name": "header",
+      "area": "header"
+    },
+    {
+      "name": "footer",
+      "area": "footer"
+    }
+  ]
+}

--- a/src/test/theme-v1/theme.json
+++ b/src/test/theme-v1/theme.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/theme-v1.json",
   "version": 1,
   "settings": {
     "color": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This adds the schema for version 1 of WordPress's [theme.json](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/) used to configure [block theme](https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/) global settings and styles.