### PR TITLE
switch to main branch for containerlab schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3654,7 +3654,7 @@
         "*.clab.yaml",
         "*.clab.yml"
       ],
-      "url": "https://raw.githubusercontent.com/srl-labs/containerlab/master/schemas/clab.schema.json"
+      "url": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/clab.schema.json"
     },
     {
       "name": "User Journey Map YAML Schema",


### PR DESCRIPTION
switching to `main` branch for containerlab schema file