### PR TITLE
Update AWS CloudFormation schemas to v5.2.11

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -674,7 +674,7 @@
         "cloudformation.yml",
         "cloudformation.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/awslabs/goformation/v5.2.9/schema/cloudformation.schema.json"
+      "url": "https://raw.githubusercontent.com/awslabs/goformation/v5.2.11/schema/cloudformation.schema.json"
     },
     {
       "name": "AWS CloudFormation Serverless Application Model (SAM)",
@@ -688,7 +688,7 @@
         "sam.yml",
         "sam.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/awslabs/goformation/v5.2.9/schema/sam.schema.json"
+      "url": "https://raw.githubusercontent.com/awslabs/goformation/v5.2.11/schema/sam.schema.json"
     },
     {
       "name": "Citation File Format",


### PR DESCRIPTION
The project https://github.com/awslabs/goformation was tagged with version v5.2.11

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
