### PR TITLE
FIX: Set the default for session idle timeout to 600 seconds.

### DIFF
--- a/src/schemas/json/airlock-microgateway-3.0.json
+++ b/src/schemas/json/airlock-microgateway-3.0.json
@@ -2290,7 +2290,7 @@
         "idle_timeout": {
           "type": "integer",
           "description": "Specifies the amount of idle time in seconds, after which an Airlock Microgateway session is terminated. This timeout should be smaller than all other session timeouts of your back-end applications. Even if the timeout can be configured in seconds, per default the resolution of the idle session timeout check is 5 seconds only.",
-          "default": "60"
+          "default": "600"
         },
         "lifetime": {
           "type": "integer",


### PR DESCRIPTION
Hi, we would like to fix a default value.

**HINTS**

- Changelog: https://docs.airlock.com/microgateway/3.0/#data/airlockmicro.html
- Docker Images: https://hub.docker.com/r/ergon/airlock-microgateway