### PR TITLE
Allow local path in reusable github-workflow call

### DIFF
--- a/src/negative_test/github-workflow/call-reusable-workflow-invalid-path.json
+++ b/src/negative_test/github-workflow/call-reusable-workflow-invalid-path.json
@@ -1,0 +1,9 @@
+{
+  "name": "should-fail-due-to-invalid-path",
+  "on": ["push"],
+  "jobs": {
+    "lint": {
+      "uses": "/_lint.yml"
+    }
+  }
+}

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -477,7 +477,7 @@
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses",
           "description": "The location and version of a reusable workflow file to run as a job, of the form '{owner}/{repo}/{path}/{filename}@{ref}'. {ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
           "type": "string",
-          "pattern": "^[^/]+/[^/]+/[^@]+@.+$"
+          "pattern": "^([^/]+/[^/]+/[^@]+@.+)|(\\./.+)$"
         },
         "with": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idwith",

--- a/src/test/github-workflow/call-reusable-workflow.json
+++ b/src/test/github-workflow/call-reusable-workflow.json
@@ -8,6 +8,9 @@
     }
   },
   "jobs": {
+    "lint": {
+      "uses": "./.github/workflows/_lint.yml"
+    },
     "build-and-publish": {
       "uses": "exampleowner/example/.github/workflows/build_and_publish.yaml@v1",
       "secrets": {


### PR DESCRIPTION
In a github workflow job which calls a reusable workflow, the "uses" value used to require a path to a repo "@" a version (a ref).
GitHub has added support for local paths beginning with "./", so update the pattern used to validate this value appropriately.

Update the positive test case for calling reusable workflows to include this usage, and add negative test with an invalid path.

---

References:
- GitHub documentation for this key, value: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iduses
- Originating issue in a downstream project: https://github.com/sirosen/check-jsonschema/issues/30