### PR TITLE
Add types_or to pre-commit-config schema

### DIFF
--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -2,6 +2,10 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "JSON schema for .pre-commit-config.yaml",
     "definitions": {
+        "file_types": {
+            "type": "string",
+            "enum": ["adobe-illustrator", "alpm", "apinotes", "asar", "asciidoc", "ash", "asm", "audio", "avif", "awk", "babelrc", "bash", "batch", "bats", "bazel", "bazelrc", "bib", "binary", "bitmap", "bowerrc", "browserslistrc", "bzip2", "c", "c#", "c++", "c2hs", "clojure", "clojurescript", "cmake", "codespellrc", "coffee", "coveragerc", "csh", "cson", "csproj", "css", "csslintrc", "csv", "cuda", "cython", "dart", "dash", "def", "diff", "directory", "dockerfile", "dockerignore", "dtd", "editorconfig", "edn", "ejs", "eot", "eps", "erb", "executable", "expect", "file", "fish", "flake8", "gdscript", "gherkin", "gif", "gitattributes", "gitconfig", "gitignore", "gitlint", "gitmodules", "go", "gotmpl", "gpx", "graphql", "groovy", "gyb", "gyp", "gzip", "haskell", "hcl", "header", "hgrc", "html", "icalendar", "icns", "icon", "idl", "idris", "image", "inc", "ini", "inx", "jade", "jar", "java", "java-properties", "javascript", "jenkins", "jinja", "jpeg", "jshintrc", "json", "jsonnet", "jsx", "jupyter", "kml", "kotlin", "ksh", "lean", "lektor", "lektorproject", "less", "literate-haskell", "lua", "mailmap", "makefile", "manifest", "map", "markdown", "mdx", "mention-bot", "mib", "modulemap", "myst", "ngdoc", "nim", "nimble", "nix", "non-executable", "npmignore", "objective-c", "objective-c++", "ocaml", "otf", "p12", "pdbrc", "pdf", "pem", "perl", "php", "pkgbuild", "plain-text", "plantuml", "plist", "png", "pofile", "powershell", "proto", "puppet", "purescript", "pyi", "pylintrc", "pypirc", "pyproj", "python", "python2", "python3", "pyz", "r", "rst", "ruby", "rust", "salt", "sass", "sbt", "scala", "scheme", "scss", "sh", "shell", "sln", "socket", "solidity", "spec", "sql", "stylus", "svg", "swf", "swift", "swiftdeps", "symlink", "system-verilog", "tar", "tcsh", "terraform", "tex", "text", "thrift", "tiff", "toml", "ts", "tsv", "tsx", "ttf", "twig", "twisted", "txsprofile", "urdf", "vb", "vbproj", "vcxproj", "vdx", "verilog", "vhdl", "vim", "vue", "wav", "webp", "wheel", "wkt", "woff", "woff2", "wsgi", "xhtml", "xml", "xquery", "xsd", "xsl", "yaml", "yamllint", "yang", "yin", "zcml", "zig", "zip", "zpt", "zsh"]
+        },
         "meta_repo": {
             "type": "object",
             "properties": {
@@ -108,7 +112,15 @@
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": ["adobe-illustrator", "alpm", "apinotes", "asar", "asciidoc", "ash", "asm", "audio", "avif", "awk", "babelrc", "bash", "batch", "bats", "bazel", "bazelrc", "bib", "binary", "bitmap", "bowerrc", "browserslistrc", "bzip2", "c", "c#", "c++", "c2hs", "clojure", "clojurescript", "cmake", "codespellrc", "coffee", "coveragerc", "csh", "cson", "csproj", "css", "csslintrc", "csv", "cuda", "cython", "dart", "dash", "def", "diff", "directory", "dockerfile", "dockerignore", "dtd", "editorconfig", "edn", "ejs", "eot", "eps", "erb", "executable", "expect", "file", "fish", "flake8", "gdscript", "gherkin", "gif", "gitattributes", "gitconfig", "gitignore", "gitlint", "gitmodules", "go", "gotmpl", "gpx", "graphql", "groovy", "gyb", "gyp", "gzip", "haskell", "hcl", "header", "hgrc", "html", "icalendar", "icns", "icon", "idl", "idris", "image", "inc", "ini", "inx", "jade", "jar", "java", "java-properties", "javascript", "jenkins", "jinja", "jpeg", "jshintrc", "json", "jsonnet", "jsx", "jupyter", "kml", "kotlin", "ksh", "lean", "lektor", "lektorproject", "less", "literate-haskell", "lua", "mailmap", "makefile", "manifest", "map", "markdown", "mdx", "mention-bot", "mib", "modulemap", "myst", "ngdoc", "nim", "nimble", "nix", "non-executable", "npmignore", "objective-c", "objective-c++", "ocaml", "otf", "p12", "pdbrc", "pdf", "pem", "perl", "php", "pkgbuild", "plain-text", "plantuml", "plist", "png", "pofile", "powershell", "proto", "puppet", "purescript", "pyi", "pylintrc", "pypirc", "pyproj", "python", "python2", "python3", "pyz", "r", "rst", "ruby", "rust", "salt", "sass", "sbt", "scala", "scheme", "scss", "sh", "shell", "sln", "socket", "solidity", "spec", "sql", "stylus", "svg", "swf", "swift", "swiftdeps", "symlink", "system-verilog", "tar", "tcsh", "terraform", "tex", "text", "thrift", "tiff", "toml", "ts", "tsv", "tsx", "ttf", "twig", "twisted", "txsprofile", "urdf", "vb", "vbproj", "vcxproj", "vdx", "verilog", "vhdl", "vim", "vue", "wav", "webp", "wheel", "wkt", "woff", "woff2", "wsgi", "xhtml", "xml", "xquery", "xsd", "xsl", "yaml", "yamllint", "yang", "yin", "zcml", "zig", "zip", "zpt", "zsh"]
+                        "$ref": "#/definitions/file_types"
+                    }
+                },
+                "types_or": {
+                    "$comment": "(optional) override the default file types to run on (OR). See Filtering files with types. new in 2.9.0.",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "$ref": "#/definitions/file_types"
                     }
                 },
                 "exclude_types": {

--- a/src/test/pre-commit-config/pre-commit-config-test.json
+++ b/src/test/pre-commit-config/pre-commit-config-test.json
@@ -23,6 +23,7 @@
                     "files": "^*.rb$",
                     "exclude": "^*.py",
                     "types": ["file", "ruby"],
+                    "types_or": ["markdown", "ruby"],
                     "exclude_types": ["symlink"],
                     "args": ["--foo=baz"],
                     "stages": ["commit", "manual"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
