### PR TITLE
Add schema for Statamic Blueprint files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2845,6 +2845,14 @@
         ".github/stale.yml"
       ],
       "url": "https://json.schemastore.org/stale.json"
+    },{
+      "name": "Statamic Blueprint",
+      "description": "A Statamic Blueprint Schema",
+      "fileMatch": [
+        "resources/blueprints/**/*.yml",
+        "resources/blueprints/**/*.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/Konafets/statamic-blueprint-validation/main/statamic.blueprint.schema.json"
     },
     {
       "name": "Stryker Mutator",

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -498,6 +498,14 @@
       }
     },
     {
+      "statamic-3.0-blueprint.json": {
+        "unknownKeywords": [
+          "uniqueItemProperties",
+          "dependentRequired"
+        ]
+      }
+    },
+    {
       "staticwebapp.config.json": {
         "unknownKeywords": [
           "examples"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
