### PR TITLE
Update tsconfig schema with new ts-node options from v10.5.0

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1016,6 +1016,9 @@
         }
       }
     },
+    "tsNodeModuleTypes": {
+      "type": "object"
+    },
     "tsNodeDefinition": {
       "properties": {
         "ts-node": {
@@ -1051,6 +1054,10 @@
               "description": "Allows the usage of top level await in REPL.\n\nUses node's implementation which accomplishes this with an AST syntax transformation.\n\nEnabled by default when tsconfig target is es2018 or above. Set to false to disable.\n\n**Note**: setting to `true` when tsconfig target is too low will throw an Error.  Leave as `undefined`\nto get default, automatic behavior.",
               "type": "boolean"
             },
+            "experimentalResolverFeatures": {
+              "description": "Enable experimental features that re-map imports and require calls to support:\n`baseUrl`, `paths`, `rootDirs`, `.js` to `.ts` file extension mappings,\n`outDir` to `rootDir` mappings for composite projects and monorepos.\n\nFor details, see https://github.com/TypeStrong/ts-node/issues/1514",
+              "type": "boolean"
+            },
             "files": {
               "default": false,
               "description": "Load \"files\" and \"include\" from `tsconfig.json` on startup.\n\nDefault is to override `tsconfig.json` \"files\" and \"include\" to only include the entrypoint script.",
@@ -1082,7 +1089,7 @@
               "type": "boolean"
             },
             "moduleTypes": {
-              "type": "object",
+              "$ref": "#/definitions/tsNodeModuleTypes",
               "description": "Override certain paths to be compiled and executed as CommonJS or ECMAScript modules.\nWhen overridden, the tsconfig \"module\" and package.json \"type\" fields are overridden.\nThis is useful because TypeScript files cannot use the .cjs nor .mjs file extensions;\nit achieves the same effect.\n\nEach key is a glob pattern following the same rules as tsconfig's \"include\" array.\nWhen multiple patterns match the same file, the last pattern takes precedence.\n\n`cjs` overrides matches files to compile and execute as CommonJS.\n`esm` overrides matches files to compile and execute as native ECMAScript modules.\n`package` overrides either of the above to default behavior, which obeys package.json \"type\" and\ntsconfig.json \"module\" options."
             },
             "preferTsExts": {
@@ -1116,6 +1123,10 @@
               "description": "Skip ignore check, so that compilation will be attempted for all files with matching extensions.",
               "type": "boolean"
             },
+            "swc": {
+              "description": "Transpile with swc instead of the TypeScript compiler, and skip typechecking.\n\nEquivalent to setting both `transpileOnly: true` and `transpiler: 'ts-node/transpilers/swc'`\n\nFor complete instructions: https://typestrong.org/ts-node/docs/transpilers",
+              "type": "boolean"
+            },
             "transpileOnly": {
               "default": false,
               "description": "Use TypeScript's faster `transpileModule`.",
@@ -1124,18 +1135,6 @@
             "transpiler": {
               "anyOf": [
                 {
-                  "additionalItems": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                      }
-                    ]
-                  },
                   "items": [
                     {
                       "type": "string"
@@ -1146,6 +1145,7 @@
                       "type": "object"
                     }
                   ],
+                  "maxItems": 2,
                   "minItems": 2,
                   "type": "array"
                 },


### PR DESCRIPTION
Similar to #1785, this updates the tsconfig.json schema with new options from ts-node v10.5.0.

https://github.com/TypeStrong/ts-node/releases/tag/v10.5.0

The schema is generated from our sources:

https://unpkg.com/browse/ts-node@10.5.0/tsconfig.schemastore-schema.json
