### PR TITLE
docs: update `golangci-lint` linter settings

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -647,9 +647,15 @@
 
         "errchkjson": {
           "type": "object",
-          "proeprties": {
+          "properties": {
             "check-error-free-encoding": {
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
+            },
+            "report-no-exported": {
+              "description": "Issue on struct that doesn't have exported fields.",
+              "type": "boolean",
+              "default": false
             }
           }
         },
@@ -1439,7 +1445,7 @@
           "properties": {
             "checked-types": {
               "type": "array",
-              "descriptions": "Return types to check.",
+              "description": "Order of return types to check.",
               "items": {
                 "enum": ["ptr", "func", "iface", "map", "chan"]
               },
@@ -1864,54 +1870,63 @@
           "type": "object",
           "properties": {
             "test": {
-              "begin": {
-                "description": "Check if `t.Helper()` begins helper function.",
-                "default": false,
-                "type": "boolean"
-              },
-              "first": {
-                "description": "Check if *testing.T is first param of helper function.",
-                "default": false,
-                "type": "boolean"
-              },
-              "name": {
-                "description": "Check if *testing.T param has t name.",
-                "default": false,
-                "type": "boolean"
+              "type": "object",
+              "properties": {
+                "begin": {
+                  "description": "Check if `t.Helper()` begins helper function.",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "first": {
+                  "description": "Check if *testing.T is first param of helper function.",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Check if *testing.T param has t name.",
+                  "default": false,
+                  "type": "boolean"
+                }
               }
             },
             "bechmark": {
-              "begin": {
-                "description": "Check if `b.Helper()` begins helper function.",
-                "default": false,
-                "type": "boolean"
-              },
-              "first": {
-                "description": "Check if *testing.B is first param of helper function.",
-                "default": false,
-                "type": "boolean"
-              },
-              "name": {
-                "description": "Check if *testing.B param has b name.",
-                "default": false,
-                "type": "boolean"
+              "type": "object",
+              "properties": {
+                "begin": {
+                  "description": "Check if `b.Helper()` begins helper function.",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "first": {
+                  "description": "Check if *testing.B is first param of helper function.",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Check if *testing.B param has b name.",
+                  "default": false,
+                  "type": "boolean"
+                }
               }
             },
             "tb": {
-              "begin": {
-                "description": "Check if `tb.Helper()` begins helper function.",
-                "default": false,
-                "type": "boolean"
-              },
-              "first": {
-                "description": "Check if *testing.TB is first param of helper function.",
-                "default": false,
-                "type": "boolean"
-              },
-              "name": {
-                "description": "Check if *testing.TB param has tb name.",
-                "default": false,
-                "type": "boolean"
+              "type": "object",
+              "properties": {
+                "begin": {
+                  "description": "Check if `tb.Helper()` begins helper function.",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "first": {
+                  "description": "Check if *testing.TB is first param of helper function.",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Check if *testing.TB param has tb name.",
+                  "default": false,
+                  "type": "boolean"
+                }
               }
             }
           }
@@ -1945,14 +1960,12 @@
             "max-distance": {
               "description": "Variables used in at most this N-many lines will be ignored.",
               "type": "integer",
-              "default": 5,
-              "minimun": 1
+              "default": 5
             },
             "min-name-length": {
               "description": "The minimum length of a variable's name that is considered `long`.",
               "type": "integer",
-              "default": 3,
-              "minimun": 1
+              "default": 3
             },
             "check-receiver": {
               "description": "Check method receiver names.",
@@ -1993,7 +2006,7 @@
               "items": {
                 "type": "string"
               },
-              "example": [
+              "examples": [
                 ["c echo.Context", "t testing.T", "f *foo.Bar", "const C"]
               ]
             }

--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -490,11 +490,40 @@
           }
         },
 
+        "decorder": {
+          "type": "object",
+          "properties": {
+            "dec-order": {
+              "type": "array",
+              "default": [["type", "const", "var", "func"]],
+              "items": {
+                "enum": ["type", "const", "var", "func"]
+              }
+            },
+            "disable-dec-order-check": {
+              "description": "Order of declarations is not checked",
+              "default": true,
+              "type": "boolean"
+            },
+            "disable-init-func-first-check": {
+              "description": "Allow init func to be anywhere in file",
+              "default": true,
+              "type": "boolean"
+            },
+            "disable-dec-num-check": {
+              "description": "Multiple global type, const and var declarations are allowed",
+              "default": true,
+              "type": "boolean"
+            }
+          }
+        },
+
         "depguard": {
           "type": "object",
           "properties": {
             "list-type": {
-              "enum": ["blacklist", "whitelist"],
+              "description": "List kind (`allowlist` or `denylist`)",
+              "enum": ["allowlist", "denylist", "blacklist", "whitelist"],
               "default": "blacklist"
             },
             "include-go-root": {
@@ -527,6 +556,32 @@
                     "github.com/OpenPeeDeeP/depguards": "Please use \"github.com/OpenPeeDeeP/depguard\"."
                   }
                 ]
+              }
+            },
+            "additional-guards": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "list-type": {},
+                  "include-go-root": {
+                    "type": "boolean"
+                  },
+                  "packages": {
+                    "description": "List of packages for the list type specified.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "ignore-file-rules": {
+                    "description": "Specify rules by which the linter ignores certain files for consideration.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }
@@ -586,6 +641,15 @@
               "items": {
                 "type": "string"
               }
+            }
+          }
+        },
+
+        "errchkjson": {
+          "type": "object",
+          "proeprties": {
+            "check-error-free-encoding": {
+              "type": "boolean"
             }
           }
         },
@@ -1014,6 +1078,44 @@
                   }
                 }
               }
+            },
+            "ignored-files": {
+              "description": "List of file patterns to exclude from analysis.",
+              "examples": [["magic1_.*.go"]],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignored-functions": {
+              "description": "Comma-separated list of function patterns to exclude from the analysis.",
+              "examples": [["math.*", "http.StatusText", "make"]],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignored-numbers": {
+              "description": "List of numbers to exclude from analysis.",
+              "examples": [["1000", "1234_567_890", "3.14159264"]],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "checks": {
+              "description": "The list of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "argument",
+                  "case",
+                  "condition",
+                  "operation",
+                  "return",
+                  "assign"
+                ]
+              }
             }
           }
         },
@@ -1093,6 +1195,11 @@
                       }
                     }
                   }
+                },
+                "local_replace_directives": {
+                  "description": "Raise lint issues if loading local path with replace directive",
+                  "type": "boolean",
+                  "default": true
                 }
               }
             }
@@ -1147,20 +1254,131 @@
           }
         },
 
+        "ifshort": {
+          "type": "object",
+          "properties": {
+            "max-decl-lines": {
+              "description": "maximum length of variable declaration measured in numbers of lines, after which the linter won't suggest using short syntax. Has precedence over max-decl-chars",
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "max-decl-chars": {
+              "description": "maximum length of variable declaration measured in number of characters, after which the linter won't suggest using short syntax.",
+              "type": "integer",
+              "minimum": 1,
+              "default": 30
+            }
+          }
+        },
+
+        "importas": {
+          "type": "object",
+          "properties": {
+            "no-unaliased": {
+              "description": "Do not allow unaliased imports of aliased packages.",
+              "type": "boolean",
+              "default": false
+            },
+            "no-extra-aliases": {
+              "description": "Do not allow non-required aliases.",
+              "type": "boolean",
+              "default": false
+            },
+            "alias": {
+              "description": "List of aliases",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pkg": {
+                    "description": "Package path e.g. knative.dev/serving/pkg/apis/autoscaling/v1alpha1",
+                    "type": "string"
+                  },
+                  "alias": {
+                    "description": "Package alias e.g. autoscalingv1alpha1",
+                    "type": "string"
+                  }
+                },
+                "required": ["pkg", "alias"]
+              }
+            }
+          }
+        },
+
+        "ireturn": {
+          "type": "object",
+          "description": "Use either `reject` or `allow` properties for interfaces matching.",
+          "properties": {
+            "allowed": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  { "type": "string" },
+                  { "enum": ["anon", "error", "empty", "stdlib"] }
+                ]
+              }
+            },
+            "reject": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  { "type": "string" },
+                  { "enum": ["anon", "error", "empty", "stdlib"] }
+                ]
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "not": {
+                "properties": {
+                  "allow": { "const": "reject" }
+                }
+              },
+              "required": ["allow"]
+            },
+            { "required": ["reject"] }
+          ]
+        },
+
         "lll": {
           "type": "object",
           "properties": {
-            "line-length": {
-              "description": "Maximum allowed line length, lines longer will be reported.",
-              "type": "integer",
-              "minimum": 1,
-              "default": 120
-            },
             "tab-width": {
               "description": "Width of \"\\t\" in spaces.",
               "type": "integer",
               "minimum": 0,
               "default": 1
+            },
+            "line-length": {
+              "description": "Maximum allowed line length, lines longer will be reported.",
+              "type": "integer",
+              "minimum": 1,
+              "default": 120
+            }
+          }
+        },
+
+        "maintidx": {
+          "description": "Maintainability index https://docs.microsoft.com/en-us/visualstudio/code-quality/code-metrics-maintainability-index-range-and-meaning?view=vs-2022",
+          "type": "object",
+          "properties": {
+            "under": {
+              "description": "Minimum accatpable maintainability index level (see https://docs.microsoft.com/en-us/visualstudio/code-quality/code-metrics-maintainability-index-range-and-meaning?view=vs-2022)",
+              "type": "number",
+              "default": 20
+            }
+          }
+        },
+
+        "makezero": {
+          "type": "object",
+          "properties": {
+            "suggest-new": {
+              "description": "Allow only slices initialized with a length of zero.",
+              "type": "boolean",
+              "default": false
             }
           }
         },
@@ -1216,6 +1434,32 @@
           }
         },
 
+        "nilnil": {
+          "type": "object",
+          "properties": {
+            "checked-types": {
+              "type": "array",
+              "descriptions": "Return types to check.",
+              "items": {
+                "enum": ["ptr", "func", "iface", "map", "chan"]
+              },
+              "default": ["ptr", "func", "iface", "map", "chan"]
+            }
+          }
+        },
+
+        "nlreturn": {
+          "type": "object",
+          "properties": {
+            "block-size": {
+              "description": "set block size that is still ok",
+              "type": "number",
+              "default": 0,
+              "minimum": 0
+            }
+          }
+        },
+
         "nolintlint": {
           "type": "object",
           "properties": {
@@ -1233,7 +1477,7 @@
               "description": "Exclude these linters from requiring an explanation.",
               "type": "array",
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/linters"
               },
               "default": []
             },
@@ -1251,7 +1495,7 @@
         },
 
         "prealloc": {
-          "description": "We do not recommend using this linter before doing performance profiling.\nFor most programs usage of prealloc will be a premature optimization.",
+          "description": "We do not recommend using this linter before doing performance profiling.\nFor most programs usage of `prealloc` will be premature optimization.",
           "type": "object",
           "properties": {
             "simple": {
@@ -1268,6 +1512,43 @@
               "description": "Report preallocation suggestions on for loops.",
               "type": "boolean",
               "default": false
+            }
+          }
+        },
+
+        "predeclared": {
+          "type": "object",
+          "properties": {
+            "ignored": {
+              "description": "Comma-separated list of predeclared identifiers to not report on.",
+              "type": "string"
+            },
+            "q": {
+              "description": "Include method names and field names (i.e., qualified names) in checks.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+
+        "promlinter": {
+          "type": "object",
+          "properties": {
+            "strict": {},
+            "disabled-linters": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Help",
+                  "MetricUnits",
+                  "Counter",
+                  "HistogramSummaryReserved",
+                  "MetricTypeInName",
+                  "ReservedChars",
+                  "CamelCase",
+                  "UnitAbbreviations"
+                ]
+              }
             }
           }
         },
@@ -1335,9 +1616,235 @@
             "packages": {
               "type": "array",
               "items": {
+                "description": "",
                 "type": "string",
                 "examples": ["github.com/jmoiron/sqlx"]
               }
+            }
+          }
+        },
+
+        "staticcheck": {
+          "type": "object",
+          "properties": {
+            "go": {
+              "description": "Targeted Go version",
+              "type": "string",
+              "default": "1.13"
+            },
+            "checks": {
+              "type": "array",
+              "items": {
+                "anyOf": [{ "enum": ["all"] }, { "type": "string" }]
+              },
+
+              "default": [
+                "all",
+                "-ST1000",
+                "-ST1003",
+                "-ST1016",
+                "-ST1020",
+                "-ST1021",
+                "-ST1022"
+              ]
+            }
+          }
+        },
+
+        "stylecheck": {
+          "type": "object",
+          "properties": {
+            "go": {
+              "description": "Targeted Go version",
+              "type": "string",
+              "default": "1.13"
+            },
+            "checks": {
+              "type": "array",
+              "items": {
+                "anyOf": [{ "enum": ["all"] }, { "type": "string" }]
+              },
+
+              "default": [
+                "all",
+                "-ST1000",
+                "-ST1003",
+                "-ST1016",
+                "-ST1020",
+                "-ST1021",
+                "-ST1022"
+              ]
+            },
+            "dot-import-whitelist": {
+              "description": "By default, ST1001 forbids all uses of dot imports in non-test packages. This setting allows setting a whitelist of import paths that can be dot-imported anywhere.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "http-status-code-whitelist": {
+              "description": "ST1013 recommends using constants from the net/http package instead of hard-coding numeric HTTP status codes. This setting specifies a list of numeric status codes that this check does not complain about.",
+              "default": ["200", "400", "404", "500"],
+              "type": "array",
+              "items": {
+                "enum": [
+                  "100",
+                  "101",
+                  "102",
+                  "103",
+                  "200",
+                  "201",
+                  "202",
+                  "203",
+                  "204",
+                  "205",
+                  "206",
+                  "207",
+                  "208",
+                  "226",
+                  "300",
+                  "301",
+                  "302",
+                  "303",
+                  "304",
+                  "305",
+                  "306",
+                  "307",
+                  "308",
+                  "400",
+                  "401",
+                  "402",
+                  "403",
+                  "404",
+                  "405",
+                  "406",
+                  "407",
+                  "408",
+                  "409",
+                  "410",
+                  "411",
+                  "412",
+                  "413",
+                  "414",
+                  "415",
+                  "416",
+                  "417",
+                  "418",
+                  "421",
+                  "422",
+                  "423",
+                  "424",
+                  "425",
+                  "426",
+                  "428",
+                  "429",
+                  "431",
+                  "451",
+                  "500",
+                  "501",
+                  "502",
+                  "503",
+                  "504",
+                  "505",
+                  "506",
+                  "507",
+                  "508",
+                  "510",
+                  "511"
+                ]
+              }
+            },
+            "initialisms": {
+              "description": "ST1003 check, among other things, for the correct capitalization of initialisms. The set of known initialisms can be configured with this option.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "default": [
+                  "ACL",
+                  "API",
+                  "ASCII",
+                  "CPU",
+                  "CSS",
+                  "DNS",
+                  "EOF",
+                  "GUID",
+                  "HTML",
+                  "HTTP",
+                  "HTTPS",
+                  "ID",
+                  "IP",
+                  "JSON",
+                  "QPS",
+                  "RAM",
+                  "RPC",
+                  "SLA",
+                  "SMTP",
+                  "SQL",
+                  "SSH",
+                  "TCP",
+                  "TLS",
+                  "TTL",
+                  "UDP",
+                  "UI",
+                  "GID",
+                  "UID",
+                  "UUID",
+                  "URI",
+                  "URL",
+                  "UTF8",
+                  "VM",
+                  "XML",
+                  "XMPP",
+                  "XSRF",
+                  "XSS"
+                ]
+              }
+            }
+          }
+        },
+
+        "tagliatelle": {
+          "type": "object",
+          "properties": {
+            "case": {
+              "type": "object",
+              "properties": {
+                "use-field-name": {
+                  "description": "Use the struct field name to check the name of the struct tag.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "rules": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^.*$": {
+                      "enum": [
+                        "camel",
+                        "pascal",
+                        "kebab",
+                        "snake",
+                        "goCamel",
+                        "goPascal",
+                        "goKebab",
+                        "goSnake",
+                        "upper",
+                        "lower"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+
+        "tenv": {
+          "type": "object",
+          "properties": {
+            "all": {
+              "description": "The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.",
+              "type": "boolean",
+              "default": false
             }
           }
         },
@@ -1353,6 +1860,63 @@
           }
         },
 
+        "thelper": {
+          "type": "object",
+          "properties": {
+            "test": {
+              "begin": {
+                "description": "Check if `t.Helper()` begins helper function.",
+                "default": false,
+                "type": "boolean"
+              },
+              "first": {
+                "description": "Check if *testing.T is first param of helper function.",
+                "default": false,
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Check if *testing.T param has t name.",
+                "default": false,
+                "type": "boolean"
+              }
+            },
+            "bechmark": {
+              "begin": {
+                "description": "Check if `b.Helper()` begins helper function.",
+                "default": false,
+                "type": "boolean"
+              },
+              "first": {
+                "description": "Check if *testing.B is first param of helper function.",
+                "default": false,
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Check if *testing.B param has b name.",
+                "default": false,
+                "type": "boolean"
+              }
+            },
+            "tb": {
+              "begin": {
+                "description": "Check if `tb.Helper()` begins helper function.",
+                "default": false,
+                "type": "boolean"
+              },
+              "first": {
+                "description": "Check if *testing.TB is first param of helper function.",
+                "default": false,
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Check if *testing.TB param has tb name.",
+                "default": false,
+                "type": "boolean"
+              }
+            }
+          }
+        },
+
         "unparam": {
           "type": "object",
           "properties": {
@@ -1364,13 +1928,74 @@
           }
         },
 
-        "unused": {
+        "varcheck": {
           "type": "object",
           "properties": {
-            "check-exported": {
-              "description": "Treat code as a program (not a library) and report unused exported identifiers.\n\nWARNING: if you enable this setting, unused will report a lot of false-positives in text editors:\nif it's called for subdir of a project it can't find funcs usages. All text editor integrations\nwith golangci-lint call it on a directory with the changed file.",
+            "exported-fields": {
+              "description": "Check usage of exported variables",
               "type": "boolean",
               "default": false
+            }
+          }
+        },
+
+        "varnamelen": {
+          "type": "object",
+          "properties": {
+            "max-distance": {
+              "description": "Variables used in at most this N-many lines will be ignored.",
+              "type": "integer",
+              "default": 5,
+              "minimun": 1
+            },
+            "min-name-length": {
+              "description": "The minimum length of a variable's name that is considered `long`.",
+              "type": "integer",
+              "default": 3,
+              "minimun": 1
+            },
+            "check-receiver": {
+              "description": "Check method receiver names.",
+              "default": false,
+              "type": "boolean"
+            },
+            "check-return": {
+              "description": "Check named return values.",
+              "default": false,
+              "type": "boolean"
+            },
+            "ignore-type-assert-ok": {
+              "description": "Ignore `ok` variables that hold the bool return value of a type assertion",
+              "default": false,
+              "type": "boolean"
+            },
+            "ignore-map-index-ok": {
+              "description": "Ignore `ok` variables that hold the bool return value of a map index.",
+              "default": false,
+              "type": "boolean"
+            },
+            "ignore-chan-recv-ok": {
+              "description": "Ignore `ok` variables that hold the bool return value of a channel receive.",
+              "default": false,
+              "type": "boolean"
+            },
+            "ignore-names": {
+              "description": "Optional list of variable names that should be ignored completely.",
+              "default": [[]],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignore-decls": {
+              "description": "Optional list of variable declarations that should be ignored completely.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "example": [
+                ["c echo.Context", "t testing.T", "f *foo.Bar", "const C"]
+              ]
             }
           }
         },
@@ -1391,26 +2016,70 @@
           }
         },
 
+        "wrapcheck": {
+          "type": "object",
+          "properties": {
+            "ignoreSigs": {
+              "description": "An array of strings which specify substrings of signatures to ignore.",
+              "default": [
+                ".Errorf(",
+                "errors.New(",
+                "errors.Unwrap(",
+                ".Wrap(",
+                ".Wrapf(",
+                ".WithMessage(",
+                ".WithMessagef(",
+                ".WithStack("
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignoreSigRegexps": {
+              "description": "An array of strings which specify regular expressions of signatures to ignore.",
+              "default": [""],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignorePackageGlobs": {
+              "description": "An array of glob patterns which, if any match the package of the function returning the error, will skip wrapcheck analysis for this error.",
+              "default": [""],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+
         "wsl": {
           "type": "object",
           "properties": {
-            "strict-append": {
-              "description": " If true, append is only allowed to be cuddled if appending value is matching variables, fields or types on line above.",
+            "allow-assign-and-anything": {
+              "description": "Controls if you may cuddle assignments and anything without needing an empty line between them.",
               "type": "boolean",
-              "default": true
+              "default": false
             },
             "allow-assign-and-call": {
               "description": "Allow calls and assignments to be cuddled as long as the lines have any matching variables, fields or types.",
               "type": "boolean",
               "default": true
             },
+            "allow-cuddle-declarations": {
+              "description": "Allow declarations (var) to be cuddled.",
+              "type": "boolean",
+              "default": false
+            },
             "allow-multiline-assign": {
               "description": "Allow multiline assignments to be cuddled.",
               "type": "boolean",
               "default": true
             },
-            "allow-cuddle-declarations": {
-              "description": "Allow declarations (var) to be cuddled.",
+            "allow-separated-leading-comment": {
+              "description": "Allow leading comments to be separated with empty lines.",
               "type": "boolean",
               "default": false
             },
@@ -1430,10 +2099,10 @@
               "type": "boolean",
               "default": false
             },
-            "allow-separated-leading-comment": {
-              "description": "Allow leading comments to be separated with empty lines.",
+            "strict-append": {
+              "description": "If true, append is only allowed to be cuddled if appending value is matching variables, fields or types on line above.",
               "type": "boolean",
-              "default": false
+              "default": true
             }
           }
         },


### PR DESCRIPTION
+ added settings for the rest of existing linters.
+ correct default values for most of them added.