### PR TITLE
Add Goreleaser config file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1292,6 +1292,22 @@
       "url": "https://json.schemastore.org/golangci-lint.json"
     },
     {
+      "name": "Goreleaser",
+      "description": "Goreleaser configuration file",
+      "fileMatch": [
+        ".goreleaser.yml",
+        ".goreleaser.yaml",
+        "goreleaser.yml",
+        "goreleaser.yaml"
+      ],
+      "url": "https://goreleaser.com/static/schema.json"
+    },
+    {
+      "name": "Goreleaser Pro",
+      "description": "Goreleaser Pro configuration file",
+      "url": "https://goreleaser.com/static/schema-pro.json"
+    },
+    {
       "name": "Grafana 5.x Dashboard",
       "description": "JSON Schema for Grafana 5.x Dashboards",
       "url": "https://json.schemastore.org/grafana-dashboard-5.x.json"


### PR DESCRIPTION
I've recently contributed JSON schema generation to Goreleaser (https://github.com/goreleaser/goreleaser/pull/2589), and I'd like to include the schema on schemastore.org. I don't know if including the pro version is acceptable, this PR currently includes it.