### PR TITLE
circleci: Improve confusing wording

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -376,7 +376,7 @@
           "default": "ubuntu-1604:202004-01"
         },
         "docker_layer_caching": {
-          "description": "Set to `true` to enable [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching). Note: You must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.",
+          "description": "Set to `true` to enable [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching). Note: If you haven't already, you must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.",
           "type": "boolean",
           "default": "true"
         }


### PR DESCRIPTION
Our customers are confused about `docker_layer_caching` saying they must open a ticket with support since they already did that. It makes them think they don't have access to the feature.