### PR TITLE
github-workflow: support expressions in `concurrency.cancel-in-progress`

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -26,7 +26,14 @@
         "cancel-in-progress": {
           "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run-1",
           "description": "To cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
-          "type": "boolean"
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
+            }
+          ]
         }
       },
       "required": [

--- a/src/test/github-workflow/concurrency.json
+++ b/src/test/github-workflow/concurrency.json
@@ -15,6 +15,18 @@
           "group": "test-${{ github.ref }}",
           "cancel-in-progress": true
         }
+      },
+      "cancel-in-progress-is-expression": {
+        "runs-on": "ubuntu-latest",
+        "concurrency": {
+          "group": "test-${{ github.ref }}",
+          "cancel-in-progress": "${{ true }}"
+        },
+        "steps": [
+          {
+            "run": ""
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
The [`concurrency.cancel-in-progress`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) and [`jobs.<job_id>.concurrency.cancel-in-progress`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idconcurrency) keys of GitHub Actions workflows accept [expressions](https://docs.github.com/en/actions/learn-github-actions/expressions).

This was previously not supported by the schema.

Minimal demonstration workflow, which was also added as a test:

```yaml
on: workflow_dispatch
jobs:
  cancel-in-progress-is-expression:
    runs-on: ubuntu-latest
    concurrency:
      group: test-${{ github.ref }}
      cancel-in-progress: ${{ true }}
    steps:
      - run: ""
```

Demonstration workflow runs:

- https://github.com/per1234/schemastore/actions/runs/1547948494 (canceled due to subsequent run trigger)
- https://github.com/per1234/schemastore/actions/runs/1547948605 (the subsequent run)