### PR TITLE
Agrippa: add $schema property to schema

### DIFF
--- a/src/schemas/json/agripparc-1.2.json
+++ b/src/schemas/json/agripparc-1.2.json
@@ -67,6 +67,11 @@
     "memo": {
       "description": "Whether to generate a memo() component. Overrides the declaration option",
       "type": "boolean"
+    },
+    "$schema": {
+      "description": "Link to https://json.schemastore.org/agripparc-1.2.json",
+      "type": "string",
+      "enum": ["https://json.schemastore.org/agripparc-1.2.json"]
     }
   }
 }


### PR DESCRIPTION
Following up on PR #1881, adding a `$schema` property to `agripparc.json`'s schema (for VSCode intellisense).
