### PR TITLE
Fix `package.json` `funding` object; `type` is optional

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -146,7 +146,7 @@
         }
       },
       "additionalProperties": false,
-      "minProperties": 2
+      "required": ["url"]
     }
   },
   "type": "object",

--- a/src/test/package/funding-way-no-type.json
+++ b/src/test/package/funding-way-no-type.json
@@ -1,0 +1,5 @@
+{
+  "funding": {
+    "url": "https://example.com/bar-baz"
+  }
+}


### PR DESCRIPTION
See:
 - https://github.com/npm/cli/commit/30f170877954acd036cb234a581e4eb155049b82#diff-a09a6421519e59b70085dd72faec1ec35ad4c98c0de1019367a5b0e01eb1e619R92 
 - https://github.com/microsoft/vscode/issues/145077
 - https://github.com/SchemaStore/schemastore/pull/2135