### PR TITLE
Add most up to date CircleCI images

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -373,7 +373,7 @@
         "image": {
           "description": "The VM image to use. View [available images](https://circleci.com/docs/2.0/configuration-reference/#available-machine-images). **Note:** This key is **not** supported on the installable CircleCI. For information about customizing machine executor images on CircleCI installed on your servers, see our [VM Service documentation](https://circleci.com/docs/2.0/vm-service).",
           "type": "string",
-          "default": "ubuntu-1604:202004-01"
+          "default": "ubuntu-2004:current"
         },
         "docker_layer_caching": {
           "description": "Set to `true` to enable [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching). Note: If you haven't already, you must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.",
@@ -606,6 +606,7 @@
             "version": {
               "description": "If your build requires a specific docker image, you can set it as an image attribute",
               "enum": [
+                "20.10.12",
                 "20.10.11",
                 "20.10.7",
                 "20.10.6",
@@ -617,7 +618,7 @@
                 "18.09.3",
                 "17.09.0-ce"
               ],
-              "default": "19.03.13"
+              "default": "20.10.12"
             }
           }
         },


### PR DESCRIPTION
- There is now a mutable `ubuntu-2004:current` tag.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
