### PR TITLE
k3d: reference versions schema in k3d repo

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1770,11 +1770,7 @@
         "*.k3d.yaml",
         "*.k3d.yml"
       ],
-      "url": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/v1alpha2/schema.json",
-      "versions": {
-        "v1alpha2": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/v1alpha2/schema.json",
-        "v1alpha3": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/v1alpha3/schema.json"
-      }
+      "url": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/config.versions.schema.json"
     },
     {
       "name": "Ory Keto configuration",


### PR DESCRIPTION
I'm a bit confused when it comes to handling `url` and `versions` entries.
Is `url` just pointing to the default? How are `versions` handled?
If `url` is the default, would you recommend to have a copy of the most recent schema file in an unversioned path, so it doesn't change?