### PR TITLE
Updating jshint schema to match https://jshint.com/docs/options/

### DIFF
--- a/src/schemas/json/jshintrc.json
+++ b/src/schemas/json/jshintrc.json
@@ -25,7 +25,7 @@
       "description": "The ECMAScript version to which the code must adhere",
       "type": "integer",
       "default": 5,
-      "enum": [3, 5, 6, 7, 8, 9]
+      "enum": [3, 5, 6, 7, 8, 9, 10 ,11]
     },
     "forin": {
       "description": "Requires all `for in` loops to filter object's items with obj.hasOwnProperty()",


### PR DESCRIPTION
jshint now supports ECMAScript 10 and 11 in the esversion field.