### PR TITLE
Move fontSize and lineHeight properties to typography object

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -213,13 +213,6 @@
       }
     },
     {
-      "block.json":{
-        "unknownKeywords": [
-          "typography"
-        ]
-      }
-    },
-    {
       "chrome-manifest.json": {
         "unknownFormat": [
           "match-pattern",

--- a/src/schemas/json/block.json
+++ b/src/schemas/json/block.json
@@ -350,21 +350,21 @@
               ]
             }
           }
-        }
-      },
-      "typography":{
-        "type":"object",
-        "description": "This value signals that a block supports some of the CSS style properties related to typography. When it does, the block editor will show UI controls for the user to set their values",
-        "properties": {
-          "fontSize": {
-            "type": "boolean",
-            "description": "This value signals that a block supports the font-size CSS style property. When it does, the block editor will show an UI control for the user to set its value.\n\nThe values shown in this control are the ones declared by the theme via the editor-font-sizes theme support, or the default ones if none is provided.\n\nWhen the block declares support for fontSize, the attributes definition is extended to include two new attributes: fontSize and style",
-            "default": false
-          },
-          "lineHeight": {
-            "type": "boolean",
-            "description": "This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value if the theme declares support.\n\nWhen the block declares support for lineHeight, the attributes definition is extended to include a new attribute style of object type with no default assigned. It stores the custom value set by the user. The block can apply a default style by specifying its own style attribute with a default",
-            "default": false
+        },
+        "typography":{
+          "type":"object",
+          "description": "This value signals that a block supports some of the CSS style properties related to typography. When it does, the block editor will show UI controls for the user to set their values",
+          "properties": {
+            "fontSize": {
+              "type": "boolean",
+              "description": "This value signals that a block supports the font-size CSS style property. When it does, the block editor will show an UI control for the user to set its value.\n\nThe values shown in this control are the ones declared by the theme via the editor-font-sizes theme support, or the default ones if none is provided.\n\nWhen the block declares support for fontSize, the attributes definition is extended to include two new attributes: fontSize and style",
+              "default": false
+            },
+            "lineHeight": {
+              "type": "boolean",
+              "description": "This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value if the theme declares support.\n\nWhen the block declares support for lineHeight, the attributes definition is extended to include a new attribute style of object type with no default assigned. It stores the custom value set by the user. The block can apply a default style by specifying its own style attribute with a default",
+              "default": false
+            }
           }
         }
       },


### PR DESCRIPTION
As of WordPress 5.8, having the `lineHeight` and `fontSize `properties in the top-level `supports` object trigger warnings that they have been moved to `supports.typography`


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
