### PR TITLE
restore CloudFormation and SAM to the original URL

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -803,7 +803,7 @@
         "cloudformation.yml",
         "cloudformation.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/awslabs/goformation/v5.2.11/schema/cloudformation.schema.json"
+      "url": "https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json"
     },
     {
       "name": "AWS CloudFormation Serverless Application Model (SAM)",
@@ -817,7 +817,7 @@
         "sam.yml",
         "sam.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/awslabs/goformation/v5.2.11/schema/sam.schema.json"
+      "url": "https://raw.githubusercontent.com/awslabs/goformation/master/schema/sam.schema.json"
     },
     {
       "name": "Citation File Format",


### PR DESCRIPTION
There is an issue created #2085 related so SAM

URL History:
Original `master` URL was added via PR #409
The original `master` URL was change to tag release `v4.15.0` via PR #1297 
This tag release was _maintained_ by PR #1830 and updated from `v4.15.0` to `v5.2.9`
No maintenance since then.
....
The present version is` v5.4.8`
Now the URL is change back to the `master`. No more maintenance required to release tags.