### PR TITLE
Chrome manifest v3 migration [issue #1986]

### DIFF
--- a/src/negative_test/chrome-manifest/v3_browser_action_is_no_longer_in_the_root_issue_1986.json
+++ b/src/negative_test/chrome-manifest/v3_browser_action_is_no_longer_in_the_root_issue_1986.json
@@ -1,0 +1,13 @@
+{
+  "name": "v3-browser_action_not_in_root_anymore",
+  "version": "1.0.0",
+  "manifest_version": 3,
+  "browser_action": {
+    "default_icon": {
+      "19": "images/h-toolbar-off@19px.png",
+      "38": "images/h-toolbar-off@38px.png"
+    },
+    "default_title": "Start a Harvest timer",
+    "default_popup": "popup.html"
+  }
+}

--- a/src/negative_test/chrome-manifest/v3_page_action_is_no_longer_in_the_root_issue_1986.json
+++ b/src/negative_test/chrome-manifest/v3_page_action_is_no_longer_in_the_root_issue_1986.json
@@ -1,0 +1,14 @@
+{
+  "name": "v3-page_action_not_in_root_anymore",
+  "version": "1.0.0",
+  "manifest_version": 3,
+  "page_action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "images/get_started16.png",
+      "32": "images/get_started32.png",
+      "48": "images/get_started48.png",
+      "128": "images/get_started128.png"
+    }
+  }
+}

--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -520,6 +520,11 @@
           "$ref": "#/definitions/web_resource"
         }
       }
+    },
+    "$comment": "browser_action and page_action are no longer present in v3",
+    "dependencies": {
+      "browser_action": { "not": { "required": [ "browser_action" ] } },
+      "page_action": { "not": { "required": [ "page_action" ] } }
     }
   },
   "else": {

--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -499,6 +499,7 @@
         "$ref": "#/definitions/action_v3"
       },
       "content_security_policy": {
+        "type": "object",
         "properties": {
           "extension_pages": {
             "description": "This policy covers pages in your extension, including html files and service workers.",


### PR DESCRIPTION
close #1986

This schema needs more improvement. Some items are missing or not explicitly defined. The Chrome manifest documentation does not contain explicit information about some items. It makes it more difficult to improve the schema without accurate documentation.