### PR TITLE
Add title to templateParts in `theme.json`

### DIFF
--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -1114,6 +1114,10 @@
             "description": "Filename, without extension, of the template in the block-template-parts folder.\nGutenberg plugin required.",
             "type": "string"
           },
+          "title": {
+            "description": "Title of the template, translatable.\nGutenberg plugin required.",
+            "type": "string"
+          },
           "area": {
             "description": "The area the template part is used for. Block variations for `header` and `footer` values exist and will be used when the area is set to one of those.\nGutenberg plugin required.",
             "type": "string",


### PR DESCRIPTION
The `title` attribute was missing in `templateParts`. Reference: https://github.com/WordPress/gutenberg/pull/36145