### PR TITLE
Add staticwebapps.config.json apiRuntime

### DIFF
--- a/src/negative_test/staticwebapp.config/invalid_apiruntime_must_fail.json
+++ b/src/negative_test/staticwebapp.config/invalid_apiruntime_must_fail.json
@@ -1,0 +1,5 @@
+{
+    "platform": {
+        "apiRuntime": "node:15"
+    }
+}

--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -640,6 +640,28 @@
                 }
             },
             "additionalProperties": false
+        },
+        "platform": {
+            "type": "object",
+            "description": "Platform configuration",
+            "properties": {
+                "apiRuntime": {
+                    "type": "string",
+                    "enum": [
+                        "dotnet:3.1",
+                        "dotnet:6.0",
+                        "dotnet-isolated:6.0",
+                        "node:12",
+                        "node:14",
+                        "node:16",
+                        "python:3.8",
+                        "python:3.9"
+                    ],
+                    "description": "Language runtime for the managed functions API",
+                    "default": "/index.html"
+                }
+            },
+            "additionalProperties": false
         }
     },
     "additionalProperties": false

--- a/src/test/staticwebapp.config/staticwebapp.config.json
+++ b/src/test/staticwebapp.config/staticwebapp.config.json
@@ -190,5 +190,8 @@
         "requiredHeaders": {
             "X-Azure-FDID": "10dd26ef"
         }
+    },
+    "platform": {
+        "apiRuntime": "node:16"
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Adding Azure Static Web Apps support for language runtime version selection.

/cc @simonaco @Reshmi-Sriram 