### PR TITLE
add `.agripparc.json` to Agrippa fileMatch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -14,6 +14,7 @@
       "name": ".agripparc.json",
       "description": "JSON schema for the Agrippa config file",
       "fileMatch": [
+        ".agripparc.json",
         "agripparc.json"
       ],
       "url": "https://json.schemastore.org/agripparc-1.3.json",


### PR DESCRIPTION
Hi, just a fix for Agrippa's `fileMatch` value in the catalog.

Thanks!