### PR TITLE
Lint must run on all branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,6 @@
 name: Lint
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   lint-editorconfig:


### PR DESCRIPTION
I've noticed that the lint check is not running on my fork after pushing to a non-master branch.
It is more practical to know if something works 100% **before** creating PR to schemastore.