### PR TITLE
Allow ecma versions 2022 and 13 in ESLint

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -505,9 +505,9 @@
           "$ref": "#/properties/ecmaFeatures"
         },
         "ecmaVersion": {
-          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018, 10, 2019, 11, 2020, 12, 2021, "latest" ],
+          "enum": [ 3, 5, 6, 2015, 7, 2016, 8, 2017, 9, 2018, 10, 2019, 11, 2020, 12, 2021, 13, 2022, "latest" ],
           "default": 11,
-          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11 (default), 12 or \"latest\" to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11) or 2021 (same as 12) to use the year-based naming. \"latest\" always enables the latest supported ECMAScript version."
+          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11 (default), 12, 13 or \"latest\" to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11) or 2021 (same as 12) or 2022 (same as 13) to use the year-based naming. \"latest\" always enables the latest supported ECMAScript version."
         },
         "sourceType": {
           "enum": [ "script", "module" ],

--- a/src/test/eslintrc/ecmaVersion13.json
+++ b/src/test/eslintrc/ecmaVersion13.json
@@ -1,0 +1,6 @@
+{
+  "extends": "aaa",
+  "parserOptions": {
+    "ecmaVersion": 13
+  }
+}

--- a/src/test/eslintrc/ecmaVersion2022.json
+++ b/src/test/eslintrc/ecmaVersion2022.json
@@ -1,0 +1,6 @@
+{
+  "extends": "aaa",
+  "parserOptions": {
+    "ecmaVersion": 2022
+  }
+}


### PR DESCRIPTION
2022 and 13 are the same version (they support year based and version based values).

See here for documentation: https://eslint.org/docs/user-guide/configuring/language-options#specifying-parser-options

Closes #1998 