### PR TITLE
Add Datadog service definition schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1897,6 +1897,14 @@
       "url": "https://raw.githubusercontent.com/rancher/k3d/main/pkg/config/config.versions.schema.json"
     },
     {
+      "name": "service.datadog.yaml",
+      "description": "Datadog service catalog definition file",
+      "fileMatch": [
+        "service.datadog.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/version.schema.json"
+    },
+    {
       "name": "Ory Keto configuration",
       "description": "Schema for Ory Keto configuration file",
       "fileMatch": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
