### PR TITLE
Update path to Haystack pipeline's schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1626,7 +1626,7 @@
       "fileMatch": [
           "*.haystack-pipeline.yml"
       ],
-      "url": "https://raw.githubusercontent.com/deepset-ai/haystack/master/json-schemas/haystack-pipeline.schema.json"
+      "url": "https://raw.githubusercontent.com/deepset-ai/haystack/master/haystack/json-schemas/haystack-pipeline.schema.json"
     },
     {
       "name": "Hazelcast 5 Configuration",


### PR DESCRIPTION
The schemas for Haystack Pipelines referenced in `catalog.json` were moved. This PR fixes the URL.