### PR TITLE
Change oneOf to anyOf in chart.json schema

### DIFF
--- a/src/schemas/json/chart.json
+++ b/src/schemas/json/chart.json
@@ -68,7 +68,7 @@
           },
           "repository": {
             "description": "The repository URL or alias",
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "string",
                 "format": "uri"


### PR DESCRIPTION
It’s ok if any of the two formats matches the schema. If the value happens to one value, there’s no need to make sure it doesn’t match the other.