### PR TITLE
Adds Fossa Cli's - fossa-deps file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1340,6 +1340,16 @@
       "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-yml.v3.schema.json"
     },
     {
+      "name": "Fossa's fossa-deps file",
+      "description": "JSON schema for FOSSA CLI's fossa-deps file",
+      "fileMatch": [
+        "fossa-deps.yml",
+        "fossa-deps.yaml",
+        "fossa-deps.json"
+      ],
+      "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-deps.schema.json"
+    },
+    {
       "name": "func.yaml",
       "description": "JSON schema for Knative Func Plugin func.yaml files",
       "fileMatch": [


### PR DESCRIPTION
## Overview

Adds schema for FOSSA CLI's fossa-deps file: `fossa-deps.yaml`, `fossa-deps.yml`, `fossa-deps.json`. 

Let me know if anything else is needed for this PR. 

## References

- Fossa: https://fossa.com/
- Fossa-cli: https://github.com/fossas/fossa-cli/
- Fossa-deps documentation:
  - https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-deps.md
