### PR TITLE
Add deferInLoop to gocritic-checks

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -23,6 +23,7 @@
         "commentedOutImport",
         "defaultCaseOrder",
         "deferUnlambda",
+        "deferInLoop",
         "deprecatedComment",
         "docStub",
         "dupArg",


### PR DESCRIPTION
When configuring a [.golangci-lint.yaml](https://github.com/golangci/golangci-lint/blob/master/.golangci.yml#L18) file for `gocritic`, I noticed VS Code was complaining about `deferInLoop` not being a valid option.

This PR adds `deferInLoop` to the list of known checks, as it is valid for `gocritic` (https://github.com/go-critic/go-critic/issues/338)
