### PR TITLE
template.json: update for new fields available from .NET 6

### DIFF
--- a/src/schemas/json/template.json
+++ b/src/schemas/json/template.json
@@ -451,6 +451,10 @@
                 "description": "A human-readable description of the action.",
                 "type": "string"
               },
+              "id": {
+                "description": "Defines identifier to be used when localizing the post action artifacts.",
+                "type": "string"
+              },
               "manualInstructions": {
                 "description": "An ordered list of possible instructions to display if the action cannot be performed. Each element in the list must contain a key named \"text\", whose value contains the instructions. Each element may also optionally provide a key named \"condition\" - a Boolean evaluate-able string. The first instruction whose condition is false or blank will be considered valid, all others are ignored.",
                 "type": "array",
@@ -463,6 +467,10 @@
                       "type": "string"
                     },
                     "text": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "Defines identifier to be used when localizing the manual instructions.",
                       "type": "string"
                     }
                   }
@@ -524,7 +532,13 @@
                         "description": "Whether or not to redirect stdout for the process (prevents output from being displayed if true)",
                         "type": "string",
                         "enum": [ "true", "false" ],
-                        "default": "false"
+                        "default": "true"
+                      },
+                      "redirectStandardError": {
+                        "description": "Defines whether or not the stderr should be redirected. If the output is redirected, it prevents it from being displayed.",
+                        "type": "string",
+                        "enum": [ "true", "false" ],
+                        "default": "true"
                       },
                       "executable": {
                         "description": "The executable to run",
@@ -939,6 +953,10 @@
               "parameter",
               "computed"
             ]
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The friendly name of the symbol to be displayed to the user. This property is localizable."
           }
         },
         "oneOf": [
@@ -1025,6 +1043,10 @@
                     "description": {
                       "description": "Help text describing the meaning of the corresponding value",
                       "type": "string"
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "description": "The friendly name of the choice to be displayed to the user. This property is localizable."
                     }
                   }
                 }
@@ -1103,7 +1125,7 @@
         },
         "type": {
           "description": "The type of template: project or item",
-          "enum": [ "project", "item" ]
+          "enum": [ "project", "item", "solution" ]
         }
       }
     },


### PR DESCRIPTION
Updates to template.json schema for .NET 6

New fields:
- `postActions\id`, `postActions\manualInstructions\id` - https://github.com/dotnet/templating/issues/3133
- `symbols\displayName`,  `choices\displayName` - https://github.com/dotnet/templating/issues/2822
- new value for `type` - `solution` - https://github.com/dotnet/templating/issues/2833#issuecomment-830265778
- new arg in run script post action - `redirectStandardError` - https://github.com/dotnet/templating/issues/3429

Fixed default value for `redirectStandardOutput` arg in run script post action 