### PR TITLE
fix: boolean values for environment in circleci config

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -332,7 +332,7 @@
             "description": "A map of environment variable names and values",
             "type": "object",
             "additionalProperties": {
-              "type": ["string", "number"]
+              "type": ["string", "number", "boolean"]
             }
           },
           "auth": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Add support of boolean values in environment variables. CircleCI config
fixes #2116
