### PR TITLE
Add Meltano discovery.yml schema definition 

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1845,6 +1845,14 @@
       "url": "https://gitlab.com/meltano/meltano/-/raw/master/schema/meltano.schema.json"
     },
     {
+      "name": "Meltano plugin discovery definition",
+      "description": "JSON schema for Meltano plugin discovery definition file",
+      "fileMatch": [
+        "*discovery.yml"
+      ],
+      "url": "https://gitlab.com/meltano/meltano/-/raw/master/schema/discovery.schema.json"
+    },
+    {
       "name": "Microsoft Band Web Tile",
       "description": "Microsoft Band Web Tile manifest file",
       "url": "https://json.schemastore.org/band-manifest.json"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This pairs with https://github.com/SchemaStore/schemastore/pull/2020 and adds a schema for the Meltano [discovery.yml](https://meltano.com/docs/contributor-guide.html#discovery-yml-version)  file. Its self hosted on gitlab so I just added it to the catalog.json.

Let me know what you think or if I need to include anything else!
