### PR TITLE
Add Block Protocol metadata schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -592,6 +592,14 @@
       }
     },
     {
+      "name": "Block Protocol Metadata",
+      "description": "Schema for Block Metadata in Block Protocol",
+      "fileMatch": [
+        "block-metadata.json"
+      ],
+      "url": "https://blockprotocol.org/schemas/block-metadata.json"
+    },
+    {
       "name": "CMake Presets",
       "description": "Schema for CMake Presets",
       "fileMatch": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This PR adds the [BlockProtocol metadata schema](https://blockprotocol.org/spec/block-types) to the schemastore catalog.
