### PR TITLE
Update WordPress theme.json schema

### DIFF
--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -995,5 +995,6 @@
       }
     }
   },
+  "required": ["version"],
   "additionalProperties": false
 }

--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -140,7 +140,8 @@
                 "type": "string"
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         "typography": {
           "type": "object",
@@ -183,7 +184,8 @@
                   "name": {
                     "type": "string"
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "fontFamilies": {
@@ -200,7 +202,8 @@
                   "name": {
                     "type": "string"
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
           },

--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -127,7 +127,7 @@
           "type": "object",
           "properties": {
             "blockGap": {
-              "oneOf": [{ "type": "number" }, { "type": "null" }]
+              "oneOf": [{ "type": "boolean" }, { "type": "null" }]
             },
             "customMargin": {
               "type": "boolean"

--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -3,7 +3,8 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "//": {
-      "explainer": "https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/",
+      "explainer": "https://developer.wordpress.org/themes/advanced-topics/theme-json/",
+      "createTheme": "https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/",
       "reference": "https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/"
     },
     "settingsProperties": {

--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -897,6 +897,7 @@
         },
         {
           "properties": {
+            "border": {},
             "color": {},
             "spacing": {},
             "typography": {},
@@ -948,6 +949,7 @@
         },
         {
           "properties": {
+            "border": {},
             "color": {},
             "spacing": {},
             "typography": {},


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This fixes a few things that I missed in the first pass for theme-v1.json.

- Added one more documentation link
- `version` is a required field
- `settings.spacing.blockGap` is a boolean not a string
- `styles.border` was mistakenly left out of the `additionalProperties` check in some places
- Some `additionalProperties` checks were missing