### PR TITLE
Add newest supported version of Docker engine

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -606,6 +606,7 @@
             "version": {
               "description": "If your build requires a specific docker image, you can set it as an image attribute",
               "enum": [
+                "20.10.11",
                 "20.10.7",
                 "20.10.6",
                 "20.10.2",


### PR DESCRIPTION
Adds support for engine version 20.10.11, as documented on CircleCI.
Source: https://circleci.com/docs/2.0/building-docker-images/#:~:text=the%20available%20versions%3A-,20.10.11,-20.10.7

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
