### PR TITLE
feat: change `opened` to `created` in discussion type

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -984,7 +984,7 @@
                   "items": {
                     "type": "string",
                     "enum": [
-                      "opened",
+                      "created",
                       "edited",
                       "deleted",
                       "transferred",
@@ -1000,7 +1000,7 @@
                     ]
                   },
                   "default": [
-                    "opened",
+                    "created",
                     "edited",
                     "deleted",
                     "transferred",


### PR DESCRIPTION
### Summery
change the `opened` discussion type to `created`.

### Related Issues
Fixes #2150 
