### PR TITLE
Add `packageManager` to `package.json`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -535,6 +535,11 @@
       "description": "Resolutions is used to support selective version resolutions, which lets you define custom package versions or ranges inside your dependencies. See: https://classic.yarnpkg.com/en/docs/selective-version-resolutions",
       "type": "object"
     },
+    "packageManager": {
+      "description": "Defines which package manager is expected to be used when working on the current project. This field is currently experimental and needs to be opted-in; see https://nodejs.org/api/corepack.html",
+      "type": "string",
+      "pattern": "(npm|pnpm|yarn)@\\d+\\.\\d+\\.\\d+(-.+)?"
+    },
     "engines": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Adds [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) to `package.json` schema.

I made used a [regex pattern](https://regexr.com/69kup) to check that it follows the correct format, but that might be overkill?