### PR TITLE
`github-actions.json`: Add `if` conditional support for action steps

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -112,6 +112,11 @@
                 "description": "A unique identifier for the step. You can use the `id` to reference the step in contexts.",
                 "type": "string"
               },
+              "if": {
+                "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsif",
+                "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
+                "type": "string"
+              },
               "env": {
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsenv",
                 "description": "Sets a map of environment variables for only that step.",


### PR DESCRIPTION
Support has been added in https://github.com/actions/runner/pull/1438
The issue was being tracked in https://github.com/actions/runner/issues/834

The "metadata syntax" documentation has not been updated yet, so the link and copy may need to change.