### PR TITLE
Fix the RoadRunner schema files location

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2615,14 +2615,14 @@
     {
       "name": "RoadRunner",
       "description": "Spiral Roadrunner config file schema",
-      "url": "https://raw.githubusercontent.com/spiral/roadrunner-binary/master/schemas/config/2.0.schema.json",
+      "url": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/2.0.schema.json",
       "fileMatch": [
         ".rr*.yml",
         ".rr*.yaml"
       ],
       "versions": {
-        "1.0": "https://raw.githubusercontent.com/spiral/roadrunner-binary/master/schemas/config/1.0.schema.json",
-        "2.0": "https://raw.githubusercontent.com/spiral/roadrunner-binary/master/schemas/config/2.0.schema.json"
+        "1.0": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/1.0.schema.json",
+        "2.0": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/2.0.schema.json"
       }
     },
     {


### PR DESCRIPTION
Old repo: https://github.com/spiral/roadrunner-binary (repository has been archived)
New repo: https://github.com/roadrunner-server/roadrunner