### PR TITLE
pre-commit-config: Fix for non `git@` repos

### DIFF
--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -55,7 +55,7 @@
                 "repo": {
                     "$comment": "the repository url to git clone from",
                     "type": "string",
-                    "pattern": "^((ssh)|(http[s]?)://)|(git@).+"
+                    "pattern": "^(((ssh)|(http[s]?)://)|(git@)).+"
                 },
                 "rev": {
                     "$comment": "the revision or tag to clone at (previously sha).",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

In PyCharm, only `git@foo` repos are shown as valid.

`http://foo`, `https://foo` and `ssh://foo` are shown as invalid:

<img width="816" alt="image" src="https://user-images.githubusercontent.com/1324225/156886751-1e717b21-0cab-40ed-aff8-ddf23b034271.png">

The problem is the `.+` at the end is only applied to the `git@` group, not the `ssh` or `http[s]://` groups.

Adding an extra pair of parentheses fixes it:

<img width="557" alt="image" src="https://user-images.githubusercontent.com/1324225/156886903-1329bde4-2c89-4ff9-bb8a-6e3c3fbfd23a.png">
