### PR TITLE
Fix src/api/javascript/catalog $schema url

### DIFF
--- a/src/api/javascript/catalog.json
+++ b/src/api/javascript/catalog.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/schema-catalog",
+  "$schema": "https://json.schemastore.org/schema-catalog.json",
 
   "version": 1.0,
   "schemas": [


### PR DESCRIPTION
Found this error by accident while working on #1887.
![Screenshot 2021-10-15 205301](https://user-images.githubusercontent.com/58311807/137533731-0f875ab7-ff3a-4d84-a215-1db37510842b.png)

(The only change in this PR is fixing the URL to the one presented in the error message in the screenshot above).
The warning seems to be fixed, and the tests pass. 
