### PR TITLE
prometheus.rules.json: allow multiple duration multipliers

### DIFF
--- a/src/schemas/json/prometheus.rules.json
+++ b/src/schemas/json/prometheus.rules.json
@@ -55,7 +55,8 @@
         "string",
         "null"
       ],
-      "pattern": "^[0-9]+(ms|[smhdwy])$"
+      "pattern": "^([0-9]+y)?([0-9]+w)?([0-9]+d)?([0-9]+h)?([0-9]+m)?([0-9]+s)?([0-9]+ms)?$",
+      "minLength": 1
     },
     "label_name": {
       "type": "string",

--- a/src/test/prometheus.rules/rules.json
+++ b/src/test/prometheus.rules/rules.json
@@ -13,6 +13,17 @@
           "annotations": {
             "description": "stuff's happening with {{ $labels.service }}"
           }
+        },
+        {
+          "alert": "InstanceDown",
+          "expr": "up == 0",
+          "for": "1m30s",
+          "labels": {
+            "severity": "critical"
+          },
+          "annotations": {
+            "description": "stuff's happening with {{ $labels.service }}"
+          }
         }
       ]
     }


### PR DESCRIPTION
This change looses the pattern constraint for a duration string. It's valid for a Prometheus duration to not only consist of one duration multiplier (y,d,h,....), but multiple as long as they are in the order year, day, hour, minute, second, millisecond, e.g. `1h30m` or `2d12h`.

The pattern has been updated to consist of multiple optional capture groups for each duration multiplier instead of requiring only a single one. This pattern alone would match empty strings as well, therefore a second constraint has been added to check that the string length is at least 1.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
