### PR TITLE
GitHub workflow_call.inputs.*.default when using a boolean type

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1481,8 +1481,12 @@
                         },
                         "default": {
                           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
-                          "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file.",
-                          "type": "string"
+                          "description": "The default value is used when an input parameter isn't specified in a workflow file.",
+                          "type": [
+                            "boolean",
+                            "number",
+                            "string"
+                          ]
                         }
                       },
                       "required": [

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -296,6 +296,7 @@
     },
     "expressionSyntax": {
       "type": "string",
+      "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
       "pattern": "^\\$\\{\\{.*\\}\\}$"
     },
     "globs": {
@@ -1615,7 +1616,7 @@
                   "cron": {
                     "$comment": "https://stackoverflow.com/a/57639657/4044345",
                     "type": "string",
-                    "pattern": "^(((\\d+,)+\\d+|((\\d+|\\*)\\/\\d+|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?))|(\\d+-\\d+)|\\d+|\\*|((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?)) ?){5,7}$"
+                    "pattern": "^(((\\d+,)+\\d+|((\\d+|\\*)/\\d+|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?))|(\\d+-\\d+)|\\d+|\\*|((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?)) ?){5}$"
                   }
                 },
                 "additionalProperties": false

--- a/src/test/github-workflow/reusable-workflow.json
+++ b/src/test/github-workflow/reusable-workflow.json
@@ -11,6 +11,18 @@
           "type": "string",
           "required": false,
           "default": ""
+        },
+        "foo_boolean": {
+          "description": "Foo",
+          "type": "boolean",
+          "default": true,
+          "required": false
+        },
+        "foo_number": {
+          "description": "Foo2",
+          "type": "number",
+          "default": 0,
+          "required": false
         }
       }
     }

--- a/src/test/github-workflow/runs-on.json
+++ b/src/test/github-workflow/runs-on.json
@@ -1,8 +1,31 @@
 {
   "name": "Test runs-on",
-  "on": [
-    "push"
-  ],
+  "on": {
+    "push": {
+      "branches": [
+        "master"
+      ]
+    },
+    "pull_request": {
+      "branches": [
+        "master"
+      ]
+    },
+    "schedule": [
+      {
+        "cron": "* * * * *"
+      },
+      {
+        "cron": "0 0 1 1 *"
+      },
+      {
+        "cron": "*/6 */3 * 1 WED"
+      },
+      {
+        "cron": "1-59 9-17 * */3 6,0"
+      }
+    ]
+  },
   "jobs": {
     "ubuntu": {
       "runs-on": "ubuntu-latest",


### PR DESCRIPTION
workflow_call.inputs.*.default is missing some type as describe in #1892
close #1892

Fix some cron regex as describe in https://github.com/SchemaStore/schemastore/issues/1162#issuecomment-951514190
The redundant //\ is also shown by IntelliJ editor as warning. It is now removed.
There are still issue with the regex that it will not accept a valid `"1-59/2 * * * *"`

Maintenance:
close #444 via #1808
close #1883 via #1884
