### PR TITLE
Support empty permission in github-workflow

### DIFF
--- a/src/negative_test/github-workflow/permissions-event-has-wrong-level.json
+++ b/src/negative_test/github-workflow/permissions-event-has-wrong-level.json
@@ -1,0 +1,18 @@
+{
+  "on": {
+    "push": null
+  },
+  "permissions": {
+    "pages": "execute"
+  },
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}

--- a/src/negative_test/github-workflow/permissions-event-has-wrong-property-keys.json
+++ b/src/negative_test/github-workflow/permissions-event-has-wrong-property-keys.json
@@ -1,0 +1,18 @@
+{
+  "on": {
+    "push": null
+  },
+  "permissions": {
+    "files": "read"
+  },
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}

--- a/src/negative_test/github-workflow/permissions-must-be-object-or-string.json
+++ b/src/negative_test/github-workflow/permissions-must-be-object-or-string.json
@@ -1,0 +1,16 @@
+{
+  "on": {
+    "push": null
+  },
+  "permissions": 123,
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}

--- a/src/negative_test/github-workflow/permissions-string-is-not-from-enum.json
+++ b/src/negative_test/github-workflow/permissions-string-is-not-from-enum.json
@@ -1,0 +1,16 @@
+{
+  "on": {
+    "push": null
+  },
+  "permissions": "speak-all",
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -167,7 +167,6 @@
     },
     "permissions-event": {
       "type": "object",
-      "minProperties": 1,
       "additionalProperties": false,
       "properties": {
         "actions": {

--- a/src/test/github-workflow/permissions-none.json
+++ b/src/test/github-workflow/permissions-none.json
@@ -1,0 +1,16 @@
+{
+  "on": {
+    "push": null
+  },
+  "permissions": {},
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/github-workflow/permissions-object.json
+++ b/src/test/github-workflow/permissions-object.json
@@ -1,0 +1,20 @@
+{
+  "on": {
+    "push": null
+  },
+  "permissions": {
+    "issues": "read",
+    "packages": "none",
+    "pages": "write"
+  },
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/github-workflow/permissions-string.json
+++ b/src/test/github-workflow/permissions-string.json
@@ -1,0 +1,16 @@
+{
+  "on": {
+    "push": null
+  },
+  "permissions": "read-all",
+  "jobs": {
+    "one": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "run": "echo 'Hello from ${{ runner.os }}'"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
GitHub allows the permission to be an empty object, which disables all permissions:

```yaml
permissions: {}
```

Closes #2107