### PR TITLE
feat: add definition for MV3

### DIFF
--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -10,7 +10,7 @@
     "manifest_version": {
       "type": "number",
       "description": "One integer specifying the version of the manifest file format your package requires.",
-      "enum": [ 2 ]
+      "enum": [ 2, 3 ]
     },
     "name": {
       "type": "string",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Just adding a small update to the version enum to show 3 as a valid value. https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/