### PR TITLE
Update template.json schema to indicate depracation of format fields

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -479,6 +479,14 @@
       }
     },
     {
+      "template.json": {
+        "unknownKeywords": [
+          "deprecationMessage",
+          "sources"
+        ]
+      }
+    },
+    {
       "dart-build.json": {
         "unknownKeywords": [
           "deprecationMessage",

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -479,14 +479,6 @@
       }
     },
     {
-      "template.json": {
-        "unknownKeywords": [
-          "deprecationMessage",
-          "sources"
-        ]
-      }
-    },
-    {
       "dart-build.json": {
         "unknownKeywords": [
           "deprecationMessage",
@@ -720,6 +712,14 @@
       "staticwebapp.config.json": {
         "unknownKeywords": [
           "examples"
+        ]
+      }
+    },
+    {
+      "template.json": {
+        "unknownKeywords": [
+          "deprecationMessage",
+          "sources"
         ]
       }
     },

--- a/src/schemas/json/template.json
+++ b/src/schemas/json/template.json
@@ -1,6 +1,6 @@
 {
   "title": "JSON schema .NET template files",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
 
   "type": "object",
   "required": [ "author", "classifications", "identity", "name", "shortName", "tags" ],

--- a/src/schemas/json/template.json
+++ b/src/schemas/json/template.json
@@ -1,6 +1,6 @@
 {
   "title": "JSON schema .NET template files",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
 
   "type": "object",
   "required": [ "author", "classifications", "identity", "name", "shortName", "tags" ],

--- a/src/schemas/json/template.json
+++ b/src/schemas/json/template.json
@@ -55,7 +55,13 @@
         "parameters": {
           "properties": {
             "format": {
-              "description": "When a string representation of the guid is needed, this is used as the format string in Guid.ToString().",
+              "deprecated": true,
+              "deprecationMessage": "This property is not maintained and may be removed in the future. Use defaultFormat instead, or use guids section.",
+              "description": "This property is not maintained and may be removed in the future. Use defaultFormat instead, or use guids section.",
+              "type": "string"
+            },
+            "defaultFormat": {
+              "description": "The format of guid to be generated. Accepts a single value from ('n', 'd', 'b', 'p', 'x') for lowercase output or ('N', 'D', 'B', 'P', 'X') for uppercase output. The formats are defined in Guid.ToString() method documentation.",
               "type": "string"
             }
           }


### PR DESCRIPTION

We are deprecating a field in our template.json schema (more details in https://github.com/dotnet/templating/issues/4186). So updating the schema in schemastore.

I as well updated the schema to draft 06 - to recognized used `deprecated` element.
I added `deprecationMessage` as well as (though not in schema) it is recognized by various tools ([vscode](https://github.com/microsoft/vscode/issues/14260), [JetBrains plugins](https://www.jetbrains.com/help/phpstorm/json-and-json5-deprecated-json-property.html))
