### PR TITLE
Qualisys PAF Module settings schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2747,6 +2747,15 @@
       "url": "https://json.schemastore.org/settings.job.json"
     },
     {
+      "name": "Settings.paf",
+      "description": "Qualisys Project Automation Framework settings file",
+      "fileMatch": [
+          "settings.paf",
+          "Settings.paf"
+      ],
+      "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/paf-module.schema.json"
+    },
+    {
       "name": "sfdx-hardis configuration",
       "description": "Configuration file for sfdx-hardis Salesforce DX plugin",
       "fileMatch": [


### PR DESCRIPTION
This adds a schema validating settings files for the [Qualisys Project Automation Framework](https://github.com/qualisys/paf-resources/blob/master/Documentation/Project%20Automation%20Framework%20Manual.md). 

I believe this is ready for review, although I have one question; I couldn't find information on whether or not the `fileMatch` patterns are case sensitive. When adding the schema manually in VS Code, it does appear to be case sensitive – so I've added the two common variants of the file names to be sure. Please let me know if you would like me to remove the alternate spelling.