### PR TITLE
Json api: limit to bare minimum the "name" character set

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3201,8 +3201,8 @@
       "url": "https://json.schemastore.org/vss-extension.json"
     },
     {
-      "name": "<div>RIOTS' studio configuration",
-      "description": "JSON schema for the <div>RIOTS' studio configuration",
+      "name": "RIOTS studio configuration",
+      "description": "JSON schema for the RIOTS studio configuration",
       "fileMatch": [
         "studio.config.json"
       ],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2525,16 +2525,16 @@
       "url": "https://raw.githubusercontent.com/readthedocs/readthedocs.org/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.json"
     },
     {
-      "name": "Red-DiscordBot Сog",
-      "description": "Red-DiscordBot Сog metadata file",
+      "name": "Red-DiscordBot Cog",
+      "description": "Red-DiscordBot Cog metadata file",
       "fileMatch": [
         "info.json"
       ],
       "url": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog.schema.json"
     },
     {
-      "name": "Red-DiscordBot Сog Repo",
-      "description": "Red-DiscordBot Сog Repo metadata file",
+      "name": "Red-DiscordBot Cog Repo",
+      "description": "Red-DiscordBot Cog Repo metadata file",
       "fileMatch": [
         "info.json"
       ],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3570,7 +3570,7 @@
       "url": "https://json.schemastore.org/container-structure-test.json"
     },
     {
-      "name": "Žinoma",
+      "name": "Zinoma",
       "description": "Žinoma incremental build configuration",
       "fileMatch": [
         "zinoma.yml"

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -3,7 +3,7 @@
 (function (global) {
 
     global.get = function (url, asJson, callback) {
-        var xhr = new XMLHttpRequest();
+        let xhr = new XMLHttpRequest();
         xhr.open('GET', url, true);
         xhr.onload = function () {
             if (asJson)
@@ -15,25 +15,25 @@
         xhr.send();
     };
 
-    var ul = document.querySelector("#schemalist ul");
-    var p = document.getElementById("count");
-    var schemas = document.getElementById("schemas");
+    let ul = document.querySelector("#schemalist ul");
+    let p = document.getElementById("count");
+    let schemas = document.getElementById("schemas");
 
     if (!ul || !p)
         return;
 
     if (schemas !== null) {
-        var api = schemas.getAttribute("data-api");
+        let api = schemas.getAttribute("data-api");
 
         get(api, true, function (catalog) {
 
             p.innerHTML = p.innerHTML.replace("{0}", catalog.schemas.length);
 
-            for (var i = 0; i < catalog.schemas.length; i++) {
+            for (let i = 0; i < catalog.schemas.length; i++) {
 
-                var schema = catalog.schemas[i];
-                var li = document.createElement("li");
-                var a = document.createElement("a");
+                let schema = catalog.schemas[i];
+                let li = document.createElement("li");
+                let a = document.createElement("a");
                 a.href = schema.url;
                 a.title = schema.description;
                 a.innerText = schema.name;

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -46,7 +46,7 @@
         });
     }
 
-}(typeof window !== undefined ? window : this));
+}(typeof window !== 'undefined' ? window : this));
 
 
 (function (i, s, o, g, r, a, m) {

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -36,7 +36,7 @@
                 var a = document.createElement("a");
                 a.href = schema.url;
                 a.title = schema.description;
-                a.innerHTML = schema.name;
+                a.innerText = schema.name;
 
                 li.appendChild(a);
                 ul.appendChild(li);

--- a/src/schemas/json/schema-catalog.json
+++ b/src/schemas/json/schema-catalog.json
@@ -32,7 +32,8 @@
           },
           "name": {
             "description": "The name of the schema",
-            "type": "string"
+            "type": "string",
+            "pattern": "^[a-zA-Z\\d\\-_.()* ]*$"
           },
           "description": {
             "description": "A description of the schema",


### PR DESCRIPTION
close #2059

Change `innerHTML` to `innerText` as suggested in #2059

Json api: keep the "name" character set to the bare minimum.
You are not allowed to use Unicode, emoji, Chinese, Greek character set, etc.
You can still use anything in the "description" variable.