### PR TITLE
Buildkite URL updated for branch rename master → main

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -503,7 +503,7 @@
         ".buildkite/pipeline.*.yaml",
         ".buildkite/pipeline.*.json"
       ],
-      "url": "https://raw.githubusercontent.com/buildkite/pipeline-schema/master/schema.json"
+      "url": "https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json"
     },
     {
       "name": ".build.yml",


### PR DESCRIPTION
The URL for Buildkite's pipeline schema is changing due to a branch rename from `master` to `main`, as tracked in https://github.com/buildkite/pipeline-schema/issues/32