### PR TITLE
Add Woodpecker CI config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3570,6 +3570,12 @@
         "*.es.yaml"
       ],
       "url": "https://raw.githubusercontent.com/fujaba/fulibWorkflows/main/schema/fulibWorklows.schema.json"
+    },
+    {
+      "name": "Woodpecker pipeline config",
+      "description": "YAML schema for configuring Woodpecker CI",
+      "fileMatch": ["**/.woodpecker/**.yml", "**/.woodpecker.yml"],
+      "url": "https://raw.githubusercontent.com/woodpecker-ci/woodpecker/master/pipeline/schema/schema.json"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Woodpecker is a community fork of the Drone CI system: https://github.com/woodpecker-ci/woodpecker
