### PR TITLE
Add `viewScript` field to `block.json` schema

### DIFF
--- a/src/schemas/json/block.json
+++ b/src/schemas/json/block.json
@@ -404,9 +404,13 @@
       "description": "Block type editor script definition. It will only be enqueued in the context of the editor."
     },
     "script": {
-      "type": "string",
-      "description": "Block type frontend script definition. It will be enqueued both in the editor and when viewing the content on the front of the site."
-    },
+ 			"type": "string",
+ 			"description": "Block type frontend and editor script definition. It will be enqueued both in the editor and when viewing the content on the front of the site."
+ 		},
+ 		"viewScript": {
+ 			"type": "string",
+ 			"description": "Block type frontend script definition. It will be enqueued only when viewing the content on the front of the site."
+ 		},
     "editorStyle": {
       "type": "string",
       "description": "Block type editor style definition. It will only be enqueued in the context of the editor."

--- a/src/schemas/json/block.json
+++ b/src/schemas/json/block.json
@@ -404,13 +404,13 @@
       "description": "Block type editor script definition. It will only be enqueued in the context of the editor."
     },
     "script": {
- 			"type": "string",
- 			"description": "Block type frontend and editor script definition. It will be enqueued both in the editor and when viewing the content on the front of the site."
- 		},
- 		"viewScript": {
- 			"type": "string",
- 			"description": "Block type frontend script definition. It will be enqueued only when viewing the content on the front of the site."
- 		},
+      "type": "string",
+      "description": "Block type frontend and editor script definition. It will be enqueued both in the editor and when viewing the content on the front of the site."
+    },
+    "viewScript": {
+      "type": "string",
+      "description": "Block type frontend script definition. It will be enqueued only when viewing the content on the front of the site."
+    },
     "editorStyle": {
       "type": "string",
       "description": "Block type editor style definition. It will only be enqueued in the context of the editor."


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
Related changes in the Gutenberg project for the `block.json` scheme and documentation in https://github.com/WordPress/gutenberg/pull/36175.
