### PR TITLE
add schema and tests for .NET release index manifest

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1072,6 +1072,14 @@
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/master/Schemas/Applications.Configuration/topology.json"
     },
     {
+      "name": "dotnet Release Index manifest",
+      "description": "JSON schema for .NET product collection manifests",
+      "fileMatch": [
+        "dotnet-release-index.json"
+      ],
+      "url": "https://json.schemastore.org/dotnet-releases-index.json"
+    },
+    {
       "name": "dotnetcli.host.json",
       "description": "JSON schema for .NET CLI template host files",
       "fileMatch": [

--- a/src/negative_test/dotnet-releases-index/invalid-null-eol-date.json
+++ b/src/negative_test/dotnet-releases-index/invalid-null-eol-date.json
@@ -1,0 +1,124 @@
+{
+  "releases-index": [
+      {
+          "channel-version": "7.0",
+          "latest-release": "7.0.0-preview.1",
+          "latest-release-date": "2022-02-17",
+          "security": false,
+          "latest-runtime": "7.0.0-preview.1.22076.8",
+          "latest-sdk": "7.0.100-preview.1.22110.4",
+          "product": ".NET",
+          "support-phase": "preview",
+          "eol-date": "null",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json"
+      },
+      {
+          "channel-version": "6.0",
+          "latest-release": "6.0.2",
+          "latest-release-date": "2022-02-08",
+          "security": true,
+          "latest-runtime": "6.0.2",
+          "latest-sdk": "6.0.200",
+          "product": ".NET",
+          "support-phase": "lts",
+          "eol-date": "2024-11-08",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json"
+      },
+      {
+          "channel-version": "5.0",
+          "latest-release": "5.0.14",
+          "latest-release-date": "2022-02-08",
+          "security": true,
+          "latest-runtime": "5.0.14",
+          "latest-sdk": "5.0.405",
+          "product": ".NET",
+          "support-phase": "maintenance",
+          "eol-date":"2022-05-08",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
+      },
+      {
+          "channel-version": "3.1",
+          "latest-release": "3.1.22",
+          "latest-release-date": "2021-12-14",
+          "security": true,
+          "latest-runtime": "3.1.22",
+          "latest-sdk": "3.1.416",
+          "product": ".NET Core",
+          "support-phase": "lts",
+          "eol-date": "2022-12-03",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json"
+      },
+      {
+          "channel-version": "3.0",
+          "latest-release": "3.0.3",
+          "latest-release-date": "2020-02-18",
+          "security": false,
+          "latest-runtime": "3.0.3",
+          "latest-sdk": "3.0.103",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2020-03-03",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json"
+      },
+      {
+          "channel-version": "2.1",
+          "latest-release": "2.1.30",
+          "latest-release-date": "2021-08-19",
+          "security": true,
+          "latest-runtime": "2.1.30",
+          "latest-sdk": "2.1.818",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2021-08-21",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json"
+      },
+      {
+          "channel-version": "2.2",
+          "latest-release": "2.2.8",
+          "latest-release-date": "2019-11-19",
+          "security": true,
+          "latest-runtime": "2.2.8",
+          "latest-sdk": "2.2.207",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2019-12-23",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json"
+        },
+      {
+          "channel-version": "2.0",
+          "latest-release": "2.0.9",
+          "latest-release-date":"2018-07-10",
+          "security": true,
+          "latest-runtime": "2.0.9",
+          "latest-sdk": "2.1.202",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2018-10-01",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.0/releases.json"
+      },
+      {
+          "channel-version": "1.1",
+          "latest-release": "1.1.13",
+          "latest-release-date": "2019-05-14",
+          "security": true,
+          "latest-runtime": "1.1.13",
+          "latest-sdk": "1.1.14",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2019-06-27",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.1/releases.json"
+      },
+      {
+          "channel-version": "1.0",
+          "latest-release": "1.0.16",
+          "latest-release-date": "2019-05-14",
+          "security": true,
+          "latest-runtime": "1.0.16",
+          "latest-sdk": "1.1.14",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2019-06-27",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.0/releases.json"
+      }
+  ]
+}

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -113,6 +113,7 @@
   ],
   "ajvFullStrictMode": [
     "bamboo-spec.json",
+    "dotnet-releases-index.json",
     "github-issue-forms.json",
     "importmap.json",
     "schema-catalog.json",

--- a/src/schemas/json/dotnet-releases-index.json
+++ b/src/schemas/json/dotnet-releases-index.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "JSON schema for .NET product collection manifests",
+  "description": "A collection of manifests for .NET products, which is updated with each preview and stable release of the .NET SDK and/or Runtime",
+  "$comment": "Schema derived from https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases-index.json and https://github.com/dotnet/deployment-tools/blob/main/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs",
+  "type": "object",
+  "definitions": {
+    "dateYYYYMMDD": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "description": "A date in the format YYYY-MM-DD",
+      "$comment": "If we targeted draft-07 we could use the 'date' format instead of this format pattern. We cannot use the 'date-time' format because our existing values don't validate against it."
+    },
+    "releaseVersion": {
+      "type": "string",
+      "description": "A SemVer-compatible version string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "supportPhase": {
+      "type": "string",
+      "enum": [
+        "current", "eol", "lts", "maintenance", "preview", "rc", "unknown"
+      ],
+      "description": "An enumeration describing the different support phases of a product",
+      "$comment": "If we targeted draft-06 we could use oneOf/const in combination to add descriptions to the enum values"
+    },
+    "product": {
+      "type": "object",
+      "properties": {
+        "channel-version": {
+          "type": "string",
+          "title": "ProductVersion",
+          "description": "The version of the product, e.g '5.0' or '1.1'",
+          "pattern": "^[0-9]+\\.[0-9]+$"
+        },
+        "eol-date": {
+          "oneOf": [
+            { "$ref": "#/definitions/dateYYYYMMDD" },
+            { "type": "null" }
+          ],
+          "title": "EndOfLifeDate",
+          "description": "The end-of-life (EOL) date for this Product when it is considered to be out of support. The value may be `null` if the EOL date is undetermined, e.g. when a product is still a prerelease."
+        },
+        "security": {
+          "type": "boolean",
+          "title": "LatestReleaseIncludesSecurityUpdate",
+          "description": "`true` if the latest release of this product includes a security update, `false` otherwise."
+        },
+        "latest-release-date": {
+          "$ref": "#/definitions/dateYYYYMMDD",
+          "title": "LatestReleaseDate",
+          "description": "The date of the latest release of this product."
+        },
+        "latest-release" :{
+          "$ref": "#/definitions/releaseVersion",
+          "title": "LatestReleaseVersion",
+          "description": "The version of the latest release"
+        },
+        "latest-runtime": {
+          "$ref": "#/definitions/releaseVersion",
+          "title": "LatestRuntimeVersion",
+          "description": "The version of the runtime included in the latest release"
+        },
+        "latest-sdk": {
+          "$ref": "#/definitions/releaseVersion",
+          "title": "LatestSdkVersion",
+          "description": "The version of the SDK included in the latest release.  This is usually the SDK with the highest feature band. A ProductRelease may include multiple SDKs across different feature bands, all of which carry the same runtime version."
+        },
+        "product": {
+          "type": "string",
+          "title": "ProductName",
+          "description": "The name of the product."
+        },
+        "releases.json": {
+          "description": "The URL pointing to the releases.json file that contains information about all the releases  associated with this Product.",
+          "type": "string",
+          "format": "uri",
+          "$comment": "Since this is always an absolute uri, the 'uri' format is unambiguous"
+        },
+        "support-phase": {
+          "$ref": "#/definitions/supportPhase",
+          "description": "The support phase of the Product. For an LTS release, the `eol-date` property should be checked to confirm whether a release is still supported. The EOL dates are often published in advance, but there can be delays to updating the support phase in the published data."
+        }
+      },
+      "required": [
+        "channel-version",
+        "security",
+        "latest-release-date",
+        "latest-release",
+        "latest-runtime",
+        "latest-sdk",
+        "product",
+        "releases.json",
+        "support-phase"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "releases-index": {
+      "type": "array",
+      "description": "A collection of all released products",
+      "items": {
+        "$ref": "#/definitions/product"
+      }
+    }
+  },
+  "required": [
+    "releases-index"
+  ],
+  "additionalProperties": false
+}

--- a/src/test/dotnet-releases-index/latest.json
+++ b/src/test/dotnet-releases-index/latest.json
@@ -1,0 +1,124 @@
+{
+  "releases-index": [
+      {
+          "channel-version": "7.0",
+          "latest-release": "7.0.0-preview.1",
+          "latest-release-date": "2022-02-17",
+          "security": false,
+          "latest-runtime": "7.0.0-preview.1.22076.8",
+          "latest-sdk": "7.0.100-preview.1.22110.4",
+          "product": ".NET",
+          "support-phase": "preview",
+          "eol-date": null,
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json"
+      },
+      {
+          "channel-version": "6.0",
+          "latest-release": "6.0.2",
+          "latest-release-date": "2022-02-08",
+          "security": true,
+          "latest-runtime": "6.0.2",
+          "latest-sdk": "6.0.200",
+          "product": ".NET",
+          "support-phase": "lts",
+          "eol-date": "2024-11-08",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json"
+      },
+      {
+          "channel-version": "5.0",
+          "latest-release": "5.0.14",
+          "latest-release-date": "2022-02-08",
+          "security": true,
+          "latest-runtime": "5.0.14",
+          "latest-sdk": "5.0.405",
+          "product": ".NET",
+          "support-phase": "maintenance",
+          "eol-date":"2022-05-08",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
+      },
+      {
+          "channel-version": "3.1",
+          "latest-release": "3.1.22",
+          "latest-release-date": "2021-12-14",
+          "security": true,
+          "latest-runtime": "3.1.22",
+          "latest-sdk": "3.1.416",
+          "product": ".NET Core",
+          "support-phase": "lts",
+          "eol-date": "2022-12-03",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json"
+      },
+      {
+          "channel-version": "3.0",
+          "latest-release": "3.0.3",
+          "latest-release-date": "2020-02-18",
+          "security": false,
+          "latest-runtime": "3.0.3",
+          "latest-sdk": "3.0.103",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2020-03-03",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json"
+      },
+      {
+          "channel-version": "2.1",
+          "latest-release": "2.1.30",
+          "latest-release-date": "2021-08-19",
+          "security": true,
+          "latest-runtime": "2.1.30",
+          "latest-sdk": "2.1.818",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2021-08-21",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json"
+      },
+      {
+          "channel-version": "2.2",
+          "latest-release": "2.2.8",
+          "latest-release-date": "2019-11-19",
+          "security": true,
+          "latest-runtime": "2.2.8",
+          "latest-sdk": "2.2.207",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2019-12-23",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json"
+        },
+      {
+          "channel-version": "2.0",
+          "latest-release": "2.0.9",
+          "latest-release-date":"2018-07-10",
+          "security": true,
+          "latest-runtime": "2.0.9",
+          "latest-sdk": "2.1.202",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2018-10-01",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.0/releases.json"
+      },
+      {
+          "channel-version": "1.1",
+          "latest-release": "1.1.13",
+          "latest-release-date": "2019-05-14",
+          "security": true,
+          "latest-runtime": "1.1.13",
+          "latest-sdk": "1.1.14",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2019-06-27",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.1/releases.json"
+      },
+      {
+          "channel-version": "1.0",
+          "latest-release": "1.0.16",
+          "latest-release-date": "2019-05-14",
+          "security": true,
+          "latest-runtime": "1.0.16",
+          "latest-sdk": "1.1.14",
+          "product": ".NET Core",
+          "support-phase": "eol",
+          "eol-date": "2019-06-27",
+          "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.0/releases.json"
+      }
+  ]
+}


### PR DESCRIPTION
This file is the source of truth for automated inspection of .NET SDK/Runtime releases, so we want it to be regular and codified for third-party consumption.