### PR TITLE
Update cspell Schema/config files from v4 to v5 (#1883)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -768,9 +768,15 @@
       "fileMatch": [
         ".cspell.json",
         "cspell.json",
-        "cSpell.json"
+        ".cSpell.json",
+        "cSpell.json",
+        "cspell.config.json",
+        "cspell.config.yaml",
+        "cspell.config.yml",
+        "cspell.yaml",
+        "cspell.yml"
       ],
-      "url": "https://raw.githubusercontent.com/streetsidesoftware/cspell/cspell4/cspell.schema.json"
+      "url": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-types/cspell.schema.json"
     },
     {
       "name": ".csscomb.json",


### PR DESCRIPTION
They were previously at cspell v4.