### PR TITLE
github-workflow: Fix workflow_dispatch inputs

### DIFF
--- a/src/negative_test/github-workflow/workflow_dispatch-inputs-bool-default-.json
+++ b/src/negative_test/github-workflow/workflow_dispatch-inputs-bool-default-.json
@@ -1,0 +1,25 @@
+{
+  "name": "inputs",
+  "on": {
+    "workflow_dispatch": {
+      "inputs": {
+        "bool": {
+          "required": false,
+          "type": "boolean",
+          "description": "bool",
+          "default": "true"
+        }
+      }
+    }
+  },
+  "jobs": {
+    "checkout": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v2"
+        }
+      ]
+    }
+  }
+}

--- a/src/negative_test/github-workflow/workflow_dispatch-inputs-choice-without-options.json
+++ b/src/negative_test/github-workflow/workflow_dispatch-inputs-choice-without-options.json
@@ -1,0 +1,24 @@
+{
+  "name": "inputs",
+  "on": {
+    "workflow_dispatch": {
+      "inputs": {
+        "choice": {
+          "required": false,
+          "type": "choice",
+          "description": "choice"
+        }
+      }
+    }
+  },
+  "jobs": {
+    "checkout": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v2"
+        }
+      ]
+    }
+  }
+}

--- a/src/negative_test/github-workflow/workflow_dispatch-inputs-string-default-bool.json
+++ b/src/negative_test/github-workflow/workflow_dispatch-inputs-string-default-bool.json
@@ -1,0 +1,25 @@
+{
+  "name": "inputs",
+  "on": {
+    "workflow_dispatch": {
+      "inputs": {
+        "string": {
+          "required": false,
+          "type": "string",
+          "description": "string",
+          "default": true
+        }
+      }
+    }
+  },
+  "jobs": {
+    "checkout": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v2"
+        }
+      ]
+    }
+  }
+}

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1606,8 +1606,7 @@
                         },
                         "default": {
                           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
-                          "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file.",
-                          "type": "string"
+                          "description": "A string representing the default value. The default value is used when an input parameter isn't specified in a workflow file."
                         },
                         "type": {
                           "description": "A string representing the type of the input.",
@@ -1629,6 +1628,51 @@
                           "minItems": 1
                         }
                       },
+                      "allOf": [
+                        {
+                          "if": {
+                            "properties": {
+                              "type": {
+                                "const": "boolean"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ]
+                          },
+                          "then": {
+                            "properties": {
+                              "default": {
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "else": {
+                            "properties": {
+                              "default": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "if": {
+                            "properties": {
+                              "type": {
+                                "const": "choice"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ]
+                          },
+                          "then": {
+                            "required": [
+                              "options"
+                            ]
+                          }
+                        }
+                      ],
                       "required": [
                         "description",
                         "required"

--- a/src/test/github-workflow/workflow_dispatch-inputs.json
+++ b/src/test/github-workflow/workflow_dispatch-inputs.json
@@ -1,0 +1,53 @@
+{
+  "name": "inputs",
+  "on": {
+    "workflow_dispatch": {
+      "inputs": {
+        "bool-true": {
+          "required": false,
+          "type": "boolean",
+          "description": "bool",
+          "default": true
+        },
+        "bool-false": {
+          "required": false,
+          "type": "boolean",
+          "description": "bool",
+          "default": false
+        },
+        "string": {
+          "required": false,
+          "type": "string",
+          "description": "string",
+          "default": "foo"
+        },
+        "env": {
+          "required": false,
+          "type": "environment",
+          "description": "environment",
+          "default": ""
+        },
+        "choice": {
+          "required": false,
+          "type": "choice",
+          "description": "choice",
+          "default": "foo",
+          "options": [
+            "foo",
+            "bar"
+          ]
+        }
+      }
+    }
+  },
+  "jobs": {
+    "checkout": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v2"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I changed behaviors as follows. 

- if type is boolean, default must be boolean
- if type is choice, input needs options.

**sample**

```yml
name: inputs
on:
  workflow_dispatch:
    inputs:
      ok_bool:
        type: boolean
        description: is this OK?
        default: true # if type is boolean, default must be boolean
      ng_bool:
        type: boolean
        description: is this OK?
        default: "true" # if type is boolean, default must be boolean
      ok_name:
        type: choice
        description: Name
        options: # if type is choice, input needs options.
        - A
        - B
      ng_name:
        type: choice
        description: Name
        # options: # if type is choice, input needs options.
        # - A
        # - B
```