### PR TITLE
Update devfile schema for versions 2.0.0 and 2.1.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1109,13 +1109,18 @@
       "url": "https://raw.githubusercontent.com/iterative/dvcyaml-schema/master/schema.json"
     },
     {
-      "name": "Eclipse Che Devfile",
-      "description": "JSON schema for Eclipse Che Devfiles",
-      "url": "https://raw.githubusercontent.com/eclipse-che/che-server/master/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
+      "name": "Devfile",
+      "description": "JSON schema for Devfiles",
+      "url": "https://raw.githubusercontent.com/devfile/api/2.1.x/schemas/latest/devfile.json",
       "fileMatch": [
         "devfile.yaml",
         ".devfile.yaml"
-      ]
+      ],
+      "versions": {
+        "1.0.0": "https://raw.githubusercontent.com/eclipse-che/che-server/master/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
+        "2.0.0": "https://raw.githubusercontent.com/devfile/api/2.0.x/schemas/latest/devfile.json",
+        "2.1.0": "https://raw.githubusercontent.com/devfile/api/2.1.x/schemas/latest/devfile.json"
+      }
     },
     {
       "name": "ecosystem.json",


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This PR adds the JSON schemas for Devfiles version 2.0.0 and 2.1.0 hosted on https://github.com/devfile/api. Devfile version 1.0.0 is still hosted in its current location https://raw.githubusercontent.com/eclipse-che/che-server/master/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json

It makes devfile version 2.1.0 as the default in the `url` property and also updates the `name` and `description` to remove the keywords Eclipse & Che.
