### PR TITLE
Mark category as optional in `block.json` schema

### DIFF
--- a/src/schemas/json/block.json
+++ b/src/schemas/json/block.json
@@ -418,8 +418,7 @@
   },
   "required": [
     "name",
-    "title",
-    "category"
+    "title"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
We had the wrong information about the `category` field in the Block Editor Handbook for WordPress. It's been updated to reflect that this field is optional. We should also align the schema:

https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#category