### PR TITLE
GitHub action stale must not run on the fork

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'SchemaStore'
     steps:
       - uses: actions/stale@v4
         with:

--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -197,7 +197,6 @@
     },
     "xcodeVersions": {
       "enum": [
-        "xcode6.4",
         "xcode7.3",
         "xcode8",
         "xcode8.3",
@@ -217,15 +216,14 @@
         "xcode11.4",
         "xcode11.5",
         "xcode11.6",
-        "xcode11.7",
         "xcode12u",
         "xcode12",
-        "xcode12.1",
         "xcode12.2",
         "xcode12.3",
         "xcode12.4",
         "xcode12.5",
-        "xcode13.1"
+        "xcode13.1",
+        "xcode13.2"
       ]
     },
     "envVars": {


### PR DESCRIPTION
The 'stale action' is disabled on the fork.
The stale action run every day for maintenance work on the **SchemaStore  PR**. But there is no maintenance work to do on the fork repository. Should not waste Ubuntu server instance on the fork.



