### PR TITLE
Adds Fossa cli configuarion schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1155,6 +1155,14 @@
       "url": "https://gitlab.com/-/snippets/2062623/raw/master/foundryvtt_template_schema.json"
     },
     {
+      "name": "Fossa configuration file",
+      "description": "JSON schema for FOSSA CLI's .fossa.yml configuration file",
+      "fileMatch": [
+        ".fossa.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-yml.v3.schema.json"
+    },
+    {
       "name": "func.yaml",
       "description": "JSON schema for Knative Func Plugin func.yaml files",
       "fileMatch": [


### PR DESCRIPTION
## Overview

Adds schema for FOSSA CLI's configuration file: `.fossa.yml`. 

Let me know if anything else is needed for this PR. 

## References

- Fossa: https://fossa.com/
- Fossa-cli: https://github.com/fossas/fossa-cli/
- `.fossa.yml` user documentation:  https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md

