### PR TITLE
chore: update Ory schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1573,7 +1573,7 @@
         "keto.yaml",
         "keto.toml"
       ],
-      "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/config.schema.json"
+      "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/version.schema.json"
     },
     {
       "name": "kustomization.yaml",
@@ -1901,7 +1901,7 @@
         "oathkeeper.yaml",
         "oathkeeper.toml"
       ],
-      "url": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schemas/config.schema.json"
+      "url": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schema/version.schema.json"
     },
     {
       "name": "ocelot.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1383,15 +1383,15 @@
       "url": "https://json.schemastore.org/htmlhint.json"
     },
     {
-      "name": "hydra.yml",
-      "description": "ORY Hydra configuration file",
+      "name": "Ory Hydra configuration",
+      "description": "Schema for Ory Hydra configuration file",
       "fileMatch": [
         "hydra.json",
         "hydra.yml",
         "hydra.yaml",
         "hydra.toml"
       ],
-      "url": "https://raw.githubusercontent.com/ory/hydra/v1.10.6/.schema/version.schema.json"
+      "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
     },
     {
       "name": "imageoptimizer.json",
@@ -1565,8 +1565,8 @@
       }
     },
     {
-      "name": "keto.yml",
-      "description": "ORY Keto configuration file",
+      "name": "Ory Keto configuration",
+      "description": "Schema for Ory Keto configuration file",
       "fileMatch": [
         "keto.json",
         "keto.yml",
@@ -1893,8 +1893,8 @@
       ]
     },
     {
-      "name": "oathkeeper.yml",
-      "description": "ORY Oathkeeper configuration file",
+      "name": "Ory Oathkeeper configuration",
+      "description": "Schema for Ory Oathkeeper configuration file",
       "fileMatch": [
         "oathkeeper.json",
         "oathkeeper.yml",
@@ -1966,12 +1966,13 @@
       "url": "https://raw.githubusercontent.com/outblocks/outblocks-cli/master/schema/schema-table.json"
     },
     {
-      "name": "kratos.yml",
-      "description": "ORY Kratos configuration file",
+      "name": "Ory Kratos configuration",
+      "description": "Schema for Ory Kratos configuration file",
       "fileMatch": [
         "kratos.json",
         "kratos.yml",
-        "kratos.yaml"
+        "kratos.yaml",
+        "kratos.toml"
       ],
       "url": "https://raw.githubusercontent.com/ory/kratos/master/.schema/version.schema.json"
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Aligned names and descriptions.

I also have a question regarding versioning: we use the `version.schema.json` to map to the correct schema. It looks like this:
```json
{
    "$id": "https://github.com/ory/kratos/.schema/versions.config.schema.json",
    "$schema": "https://raw.githubusercontent.com/ory/cli/v0.0.21/.schema/version_meta.schema.json#",
    "title": "All Versions of the ORY Hydra Configuration",
    "type": "object",
    "oneOf": [
        {
            "allOf": [
                {
                    "properties": {
                        "version": {
                            "const": "v1.7.0"
                        }
                    }
                },
                {
                    "$ref": "https://raw.githubusercontent.com/ory/hydra/v1.7.0/.schema/config.schema.json"
                }
            ]
        },
        {
            "allOf": [
                {
                    "properties": {
                        "version": {
                            "const": "v1.7.4"
                        }
                    }
                },
                {
                    "$ref": "https://raw.githubusercontent.com/ory/hydra/v1.7.4/.schema/config.schema.json"
                }
            ]
        },
...
```

This allows us to append to this list on every release, and to have the right version available without the need for tools to detect which one to use. It would be very hard to detect the right version anyway...

Any concerns around that? It seems to work very well so far.

Also, this requires to always reference the `master` branch instead of a specific release here in the `catalog.json`, and some people seem to update it here to a fixed version (like #1297). Any way to denote that those URLs should be kept like they are?