### PR TITLE
Undo most of pr ##1297 (Fetch github tags as versions for urls)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -306,7 +306,7 @@
         "azure-pipelines.yml",
         "azure-pipelines.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/v1.174.2/service-schema.json"
+      "url": "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json"
     },
     {
       "name": "Foxx Manifest",
@@ -583,7 +583,7 @@
     {
       "name": "CityJSON",
       "description": "Schema for the representation of 3D city models",
-      "url": "https://raw.githubusercontent.com/cityjson/specs/1.0.1/schemas/cityjson.min.schema.json"
+      "url": "https://raw.githubusercontent.com/cityjson/specs/master/schemas/cityjson.min.schema.json"
     },
     {
       "name": "Helm Chart.yaml",
@@ -1008,7 +1008,7 @@
       "fileMatch": [
         "bounded-context.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/Runtime/v5.1.1/Schemas/Applications.Configuration/bounded-context.json"
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Applications.Configuration/bounded-context.json"
     },
     {
       "name": "Dolittle Event Horizons Configuration",
@@ -1016,7 +1016,7 @@
       "fileMatch": [
         ".dolittle/event-horizons.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/Runtime/v5.1.1/Schemas/Events/event-horizons.json"
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Events/event-horizons.json"
     },
     {
       "name": "Dolittle Resources Configuration",
@@ -1032,7 +1032,7 @@
       "fileMatch": [
         ".dolittle/server.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/Runtime/v5.1.1/Schemas/Server/server.json"
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Server/server.json"
     },
     {
       "name": "Dolittle Tenants Configuration",
@@ -1040,7 +1040,7 @@
       "fileMatch": [
         ".dolittle/tenants.json"
       ],
-      "url": "https://raw.githubusercontent.com/dolittle/Runtime/v5.1.1/Schemas/Tenancy/tenants.json"
+      "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Tenancy/tenants.json"
     },
     {
       "name": "Dolittle Tenant Map Configuration",
@@ -1098,7 +1098,7 @@
     {
       "name": "Eclipse Che Devfile",
       "description": "JSON schema for Eclipse Che Devfiles",
-      "url": "https://raw.githubusercontent.com/eclipse/che/7.19.2/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
+      "url": "https://raw.githubusercontent.com/eclipse-che/che-server/master/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
       "fileMatch": [
         "devfile.yaml",
         ".devfile.yaml"
@@ -2759,7 +2759,7 @@
         "skyuxconfig.json",
         "skyuxconfig.*.json"
       ],
-      "url": "https://raw.githubusercontent.com/blackbaud/skyux-config/4.0.4/skyuxconfig-schema.json"
+      "url": "https://raw.githubusercontent.com/blackbaud/skyux-config/master/skyuxconfig-schema.json"
     },
     {
       "name": "snapcraft",
@@ -2880,7 +2880,7 @@
         "stryker.conf.json",
         "stryker-*.conf.json"
       ],
-      "url": "https://raw.githubusercontent.com/stryker-mutator/stryker/v4.0.0/packages/api/schema/stryker-core.json"
+      "url": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/api/schema/stryker-core.json"
     },
     {
       "name": "StyleCop Analyzers Configuration",
@@ -2888,7 +2888,7 @@
       "fileMatch": [
         "stylecop.json"
       ],
-      "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/1.1.118/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
+      "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
     },
     {
       "name": ".stylelintrc",
@@ -3133,7 +3133,7 @@
       "fileMatch": [
         "version.json"
       ],
-      "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/v3.3.37/src/NerdBank.GitVersioning/version.schema.json"
+      "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
       "name": "vim-addon-info",
@@ -3261,7 +3261,7 @@
       "fileMatch": [
         "*.version"
       ],
-      "url": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/1.4.1.5/KSP-AVC.schema.json"
+      "url": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/master/KSP-AVC.schema.json"
     },
     {
       "name": "KSP-CKAN",
@@ -3269,7 +3269,7 @@
       "fileMatch": [
         "*.ckan"
       ],
-      "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/v1.28.0/CKAN.schema"
+      "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/CKAN.schema"
     },
     {
       "name": "JSON Schema Draft 4",
@@ -3458,7 +3458,7 @@
       "fileMatch": [
         ".taskcat.yml"
       ],
-      "url": "https://raw.githubusercontent.com/aws-quickstart/taskcat/0.9.20/taskcat/cfg/config_schema.json"
+      "url": "https://raw.githubusercontent.com/aws-quickstart/taskcat/master/taskcat/cfg/config_schema.json"
     },
     {
       "name": "BizTalkServerApplicationSchema",
@@ -3488,7 +3488,7 @@
         ".neoload.yml",
         ".neoload.json"
       ],
-      "url": "https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/1.1.4/resources/as-code.latest.schema.json"
+      "url": "https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/master/resources/as-code.latest.schema.json"
     },
     {
       "name": "release drafter",
@@ -3505,7 +3505,7 @@
         "*zuul.d/*.yaml",
         "*/.zuul.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/pycontribs/zuul-lint/0.1.1/zuul_lint/zuul-schema.json"
+      "url": "https://raw.githubusercontent.com/pycontribs/zuul-lint/master/zuul_lint/zuul-schema.json"
     },
     {
       "name": "Briefcase",
@@ -3521,7 +3521,7 @@
       "fileMatch": [
         "*.har"
       ],
-      "url": "https://raw.githubusercontent.com/ahmadnassri/har-schema/v2.0.0/lib/har.json"
+      "url": "https://raw.githubusercontent.com/ahmadnassri/har-schema/master/lib/har.json"
     },
     {
       "name": "jsdoc",
@@ -3639,7 +3639,7 @@
         "**/yippee-*.yml",
         "**/*.yippee.yml"
       ],
-      "url": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/v1.3.2/schema/yippee-ki-json_config_schema.json",
+      "url": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json",
       "versions": {
         "1.1.2": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/v1.1.2/schema/yippee-ki-json_config_schema.json",
         "latest": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json"


### PR DESCRIPTION
Reason: [comment](https://github.com/SchemaStore/schemastore/pull/2043#issuecomment-1022701544).

Some URL are already change back by other users.

But some URLs I have not restored to the original because they are no longer present.
Those are:
https://github.com/SchemaStore/schemastore/blob/0498066e30778f6e126aa5da4e360ccce207428f/src/api/json/catalog.json#L214
https://github.com/SchemaStore/schemastore/blob/0498066e30778f6e126aa5da4e360ccce207428f/src/api/json/catalog.json#L1003

------------

Angular have change/rename (schema.json -> workspace-schema.json) it schema via this [PR](https://github.com/angular/angular-cli/commit/4b0223b64ee091e4bd65b97e7867bb83afefa950#diff-eb96cc0e905d47076416b932e139a8f25be6dc92c94243e8b9fb0ac938986b70)
https://github.com/SchemaStore/schemastore/blob/0498066e30778f6e126aa5da4e360ccce207428f/src/api/json/catalog.json#L80
But this new 'rename' schema reappears via another json API
https://github.com/SchemaStore/schemastore/blob/0498066e30778f6e126aa5da4e360ccce207428f/src/api/json/catalog.json#L71
I leave Angular as it is. Don't know what to do with it.

