### PR TITLE
Add Ansible meta/runtime and execution-environment schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -79,6 +79,22 @@
       "url": "https://raw.githubusercontent.com/angular/angular-cli/v10.1.6/packages/angular/cli/lib/config/schema.json"
     },
     {
+      "name": "Ansible Execution Environment",
+      "description": "Ansible execution-environment.yml file",
+      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-ee.json",
+      "fileMatch": [
+        "**/execution-environment.yml"
+      ]
+    },
+    {
+      "name": "Ansible Meta Runtime",
+      "description": "Ansible meta/runtime.yml file",
+      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-meta-runtime.json",
+      "fileMatch": [
+        "**/meta/runtime.yml"
+      ]
+    },
+    {
       "name": "Ansible Tasks File",
       "description": "Ansible tasks file",
       "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-tasks.json",


### PR DESCRIPTION
Related: https://github.com/ansible/vscode-ansible/pull/379
Related: https://github.com/ansible-community/schemas/issues/130
Related: https://github.com/ansible-community/schemas/pull/132

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
