### PR TITLE
Add Build Info schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -525,6 +525,16 @@
       "url": "https://raw.githubusercontent.com/rescript-lang/rescript-compiler/master/docs/docson/build-schema.json"
     },
     {
+      "name": "Build Info",
+      "description": "Build Info is the metadata of a build. It includes all the details about the build broken down into segments that include version history, artifacts, project modules, dependencies, and everything that was required to create the build.",
+      "fileMatch": [
+        "*buildinfo*.json",
+        "*build-info*.json",
+        "*.buildinfo"
+      ],
+      "url": "https://raw.githubusercontent.com/jfrog/build-info-go/main/buildinfo-schema.json"
+    },
+    {
       "name": "Bukkit plugin.yml",
       "description": "Schema for Minecraft Bukkit plugin description files",
       "fileMatch": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

### What is build Info?
Build Info is the metadata of a build. It includes all the details about the build broken down into segments that include version history, artifacts, project modules, dependencies, and everything that was required to create the build. In short, it is a snapshot of the components used to build your application, collected by the build agent. 
Read more about Build Info: https://buildinfo.org/

### Build Info Schema
The suggested schema is available here: https://github.com/jfrog/build-info-go/blob/main/buildinfo-schema.json

### Tests
The tests are available here: https://github.com/jfrog/build-info-go/blob/main/buildinfoschema_test.go
The tests on the schema are running automatically for each commit in the [build-info-go](https://github.com/jfrog/build-info-go). The tests validate each one of the generated build-info.json files generated from the projects here: https://github.com/jfrog/build-info-go/tree/main/build/testdata.
