### PR TITLE
Update Bucklescript schema URL

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -387,7 +387,7 @@
       "fileMatch": [
         "bsconfig.json"
       ],
-      "url": "https://raw.githubusercontent.com/rescript-lang/rescript-compiler/8.2.0/docs/docson/build-schema.json"
+      "url": "https://raw.githubusercontent.com/rescript-lang/rescript-compiler/master/docs/docson/build-schema.json"
     },
     {
       "name": "Bukkit plugin.yml",


### PR DESCRIPTION
I've changed the schema URL to reference the master branch rather than a version tag. Is this okay, or is it preferable to reference the latest version instead?