### PR TITLE
add shopware extension store schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3948,6 +3948,14 @@
         "serverless.yml"
       ],
       "url": "https://raw.githubusercontent.com/lalcebo/json-schema/master/serverless/reference.json"
+    },
+    {
+      "name": "Shopware CLI Extension Store Configuration",
+      "description": "Schema for Shopware CLI Extension Store Configuration",
+      "fileMatch": [
+        ".shopware-extension.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/FriendsOfShopware/shopware-cli/main/extension/shopware-extension-schema.json"
     }
   ]
 }


### PR DESCRIPTION
Hey,

I have started with a small project and created a JSON schema for the config. Idk if you accept also schemas for tiny tiny projects, but I would be happy if it would be accepted. Building a JetBrains extension to add it automatically drives me crazy 😅 