### PR TITLE
Update location of Ansible Navigator schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -195,7 +195,7 @@
     {
       "name": "Ansible Navigator Configuration",
       "description": "Ansible Navigator Configuration",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-navigator.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-navigator/main/src/ansible_navigator/data/ansible-navigator.json",
       "fileMatch": [
         ".ansible-navigator.json",
         ".ansible-navigator.yaml",


### PR DESCRIPTION
Now schema is part of ansible-navigator project itself.