### PR TITLE
[Github Workflow] allowing uses to reference also local shared actions

### DIFF
--- a/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-filetype.json
+++ b/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-filetype.json
@@ -1,0 +1,18 @@
+{
+  "name": "publish on release",
+  "on": {
+    "release": {
+      "types": [
+        "published"
+      ]
+    }
+  },
+  "jobs": {
+    "build-and-publish": {
+      "uses": "./.github/workflows/somefile.exe",
+      "secrets": {
+        "api_token": "${{ secrets.API_TOKEN }}"
+      }
+    }
+  }
+}

--- a/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-pattern.json
+++ b/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-pattern.json
@@ -1,0 +1,18 @@
+{
+  "name": "publish on release",
+  "on": {
+    "release": {
+      "types": [
+        "published"
+      ]
+    }
+  },
+  "jobs": {
+    "build-and-publish": {
+      "uses": "some-other@String.com",
+      "secrets": {
+        "api_token": "${{ secrets.API_TOKEN }}"
+      }
+    }
+  }
+}

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -475,9 +475,9 @@
         },
         "uses": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses",
-          "description": "The location and version of a reusable workflow file to run as a job, of the form '{path/{to}/{localfile}.yml' or '{owner}/{repo}/{path}/{filename}.yml@{ref}'. {ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
+          "description": "The location and version of a reusable workflow file to run as a job, of the form '{path/{to}/{localfile}.yml' or '{owner}/{repo}/{path}/{filename}@{ref}'. {ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
           "type": "string",
-          "pattern": "^(.+\/)+(.+).yml(@.+)?$"
+          "pattern": "^(.+\/)+(.+).[yml|yaml](@.+)?$"
         },
         "with": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idwith",

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -475,9 +475,9 @@
         },
         "uses": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses",
-          "description": "The location and version of a reusable workflow file to run as a job, of the form '{owner}/{repo}/{path}/{filename}@{ref}'. {ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
+          "description": "The location and version of a reusable workflow file to run as a job, of the form '{path/{to}/{localfile}.yml' or '{owner}/{repo}/{path}/{filename}.yml@{ref}'. {ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
           "type": "string",
-          "pattern": "^[^/]+/[^/]+/[^@]+@.+$"
+          "pattern": "^(.+\/)+(.+).yml(@.+)?$"
         },
         "with": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idwith",

--- a/src/test/github-workflow/call-reusable-workflow-local-file.json
+++ b/src/test/github-workflow/call-reusable-workflow-local-file.json
@@ -1,0 +1,18 @@
+{
+  "name": "publish on release",
+  "on": {
+    "release": {
+      "types": [
+        "published"
+      ]
+    }
+  },
+  "jobs": {
+    "build-and-publish": {
+      "uses": "./.github/workflows/somefile.yml",
+      "secrets": {
+        "api_token": "${{ secrets.API_TOKEN }}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
we use the Github Action workflow linter on one of our step fails because the schema does not allow us to use this syntax

```yml
 Code-Checks:
    needs: Build-Configuration
    uses: ./.github/workflows/reusable.code-checks.yml
```

but only
```yml
 Code-Checks:
    needs: Build-Configuration
    uses: owner/repo/.github/workflows/reusable.code-checks.yml@master
```

so if you do changes to a local shared action you will need to merge it before actually using it.

added tests to cover cases