### PR TITLE
Add interactive CLI key in taskfile jsonschema

### DIFF
--- a/src/schemas/json/taskfile.json
+++ b/src/schemas/json/taskfile.json
@@ -235,6 +235,10 @@
             "items": {
               "$ref": "#/definitions/3/precondition"
             }
+          },
+          "interactive": {
+            "description": "Indicates that this task runs an interactive CLI application",
+            "type": "boolean"
           }
         }
       },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Added the `interactive` property that was included in `task` version `3.8`.

Cf: https://github.com/go-task/task/blob/master/CHANGELOG.md#v380---2021-09-26