### PR TITLE
Note src/negative_test/ in contrib doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,10 @@ If the build succeeds, your changes are valid and you can safely create a PR.
 
 A valid YAML file can be [translated to JSON](https://www.json2yaml.com/convert-yaml-to-json) file and used as a test file.
 
+#### Adding negative tests
+
+To make sure that invalid files fail to validate against your schema, use a subfolder in [`src/negative_test/`](src/negative_test) instead.
+
 ### Self-hosting schemas
 
 If you wish to retain full control over your schema definition, simply register it in the [schema catalog](src/api/json/catalog.json) by providing a `url` pointing to the self-hosted schema file to the [entry](#catalog).


### PR DESCRIPTION
The contrib doc describes how to add test cases for a schema well and succinctly. However, as a new contributor, it was not clear that the `negative_test` exists. This adds a note, keeping it a brief as possible, to point contributors towards negative tests.