### PR TITLE
Pre-commit: Add missing stages to schema

### DIFF
--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -73,7 +73,7 @@
                                     "type": "array",
                                     "items": {
                                         "type": "string",
-                                        "enum": ["commit", "merge-commit", "push", "prepare-commit-msg", "commit-msg", "post-checkout", "post-commit", "manual"]
+                                        "enum": ["commit", "merge-commit", "push", "prepare-commit-msg", "commit-msg", "post-checkout", "post-commit", "post-merge", "post-rewrite", "manual"]
                                     }
                                 },
                                 "additional_dependencies": {


### PR DESCRIPTION
There are a few stages missing from the schema
https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
