### PR TITLE
feat: add serverless schema json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3892,6 +3892,14 @@
         "stackhawk-*.yaml"
       ],
       "url": "https://download.stackhawk.com/hawk/jsonconfig/hawkconfig.json"
+    },
+    {
+      "name": "Serverless Framework Configuration",
+      "description": "Schema for serverless framework configuration files",
+      "fileMatch": [
+        "serverless.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/lalcebo/json-schema/master/serverless/reference.json"
     }
   ]
 }


### PR DESCRIPTION
## Overview
Adds schema for Serverless Framework configuration file: `serverless.yml`.

Let me know if anything else is needed for this PR.

## References

- Serverless: https://www.serverless.com/
- Reference Docs: https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml