### PR TITLE
[github-workflow] Fix pattern and description for `jobs.<job_id>.uses`

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -476,9 +476,9 @@
         },
         "uses": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses",
-          "description": "The location and version of a reusable workflow file to run as a job, of the form '{path/{to}/{localfile}.yml' or '{owner}/{repo}/{path}/{filename}@{ref}'. {ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
+          "description": "The location and version of a reusable workflow file to run as a job, of the form './{path/to}/{localfile}.yml' or '{owner}/{repo}/{path}/{filename}@{ref}'. {ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
           "type": "string",
-          "pattern": "^(.+\/)+(.+).[yml|yaml](@.+)?$"
+          "pattern": "^(.+\/)+(.+)\\.(ya?ml)(@.+)?$"
         },
         "with": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idwith",


### PR DESCRIPTION
inline with https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iduses
