### PR TITLE
Add `singleAttributePerLine` to `.prettierrc` schema

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -110,6 +110,7 @@
             { "enum": ["babel-flow"], "description": "Flow" },
             { "enum": ["babel-ts"], "description": "TypeScript" },
             { "enum": ["typescript"], "description": "TypeScript" },
+            { "enum": ["acorn"], "description": "JavaScript" },
             { "enum": ["espree"], "description": "JavaScript" },
             { "enum": ["meriyah"], "description": "JavaScript" },
             { "enum": ["css"], "description": "CSS" },
@@ -195,6 +196,11 @@
         "semi": {
           "description": "Print semicolons.",
           "default": true,
+          "type": "boolean"
+        },
+        "singleAttributePerLine": {
+          "description": "Enforce single attribute per line in HTML, Vue and JSX.",
+          "default": false,
           "type": "boolean"
         },
         "singleQuote": {

--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -134,8 +134,10 @@
         "pluginSearchDirs": {
           "description": "Custom directory that contains prettier plugins in node_modules subdirectory.\nOverrides default behavior when plugins are searched relatively to the location of Prettier.\nMultiple values are accepted.",
           "default": [],
-          "type": "array",
-          "items": { "type": "string" }
+          "oneOf": [
+            { "type": "array", "items": { "type": "string" } },
+            { "enum": [false], "description": "Disable plugin autoloading." }
+          ]
         },
         "plugins": {
           "description": "Add a plugin. Multiple plugins can be passed as separate `--plugin`s.",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Support [Prettier 2.6](https://prettier.io/blog/2022/03/16/2.6.0.html).

- Add new `singleAttributePerLine` option. (ref: [release blog post](https://prettier.io/blog/2022/03/16/2.6.0.html#html))
- Update `pluginSearchDir`. (ref: [release blog post](https://prettier.io/blog/2022/03/16/2.6.0.html#add---no-plugin-search-option-to-turn-off-plugin-autoloading-10274httpsgithubcomprettierprettierpull10274-by-fiskerhttpsgithubcomfisker))
