### PR TITLE
Update MegaLinter links after migration to megalinter github org

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1703,21 +1703,23 @@
       "url": "https://json.schemastore.org/lsdlschema.json"
     },
     {
-      "name": "Mega-Linter configuration",
+      "name": "MegaLinter configuration",
       "description": "JSON schema for Mega-Linter configuration file (for Mega-Linter users)",
       "fileMatch": [
         ".mega-linter.yml",
-        "*.mega-linter-config.yml"
+        ".megalinter.yml",
+        "*.mega-linter-config.yml",
+        "*.megalinter-config.yml"
       ],
-      "url": "https://raw.githubusercontent.com/nvuillam/mega-linter/master/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json"
+      "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json"
     },
     {
-      "name": "Mega-Linter descriptor",
-      "description": "JSON schema for Mega-Linter descriptor files (for Mega-Linter contributors)",
+      "name": "MegaLinter descriptor",
+      "description": "JSON schema for MegaLinter descriptor files (for MegaLinter contributors)",
       "fileMatch": [
         "*.megalinter-descriptor.yml"
       ],
-      "url": "https://raw.githubusercontent.com/nvuillam/mega-linter/master/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
+      "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
     },
     {
       "name": "Microsoft Band Web Tile",

--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -91,7 +91,7 @@
     </p>
 
     <ul>
-        <li><a href="https://nvuillam.github.io/mega-linter/" target="_blank">Mega-Linter</a></li>
+        <li><a href="https://megalinter.github.io" target="_blank">MegaLinter</a></li>
     </ul>
 </article>
 


### PR DESCRIPTION
Just update of urls :)