### PR TITLE
Add *meltano.yml for Meltano project definitions

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1821,6 +1821,14 @@
       "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
     },
     {
+      "name": "Meltano project definition",
+      "description": "JSON schema for Meltano project definition files",
+      "fileMatch": [
+        "*meltano.yml"
+      ],
+      "url": "https://gitlab.com/meltano/meltano/-/raw/master/schema/meltano.schema.json"
+    },
+    {
       "name": "Microsoft Band Web Tile",
       "description": "Microsoft Band Web Tile manifest file",
       "url": "https://json.schemastore.org/band-manifest.json"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
This is ready for review. 

> **Self-hosting schemas**
> 
> If you wish to retain full control over your schema definition, simply register it in the schema catalog by providing a url pointing to the self-hosted schema file to the entry.

I think this defines our ideal scenario - since we can control the single source of truth (SSOT) and we can loop together with our own test suite and autoformat configuration.

EDIT: I removed the steps regarding hosting locally within this repo, since it sounds like self-hosting on the Meltano is the better fit.
