### PR TITLE
Add the options of the dropdown list when the input type is choice

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1594,6 +1594,15 @@
                             "boolean",
                             "environment"
                           ]
+                        },
+                        "options": {
+                          "$comment": "https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows",
+                          "description": "The options of the dropdown list, if the type is a choice.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
                         }
                       },
                       "required": [


### PR DESCRIPTION
This adds the options of the dropdown list when the input type is choice to allow the following:

```on:
  workflow_dispatch:
    inputs:
      name:
        type: choice
        description: Who to greet
        options: 
        - monalisa
        - cschleiden
```
 
https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/