### PR TITLE
Add schema for the Sapphire CLI Config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2349,6 +2349,15 @@
       }
     },
     {
+      "name": "Sapphire CLI Config",
+      "description": "Scheme for Sapphire CLI Config (@sapphire/cli)",
+      "fileMatch": [
+        ".sapphirerc.json",
+        ".sapphirerc.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/sapphiredev/cli/main/templates/schemas/.sapphirerc.scheme.json"
+    },
+    {
       "name": "sarif-1.0.0.json",
       "description": "Static Analysis Results Interchange Format (SARIF) version 1",
       "url": "https://json.schemastore.org/sarif-1.0.0.json"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This PR adds the JSON scheme for the Sapphire CLI Config