### PR TITLE
Add schema for Deno

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1041,6 +1041,12 @@
       "url": "https://json.schemastore.org/debugsettings.json"
     },
     {
+      "name": "Deno",
+      "description": "A JSON representation of a Deno configuration file.",
+      "fileMatch": ["deno.json", "deno.jsonc"],
+      "url": "https://deno.land/x/deno/cli/schemas/config-file.v1.json"
+    },
+    {
       "name": "dependabot.json",
       "description": "A JSON schema for the Dependabot config.yml files",
       "fileMatch": [


### PR DESCRIPTION
From the docs:

> A JSON schema file is available for editors to provide autocomplete.
> The file is versioned and available at:
> https://deno.land/x/deno/cli/schemas/config-file.v1.json

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
