### PR TITLE
[WIP] Allow additional properties in the schema of the dotnet release index

### DIFF
--- a/src/schemas/json/dotnet-releases-index.json
+++ b/src/schemas/json/dotnet-releases-index.json
@@ -107,6 +107,5 @@
   },
   "required": [
     "releases-index"
-  ],
-  "additionalProperties": false
+  ]
 }


### PR DESCRIPTION
In order to allow files to explicitly annotate schema (via the `"$schema"` property) the set of properties cannot be constrained in this way.
I discovered this while trying to dogfood the schema over in dotnet/core.

![image](https://user-images.githubusercontent.com/573979/154747568-8e3fafcb-d574-4f59-af99-05be28887cb3.png)
