### PR TITLE
GitHub Workflow: Add Missing Permission Names

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -175,10 +175,19 @@
         "deployments": {
           "$ref": "#/definitions/permissions-level"
         },
+        "discussions": {
+          "$ref": "#/definitions/permissions-level"
+        },
+        "id-token": {
+          "$ref": "#/definitions/permissions-level"
+        },
         "issues": {
           "$ref": "#/definitions/permissions-level"
         },
         "packages": {
+          "$ref": "#/definitions/permissions-level"
+        },
+        "pages": {
           "$ref": "#/definitions/permissions-level"
         },
         "pull-requests": {
@@ -191,9 +200,6 @@
           "$ref": "#/definitions/permissions-level"
         },
         "statuses": {
-          "$ref": "#/definitions/permissions-level"
-        },
-        "id-token": {
           "$ref": "#/definitions/permissions-level"
         }
       }


### PR DESCRIPTION
This adds support for the `discussions` and `pages` properties in the `permissions` object on GitHub Workflows. There is also a documented `metadata` property, but GitHub appears to always mark the workflow file as invalid if you set it, so it's not included here.

I ran across issues here when trying to use `permissions` in a workflow for the first time yesterday. There doesn’t seem to be any comprehensive documentation, so I attempted to make sure the schema allows values that are listed in any of the below sources:

- List of permissions in the security guide: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

- Example code blocks in the workflow syntax docs: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions

- Logs from a recent workflow run:

    <img width="326" alt="Screen Shot 2021-11-30 at 5 06 32 PM" src="https://user-images.githubusercontent.com/74178/144153101-ebf8cb99-806f-4ab1-8b89-4907a0bc1f74.png">

The one exception here is `metadata` — it’s documented, but GitHub won’t run a workflow file that includes it, regardless of the value (at least in my tests). It also turns out that the values allowed for `id-token` depend on the context, but I’m not sure there’s any way to validate that statically in the schema here, so I didn’t change that one (I did put it in alphabetical order with the rest, though).