### PR TITLE
Add new CircleCI macOS resource classes

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -446,7 +446,7 @@
             "description": "Amount of CPU and RAM allocated to each container in a job. Note: A performance plan is required to access this feature.",
             "type": "string",
             "default": "medium",
-            "enum": ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+", "gpu.nvidia.small", "gpu.nvidia.medium", "windows.gpu.nvidia.medium"]
+            "enum": ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+", "gpu.nvidia.small", "gpu.nvidia.medium", "windows.gpu.nvidia.medium", "macos.x86.medium.gen2", "macos.x86.metal.gen1"]
           },
           "shell": {
             "description": "Shell to use for execution command in all steps. Can be overridden by shell in each step (default: See [Default Shell Options](https://circleci.com/docs/2.0/configuration-reference/#default-shell-options)",


### PR DESCRIPTION
Add support for the two new macOS resource classes available on CircleCI:

https://circleci.com/docs/2.0/configuration-reference/#macos-executor