### PR TITLE
Updated `swcrc` definition with `$schema` key

### DIFF
--- a/src/schemas/json/swcrc.json
+++ b/src/schemas/json/swcrc.json
@@ -295,6 +295,9 @@
           "required": ["type"],
           "additionalProperties": false
         },
+        "$schema": {
+          "type": "string"
+        },
         "jsc": {
           "type": "object",
           "description": "Main Jsc configuration",


### PR DESCRIPTION
The official support to the `$schema` key has been added in [#3622](https://github.com/swc-project/swc/pull/3622)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
