### PR TITLE
Fix margin and padding in block.json

### DIFF
--- a/src/schemas/json/block.json
+++ b/src/schemas/json/block.json
@@ -289,7 +289,15 @@
                       "top",
                       "right",
                       "left",
-                      "bottom",
+                      "bottom"
+                    ]
+                  }
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
                       "vertical",
                       "horizontal"
                     ]
@@ -310,7 +318,15 @@
                       "top",
                       "right",
                       "left",
-                      "bottom",
+                      "bottom"
+                    ]
+                  }
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
                       "vertical",
                       "horizontal"
                     ]


### PR DESCRIPTION
Merged enums in margin and padding since they can be used together according to https://github.com/WordPress/gutenberg/pull/31774

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
