### PR TITLE
Add input types for github-workflow

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1582,6 +1582,16 @@
                           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
                           "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file.",
                           "type": "string"
+                        },
+                        "type": {
+                          "description": "A string representing the type of the input.",
+                          "type": "string",
+                          "enum": [
+                            "string",
+                            "choice",
+                            "boolean",
+                            "environment"
+                          ]
                         }
                       },
                       "required": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/
