### PR TITLE
'Add syslog-drain-url' parameter for resources in mtad.json

### DIFF
--- a/src/schemas/json/mtad.json
+++ b/src/schemas/json/mtad.json
@@ -769,6 +769,10 @@
                     "description": "Map value, containing the service creation configuration, for example, url and user credentials (user and password).",
                     "type": "object"
                 },
+                "syslog-drain-url": {
+                    "description": "URL to which logs for bound applications are streamed.",
+                    "type": "string"
+                },
                 "skip-service-updates": {
                     "description": "Map value, containing the service components (parameters, plan, tags) to skip when updating a service.",
                     "$ref": "#/definitions/resource-skip-service-updates"
@@ -808,6 +812,10 @@
                 },
                 "tags": {
                     "description": "The custom tags for a service instance.",
+                    "type": "boolean"
+                },
+                "syslog-drain-url": {
+                    "description": "URL to which logs for bound applications are streamed.",
                     "type": "boolean"
                 }
             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
