### PR TITLE
ui5 manifest: enhance file match for TypeScript project support

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2768,7 +2768,8 @@
       "description": "UI5 Manifest (manifest.json)",
       "fileMatch": [
         "webapp/manifest.json",
-        "src/main/webapp/manifest.json"
+        "src/main/webapp/manifest.json",
+        "src/manifest.json"
       ],
       "url": "https://raw.githubusercontent.com/SAP/ui5-manifest/master/schema.json"
     },


### PR DESCRIPTION
Project templates for TypeScript had been established by some teams to
develop the TypeScript code in the src folder and let the transpiling
happen into the webapp folder. In case of editing the manifest.json in
the TypeScript project we need to enhance the file match.

