### PR TITLE
Add codeowners for ansible schemas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+#
+# These owners will be the default owners for everything in
+# the repo, unless a later match takes precedence.
+* @madskristensen
+
+# Managed by Ansible DevTools Team members:
+src/schemas/json/ansible-* @ssbarnea @webknjaz
+src/test/ansible-* @ssbarnea @webknjaz
+src/test/yamllint/ansible-* @ssbarnea @webknjaz


### PR DESCRIPTION
This will help adding reviewers for schemas as @madskristensen may
use help from others that know specific schemas better, being either
owners, authors or maintainers of these schemas.

We are unable to use github organization teams because these work only when these teams have write access to the repository, something that is not required for individual accounts. That is documented at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax