### PR TITLE
feat: Add controller as options in generateOptions.spec

### DIFF
--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -316,6 +316,9 @@
         },
         "compilerOptions": {
           "$ref": "#/definitions/CompilerOptions"
+        },
+        "generateOptions": {
+          "$ref": "#/definitions/GenerateOptions"
         }
       },
       "additionalProperties": false

--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -168,9 +168,17 @@
           "type": "boolean",
           "description": "Generate spec file for configuration schematics or not."
         },
-        "co": {
+        "config": {
           "type": "boolean",
           "description": "Alias for configuration"
+        },
+        "controller": {
+          "type": "boolean",
+          "description": "Generate spec file for controller schematics or not."
+        },
+        "co": {
+          "type": "boolean",
+          "description": "Alias for controller"
         },
         "decorator": {
           "type": "boolean",

--- a/src/test/nest-cli/nest-cli-generateOptions.json
+++ b/src/test/nest-cli/nest-cli-generateOptions.json
@@ -52,6 +52,14 @@
       "sourceRoot": "apps/my-app/src",
       "compilerOptions": {
         "tsConfigPath": "apps/my-app/tsconfig.app.json"
+      },
+      "generateOptions": {
+        "spec": {
+          "configuration": false,
+          "config": false,
+          "controller": true,
+          "co": true
+        }
       }
     }
   }

--- a/src/test/nest-cli/nest-cli-generateOptions.json
+++ b/src/test/nest-cli/nest-cli-generateOptions.json
@@ -1,0 +1,58 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "apps/my-project/src",
+  "monorepo": true,
+  "root": "apps/my-project",
+  "compilerOptions": {
+    "webpack": true,
+    "tsConfigPath": "apps/my-project/tsconfig.app.json",
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "classValidatorShim": true,
+          "controllerFileNameSuffix": ".controller.ts",
+          "controllerKeyOfComment": "description",
+          "dtoFileNameSuffix": [],
+          "dtoKeyOfComment": "description",
+          "introspectComments": true
+        }
+      },
+      {
+        "name": "@nestjs/graphql",
+        "options": {
+          "typeFileNameSuffix": [],
+          "introspectComments": true
+        }
+      }
+    ]
+  },
+  "generateOptions": {
+    "spec": {
+      "configuration": true,
+      "config": true,
+      "controller": false,
+      "co": false
+    }
+  },
+  "projects": {
+    "my-project": {
+      "type": "application",
+      "root": "apps/my-project",
+      "entryFile": "main",
+      "sourceRoot": "apps/my-project/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/my-project/tsconfig.app.json"
+      }
+    },
+    "my-app": {
+      "type": "application",
+      "root": "apps/my-app",
+      "entryFile": "main",
+      "sourceRoot": "apps/my-app/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/my-app/tsconfig.app.json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

The nest-cli.json generateOptions.spec object accepts "controller", "co" and "config" options.

https://github.com/nestjs/schematics/blob/master/src/collection.json