### PR TITLE
WiP: Added the new Typescript 4.5 moduleResolutions

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -313,17 +313,19 @@
               "markdownDescription": "Specify what module code is generated.\n\nSee more: https://www.typescriptlang.org/tsconfig#module"
             },
             "moduleResolution": {
-              "description": "Specify how TypeScript looks up a file from a given module specifier.",
+              "description": "Specify how TypeScript looks up a file from a given module specifier. nodenext and node12 are only supported in Typescript 4.5+",
               "type": "string",
               "anyOf": [
                 {
                   "enum": [
+                    "node12",
+                    "nodenext",
                     "Classic",
                     "Node"
                   ]
                 },
                 {
-                  "pattern": "^(([Nn]ode)|([Cc]lassic))$"
+                  "pattern": "^(([Nn]ode)|([Cc]lassic)|([Nn]ode[Nn]ext)|([Nn]ode12))$"
                 }
               ],
               "default": "classic",


### PR DESCRIPTION
Added the new Typescript 4.5 moduleResolutions as discribed https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

## WiP 
I am Not sure if the repo supports versioning 
- [x] - https://github.com/SchemaStore/schemastore/issues/2099
- [ ] - https://github.com/microsoft/TypeScript/issues/47987#event-6144650044 issue rated as external but needs to be internal as we need to offer the specs
- [ ] This issue is part of https://github.com/microsoft/TypeScript/issues/46452

## Result of versioning issue
It is not possible without a built-in version. 

With the built-in version it is still problematic in the JSON schema as there is only [check](https://json-schema.org/understanding-json-schema/reference/numeric.html#id7) with a single type number value. x.y.z is the type string format
The only proper implementation I can think of with the many multiple x.y.z-type string versions is this [external schema](https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json) which loads the correct JSON schema file via tag release.

_Originally posted by @GerryFerdinandus in https://github.com/SchemaStore/schemastore/issues/2099#issuecomment-1050150352_
