### PR TITLE
Fix: Add "wide" to allowed properties for `supports.align`

### DIFF
--- a/src/schemas/json/block.json
+++ b/src/schemas/json/block.json
@@ -189,6 +189,7 @@
                   "wide",
                   "full",
                   "left",
+                  "center",
                   "right"
                 ]
               }


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-supports.md#align

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
