### PR TITLE
Add support for multiple rollback variants in liquibase changelogs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3547,7 +3547,11 @@
         "**/db/changelog/**/*.yml",
         "**/db/changelog/**/*.json"
       ],
-      "url": "https://json.schemastore.org/liquibase.json"
+      "url": "https://json.schemastore.org/liquibase-3.2.json",
+      "versions": {
+        "1.0": "https://json.schemastore.org/liquibase.json",
+        "3.2": "https://json.schemastore.org/liquibase-3.2.json"
+      }
     },
     {
       "name": "Pipeline component",

--- a/src/schemas/json/liquibase-3.2.json
+++ b/src/schemas/json/liquibase-3.2.json
@@ -1,0 +1,3145 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "catalogName": {
+            "description": "The name of the catalog",
+            "type": "string",
+            "default": ""
+        },
+        "schemaName": {
+            "description": "The name of the schema",
+            "type": "string",
+            "default": ""
+        },
+        "remarks": {
+            "description": "The comments stored for the table/view/column",
+            "type": "string",
+            "default": ""
+        },
+        "tableName": {
+            "description": "The name of the table",
+            "type": "string",
+            "default": ""
+        },
+        "where": {
+            "description": "Allows to define the 'where' condition(s) string",
+            "type": "string",
+            "default": ""
+        },
+        "dbms": {
+            "$comment": "https://www.liquibase.org/get-started/databases",
+            "description": "Specifies logical expression of database type(s) on which the change must be applied. Valid database type names are listed on the supported databases page. It can be a comma-separated list of multiple databases or you can also specify that a change is not applicable to a particular database type by prefixing with !. The keywords all and none are also available.",
+            "type": "string",
+            "default": ""
+        },
+        "column": {
+            "type": "object",
+            "default": {},
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "description": "The name of the column.",
+                    "type": "string",
+                    "default": ""
+                },
+                "computed": {
+                    "description": "The attribute which is used if the value in name isn't actually a column name but a function. Since 3.3.0",
+                    "type": "boolean",
+                    "default": false
+                },
+                "descending": {
+                    "description": "The boolean attribute which allows you to specify that a column should be used in a descending order in the index if it is used in a createIndex command. Default value is false (in an ascending order) Since 3.4",
+                    "type": "boolean",
+                    "default": false
+                },
+                "type": {
+                    "description": "The column data type.",
+                    "type": "string",
+                    "default": ""
+                },
+                "value": {
+                    "description": "The value for which to set the column. The value will be surrounded by quote marks and nested quote marks will be escaped.",
+                    "type": "string",
+                    "default": ""
+                },
+                "valueNumeric": {
+                    "description": "The numeric value to set the column to. The value will not be escaped and will not be nested in quote marks.",
+                    "type": "number",
+                    "default": ""
+                },
+                "valueBoolean": {
+                    "description": "The boolean value to set the column to. The actual value string inserted will depend on the database implementation.",
+                    "type": "boolean",
+                    "default": ""
+                },
+                "valueDate": {
+                    "description": "The date and time value to set the column to. The value is specified in one of the following forms: YYYY-MM-DD, hh:mm:ss, or YYYY-MM-DDThh:mm:ss.",
+                    "type": "string",
+                    "default": ""
+                },
+                "valueComputed": {
+                    "description": "The value that is returned from a function or procedure call. This attribute will contain the function to call.",
+                    "type": "string",
+                    "default": ""
+                },
+                "valueSequenceCurrent": {
+                    "$comment": "https://docs.liquibase.com/change-types/community/update.html",
+                    "description": "The name of the sequence in which the current value is used.",
+                    "type": "string",
+                    "default": ""
+                },
+                "valueSequenceNext": {
+                    "$comment": "https://docs.liquibase.com/change-types/community/update.html",
+                    "description": "The name of the sequence in which the next value is used.",
+                    "type": "string",
+                    "default": ""
+                },
+                "valueBlobFile": {
+                    "description": "The path to a file, whose contents will be written as a BLOB (i.e. chunk of binary data).\n\nThe path to the changelog file location must be either absolute or relative. An example of an absolute path is: /usr/local/somefile.dat on Unix or c:\\Directory\\somefile.dat on Windows.",
+                    "type": "string",
+                    "default": ""
+                },
+                "valueClobFile": {
+                    "description": "The path to a file, whose contents will be written as a CLOB (i.e. chunk of character data).\nThe path to the changelog file location must be either absolute or relative. An example of an absolute path is: /usr/local/somefile.dat on Unix or c:\\Directory\\somefile.dat on Windows.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValue": {
+                    "description": "The default value for column.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueNumeric": {
+                    "description": "The default numeric value for column.",
+                    "type": "number",
+                    "default": ""
+                },
+                "defaultValueDate": {
+                    "description": "The default date and time value for column. The value is specified in one of the following forms: YYYY-MM-DD, hh:mm:ss, or YYYY-MM-DDThh:mm:ss.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueBoolean": {
+                    "description": "The default boolean value for column.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "defaultValueComputed": {
+                    "description": "The default value that is returned from a function or procedure call. This attribute will contain the function to call.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueSequenceCurrent": {
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueSequenceNext": {
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueConstraintName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "autoIncrement": {
+                    "description": "The auto-increment column. Ignored on databases that do not support the autoincrement/identity functionality.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "startWith": {
+                    "description": "The value auto-increment start. Ignored on databases that do not support autoincrement/identity functionality.",
+                    "type": "integer",
+                    "default": 0
+                },
+                "incrementBy": {
+                    "description": "The value of each step by auto-increment. Ignored on databases that do not support autoincrement/identity functionality.",
+                    "type": "integer",
+                    "default": 0
+                },
+                "generationType": {
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultOnNull": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "remarks": {
+                    "description": "A short description of the column (column comment).",
+                    "type": "string",
+                    "default": ""
+                },
+                "encoding": {
+                    "description": "The name of the encoding (specified in java.nio.Charset javadoc, e.g. \"UTF-8\") of the CLOB file (specified in valueClobFile) contents.",
+                    "type": "string",
+                    "default": ""
+                },
+                "beforeColumn": {
+                    "$comment": "https://docs.liquibase.com/change-types/community/create-table.html",
+                    "description": "The attribute that allows you to control where in the table column order the new column goes if it is used in an addColumn command. Only one of beforeColumn, afterColumn, or position is allowed. Since 3.1",
+                    "type": "string",
+                    "default": ""
+                },
+                "afterColumn": {
+                    "$comment": "https://docs.liquibase.com/change-types/community/create-table.html",
+                    "description": "The attribute that allows you to control where in the table column order the new column goes if it is used in an addColumn command. Only one of beforeColumn, afterColumn, or position is allowed. Since 3.1",
+                    "type": "string",
+                    "default": ""
+                },
+                "position": {
+                    "$comment": "https://docs.liquibase.com/change-types/community/create-table.html",
+                    "description": "The attribute that allows you to control where in the table column order the new column goes if it is used in an addColumn command. Only one of beforeColumn, afterColumn, or position is allowed. Uses one based index. Since 3.1",
+                    "type": "number",
+                    "default": ""
+                },
+                "header": {
+                    "$comment": "https://docs.liquibase.com/change-types/community/load-data.html",
+                    "description": "Name of the column in the CSV file from which the value for the column will be taken if its different from the column name. Ignored if index is also defined.",
+                    "type": "string",
+                    "default": ""
+                },
+                "index": {
+                    "$comment": "https://docs.liquibase.com/change-types/community/load-data.html",
+                    "description": "Index of the column in the CSV file from which the value for the column will be taken.",
+                    "type": "integer",
+                    "default": ""
+                },
+                "constraints": {
+                    "description": "Constraint definitions",
+                    "type": "object",
+                    "default": {},
+                    "properties": {
+                        "nullable": {
+                            "description": "The attribute that defines whether the column is nullable.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "notNullConstraintName": {
+                            "description": "The not null constraint name.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "primaryKey": {
+                            "description": "The attribute that defines whether the column is a primary key.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "primaryKeyName": {
+                            "description": "The primary key name Since 1.6.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "primaryKeyTablespace": {
+                            "description": "The tablespace to use for the defined primary key.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "unique": {
+                            "description": "The attribute that defines whether a unique clause should be applied.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "uniqueConstraintName": {
+                            "description": "The unique constraint name.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "references": {
+                            "description": "The foreign key definition.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "referencedTableCatalogName": {
+                            "description": "The name of the catalog.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "referencedTableSchemaName": {
+                            "description": "The name of the schema.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "referencedTableName": {
+                            "description": "The name of the table.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "referencedColumnNames": {
+                            "description": "The name of the column.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "foreignKeyName": {
+                            "description": "The foreign key name.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "deleteCascade": {
+                            "description": "The attribute that sets delete cascade.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "deferrable": {
+                            "description": "The attribute that defines whether constraints are deferrable.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "initiallyDeferred": {
+                            "description": "The attribute that defines whether constraints are initially deferred.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "checkConstraint": {
+                            "description": "The attribute that defines whether to validate the defined check constraint.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "validateNullable": {
+                            "description": "The attribute that defines whether to validate the defined not null constraint.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "validateUnique": {
+                            "description": "The attribute that defines whether to validate the defined unique constraint.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "validatePrimaryKey": {
+                            "description": "The attribute that defines whether to validate the defined primary key constraint.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "validateForeignKey": {
+                            "description": "The attribute that defines whether to validate the defined foreign key constraint.",
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    "additionalProperties": true
+                }
+            },
+            "additionalProperties": true
+        },
+        "columns": {
+            "description": "The column constraint and foreign key information. Setting the defaultValue attribute will specify a default value for the column. Setting the value attribute will set all rows existing to the specified value without modifying the column default.\nSee Information about the <column> tag section for more information.",
+            "type": "array",
+            "default": [],
+            "minItems": 1,
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "default": {},
+                        "properties": {
+                            "column": {
+                                "$ref": "#/definitions/column"
+                            },
+                            "modifySql": {
+                                "$ref": "#/definitions/modifySql"
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            }
+        },
+        "preConditions": {
+            "$comment": "https://docs.liquibase.com/concepts/advanced/preconditions.html",
+            "description": "Preconditions are changelog or changeset tags which control the execution of an update based on the state of the database.",
+            "type": "array",
+            "default": [],
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "default": {},
+                        "properties": {
+                            "onFailMessage": {
+                                "description": "Provides a custom message to output when preconditions fail. Since 2.0",
+                                "type": "string",
+                                "default": ""
+                            },
+                            "onErrorMessage": {
+                                "description": "Provides a custom message to output when preconditions fail. Since 2.0",
+                                "type": "string",
+                                "default": ""
+                            },
+                            "onFail": {
+                                "description": "Controls what happens if the preconditions check fails.",
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "const": "HALT",
+                                        "description": "Halts the execution of the entire changelog (default). HALT can be put outside a changeset (e.g. at the beginning of the changelog)."
+                                    },
+                                    {
+                                        "const": "CONTINUE",
+                                        "description": "Skips over the changeset. Execution of the changeset will be attempted again on the next update. Continues with the changelog."
+                                    },
+                                    {
+                                        "const": "MARK_RAN",
+                                        "description": "Skips over the changeset but mark it as executed. Continues with the changelog."
+                                    },
+                                    {
+                                        "const": "WARN",
+                                        "description": "Sends a warning and continues executing the changeset / changelog as normal. WARN can be put outside a changeset (e.g. at the beginning of the changelog)."
+                                    }
+                                ],
+                                "default": "HALT"
+                            },
+                            "onError": {
+                                "description": "Controls what happens if there is an error checking whether the precondition passed or not.",
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "const": "HALT",
+                                        "description": "Halts the execution of the entire changelog (default). HALT can be put outside a changeset (e.g. at the beginning of the changelog)."
+                                    },
+                                    {
+                                        "const": "CONTINUE",
+                                        "description": "Skips over the changeset. Execution of the changeset will be attempted again on the next update. Continues with the changelog."
+                                    },
+                                    {
+                                        "const": "MARK_RAN",
+                                        "description": "Skips over the changeset but mark it as executed. Continues with the changelog."
+                                    },
+                                    {
+                                        "const": "WARN",
+                                        "description": "Sends a warning and continues executing the changeset / changelog as normal. WARN can be put outside a changeset (e.g. at the beginning of the changelog)."
+                                    }
+                                ],
+                                "default": "HALT"
+                            },
+                            "onSqlOutput": {
+                                "description": "Controls what to do in the updateSQL mode. Since 1.9.5",
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "const": "TEST",
+                                        "description": "Runs the changeset in the updateSQL mode."
+                                    },
+                                    {
+                                        "const": "FAIL",
+                                        "description": "Fails the preCondition in the updateSQL mode."
+                                    },
+                                    {
+                                        "const": "IGNORE",
+                                        "description": "Ignores the preCondition in the updateSQL mode (default)."
+                                    }
+                                ],
+                                "default": "IGNORE"
+                            },
+                            "dbms": {
+                                "description": "Defines if the database executed against matches the type specified.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "type"
+                                ],
+                                "properties": {
+                                    "type": {
+                                        "description": "The type of database expected. Multiple dbms values can be specified using comma-separated values. (required)",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "runningAs": {
+                                "description": "Defines if the database user executed under matches the username specified.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "username"
+                                ],
+                                "properties": {
+                                    "username": {
+                                        "description": "The database user script which is expected to run as. (required)",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "changeSetExecuted": {
+                                "description": "Defines if the specified changeset has already been executed.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "id",
+                                    "author",
+                                    "changeLogFile"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "description": "The changeset id. (required)",
+                                        "type": "string"
+                                    },
+                                    "author": {
+                                        "description": "The changeset author. (required)",
+                                        "type": "string"
+                                    },
+                                    "changeLogFile": {
+                                        "description": "The file name (including classpath relative path) of the changeset. (required)",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "columnExists": {
+                                "description": "Defines if the specified column exists in the database.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "tableName",
+                                    "columnName"
+                                ],
+                                "properties": {
+                                    "schemaName": {
+                                        "description": "The name of the table's schema.",
+                                        "type": "string"
+                                    },
+                                    "tableName": {
+                                        "description": "The name of the column's table. (required)",
+                                        "type": "string"
+                                    },
+                                    "columnName": {
+                                        "description": "The name of the column. (required)",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "tableExists": {
+                                "description": "Defines if the specified table exists in the database.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "tableName"
+                                ],
+                                "properties": {
+                                    "schemaName": {
+                                        "description": "The name of the table's schema.",
+                                        "type": "string"
+                                    },
+                                    "tableName": {
+                                        "description": "The name of the table. (required)",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "viewExists": {
+                                "description": "Defines if the specified view exists in the database.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "viewName"
+                                ],
+                                "properties": {
+                                    "schemaName": {
+                                        "description": "The name of the view's schema.",
+                                        "type": "string"
+                                    },
+                                    "viewName": {
+                                        "description": "The name of the view. (required)",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "foreignKeyConstraintExists": {
+                                "description": "Defines if the specified foreign key exists in the database.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "foreignKeyName"
+                                ],
+                                "properties": {
+                                    "schemaName": {
+                                        "description": "The name of the foreign key's schema.",
+                                        "type": "string"
+                                    },
+                                    "foreignKeyName": {
+                                        "description": "The name of the foreign key. (required)",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "indexExists": {
+                                "description": "Defines if the specified index exists in the database. You can either specify the indexName attribute or tableName and columnName attributes.\nNote: There are a few databases where the indexName is not unique, that's why both indexName and tableName can be used.",
+                                "type": "object",
+                                "default": {},
+                                "properties": {
+                                    "schemaName": {
+                                        "description": "The name of the index's schema.",
+                                        "type": "string"
+                                    },
+                                    "indexName": {
+                                        "description": "The name of the index.",
+                                        "type": "string"
+                                    },
+                                    "tableName": {
+                                        "description": "The name of the table.",
+                                        "type": "string"
+                                    },
+                                    "columnName": {
+                                        "description": "The name of the column.",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "sequenceExists": {
+                                "description": "Defines if the specified sequence exists in the database.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "sequenceName"
+                                ],
+                                "properties": {
+                                    "schemaName": {
+                                        "description": "The name of the sequences' schema.",
+                                        "type": "string"
+                                    },
+                                    "sequenceName": {
+                                        "description": "The name of the sequence. (required)",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "primaryKeyExists": {
+                                "description": "Defines if the specified primary key exists in the database.\n(tableName or primaryKeyName is required)",
+                                "type": "object",
+                                "default": {},
+                                "properties": {
+                                    "schemaName": {
+                                        "description": "The name of the primary key's schema.",
+                                        "type": "string"
+                                    },
+                                    "primaryKeyName": {
+                                        "description": "The name of the primary key.",
+                                        "type": "string"
+                                    },
+                                    "tableName": {
+                                        "description": "The name of the table containing primary key.",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "sqlCheck": {
+                                "description": "Executes an SQL string and checks the returned value. The SQL must return a single row with a single value.\n\nTo check a number of rows, use the count SQL function.\nTo check for ranges of values, perform the check in the SQL and return a value that can be easily compared against.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "expectedResult"
+                                ],
+                                "properties": {
+                                    "expectedResult": {
+                                        "description": "The value to compare the SQL result to. (required)",
+                                        "type": "integer"
+                                    },
+                                    "sql": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "changeLogPropertyDefined": {
+                                "description": "Checks whether given changelog attribute is present. It fails if the value is not the same as given.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "property"
+                                ],
+                                "properties": {
+                                    "property": {
+                                        "description": "The name of the property to check. (required)",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The required value for a given property.",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "customPrecondition": {
+                                "description": "Can be created by adding a class that implements the liquibase.precondition.CustomPrecondition interface. Parameters on custom classes are set through reflection based on the <param> sub-tags. Pass parameters as strings to the custom precondition.\n\nThe customPrecondition sub-tags:\nparam - the parameter to pass to the custom precondition.\nname - the name of the parameter to set. (required)\nvalue - a string value to set parameter to. (required)",
+                                "$comment": "FIXME How can pass params?",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "className"
+                                ],
+                                "properties": {
+                                    "className": {
+                                        "description": "The name of the custom precondition class. (required)",
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": true
+                            },
+                            "and": {
+                                "$ref": "#/definitions/preConditions"
+                            },
+                            "or": {
+                                "$ref": "#/definitions/preConditions"
+                            },
+                            "not": {
+                                "$ref": "#/definitions/preConditions"
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            }
+        },
+        "createTable": {
+            "$comment": "https://docs.liquibase.com/change-types/community/create-table.html",
+            "description": "You can typically use the createTable Change Type when you want to create a table in your changelog file and then deploy it to your database. It can include columns and another values listed in this documentation.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName",
+                "columns"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "tablespace": {
+                    "description": "The name of the tablespace in which the table is created",
+                    "type": "string",
+                    "default": ""
+                },
+                "remarks": {
+                    "$ref": "#/definitions/remarks"
+                },
+                "columns": {
+                    "$ref": "#/definitions/columns"
+                }
+            },
+            "additionalProperties": true
+        },
+        "createView": {
+            "$comment": "https://docs.liquibase.com/change-types/community/create-view.html",
+            "description": "Creates a new database view.",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "viewName": {
+                    "description": "Name of the view to create",
+                    "type": "string",
+                    "default": ""
+                },
+                "remarks": {
+                    "$ref": "#/definitions/remarks"
+                },
+                "replaceIfExists": {
+                    "description": "Use 'create or replace' syntax",
+                    "type": "boolean",
+                    "default": false
+                },
+                "fullDefinition": {
+                    "description": "Set to true if selectQuery is the entire view definition. False if the CREATE VIEW header should be added.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "path": {
+                    "description": "Path to file containing view definition",
+                    "type": "string",
+                    "default": ""
+                },
+                "encoding": {
+                    "description": "Encoding used in the file defined in the `path` attribute",
+                    "type": "string",
+                    "default": ""
+                },
+                "relativeToChangelogFile": {
+                    "description": "Whether the file path relative to the root changelog file rather than to the classpath.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "selectQuery": {
+                    "description": "SQL for generating the view",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "sql": {
+            "$comment": "https://docs.liquibase.com/change-types/community/sql.html",
+            "description": "It is useful for complex changes that aren't supported through Liquibase's automated Change Types and to work around bugs and limitations of Liquibase. The SQL contained in the <SQL> Change Type can be multi-line.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "sql"
+            ],
+            "properties": {
+                "stripComments": {
+                    "description": "Set to true to remove any comments in the SQL before executing, otherwise false.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "splitStatements": {
+                    "description": "Set to false to not have Liquibase split statements on ;'s and GO's. Defaults to true if not set",
+                    "type": "boolean",
+                    "default": false
+                },
+                "endDelimiter": {
+                    "description": "Indicates the end of the SQL statement and prevents incomplete SQL statements from being processed when the SQL files contain statements referencing a ; which Liquibase treats as the default end delimiter. You can use the endDelimiter when the changeset contains SQL to create a stored procedure or function that contains the default ; end delimiter to separate the statements inside the procedure.\nFor more information, see The endDelimiter SQL attribute.",
+                    "type": "string",
+                    "default": ""
+                },
+                "dbms": {
+                    "$ref": "#/definitions/dbms"
+                },
+                "comment": {
+                    "type": "string",
+                    "default": ""
+                },
+                "sql": {
+                    "description": "Specifies the SQL to execute",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "update": {
+            "$comment": "https://docs.liquibase.com/change-types/community/update.html",
+            "description": "You can typically use the update Change Type when you want to update a table in your changelog file and then deploy this update to your database. It can include columns and another values listed in this documentation.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName",
+                "columns"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columns": {
+                    "$ref": "#/definitions/columns"
+                },
+                "where": {
+                    "$ref": "#/definitions/where"
+                },
+                "whereParams": {
+                    "$ref": "#/definitions/whereParams"
+                }
+            },
+            "additionalProperties": true
+        },
+        "delete": {
+            "$comment": "https://docs.liquibase.com/change-types/community/delete.html",
+            "description": "Deletes data from an existing table.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "where": {
+                    "$ref": "#/definitions/where"
+                },
+                "whereParams": {
+                    "$ref": "#/definitions/whereParams"
+                }
+            },
+            "additionalProperties": true
+        },
+        "whereParams": {
+            "$comment": "https://docs.liquibase.com/change-types/community/update.html",
+            "$comment": "https://docs.liquibase.com/change-types/community/delete.html",
+            "type": "array",
+            "default": [],
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "default": {},
+                        "properties": {
+                            "param": {
+                                "type": "object",
+                                "default": {},
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "value": {
+                                        "description": "Value of the attribute.\nNote: If not set, then the first valueXXX defined is used in the order they appear.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "valueNumeric": {
+                                        "description": "integer value of the attribute.",
+                                        "type": "number",
+                                        "default": ""
+                                    },
+                                    "valueBoolean": {
+                                        "description": "boolean value of the attribute.",
+                                        "type": "boolean",
+                                        "default": ""
+                                    },
+                                    "valueDate": {
+                                        "description": "Date and/or Time value to set the attribute to. The value shall be specified in one of the following forms: \"YYYY-MM-DD\", \"hh:mm:ss\" or \"YYYY-MM-DDThh:mm:ss\".",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "valueComputed": {
+                                        "description": "A value that is returned from a function or procedure call. This attribute shall contain the function name to call.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "valueSequenceNext": {
+                                        "description": "Name of the sequence which next value is used",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "valueSequenceCurrent": {
+                                        "description": "Name of the sequence which current value is used",
+                                        "type": "string",
+                                        "default": ""
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            }
+        },
+        "tagDatabase": {
+            "$comment": "https://docs.liquibase.com/change-types/community/tag-database.html",
+            "description": "The tagDatabase Change Type applies a tag to the database for future update or rollback.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tag"
+            ],
+            "properties": {
+                "tag": {
+                    "description": "The tag to apply",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropTable": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-table.html",
+            "description": "Drops an existing table from your database.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "cascadeConstraints": {
+                    "description": "Add the `CASCADE CONSTRAINTS` to the statement",
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": true
+        },
+        "renameView": {
+            "$comment": "https://docs.liquibase.com/change-types/community/rename-view.html",
+            "type": "object",
+            "default": {},
+            "required": [
+                "oldViewName",
+                "newViewName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "oldViewName": {
+                    "description": "Name of the view to rename",
+                    "type": "string",
+                    "default": ""
+                },
+                "newViewName": {
+                    "description": "Name to rename the view to",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropView": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-view.html",
+            "description": "Drops an existing view.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "viewName"
+            ],
+            "properties": {
+                "viewName": {
+                    "description": "Name of the view to drop",
+                    "type": "string",
+                    "default": ""
+                },
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                }
+            },
+            "additionalProperties": true
+        },
+        "empty": {
+            "$comment": "https://docs.liquibase.com/change-types/community/empty.html",
+            "description": "empty",
+            "type": "object",
+            "default": {},
+            "additionalProperties": true
+        },
+        "insert": {
+            "$comment": "https://docs.liquibase.com/change-types/community/insert.html",
+            "description": "You can typically use the insert Change Type when you want to add and deploy the specific data or values to the existing table in your database. It can include columns and another attributes listed in this documentation.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "dbms": {
+                    "$ref": "#/definitions/dbms"
+                },
+                "columns": {
+                    "$ref": "#/definitions/columns"
+                }
+            },
+            "additionalProperties": true
+        },
+        "addColumn": {
+            "$comment": "https://docs.liquibase.com/change-types/community/add-column.html",
+            "description": "You can typically use the addColumn Change Type when you want to add a new column and deploy it to the table in your database.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName",
+                "columns"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columns": {
+                    "$ref": "#/definitions/columns"
+                }
+            },
+            "additionalProperties": true
+        },
+        "createProcedure": {
+            "$comment": "https://docs.liquibase.com/change-types/community/create-procedure.html",
+            "description": "The createProcedure Change Type defines the definition for a stored procedure. This Change Type is better to use for creating procedures than the raw SQL command because it will not attempt to strip comments or break up lines.\n\nOften times it is best to use the CREATE OR REPLACE syntax along with setting runOnChange='true' on the enclosing changeset tag. That way if you need to make a change to your procedure, you can change your existing code rather than creating a new REPLACE PROCEDURE call. The advantage to this approach is that it keeps your changelog smaller and allows you to more easily see what has changed in your procedure code through your source control system's diff command.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "path",
+                "procedureText"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "procedureText": {
+                    "description": "The SQL creating the procedure. You need to define either this attribute or the path attribute. The procedureText attribute is not supported in the XML format; however, you can specify the procedure SQL within <createProcedure></<createProcedure> tags. See the XML example.",
+                    "type": "string",
+                    "default": ""
+                },
+                "procedureName": {
+                    "description": "The name of the procedure. It is required if replaceIfExists= true",
+                    "type": "string",
+                    "default": ""
+                },
+                "path": {
+                    "description": "The file containing the procedure text. Either this attribute or a nested procedure text is required.",
+                    "type": "string",
+                    "default": ""
+                },
+                "encoding": {
+                    "description": "The encoding used in the file defined in the `path` attribute",
+                    "type": "string",
+                    "default": ""
+                },
+                "relativeToChangelogFile": {
+                    "description": "Defines whether the file path is relative to the root changelog file rather than to the classpath.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "dbms": {
+                    "$ref": "#/definitions/dbms"
+                },
+                "replaceIfExists": {
+                    "description": "If the stored procedure defined by procedureName already exits, alter it instead of creating it.",
+                    "type": "boolean",
+                    "default": ""
+                },
+                "comments": {
+                    "description": "The comments you can specify in the changeset.",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropProcedure": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-procedure.html",
+            "description": "Drops an existing procedure",
+            "type": "object",
+            "default": {},
+            "required": [
+                "procedureName"
+            ],
+            "properties": {
+                "procedureName": {
+                    "description": "Name of the stored procedure to drop",
+                    "type": "string",
+                    "default": ""
+                },
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                }
+            },
+            "additionalProperties": true
+        },
+        "sqlFile": {
+            "$comment": "https://docs.liquibase.com/change-types/community/sql-file.html",
+            "description": "The <sqlFile> Change Type is useful for complex changes that are not supported through Liquibase automated Change Types such as stored procedures. The SQL contained in the <sqlFile> Change Type can be multi-line.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "path"
+            ],
+            "properties": {
+                "path": {
+                    "description": "Specifies the file path of the SQL file to load.",
+                    "type": "string",
+                    "default": ""
+                },
+                "stripComments": {
+                    "description": "Set to true to remove any comments in the SQL before executing, otherwise false.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "splitStatements": {
+                    "description": "Set to false to not have Liquibase split statements on ;'s and GO's. Defaults to true if not set.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "encoding": {
+                    "description": "Specifies encoding used in the file defined in the `path` attribute.",
+                    "type": "string",
+                    "default": ""
+                },
+                "endDelimiter": {
+                    "description": "Indicates the end of the SQL statement and prevents incomplete SQL statements from being processed when the SQL files contain statements referencing a ; which Liquibase treats as the default end delimiter. You can use the endDelimiter when the changeset contains SQL to create a stored procedure or function that contains the default ; end delimiter to separate the statements inside the procedure.\nFor more information, see The endDelimiter SQL attribute.",
+                    "type": "string",
+                    "default": ""
+                },
+                "relativeToChangelogFile": {
+                    "description": "Indicates whether the file path is relative to the root changelog file rather than to the classpath.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "dbms": {
+                    "$ref": "#/definitions/dbms"
+                },
+                "comment": {
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "stop": {
+            "$comment": "https://docs.liquibase.com/change-types/community/stop.html",
+            "description": "Stops Liquibase execution with a message. Mainly useful for debugging and stepping through a changelog",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "message": {
+                    "description": "Message to output when execution stops",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "renameTable": {
+            "$comment": "https://docs.liquibase.com/change-types/community/rename-table.html",
+            "description": "Renames an existing table.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "newTableName",
+                "oldTableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "oldTableName": {
+                    "description": "Name of the table to rename",
+                    "type": "string",
+                    "default": ""
+                },
+                "newTableName": {
+                    "description": "New name for the table",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "renameColumn": {
+            "$comment": "https://docs.liquibase.com/change-types/community/rename-column.html",
+            "description": "Renames an existing column.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "newColumnName",
+                "oldColumnName",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "oldColumnName": {
+                    "description": "Name of the existing column to rename",
+                    "type": "string",
+                    "default": ""
+                },
+                "newColumnName": {
+                    "description": "Name to rename the column to",
+                    "type": "string",
+                    "default": ""
+                },
+                "columnDataType": {
+                    "description": "Data type of the column",
+                    "type": "string",
+                    "default": ""
+                },
+                "remarks": {
+                    "description": "Remarks of the column",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropColumn": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-column.html",
+            "description": "Drops an existing column(s).\n\nTo drop a single column, use the simple form of this element where the tableName and columnName are specified as attributes. To drop several columns, specify the tableName as an attribute, and then specify a set of nested <column> tags. If nested <column> tags are present, the columnName attribute will be ignored.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnName": {
+                    "description": "Name of the column to drop, if dropping a single column. Ignored if nested 'column's are defined",
+                    "type": "string",
+                    "default": ""
+                },
+                "columns": {
+                    "$ref": "#/definitions/columns"
+                }
+            },
+            "additionalProperties": true
+        },
+        "mergeColumns": {
+            "$comment": "https://docs.liquibase.com/change-types/community/merge-columns.html",
+            "description": "The mergeColumns Change Type concatenates the values in two columns and joins them with a string. The Change Type stores the resulting value in a new column.\nYou can typically use the mergeColumns Change Type when you want to combine the values from two columns into one.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "column1Name",
+                "column2Name",
+                "finalColumnName",
+                "finalColumnType",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "column1Name": {
+                    "description": "The name of the column containing the first half of the data",
+                    "type": "string",
+                    "default": ""
+                },
+                "joinString": {
+                    "description": "The string to place between the values from column1 and column2 (may be empty)",
+                    "type": "string",
+                    "default": ""
+                },
+                "column2Name": {
+                    "description": "The name of the column containing the second half of the data",
+                    "type": "string",
+                    "default": ""
+                },
+                "finalColumnName": {
+                    "description": "The name of the column to create",
+                    "type": "string",
+                    "default": ""
+                },
+                "finalColumnType": {
+                    "description": "The data type of the column to create",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "modifyDataType": {
+            "$comment": "https://docs.liquibase.com/change-types/community/modify-data-type.html",
+            "description": "Allows you to modify data types.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnName",
+                "newDataType",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnName": {
+                    "description": "Name of the column",
+                    "type": "string",
+                    "default": ""
+                },
+                "newDataType": {
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "createSequence": {
+            "$comment": "https://docs.liquibase.com/change-types/community/create-sequence.html",
+            "description": "Creates a new database sequence.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "sequenceName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "sequenceName": {
+                    "description": "Name of the sequence to create",
+                    "type": "string",
+                    "default": ""
+                },
+                "startValue": {
+                    "description": "The first sequence number to be generated.",
+                    "type": "integer",
+                    "default": ""
+                },
+                "incrementBy": {
+                    "description": "Interval between sequence numbers",
+                    "type": "integer",
+                    "default": ""
+                },
+                "maxValue": {
+                    "description": "The maximum value of the sequence",
+                    "type": "integer",
+                    "default": ""
+                },
+                "minValue": {
+                    "description": "The minimum value of the sequence",
+                    "type": "integer",
+                    "default": ""
+                },
+                "ordered": {
+                    "description": "Does the sequence need to be guaranteed to be generated in the order of request?",
+                    "type": "boolean",
+                    "default": ""
+                },
+                "cacheSize": {
+                    "description": "Number of values to fetch per query",
+                    "type": "integer",
+                    "default": ""
+                },
+                "dataType": {
+                    "description": "Data type of the sequence",
+                    "type": "string",
+                    "default": ""
+                },
+                "cycle": {
+                    "description": "Can the sequence cycle when it hits the max value?",
+                    "type": "boolean",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "alterSequence": {
+            "$comment": "https://docs.liquibase.com/change-types/community/alter-sequence.html",
+            "description": "Alters properties of an existing sequence.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "sequenceName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "sequenceName": {
+                    "description": "Name of the sequence to alter",
+                    "type": "string",
+                    "default": ""
+                },
+                "incrementBy": {
+                    "description": "New amount the sequence should increment by",
+                    "type": "integer",
+                    "default": ""
+                },
+                "maxValue": {
+                    "description": "New maximum value for the sequence",
+                    "type": "integer",
+                    "default": ""
+                },
+                "minValue": {
+                    "description": "New minimum value for the sequence",
+                    "type": "integer",
+                    "default": ""
+                },
+                "ordered": {
+                    "description": "Does the sequence need to be guaranteed to be generated in the order of request?",
+                    "type": "boolean",
+                    "default": ""
+                },
+                "cacheSize": {
+                    "description": "Change the cache size",
+                    "type": "integer",
+                    "default": ""
+                },
+                "dataType": {
+                    "description": "Data type of the sequence",
+                    "type": "string",
+                    "default": ""
+                },
+                "cycle": {
+                    "description": "Can the sequence cycle when it hits the max value?",
+                    "type": "boolean",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropSequence": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-sequence.html",
+            "description": "Drops an existing sequence.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "sequenceName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "sequenceName": {
+                    "description": "Name of the sequence to drop",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "renameSequence": {
+            "$comment": "https://docs.liquibase.com/change-types/community/rename-sequence.html",
+            "description": "Renames an existing sequence.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "newSequenceName",
+                "oldSequenceName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "oldSequenceName": {
+                    "description": "Name of the sequence to rename",
+                    "type": "string",
+                    "default": ""
+                },
+                "newSequenceName": {
+                    "description": "New name for the sequence",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "createIndex": {
+            "$comment": "https://docs.liquibase.com/change-types/community/create-index.html",
+            "description": "The createIndex Change Type creates an index on an existing column or a set of columns.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "indexName": {
+                    "description": "The name of the index to create.",
+                    "type": "string",
+                    "default": ""
+                },
+                "associatedWith": {
+                    "type": "string",
+                    "default": ""
+                },
+                "unique": {
+                    "description": "The unique values in the index.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "clustered": {
+                    "description": "The attribute that creates a clustered index.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "tablespace": {
+                    "description": "The tablespace in which you create the index.",
+                    "type": "string",
+                    "default": ""
+                },
+                "column": {
+                    "$ref": "#/definitions/column"
+                },
+                "columns": {
+                    "$ref": "#/definitions/columns"
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropIndex": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-index.html",
+            "description": "The dropIndex Change Type drops an existing index on a column.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "indexName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "indexName": {
+                    "description": "The name of the index to drop.",
+                    "type": "string",
+                    "default": ""
+                },
+                "associatedWith": {
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "addNotNullConstraint": {
+            "$comment": "https://docs.liquibase.com/change-types/community/add-not-null-constraint.html",
+            "description": "The addNotNullConstraint Change Type adds a NOT NULL constraint to an existing table.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnName",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnName": {
+                    "description": "The name of the column for which to add the constraint.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultNullValue": {
+                    "description": "The value for which you can set all values that currently equal null in a column. If null values exist and if defaultNullValue is not set, the change will fail.",
+                    "type": "string",
+                    "default": ""
+                },
+                "columnDataType": {
+                    "description": "The current data type of the column.",
+                    "type": "string",
+                    "default": ""
+                },
+                "constraintName": {
+                    "description": "The created constraint name (if database supports names for NOT NULL constraints).",
+                    "type": "string",
+                    "default": ""
+                },
+                "validate": {
+                    "description": "The attribute which is true if the NOT NULL constraint has 'ENABLE VALIDATE' set, or which is false if the NOT NULL constrain has 'ENABLE NOVALIDATE' set.",
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropNotNullConstraint": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-not-null-constraint.html",
+            "description": "Makes a column nullable.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnName",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnName": {
+                    "description": "Name of the column to drop the constraint from",
+                    "type": "string",
+                    "default": ""
+                },
+                "columnDataType": {
+                    "description": "Current data type of the column",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "addForeignKeyConstraint": {
+            "$comment": "https://docs.liquibase.com/change-types/community/add-foreign-key-constraint.html",
+            "description": "Adds a foreign key constraint to an existing column.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "baseColumnNames",
+                "baseTableName",
+                "constraintName",
+                "referencedColumnNames",
+                "referencedTableName"
+            ],
+            "properties": {
+                "baseTableCatalogName": {
+                    "description": "Catalog name of the base table",
+                    "type": "string",
+                    "default": ""
+                },
+                "baseTableSchemaName": {
+                    "description": "Schema name of the base table",
+                    "type": "string",
+                    "default": ""
+                },
+                "baseTableName": {
+                    "description": "Name of the table containing the column to constraint",
+                    "type": "string",
+                    "default": ""
+                },
+                "baseColumnNames": {
+                    "description": "Name of column(s) to place the foreign key constraint on. Comma-separate if multiple",
+                    "type": "string",
+                    "default": ""
+                },
+                "constraintName": {
+                    "description": "Name of the new foreign key constraint",
+                    "type": "string",
+                    "default": ""
+                },
+                "referencedTableCatalogName": {
+                    "description": "Schema name of the referenced table",
+                    "type": "string",
+                    "default": ""
+                },
+                "referencedTableSchemaName": {
+                    "description": "Schema name of the referenced table",
+                    "type": "string",
+                    "default": ""
+                },
+                "referencedTableName": {
+                    "description": "Name of the table the foreign key points to",
+                    "type": "string",
+                    "default": ""
+                },
+                "referencedColumnNames": {
+                    "description": "Column(s) the foreign key points to. Comma-separate if multiple",
+                    "type": "string",
+                    "default": ""
+                },
+                "deferrable": {
+                    "description": "Is the foreign key deferrable",
+                    "type": "boolean",
+                    "default": false
+                },
+                "initiallyDeferred": {
+                    "description": "Is the foreign key initially deferred",
+                    "type": "boolean",
+                    "default": false
+                },
+                "deleteCascade": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "onDelete": {
+                    "description": "ON DELETE functionality. Possible values: 'CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION'",
+                    "type": "string",
+                    "default": ""
+                },
+                "onUpdate": {
+                    "description": "ON UPDATE functionality. Possible values: 'CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION'",
+                    "type": "string",
+                    "default": ""
+                },
+                "referencesUniqueColumn": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "validate": {
+                    "description": "Shall be true if the foreign key should 'ENABLE VALIDATE' set, or false if the foreign key should 'ENABLE NOVALIDATE' set.",
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropForeignKeyConstraint": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-foreign-key-constraint.html",
+            "description": "Drops an existing foreign key.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "baseTableName",
+                "constraintName"
+            ],
+            "properties": {
+                "baseTableCatalogName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "baseTableSchemaName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "baseTableName": {
+                    "description": "Name of the table containing the column constrained by the foreign key",
+                    "type": "string",
+                    "default": ""
+                },
+                "constraintName": {
+                    "description": "Name of the foreign key constraint to drop",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropAllForeignKeyConstraints": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-all-foreign-key-constraints.html",
+            "description": "Drops all foreign key constraints for a table.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "baseTableName"
+            ],
+            "properties": {
+                "baseTableCatalogName": {
+                    "description": "Catalog name of the table containing columns constrained by foreign keys",
+                    "type": "string",
+                    "default": ""
+                },
+                "baseTableSchemaName": {
+                    "description": "Schema name of the table containing columns constrained by foreign keys",
+                    "type": "string",
+                    "default": ""
+                },
+                "baseTableName": {
+                    "description": "Name of the table containing columns constrained by foreign keys",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "addPrimaryKey": {
+            "$comment": "https://docs.liquibase.com/change-types/community/add-primary-key.html",
+            "description": "Adds a primary key out of an existing column or set of columns.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnNames",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnNames": {
+                    "description": "Name of the column(s) to create the primary key on. Comma separated if multiple",
+                    "type": "string",
+                    "default": ""
+                },
+                "constraintName": {
+                    "description": "Name of primary key constraint",
+                    "type": "string",
+                    "default": ""
+                },
+                "tablespace": {
+                    "type": "string",
+                    "default": ""
+                },
+                "clustered": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "forIndexCatalogName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "forIndexSchemaName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "forIndexName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "validate": {
+                    "description": "This is true if the primary key has 'ENABLE VALIDATE' set, or false if the primary key has 'ENABLE NOVALIDATE' set.",
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropPrimaryKey": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-primary-key.html",
+            "description": "The dropPrimaryKey Change Type drops an existing primary key in the table.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "constraintName": {
+                    "description": "The name of the primary key.",
+                    "type": "string",
+                    "default": ""
+                },
+                "dropIndex": {
+                    "description": "The index to drop.",
+                    "type": "boolean",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "addLookupTable": {
+            "$comment": "https://docs.liquibase.com/change-types/community/add-lookup-table.html",
+            "description": "Creates a lookup table containing values stored in a column and creates a foreign key to the new table.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "existingColumnName",
+                "existingTableName",
+                "newColumnName",
+                "newTableName"
+            ],
+            "properties": {
+                "existingTableCatalogName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "existingTableSchemaName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "existingTableName": {
+                    "description": "Name of the table containing the data to extract",
+                    "type": "string",
+                    "default": ""
+                },
+                "existingColumnName": {
+                    "description": "Name of the column in the new table to create",
+                    "type": "string",
+                    "default": ""
+                },
+                "newTableCatalogName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "newTableSchemaName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "newTableName": {
+                    "description": "Name of lookup table to create",
+                    "type": "string",
+                    "default": ""
+                },
+                "newColumnName": {
+                    "description": "Name of the column in the new table to create",
+                    "type": "string",
+                    "default": ""
+                },
+                "newColumnDataType": {
+                    "description": "Data type of the new table column",
+                    "type": "string",
+                    "default": ""
+                },
+                "constraintName": {
+                    "description": "Name of the foreign-key constraint to create between the existing table and the lookup table",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "addAutoIncrement": {
+            "$comment": "https://docs.liquibase.com/change-types/community/add-auto-increment.html",
+            "description": "Converts an existing column to be an auto-increment (a.k.a ‘identity') column.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnName",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnName": {
+                    "description": "Name of the column",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultOnNull": {
+                    "description": "When using generationType 'BY DEFAULT' then defaultOnNull = true allows the identity to be used if the identity column is referenced, but a value of NULL is specified.",
+                    "type": "boolean",
+                    "default": ""
+                },
+                "generationType": {
+                    "description": "Type of the generation in 'GENERATED %s AS IDENTITY'. ALWAYS | BY DEFAULT",
+                    "enum": [
+                        "ALWAYS",
+                        "BY DEFAULT"
+                    ],
+                    "default": ""
+                },
+                "columnDataType": {
+                    "description": "Current data type of the column to make auto-increment",
+                    "type": "string",
+                    "default": ""
+                },
+                "startWith": {
+                    "description": "Initial integer value of the increment",
+                    "type": "integer",
+                    "default": 0
+                },
+                "incrementBy": {
+                    "description": "Integer value the increment increments at each call",
+                    "type": "integer",
+                    "default": 0
+                }
+            },
+            "additionalProperties": true
+        },
+        "addDefaultValue": {
+            "$comment": "https://docs.liquibase.com/change-types/community/add-default-value.html",
+            "description": "The addDefaultValue Change Type adds a default value to the database definition for the specified column.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnName",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnName": {
+                    "description": "The name of the column for which to add a default value.",
+                    "type": "string",
+                    "default": ""
+                },
+                "columnDataType": {
+                    "description": "The current data type of the column for which to add a default value.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValue": {
+                    "description": "The default value. Either this property or one of the other defaultValue* properties are required.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueNumeric": {
+                    "description": "The attribute that sets the default value for a column of a numeric type. For example: integer, bigint, bigdecimal, and others.",
+                    "type": "number",
+                    "default": ""
+                },
+                "defaultValueDate": {
+                    "description": "The attribute that sets the default value for a column of a date type. For example: timestamp, datetime, date, and others.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueBoolean": {
+                    "description": "The attribute that sets the default value for a column of a boolean type.",
+                    "type": "boolean",
+                    "default": ""
+                },
+                "defaultValueComputed": {
+                    "description": "The attribute that sets the default value for a column using a function which returns value of the same type as the column has.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueSequenceNext": {
+                    "description": "The attribute that sets value for a specified column by using the value of the existing sequence. With every new input, the next value of the sequence will be taken.",
+                    "type": "string",
+                    "default": ""
+                },
+                "defaultValueConstraintName": {
+                    "description": "The attribute that sets a unique name for default constraint used for a specific column. It works only along with any of defaultValue* attributes listed.",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropDefaultValue": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-default-value.html",
+            "description": "Removes the database default value for a column.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnName",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnName": {
+                    "description": "Name of column to drop the default value from",
+                    "type": "string",
+                    "default": ""
+                },
+                "columnDataType": {
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "addUniqueConstraint": {
+            "$comment": "https://docs.liquibase.com/change-types/community/add-unique-constraint.html",
+            "description": "Adds a unique constraint to an existing column or set of columns.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnNames",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnNames": {
+                    "description": "Name of the column(s) to create the unique constraint on. Comma separated if multiple",
+                    "type": "string",
+                    "default": ""
+                },
+                "constraintName": {
+                    "description": "Name of the unique constraint",
+                    "type": "string",
+                    "default": ""
+                },
+                "tablespace": {
+                    "description": "'Tablespace' to create the index in. Corresponds to file group in mssql",
+                    "type": "string",
+                    "default": ""
+                },
+                "disabled": {
+                    "description": "True if this constraint is disabled, False otherwise",
+                    "type": "boolean",
+                    "default": false
+                },
+                "deferrable": {
+                    "description": "True if this constraint is deferrable, False otherwise",
+                    "type": "boolean",
+                    "default": false
+                },
+                "initiallyDeferred": {
+                    "description": "True if this constraint is initially deferred, False otherwise",
+                    "type": "boolean",
+                    "default": false
+                },
+                "forIndexCatalogName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "forIndexSchemaName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "forIndexName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "clustered": {
+                    "description": "Whether create a clustered index",
+                    "type": "boolean",
+                    "default": false
+                },
+                "validate": {
+                    "description": "Should be true if the unique constraint shall 'ENABLE VALIDATE' set, or false if the 'ENABLE NOVALIDATE' shall.",
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": true
+        },
+        "dropUniqueConstraint": {
+            "$comment": "https://docs.liquibase.com/change-types/community/drop-unique-constraint.html",
+            "description": "Drops an existing unique constraint.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "constraintName",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "constraintName": {
+                    "description": "Name of unique constraint to drop",
+                    "type": "string",
+                    "default": ""
+                },
+                "uniqueColumns": {
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "setTableRemarks": {
+            "$comment": "https://docs.liquibase.com/change-types/community/set-table-remarks.html",
+            "description": "Sets remarks on a table.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "remarks",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "remarks": {
+                    "description": "Comment to set on the table",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "setColumnRemarks": {
+            "$comment": "https://docs.liquibase.com/change-types/community/set-column-remarks.html",
+            "description": "The setColumnRemarks Change Type sets remarks on a column.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "columnName",
+                "remarks",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "columnName": {
+                    "description": "The name of the column",
+                    "type": "string",
+                    "default": ""
+                },
+                "remarks": {
+                    "description": "The comment to set on the column",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "customChange": {
+            "$comment": "https://docs.liquibase.com/change-types/community/custom-change.html",
+            "description": "The customChange type creates a custom Change Type class.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "class"
+            ],
+            "properties": {
+                "class": {
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": true
+        },
+        "loadData": {
+            "$comment": "https://docs.liquibase.com/change-types/community/load-data.html",
+            "description": "Loads data from a CSV file into an existing table when you add it to your changelog.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "file",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "file": {
+                    "description": "CSV file to load.",
+                    "type": "string",
+                    "default": ""
+                },
+                "relativeToChangelogFile": {
+                    "description": "Whether the file path relative to the root changelog file rather than to the classpath.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "usePreparedStatements": {
+                    "description": "Use prepared statements instead of insert statement strings if the database supports it.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "encoding": {
+                    "description": "Encoding of the CSV file (defaults to UTF-8).",
+                    "type": "string",
+                    "default": ""
+                },
+                "separator": {
+                    "description": "Character separating the fields.",
+                    "type": "string",
+                    "default": ""
+                },
+                "quotchar": {
+                    "description": "The quote character for string fields containing the separator character.",
+                    "type": "string",
+                    "default": ""
+                },
+                "commentLineStartsWith": {
+                    "description": "Lines starting with this are treated as comment and ignored.",
+                    "type": "string",
+                    "default": ""
+                },
+                "column": {
+                    "$ref": "#/definitions/column"
+                },
+                "columns": {
+                    "$ref": "#/definitions/columns"
+                }
+            },
+            "additionalProperties": true
+        },
+        "loadUpdateData": {
+            "$comment": "https://docs.liquibase.com/change-types/community/load-update-data.html",
+            "description": "Loads or updates data from a CSV file into an existing table. Differs from loadData by issuing a SQL batch that checks for the existence of a record. If found, the record is UPDATEd, else the record is INSERTed. Also, generates DELETE statements for a rollback.\n\nA value of NULL in a cell will be converted to a database NULL rather than the string ‘NULL'",
+            "type": "object",
+            "default": {},
+            "required": [
+                "file",
+                "primaryKey",
+                "tableName"
+            ],
+            "properties": {
+                "catalogName": {
+                    "$ref": "#/definitions/catalogName"
+                },
+                "commentLineStartsWith": {
+                    "description": "Lines starting with this are treated as comment and ignored.",
+                    "type": "string",
+                    "default": ""
+                },
+                "schemaName": {
+                    "$ref": "#/definitions/schemaName"
+                },
+                "tableName": {
+                    "$ref": "#/definitions/tableName"
+                },
+                "file": {
+                    "description": "CSV file to load",
+                    "type": "string",
+                    "default": ""
+                },
+                "relativeToChangelogFile": {
+                    "description": "Whether the file path relative to the root changelog file rather than to the classpath.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "encoding": {
+                    "description": "Encoding of the CSV file (defaults to UTF-8)",
+                    "type": "string",
+                    "default": ""
+                },
+                "primaryKey": {
+                    "description": "Comma delimited list of the columns for the primary key",
+                    "type": "string",
+                    "default": ""
+                },
+                "onlyUpdate": {
+                    "description": "If true, records with no matching database record should be ignored",
+                    "type": "boolean",
+                    "default": ""
+                },
+                "separator": {
+                    "description": "Character separating the fields.",
+                    "type": "string",
+                    "default": ""
+                },
+                "quotchar": {
+                    "description": "The quote character for string fields containing the separator character.",
+                    "type": "string",
+                    "default": ""
+                },
+                "usePreparedStatements": {
+                    "description": "Use prepared statements instead of insert statement strings if the DB supports it.",
+                    "type": "boolean",
+                    "default": ""
+                },
+                "column": {
+                    "$ref": "#/definitions/column"
+                },
+                "columns": {
+                    "$ref": "#/definitions/columns"
+                }
+            },
+            "additionalProperties": true
+        },
+        "executeCommand": {
+            "$comment": "https://docs.liquibase.com/change-types/community/execute-command.html",
+            "description": "The executeCommand Change Type executes a system command.",
+            "type": "object",
+            "default": {},
+            "required": [
+                "executable"
+            ],
+            "properties": {
+                "executable": {
+                    "description": "The name of the executable to run",
+                    "type": "string",
+                    "default": ""
+                },
+                "os": {
+                    "description": "The list of operating systems on which to execute the command (taken from the os.name Java system property)",
+                    "type": "string",
+                    "default": ""
+                },
+                "timeout": {
+                    "description": "The timeout value for executable to run",
+                    "type": "string",
+                    "default": ""
+                },
+                "arg": {
+                    "description": "Arguments for the executable",
+                    "type": "object",
+                    "default": {},
+                    "properties": {
+                        "value": {
+                            "description": "The value of the attribute (for example: '-param')",
+                            "type": "string",
+                            "default": ""
+                        }
+                    },
+                    "additionalProperties": true
+                },
+                "args": {
+                    "description": "Arguments for the executable",
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "description": "The value of the attribute (for example: '-param')",
+                                        "type": "string",
+                                        "default": ""
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "additionalProperties": true
+        },
+        "output": {
+            "$comment": "https://docs.liquibase.com/change-types/community/output.html",
+            "description": "Logs a message and continues execution.",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "message": {
+                    "description": "Message to output",
+                    "type": "string",
+                    "default": ""
+                },
+                "target": {
+                    "description": "Target for message. Possible values: STDOUT, STDERR, FATAL, WARN, INFO, DEBUG. Default value: STDERR",
+                    "enum": [
+                        "STDOUT",
+                        "STDERR",
+                        "FATAL",
+                        "WARN",
+                        "INFO",
+                        "DEBUG"
+                    ],
+                    "default": "STDERR"
+                }
+            },
+            "additionalProperties": true
+        },
+        "modifySql": {
+            "$comment": "https://docs.liquibase.com/workflows/liquibase-community/modify-sql.html?Highlight=modifySql",
+            "description": "Although Liquibase supports most standard SQL statements with its Change Types, there are times when you need the generated SQL to be different. The following examples show how to change data types or add additional vendor-specific clauses such as ENGINE INNODB to CREATE TABLE statements. Since 1.9",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "dbms": {
+                    "$ref": "#/definitions/dbms"
+                },
+                "context": {
+                    "description": "Specifies the list of Contexts in which to run the SQL modification. If you do not specify any context, every changeset will be applied. Since 2.0",
+                    "type": "string",
+                    "default": ""
+                },
+                "labels": {
+                    "type": "string",
+                    "default": ""
+                },
+                "applyToRollback": {
+                    "description": "Defines whether the SQL modification should be applied to rollback statements. The default value is false. Since 2.0",
+                    "type": "boolean",
+                    "default": false
+                },
+                "prepend": {
+                    "description": "Adds SQL to the beginning of the statement.",
+                    "type": "object",
+                    "default": {},
+                    "properties": {
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "append": {
+                    "description": "Adds SQL to the end of the statement.",
+                    "type": "object",
+                    "default": {},
+                    "properties": {
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "replace": {
+                    "description": "Replaces all instances of the text specified.",
+                    "type": "object",
+                    "default": {},
+                    "properties": {
+                        "replace": {
+                            "type": "string"
+                        },
+                        "with": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "regExpReplace": {
+                    "description": "Replaces all instances of the regular expression specified.",
+                    "type": "object",
+                    "default": {},
+                    "properties": {
+                        "replace": {
+                            "type": "string"
+                        },
+                        "with": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "additionalProperties": true
+        },
+        "changes": {
+            "type": "array",
+            "default": [],
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "default": {},
+                        "properties": {
+                            "tagDatabase": {
+                                "$ref": "#/definitions/tagDatabase"
+                            },
+                            "createTable": {
+                                "$ref": "#/definitions/createTable"
+                            },
+                            "dropTable": {
+                                "$ref": "#/definitions/dropTable"
+                            },
+                            "createView": {
+                                "$ref": "#/definitions/createView"
+                            },
+                            "renameView": {
+                                "$ref": "#/definitions/renameView"
+                            },
+                            "dropView": {
+                                "$ref": "#/definitions/dropView"
+                            },
+                            "empty": {
+                                "$ref": "#/definitions/empty"
+                            },
+                            "insert": {
+                                "$ref": "#/definitions/insert"
+                            },
+                            "addColumn": {
+                                "$ref": "#/definitions/addColumn"
+                            },
+                            "sql": {
+                                "$ref": "#/definitions/sql"
+                            },
+                            "createProcedure": {
+                                "$ref": "#/definitions/createProcedure"
+                            },
+                            "dropProcedure": {
+                                "$ref": "#/definitions/dropProcedure"
+                            },
+                            "sqlFile": {
+                                "$ref": "#/definitions/sqlFile"
+                            },
+                            "stop": {
+                                "$ref": "#/definitions/stop"
+                            },
+                            "renameTable": {
+                                "$ref": "#/definitions/renameTable"
+                            },
+                            "renameColumn": {
+                                "$ref": "#/definitions/renameColumn"
+                            },
+                            "dropColumn": {
+                                "$ref": "#/definitions/dropColumn"
+                            },
+                            "mergeColumns": {
+                                "$ref": "#/definitions/mergeColumns"
+                            },
+                            "modifyDataType": {
+                                "$ref": "#/definitions/modifyDataType"
+                            },
+                            "createSequence": {
+                                "$ref": "#/definitions/createSequence"
+                            },
+                            "alterSequence": {
+                                "$ref": "#/definitions/alterSequence"
+                            },
+                            "dropSequence": {
+                                "$ref": "#/definitions/dropSequence"
+                            },
+                            "renameSequence": {
+                                "$ref": "#/definitions/renameSequence"
+                            },
+                            "createIndex": {
+                                "$ref": "#/definitions/createIndex"
+                            },
+                            "dropIndex": {
+                                "$ref": "#/definitions/dropIndex"
+                            },
+                            "addNotNullConstraint": {
+                                "$ref": "#/definitions/addNotNullConstraint"
+                            },
+                            "dropNotNullConstraint": {
+                                "$ref": "#/definitions/dropNotNullConstraint"
+                            },
+                            "addForeignKeyConstraint": {
+                                "$ref": "#/definitions/addForeignKeyConstraint"
+                            },
+                            "dropForeignKeyConstraint": {
+                                "$ref": "#/definitions/dropForeignKeyConstraint"
+                            },
+                            "dropAllForeignKeyConstraints": {
+                                "$ref": "#/definitions/dropAllForeignKeyConstraints"
+                            },
+                            "addPrimaryKey": {
+                                "$ref": "#/definitions/addPrimaryKey"
+                            },
+                            "dropPrimaryKey": {
+                                "$ref": "#/definitions/dropPrimaryKey"
+                            },
+                            "addLookupTable": {
+                                "$ref": "#/definitions/addLookupTable"
+                            },
+                            "addAutoIncrement": {
+                                "$ref": "#/definitions/addAutoIncrement"
+                            },
+                            "addDefaultValue": {
+                                "$ref": "#/definitions/addDefaultValue"
+                            },
+                            "dropDefaultValue": {
+                                "$ref": "#/definitions/dropDefaultValue"
+                            },
+                            "addUniqueConstraint": {
+                                "$ref": "#/definitions/addUniqueConstraint"
+                            },
+                            "dropUniqueConstraint": {
+                                "$ref": "#/definitions/dropUniqueConstraint"
+                            },
+                            "setTableRemarks": {
+                                "$ref": "#/definitions/setTableRemarks"
+                            },
+                            "setColumnRemarks": {
+                                "$ref": "#/definitions/setColumnRemarks"
+                            },
+                            "customChange": {
+                                "$ref": "#/definitions/customChange"
+                            },
+                            "update": {
+                                "$ref": "#/definitions/update"
+                            },
+                            "delete": {
+                                "$ref": "#/definitions/delete"
+                            },
+                            "loadData": {
+                                "$ref": "#/definitions/loadData"
+                            },
+                            "loadUpdateData": {
+                                "$ref": "#/definitions/loadUpdateData"
+                            },
+                            "executeCommand": {
+                                "$ref": "#/definitions/executeCommand"
+                            },
+                            "output": {
+                                "$ref": "#/definitions/output"
+                            },
+                            "modifySql": {
+                                "$ref": "#/definitions/modifySql"
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            }
+        }
+    },
+    "type": "object",
+    "default": {},
+    "required": [
+        "databaseChangeLog"
+    ],
+    "properties": {
+        "databaseChangeLog": {
+            "$comment": "https://docs.liquibase.com/concepts/basic/changelog.html",
+            "description": "The root of all Liquibase changes is the changelog file. Liquibase uses a changelog to sequentially list all changes made to your database. Think of it as a ledger. It is a file that contains a record of all your database changes (changesets). Liquibase uses this changelog record to audit your database and execute any changes that are not yet applied to your database.",
+            "type": "array",
+            "default": [],
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "default": {},
+                        "properties": {
+                            "logicalFilePath": {
+                                "description": "Overrides the file name and path when creating the unique identifier of changesets. It is required when you want to move or rename changelogs.",
+                                "type": "string",
+                                "default": ""
+                            },
+                            "context": {
+                                "$comment": "https://docs.liquibase.com/concepts/advanced/contexts.html",
+                                "type": "string",
+                                "default": ""
+                            },
+                            "objectQuotingStrategy": {
+                                "description": "Controls how object names are quoted in the generated SQL or used in calls to the database. The names of objects are used differently in databases. For example, Oracle converts everything to uppercase (unless quoted). There are three possible values. The default value is LEGACY.\nLEGACY - the same behavior as in Liquibase 2.0\nQUOTE_ALL_OBJECTS - every object gets quoted. For example: person becomes \"person\".\nQUOTE_ONLY_RESERVED_WORDS - reserved keywords and invalid column names are quoted.",
+                                "type": "string",
+                                "default": ""
+                            },
+                            "property": {
+                                "$comment": "https://docs.liquibase.com/concepts/basic/changelog-property-substitution.html",
+                                "description": "Liquibase allows a dynamic substitution of properties in your changelog. The tokens to replace in your changelog are described using the ${property-name} syntax.",
+                                "type": "object",
+                                "default": {},
+                                "properties": {
+                                    "file": {
+                                        "description": "The name of the file from which the properties should be loaded. It will create a property for all properties in the file. The content of the file must follow the java properties file format.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "name": {
+                                        "description": "The name of the parameter. Required if file is not set",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "value": {
+                                        "description": "The value of the property. Required if file is not set",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "dbms": {
+                                        "$ref": "#/definitions/dbms"
+                                    },
+                                    "context": {
+                                        "description": "Contexts in which the property is valid. Expected as a comma-separated list.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "labels": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "global": {
+                                        "description": "Boolean. Defines whether the property is global or limited to the actual DATABASECHANGELOG. It is given as true or false.",
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "target": {
+                                        "type": "string",
+                                        "default": ""
+                                    }
+                                },
+                                "additionalProperties": true
+                            },
+                            "preConditions": {
+                                "$ref": "#/definitions/preConditions"
+                            },
+                            "changeSet": {
+                                "$comment": "https://docs.liquibase.com/concepts/basic/changeset.html",
+                                "description": "The changeset tag is a unit of change that Liquibase executes on a database and which is used to group database Change Types together. A list of changes created by multiple changesets are tracked in a changelog.\n\nA changeset is uniquely tagged by both an author and an id attributes (author:id), as well as the changelog file path. The id tag is only used as an identifier, it does not direct the order that changes are run and does not have to be an integer. If you do not know or do not want to save the actual author, use a placeholder value such as UNKNOWN. To execute the changeset, you must include both author and id.",
+                                "type": "object",
+                                "default": {},
+                                "required": [
+                                    "id",
+                                    "author"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "description": "Specifies an alpha-numeric identifier. Required",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "author": {
+                                        "description": "Specifies the creator of the changeset. Required",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "context": {
+                                        "description": "Controls whether a changeset is executed depending on runtime settings. Any string can be used for the context name and they are checked case-insensitively.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "labels": {
+                                        "description": "Controls whether a changeset is executed depending on runtime settings. Any string can be used for the label name and they are checked case-insensitively.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "dbms": {
+                                        "$ref": "#/definitions/dbms"
+                                    },
+                                    "runOnChange": {
+                                        "description": "Executes the changeset the first time and each time the changeset has been changed.",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "runAlways": {
+                                        "description": "Executes the changeset on every run, even if it has been run before.",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "failOnError": {
+                                        "description": "Defines whether the migration will fail if an error occurs while executing the changeset. Default value is true.",
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "onValidationFail": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "runInTransaction": {
+                                        "description": "Specifies whether the changeset can be ran as a single transaction (if possible). Default value is true.",
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "logicalFilePath": {
+                                        "description": "Overrides the file name and path when creating the unique identifier of changesets. Required when moving or renaming changelog.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "objectQuotingStrategy": {
+                                        "description": "Controls how object names are quoted in the generated SQL or used in calls to the database. Different databases do different things to the names of objects. For example, Oracle converts everything to uppercase (unless quoted). There are three possible values. The default value is LEGACY.\nLEGACY - the same behavior as in Liquibase 2.0\nQUOTE_ALL_OBJECTS - every object gets quoted. For example: person becomes \"person\".\nQUOTE_ONLY_RESERVED_WORDS - reserved keywords and invalid column names are quoted.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "created": {
+                                        "description": "Stores dates, versions, or any other string of value without using remarks (comments) attributes. Since 3.5",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "runOrder": {
+                                        "description": "Overrides the order in the changelog from where the changeset with the runOrder=\"first|last\" will be run. It is typically used when you want a changeset to be always executed after everything else but don’t want to keep moving it to the end of the changelog. Setting the runOrder to last will automatically move it in the final changeset order.Since 3.5",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "ignore": {
+                                        "description": "Ignores the changeset from the execution. Since 3.6",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "runWith": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "validCheckSum": {
+                                        "description": "Adds a checksum that is considered valid for this changeset, regardless of what is stored in the database. It is primarily used when you need to change a changeset and don't want errors thrown on databases on which it has already been run (not a recommended procedure). Special value \"1:any\" will match to any checksum and will not execute the changeset on ANY change. Since 1.7",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "preConditions": {
+                                        "$ref": "#/definitions/preConditions"
+                                    },
+                                    "comment": {
+                                        "description": "Specifies the description of the changeset. XML comments will provide the same benefit. Future releases of Liquibase may be able to make use of <comment> tag comments to generate documentation.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "changes": {
+                                        "$ref": "#/definitions/changes"
+                                    },
+                                    "rollback": {
+                                        "anyOf": [
+                                          {
+                                            "$ref": "#/definitions/changes"
+                                          },
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "object",
+                                            "required": ["changeSetId", "changeSetAuthor"],
+                                            "properties": {
+                                              "changeSetId": {
+                                                "type": "string"
+                                              },
+                                              "changeSetAuthor": {
+                                                "type": "string"
+                                              },
+                                              "changeSetPath": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                    },
+                                    "modifySql": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/modifySql"
+                                        }
+                                    }
+                                },
+                                "additionalProperties": true
+                            },
+                            "include": {
+                                "$comment": "https://docs.liquibase.com/concepts/advanced/include.html",
+                                "description": "The <include> tag is used within your master changelog to reference other changelogs.",
+                                "type": "object",
+                                "default": {},
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "author": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "file": {
+                                        "description": "Name of the file you want to import required.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "relativeToChangelogFile": {
+                                        "description": "File path relative to the changelog file containing the element rather than to the classpath. Default: false",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "context": {
+                                        "description": "Appends a context (using an AND statement) to all contained changesets.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "labels": {
+                                        "description": "Appends a label to all contained changesets.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "ignore": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "created": {
+                                        "type": "string",
+                                        "default": ""
+                                    }
+                                },
+                                "additionalProperties": true
+                            },
+                            "includeAll": {
+                                "$comment": "https://docs.liquibase.com/concepts/advanced/includeall.html?Highlight=includeAll",
+                                "description": "The <includeAll> tag allows you to specify a directory that contains multiple changelog files. It is used within your master changelog file to call on the directory and include all .xml files as changelog files, and all .sql files as individual changes.",
+                                "type": "object",
+                                "default": {},
+                                "properties": {
+                                    "path": {
+                                        "description": "Name of the path you want to reference.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "errorIfMissingOrEmpty": {
+                                        "description": "Controls what happens if the path listed does not exist or is an empty directory. Default: false. If set to true, the update will fail.",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "relativeToChangelogFile": {
+                                        "description": "File path relative to the changelog file containing the element rather than to the classpath. Default: false.",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "resourceComparator": {
+                                        "description": "A string containing the name of the class you want to use for sorting.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "filter": {
+                                        "description": "A class name that allows you to create custom filters.",
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "context": {
+                                        "description": "Appends a context (using an AND statement) to all contained changesets.",
+                                        "type": "string",
+                                        "default": ""
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            }
+        }
+    },
+    "additionalProperties": true
+}

--- a/src/test/liquibase-3.2/rollbackVariants.json
+++ b/src/test/liquibase-3.2/rollbackVariants.json
@@ -1,0 +1,85 @@
+{
+  "databaseChangeLog": [
+    {},
+    {
+      "changeSet": {
+        "id": "rollbackString",
+        "author": "liquibase-docs",
+        "changes": [
+          {
+            "dropColumn": {
+              "columns": [
+                {
+                  "column": {
+                    "name": "address"
+                  }
+                }
+              ],
+              "tableName": "person"
+            }
+          }
+        ],
+        "rollback": "ALTER TABLE person ADD COLUMN address varchar(255);"
+      }
+    },
+    {
+      "changeSet": {
+        "id": "rollbackChangeArray",
+        "author": "liquibase-docs",
+        "changes": [
+          {
+            "dropColumn": {
+              "columns": [
+                {
+                  "column": {
+                    "name": "address"
+                  }
+                }
+              ],
+              "tableName": "person"
+            }
+          }
+        ],
+        "rollback": [
+          {
+            "addColumn": {
+              "tableName": "person",
+              "columns": [
+                {
+                  "column": {
+                    "name": "address",
+                    "type": "varchar(255)"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "rollbackChangeReference",
+        "author": "liquibase-docs",
+        "changes": [
+          {
+            "dropColumn": {
+              "columns": [
+                {
+                  "column": {
+                    "name": "address"
+                  }
+                }
+              ],
+              "tableName": "person"
+            }
+          }
+        ],
+        "rollback": {
+          "changeSetId": "addAddressColumnToPersonTable",
+          "changeSetAuthor": "liquibase-docs"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Liquibase supports three different syntaxes for rollbacks since at least v3.2 as seen in https://github.com/liquibase/liquibase/blob/2b9b726822a82645a1e7baa3b9deaf3a8a3459f3/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java#L349-L389; however, the current schema only supports the array of changes syntax.

This pull request adds support and tests for the other two value formats for rollback:

1. A string value which will be executed as a SQL statement.
2. An object which references another changeSet to run in order to perform the rollback.

I wasn't sure how to name the new .json file so I went with 3.2 since that's the version of liquibase source code I referenced; and the `handleRollback` method does not exist in the 3.1.x branch.  Please suggest a better option for this if it makes more sense.

Here is the relevent change between the existing liquibase.json and the new liquibase-3.2.json:

```diff
...
{
  "changeSet": {
    ...
    "properties": {
      ...
      "rollback": {
-       "$ref": "#/definitions/changes"
+       "anyOf": [
+         {
+           "$ref": "#/definitions/changes"
+         },
+         {
+           "type": "string"
+         },
+         {
+           "type": "object",
+           "required": ["changeSetId", "changeSetAuthor"],
+           "properties": {
+             "changeSetId": {
+               "type": "string"
+             },
+             "changeSetAuthor": {
+               "type": "string"
+             },
+             "changeSetPath": {
+               "type": "string"
+             }
+         }
+       ]
      },
      ...
    }
}
```
