### PR TITLE
Remove 2.0 from CircleCI description

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -616,7 +616,7 @@
     },
     {
       "name": "CircleCI config.yml",
-      "description": "Schema for CircleCI 2.0 config files",
+      "description": "Schema for CircleCI config files",
       "fileMatch": [
         ".circleci/config.yml"
       ],


### PR DESCRIPTION
Current CircleCI config file version is 2.1 and the schema does have rules for the latest version, like orbs. To remove any confusion, propose that the version call out in the description be removed.

Note: The schema may still have older rules pertaining specifically to config file version 2.0, have not verified.