### PR TITLE
Update schema URLs (error-pages)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1142,13 +1142,13 @@
     {
       "name": "Error pages",
       "description": "Error-Pages configuration file",
-      "url": "https://raw.githubusercontent.com/tarampampam/error-pages/master/schemas/config/1.0.schema.json",
+      "url": "https://cdn.jsdelivr.net/gh/tarampampam/error-pages@latest/schemas/config/1.0.schema.json",
       "fileMatch": [
         "error-pages*.yml",
         "error-pages*.yaml"
       ],
       "versions": {
-        "1.0": "https://raw.githubusercontent.com/tarampampam/error-pages/master/schemas/config/1.0.schema.json"
+        "1.0": "https://cdn.jsdelivr.net/gh/tarampampam/error-pages@latest/schemas/config/1.0.schema.json"
       }
     },
     {


### PR DESCRIPTION
New links follow to the latest release (not git repository branch state), which is better.