### PR TITLE
Add vercel.json schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -677,6 +677,14 @@
       "url": "https://json.schemastore.org/codeship-steps.json"
     },
     {
+      "name": "Vercel",
+      "description": "Vercel configuration file",
+      "fileMatch": [
+        "vercel.json"
+      ],
+      "url": "https://openapi.vercel.sh/vercel.json"
+    },
+    {
       "name": "VSCode Code Snippets",
       "description": "Schema for code snippet files in visual studio code extensions",
       "fileMatch": [


### PR DESCRIPTION
using the public schema at https://openapi.vercel.sh/vercel.json

This fixes #1942
