### PR TITLE
github-workflows: Allow use of expression inside shell defaults

### DIFF
--- a/src/negative_test/github-workflow/defaults.json
+++ b/src/negative_test/github-workflow/defaults.json
@@ -1,0 +1,18 @@
+{
+  "on": {
+    "push": null
+    },
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "defaults": {
+        "run": { "shell": "invalid-value"}
+      },
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -411,9 +411,10 @@
       "type": "string",
       "anyOf": [
         {
-          "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell"
+          "$ref": "#/definitions/expressionSyntax"
         },
         {
+          "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell",
           "enum": [
             "bash",
             "pwsh",

--- a/src/test/github-workflow/defaults.json
+++ b/src/test/github-workflow/defaults.json
@@ -1,0 +1,33 @@
+{
+  "on": {
+    "push": null
+  },
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "defaults": {
+        "run": {
+          "shell": "bash"
+        }
+      },
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    },
+    "two": {
+      "runs-on": "ubuntu-latest",
+      "defaults": {
+        "run": {
+          "shell": "${{ matrix.shell || 'bash' }}"
+        }
+      },
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Allow use of expressions inside shell defaults. Also includes positive and negative tests for it. Please note that use of expressions inside `shell:` for `run:` steps is still not allowed, thus we do not alter these.

Using defaults with expressions does work well for changing default shell to be used for different matrix jobs.