### PR TITLE
Add support for GitHub Issue Template Configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1263,6 +1263,15 @@
       "url": "https://json.schemastore.org/github-issue-forms.json"
     },
     {
+      "name": "GitHub Issue Template configuration",
+      "description": "YAML schema for configuring GitHub Issue Templates",
+      "fileMatch": [
+          ".github/ISSUE_TEMPLATE/config.yml",
+          ".github/ISSUE_TEMPLATE/config.yaml"
+      ],
+      "url": "https://json.schemastore.org/github-issue-config.json"
+    },
+    {
       "name": "GitHub Workflow",
       "description": "YAML schema for GitHub Workflow",
       "fileMatch": [

--- a/src/negative_test/github-issue-config/links-must-have-name-url-and-about.json
+++ b/src/negative_test/github-issue-config/links-must-have-name-url-and-about.json
@@ -1,0 +1,8 @@
+{
+  "contact_links": [
+    {
+      "name": "GitHub Community Support",
+      "url": "https://github.community/"
+    }
+  ]
+}

--- a/src/schemas/json/github-issue-config.json
+++ b/src/schemas/json/github-issue-config.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",
+  "title": "GitHub issue template configuration",
+  "description": "You can customize the issue template chooser that people see when creating a new issue in your repository.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "blank_issues_enabled": {
+      "description": "Should contributors be able to create blank issues, or must they use a template?",
+      "type": "boolean"
+    },
+    "contact_links": {
+      "description": "Link to places outside of GitHub where you'd prefer certain reports or discussion take place",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "url", "about"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name or title of the link"
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL this link goes to (must be a valid HTTP or HTTPS URL)"
+          },
+          "about": {
+            "type": "string",
+            "description": "A short text description of the link"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/github-issue-config/just-contact-links.json
+++ b/src/test/github-issue-config/just-contact-links.json
@@ -1,0 +1,9 @@
+{
+  "contact_links": [
+    {
+      "name": "GitHub Community Support",
+      "url": "https://github.community/",
+      "about": "Please ask and answer questions here."
+    }
+  ]
+}

--- a/src/test/github-issue-config/no-contact-links.json
+++ b/src/test/github-issue-config/no-contact-links.json
@@ -1,0 +1,3 @@
+{
+  "blank_issues_enabled": false
+}

--- a/src/test/github-issue-config/official-example.json
+++ b/src/test/github-issue-config/official-example.json
@@ -1,0 +1,15 @@
+{
+  "blank_issues_enabled": false,
+  "contact_links": [
+    {
+      "name": "GitHub Community Support",
+      "url": "https://github.community/",
+      "about": "Please ask and answer questions here."
+    },
+    {
+      "name": "GitHub Security Bug Bounty",
+      "url": "https://bounty.github.com/",
+      "about": "Please report security vulnerabilities here."
+    }
+  ]
+}


### PR DESCRIPTION
Adds support for GitHub's issue template configuration files --- these are very basic, and essentially provide only two options, a boolean to disable the creation of blank issues that don't use a template, and an array of links to other sites where some types of issues may be better suited.

More information here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

---

A major factor leading to me contributing this is that the definition for `github-issue-forms` currently causes editors to display errors for these config files. Essentially, in the `.github/ISSUE_TEMPLATE/` folder, you can either have `config.yml` (which should be parsed with these rules I'm contributing), or _any other `.yml` file_, which should be parsed as an issue form. `github-issue-forms`'s current `fileMatch` definition of `github/ISSUE_TEMPLATE/**.yml` is thus making editors attempt to parse these `config.yml` files as forms, which of course causes errors / warnings.

I am hoping that schemas are applyed in order of specificity, and that my `.github/ISSUE_TEMPLATE/config.yml` rule will override that one. Otherwise, I'm open to suggestions as to how this can be resolved, because as far as I know the glob patterns can't contain negatives of more than a single character.
