### PR TITLE
Add Neovim/SchemaStore.nvim to list of editors

### DIFF
--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -79,6 +79,7 @@
         <li>Visual Studio for Mac</li>
         <li>WebStorm</li>
         <li>JSONBuddy</li>
+        <li>Neovim via <a href="https://github.com/b0o/SchemaStore.nvim" target="_blank">SchemaStore.nvim</a></li>
     </ul>
 
     <p>Any schema on SchemaStore.org will automatically be synchronized to the supporting editors.</p>


### PR DESCRIPTION
Hi! I created the Neovim plugin [SchemaStore.nvim](https://github.com/b0o/SchemaStore.nvim) which allows users to load the SchemaStore catalog for use with [jsonls](https://github.com/hrsh7th/vscode-langservers-extracted).

This PR adds Neovim to the list of supporting editors on the website and links to the plugin.