### PR TITLE
Fix location of fulibWorkflows schema file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3674,11 +3674,12 @@
     },
     {
       "name": "fulibWorkflows",
-      "description": "JSON Schema for fulib Workflow files.",
+      "description": "JSON Schema for fulibWorkflows",
       "fileMatch": [
-        "*.es.yaml"
+        "*.es.yaml",
+        "*.es.yml"
       ],
-      "url": "https://raw.githubusercontent.com/fujaba/fulibWorkflows/main/schema/fulibWorklows.schema.json"
+      "url": "https://raw.githubusercontent.com/fujaba/fulibWorkflows/main/schemas/fulibWorkflows.schema.json"
     },
     {
       "name": "Woodpecker pipeline config",


### PR DESCRIPTION
This PR fixes the location of the fulibWorkflows schema file, which went through it's own refactoring.
