### PR TITLE
Add support for the WebShareTarget extension to the WebAppManifest.

### DIFF
--- a/src/negative_test/web-manifest-share-target/file_share_invalid_accept.json
+++ b/src/negative_test/web-manifest-share-target/file_share_invalid_accept.json
@@ -1,0 +1,17 @@
+{
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "share example",
+      "files": {
+        "name": "file1",
+        "accept": [
+          "no_slash",
+          "text/plain"
+        ]
+      }
+    }
+  }
+}

--- a/src/negative_test/web-manifest-share-target/file_share_target_has_no_name.json
+++ b/src/negative_test/web-manifest-share-target/file_share_target_has_no_name.json
@@ -1,0 +1,15 @@
+{
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "share example",
+      "files": {
+        "accept": [
+          "text/plain"
+        ]
+      }
+    }
+  }
+}

--- a/src/negative_test/web-manifest-share-target/share_target_has_no_action.json
+++ b/src/negative_test/web-manifest-share-target/share_target_has_no_action.json
@@ -1,0 +1,9 @@
+{
+  "share_target": {
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "share example"
+    }
+  }
+}

--- a/src/negative_test/web-manifest-share-target/text_share_invalid_method.json
+++ b/src/negative_test/web-manifest-share-target/text_share_invalid_method.json
@@ -1,0 +1,10 @@
+{
+  "share_target": {
+    "action": "/share-target",
+    "method": "FETCH",
+    "params": {
+      "title": "share example",
+      "text": "this is a share"
+    }
+  }
+}

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -66,6 +66,7 @@
     "kubernetes-definitions.json",
     "web-manifest.json",
     "web-manifest-app-info.json",
+    "web-manifest-share-target.json",
     "lsdlschema-0.7.json",
     "lsdlschema-1.0.json",
     "lsdlschema-1.2.json",
@@ -113,7 +114,8 @@
   "ajvFullStrictMode": [
     "github-issue-forms.json",
     "importmap.json",
-    "schema-catalog.json"
+    "schema-catalog.json",
+    "web-manifest-share-target.json"
   ],
   "options": [
     {
@@ -539,7 +541,8 @@
       "web-manifest-combined.json": {
         "externalSchema": [
           "web-manifest.json",
-          "web-manifest-app-info.json"
+          "web-manifest-app-info.json",
+          "web-manifest-share-target.json"
         ]
       }
     },

--- a/src/schemas/json/web-manifest-combined.json
+++ b/src/schemas/json/web-manifest-combined.json
@@ -5,5 +5,7 @@
     "$ref": "https://json.schemastore.org/web-manifest.json"
   }, {
     "$ref": "https://json.schemastore.org/web-manifest-app-info.json"
+  }, {
+    "$ref": "https://json.schemastore.org/web-manifest-share-target.json"
   }]
 }

--- a/src/schemas/json/web-manifest-share-target.json
+++ b/src/schemas/json/web-manifest-share-target.json
@@ -1,0 +1,112 @@
+{
+  "title": "JSON schema for Web Application manifest files with Web Share Target and Web Share Target Level 2 extensions",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/web-manifest-share-target.json",
+
+  "type": "object",
+
+  "properties": {
+    "share_target": {
+      "description": "Declares the application to be a web share target, and describes how it receives share data.",
+      "$ref": "#/definitions/share_target"
+    }
+  },
+  "definitions": {
+    "share_target": {
+      "type": "object",
+      "description": "Describes how the application receives share data.",
+      "properties": {
+        "action": {
+          "description": "The URL for the web share target.",
+          "type": "string"
+        },
+        "method": {
+          "description": "The HTTP request method for the web share target.",
+          "type": "string",
+          "enum": [
+            "GET",
+            "POST",
+            "get",
+            "post"
+          ],
+          "default": "GET"
+        },
+        "enctype": {
+          "description": "This member specifies the encoding in the share request.",
+          "type": "string",
+          "enum": [
+            "application/x-www-form-urlencoded",
+            "multipart/form-data",
+            "APPLICATION/X-WWW-FORM-URLENCODED",
+            "MULTIPART/FORM-DATA"
+          ],
+          "default": "application/x-www-form-urlencoded"
+        },
+        "params": {
+          "description": "Specifies what data gets shared in the request.",
+          "$ref": "#/definitions/share_target_params"
+        }
+      },
+      "required": ["action", "params"]
+    },
+    "share_target_params": {
+      "type": "object",
+      "description": "Specifies what data gets shared in the request.",
+      "properties": {
+        "title": {
+          "description": "The name of the query parameter used for the title of the document being shared.",
+          "type": "string"
+        },
+        "text": {
+          "description": "The name of the query parameter used for the message body, made of arbitrary text.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The name of the query parameter used for the URL string referring to a resource being shared.",
+          "type": "string"
+        },
+        "files": {
+          "description": "Description of how the application receives files from share requests.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/share_target_files"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/share_target_files"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "share_target_files": {
+      "type": "object",
+      "description": "Description of how the application receives files from share requests.",
+      "properties": {
+        "name": {
+          "description": "The name of the form field used to share the files.",
+          "type": "string"
+        },
+        "accept": {
+          "description": "Sequence of accepted MIME types or file extensions can be shared to the application.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^((\\..*)|(.*/.*))$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^((\\..*)|(.*/.*))$"
+              }
+            }
+          ]
+        }
+      },
+      "required": ["name", "accept"]
+    }
+  }
+}

--- a/src/test/web-manifest-share-target/file_share_accept_extension.json
+++ b/src/test/web-manifest-share-target/file_share_accept_extension.json
@@ -1,0 +1,14 @@
+{
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "share example",
+      "files": {
+        "name": "file1",
+        "accept": ".exe"
+      }
+    }
+  }
+}

--- a/src/test/web-manifest-share-target/file_share_multiple_file_multiple_accept.json
+++ b/src/test/web-manifest-share-target/file_share_multiple_file_multiple_accept.json
@@ -1,0 +1,26 @@
+{
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "share example",
+      "files": [
+        {
+          "name": "file1",
+          "accept": [
+            "image/*",
+            "text/plain"
+          ]
+        },
+        {
+          "name": "file2",
+          "accept": [
+            "application/json",
+            "video/mp4"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/web-manifest-share-target/file_share_single_file_single_accept.json
+++ b/src/test/web-manifest-share-target/file_share_single_file_single_accept.json
@@ -1,0 +1,14 @@
+{
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "share example",
+      "files": {
+        "name": "file1",
+        "accept": "*/*"
+      }
+    }
+  }
+}

--- a/src/test/web-manifest-share-target/text_share_correct_method_and_enctype.json
+++ b/src/test/web-manifest-share-target/text_share_correct_method_and_enctype.json
@@ -1,0 +1,11 @@
+{
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "share example",
+      "text": "this is a share"
+    }
+  }
+}

--- a/src/test/web-manifest-share-target/text_share_no_method_or_enctype.json
+++ b/src/test/web-manifest-share-target/text_share_no_method_or_enctype.json
@@ -1,0 +1,10 @@
+{
+  "share_target": {
+    "action": "/share-target",
+    "params": {
+      "title": "share example",
+      "text": "this is a share",
+      "url": "https://example.com"
+    }
+  }
+}


### PR DESCRIPTION
Supporting documentation:
* https://w3c.github.io/web-share-target/
* https://w3c.github.io/web-share-target/level-2/
* https://web.dev/web-share-target/
* https://github.com/w3c/web-share-target/blob/main/docs/explainer.md
* https://chromestatus.com/feature/5662315307335680
* https://chromestatus.com/feature/6124071381106688

Shortcomings of the current schema:
* does not enforce the following spec constraints:
  * `{"method": "GET"}` should only be allowed with
    `{"enctype": "application/x-www-form-urlencoded"}`
  * the `files` member should only be allowed with
    `{"method": "POST"}` and `{"enctype": "multipart/form-data"}`
  * `accept` should be more strict and only accept
    [RFC7230 tokens](https://httpwg.org/specs/rfc7230.html#rfc.section.3.2.6)
    instead of `.*` in MIME types.
* does not allow arbitrary mixtures of upper- and lower-case `method`
  and `enctype` strings

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
