### PR TITLE
Fix "composite" to "composites" in golangci-lint

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -106,7 +106,7 @@
         "bools",
         "buildtag",
         "cgocall",
-        "composite",
+        "composites",
         "copylocks",
         "deepequalerrors",
         "errorsas",


### PR DESCRIPTION
ref: https://pkg.go.dev/cmd/vet#pkg-overview

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
