### PR TITLE
golangci-lint: add missing configuration

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -1749,10 +1749,13 @@
           ],
           "properties": {
             "max-open-files": {
-              "type": "number"
+              "type": "integer"
             },
             "ignore-generated-header": {
               "type": "boolean"
+            },
+            "confidence": {
+              "type": "number"
             },
             "severity": {
               "type": "string",

--- a/src/test/golangci-lint/example-values.json
+++ b/src/test/golangci-lint/example-values.json
@@ -617,6 +617,7 @@
       "ignore-generated-header": true,
       "severity": "warning",
       "enable-all-rules": false,
+      "confidence": 0.1,
       "rules": [
         {
           "name": "add-constant",


### PR DESCRIPTION
- add missing revive configuration
- fix wrong type