### PR TITLE
Move Zuul CI schema into the schemastore catalog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,8 @@
 src/schemas/json/ansible-* @ssbarnea @webknjaz
 src/test/ansible-* @ssbarnea @webknjaz
 src/test/yamllint/ansible-* @ssbarnea @webknjaz
+
+# Zuul CI Schemas:
+src/schemas/json/zuul.json @ssbarnea
+src/test/zuul/ @ssbarnea
+src/negative_test/zuul/ @ssbarnea

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3655,7 +3655,7 @@
         "*zuul.d/*.yaml",
         "*/.zuul.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/pycontribs/zuul-lint/master/zuul_lint/zuul-schema.json"
+      "url": "https://json.schemastore.org/zuul.json"
     },
     {
       "name": "Briefcase",

--- a/src/negative_test/zuul/jobs.yaml
+++ b/src/negative_test/zuul/jobs.yaml
@@ -1,0 +1,2 @@
+- jobs: # <-- job is correct
+    name: minimal

--- a/src/negative_test/zuul/jobs2.yaml
+++ b/src/negative_test/zuul/jobs2.yaml
@@ -1,0 +1,2 @@
+# invalid as zuul jobs are lists of dictionaries, not a dictionary
+foo: bar

--- a/src/schemas/json/zuul.json
+++ b/src/schemas/json/zuul.json
@@ -1,0 +1,506 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "definitions": {
+    "JobEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "job": {
+          "$ref": "#/definitions/JobModel"
+        }
+      },
+      "required": [
+        "job"
+      ],
+      "title": "JobEntry",
+      "type": "object"
+    },
+    "JobModel": {
+      "additionalProperties": false,
+      "properties": {
+        "abstract": {
+          "default": false,
+          "title": "Abstract",
+          "type": "boolean"
+        },
+        "allowed-projects": {
+          "title": "Allowed-Projects",
+          "type": "string"
+        },
+        "ansible-version": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "2.7",
+                "2.8",
+                "2.9",
+                "2.10",
+                "2.11"
+              ],
+              "type": "string"
+            }
+          ],
+          "title": "Ansible-Version"
+        },
+        "attempts": {
+          "title": "Attempts",
+          "type": "integer"
+        },
+        "branches": {
+          "title": "Branches",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "failure-url": {
+          "title": "Failure-Url",
+          "type": "string"
+        },
+        "files": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Files"
+        },
+        "final": {
+          "default": false,
+          "title": "Final",
+          "type": "boolean"
+        },
+        "host-vars": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "title": "Host-Vars",
+          "type": "object"
+        },
+        "irrelevant-files": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Irrelevant-Files"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "nodeset": {
+          "title": "Nodeset"
+        },
+        "override-checkout": {
+          "title": "Override-Checkout",
+          "type": "string"
+        },
+        "parent": {
+          "title": "Parent",
+          "type": "string"
+        },
+        "post-run": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Post-Run"
+        },
+        "post-timeout": {
+          "title": "Post-Timeout",
+          "type": "integer"
+        },
+        "pre-run": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Pre-Run"
+        },
+        "provides": {
+          "title": "Provides",
+          "type": "string"
+        },
+        "required-projects": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/RequiredProjectModel"
+              }
+            ]
+          },
+          "title": "Required-Projects",
+          "type": "array"
+        },
+        "requires": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Requires",
+          "type": "array"
+        },
+        "roles": {
+          "items": {
+            "$ref": "#/definitions/ZuulRoleModel"
+          },
+          "title": "Roles",
+          "type": "array"
+        },
+        "run": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Run"
+        },
+        "secrets": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JobSecretModel"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/JobSecretModel"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Secrets"
+        },
+        "success-url": {
+          "title": "Success-Url",
+          "type": "string"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Tags"
+        },
+        "timeout": {
+          "title": "Timeout",
+          "type": "integer"
+        },
+        "vars": {
+          "title": "Vars",
+          "type": "object"
+        },
+        "voting": {
+          "default": true,
+          "title": "Voting",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "JobModel",
+      "type": "object"
+    },
+    "JobSecretModel": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "pass-to-parent": {
+          "default": false,
+          "title": "Pass-To-Parent",
+          "type": "boolean"
+        },
+        "secret": {
+          "title": "Secret",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "secret"
+      ],
+      "title": "JobSecretModel",
+      "type": "object"
+    },
+    "PipelineModel": {
+      "additionalProperties": false,
+      "properties": {
+        "jobs": {
+          "items": {},
+          "title": "Jobs",
+          "type": "array"
+        },
+        "queue": {
+          "title": "Queue",
+          "type": "string"
+        }
+      },
+      "title": "PipelineModel",
+      "type": "object"
+    },
+    "ProjectEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "project": {
+          "$ref": "#/definitions/ProjectModel"
+        }
+      },
+      "required": [
+        "project"
+      ],
+      "title": "ProjectEntry",
+      "type": "object"
+    },
+    "ProjectModel": {
+      "additionalProperties": false,
+      "properties": {
+        "check": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "default-branch": {
+          "title": "Default-Branch",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "gate": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "periodic-weekly": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "post": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "promote": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "release": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "templates": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Templates",
+          "type": "array"
+        },
+        "third-party-check": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "vars": {
+          "title": "Vars",
+          "type": "object"
+        }
+      },
+      "title": "ProjectModel",
+      "type": "object"
+    },
+    "ProjectTemplateEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "project-template": {
+          "$ref": "#/definitions/ProjectTemplateModel"
+        }
+      },
+      "required": [
+        "project-template"
+      ],
+      "title": "ProjectTemplateEntry",
+      "type": "object"
+    },
+    "ProjectTemplateModel": {
+      "additionalProperties": false,
+      "properties": {
+        "check": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "default-branch": {
+          "title": "Default-Branch",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "gate": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "periodic-weekly": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "post": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "promote": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "release": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "third-party-check": {
+          "$ref": "#/definitions/PipelineModel"
+        },
+        "vars": {
+          "title": "Vars",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ProjectTemplateModel",
+      "type": "object"
+    },
+    "RequiredProjectModel": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "override-checkout": {
+          "title": "Override-Checkout",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "RequiredProjectModel",
+      "type": "object"
+    },
+    "SecretEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "secret": {
+          "$ref": "#/definitions/SecretModel"
+        }
+      },
+      "required": [
+        "secret"
+      ],
+      "title": "SecretEntry",
+      "type": "object"
+    },
+    "SecretModel": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "title": "Data",
+          "type": "object"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "data"
+      ],
+      "title": "SecretModel",
+      "type": "object"
+    },
+    "ZuulRoleModel": {
+      "additionalProperties": false,
+      "properties": {
+        "zuul": {
+          "title": "Zuul",
+          "type": "string"
+        }
+      },
+      "required": [
+        "zuul"
+      ],
+      "title": "ZuulRoleModel",
+      "type": "object"
+    }
+  },
+  "examples": [
+    "zuul.d/*.yaml",
+    "zuul-tests.d/*.yaml",
+    ".zuul.yaml"
+  ],
+  "items": {
+    "anyOf": [
+      {
+        "$ref": "#/definitions/JobEntry"
+      },
+      {
+        "$ref": "#/definitions/ProjectEntry"
+      },
+      {
+        "$ref": "#/definitions/ProjectTemplateEntry"
+      },
+      {
+        "$ref": "#/definitions/SecretEntry"
+      }
+    ]
+  },
+  "title": "Zuul Config Schema",
+  "type": "array"
+}

--- a/src/test/zuul/jobs.yaml
+++ b/src/test/zuul/jobs.yaml
@@ -1,0 +1,95 @@
+# valid zuul config sample
+- job:
+    name: minimal
+
+- job:
+    name: b
+    description: ...
+    pre-run: ...
+    run: ...
+    files:
+      - foo
+      - bar
+
+- job:
+    name: maximal
+    abstract: true
+    attempts: 1
+    voting: true
+    ansible-version: 2.8
+    host-vars:
+      primary:
+        ansible_user: root
+    timeout: 3400
+    description: ...
+    run: ...
+    nodeset:
+      nodes: []
+    pre-run:
+      - foo
+      - bar
+    post-run:
+      - foo
+      - bar
+    parent: ...
+    vars:
+      foo: bar
+    files: "pattern" # or list of patterns
+    override-checkout: master
+    success-url: docs/
+    failure-url: docs/
+    secrets: # https://zuul-ci.org/docs/zuul/reference/job_def.html#attr-job.secrets
+      - foo
+      - name: bar
+        secret: pass
+        pass-to-parent: true
+    tags: all-platforms
+    required-projects:
+      - foo
+      - bar
+      - name: foo
+        override-checkout: branch-name
+    roles:
+      - zuul: some_role_name
+    final: false
+    branches: master
+
+- project-template:
+    name: sample-template
+    description: Description
+    vars:
+      var_from_template: foo
+    post:
+      jobs:
+        - template_job
+    release:
+      jobs:
+        - template_job
+
+# project minimal
+- project: {}
+
+# project maximal
+- project:
+    name: Sample project
+    description: Description
+    templates:
+      - sample-template
+    vars:
+      var_for_all_jobs: value
+    # common pipeline names (sadly at same level as properties)
+    check:
+      jobs:
+        - job1
+        - job2:
+            vars:
+              var_for_all_jobs: override
+    gate: {}
+    promote: {}
+    periodic-weekly: {}
+
+# https://zuul-ci.org/docs/zuul/reference/secret_def.html#secret
+- secret:
+    name: foo
+    data:
+      foo: bar


### PR DESCRIPTION
As zuul-lint project is pending archival, we move Zuul CI schema in schemastore. I will continue to help with its maintenance.

This will decouple Zuul CI schema from Ansible schemas, which do not have anything in common.