### PR TITLE
Add theme.json schema annotations

### DIFF
--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -284,10 +284,7 @@
         },
         "custom": {
           "description": "Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. `camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema. Keys at different depth levels are separated by `--`, so keys should not include `--` in the name.\nSince 5.8.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/settingsCustomProperties"
-          }
+          "$ref": "#/definitions/settingsCustomAdditionalProperties"
         }
       }
     },
@@ -553,18 +550,21 @@
       },
       "additionalProperties": false
     },
-    "settingsCustomProperties": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "number"
-        },
-        {
-          "$ref": "#/definitions/settingsCustomProperties"
-        }
-      ]
+    "settingsCustomAdditionalProperties": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "$ref": "#/definitions/settingsCustomAdditionalProperties"
+          }
+        ]
+      }
     },
     "stylesProperties": {
       "properties": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
This adds description and default value annotations to the theme.json schema.

It also adds required values for post types and template parts.

cc @mkaz