### PR TITLE
Adding Hazelcast configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1394,6 +1394,17 @@
       "url": "https://raw.githubusercontent.com/j2inn/hayson/master/hayson-json-schema.json"
     },
     {
+      "name": "Hazelcast 5 Configuration",
+      "description": "YAML schema for configuring Hazelcast 5 Platform (member and client)",
+      "fileMatch": [
+        "hazelcast*.yaml",
+        "hazelcast*.json",
+        "hz-*.yaml",
+        "hz-*.json"
+      ],
+      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.0.json"
+    },
+    {
       "name": "host.json",
       "description": "JSON schema for Azure Functions host.json files",
       "fileMatch": [
@@ -3688,17 +3699,6 @@
       "description": "YAML schema for configuring Woodpecker CI",
       "fileMatch": ["**/.woodpecker/**.yml", "**/.woodpecker.yml"],
       "url": "https://raw.githubusercontent.com/woodpecker-ci/woodpecker/master/pipeline/schema/schema.json"
-    },
-    {
-      "name": "Hazelcast 5 Configuration",
-      "description": "YAML schema for configuring Hazelcast 5 Platform (member and client)",
-      "fileMatch": [
-        "hazelcast*.yaml"
-        "hazelcast*.json"
-        "hz-*.yaml"
-        "hz-*.json"
-	  ],
-      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.0.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3688,6 +3688,17 @@
       "description": "YAML schema for configuring Woodpecker CI",
       "fileMatch": ["**/.woodpecker/**.yml", "**/.woodpecker.yml"],
       "url": "https://raw.githubusercontent.com/woodpecker-ci/woodpecker/master/pipeline/schema/schema.json"
+    },
+    {
+      "name": "Hazelcast 5 Configuration",
+      "description": "YAML schema for configuring Hazelcast 5 Platform (member and client)",
+      "fileMatch": [
+        "hazelcast*.yaml"
+        "hazelcast*.json"
+        "hz-*.yaml"
+        "hz-*.json"
+	  ],
+      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.0.json"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the json schema of Hazelcast's YAML configuration. 

An extensive test suite is already provided for this schema in the [hazelcast repository](https://github.com/hazelcast/hazelcast/tree/master/hazelcast/src/test/resources/com/hazelcast/config).