### PR TITLE
Removed a conflicting glob for Windows Package Manager singleton manifests.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3323,7 +3323,6 @@
       "description": "Windows Package Manager Singleton Manifest file",
       "url": "https://json.schemastore.org/winget-pkgs-singleton-1.0.0.json",
       "fileMatch": [
-        "manifests/*/*/*.yaml",
         "manifests/?/*/*/*/*.*.yaml"
       ],
       "versions": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This PR removes one of the glob patterns for Windows Package Manager singleton manifests, as it was causing conflicts. (https://github.com/redhat-developer/vscode-yaml/issues/588, and I've noticed it myself on other projects) 

The other glob should be sufficient for the community repo. Thanks!