### PR TITLE
chart.json: fix rejecting imports using the child-parent format

### DIFF
--- a/src/schemas/json/chart.json
+++ b/src/schemas/json/chart.json
@@ -94,7 +94,26 @@
             "description": "ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.",
             "type": "array",
             "items": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["parent", "child"],
+                  "properties": {
+                    "parent": {
+                      "description": "The destination path in the parent chart's values",
+                      "type": "string"
+                    },
+                    "child": {
+                      "description": "The source key of the values to be imported",
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
             }
           },
           "alias": {

--- a/src/test/chart/full.json
+++ b/src/test/chart/full.json
@@ -15,7 +15,10 @@
       "repository": "https://example.com/charts",
       "condition": "subchart1.enabled",
       "tags": ["tag"],
-      "import-values": ["world"],
+      "import-values": [
+        "world",
+        {"child": "default.data", "parent": "myimports"}
+      ],
       "alias": "welt"
     }
   ],


### PR DESCRIPTION
See helm documentation: https://helm.sh/docs/topics/charts/#using-the-child-parent-format

It is even already mentioned in the `description` of the array: 

https://github.com/SchemaStore/schemastore/blob/fa57555f8e44ed2350fad93642a30fa8a965917e/src/schemas/json/chart.json#L93-L95

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
