### PR TITLE
Add catalog entry for Haystack pipelines

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1554,6 +1554,17 @@
       "url": "https://raw.githubusercontent.com/j2inn/hayson/master/hayson-json-schema.json"
     },
     {
+      "name": "Haystack Pipeline",
+      "description": "Haystack Pipeline YAML file describing the nodes of the pipelines. For more info read the docs at: https://haystack.deepset.ai/components/pipelines#yaml-file-definitions",
+      "fileMatch": [
+          "*.haystack-pipeline.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/deepset-ai/haystack/master/json-schemas/haystack-pipeline-1.1.0.schema.json",
+      "versions": {
+        "1.1.0": "https://raw.githubusercontent.com/deepset-ai/haystack/master/json-schemas/haystack-pipeline-1.1.0.schema.json"
+      }
+    },
+    {
       "name": "Hazelcast 5 Configuration",
       "description": "YAML schema for configuring Hazelcast 5 Platform (member and client)",
       "fileMatch": [

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1559,10 +1559,7 @@
       "fileMatch": [
           "*.haystack-pipeline.yml"
       ],
-      "url": "https://raw.githubusercontent.com/deepset-ai/haystack/master/json-schemas/haystack-pipeline-1.1.0.schema.json",
-      "versions": {
-        "1.1.0": "https://raw.githubusercontent.com/deepset-ai/haystack/master/json-schemas/haystack-pipeline-1.1.0.schema.json"
-      }
+      "url": "https://raw.githubusercontent.com/deepset-ai/haystack/master/json-schemas/haystack-pipeline.schema.json"
     },
     {
       "name": "Hazelcast 5 Configuration",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This PR adds an entry in the catalog for the self-hosted JSON schema of Haystack pipelines (https://haystack.deepset.ai/components/pipelines#yaml-file-definitions).
