### PR TITLE
eslintrc.json: add support for nested overrides

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -622,6 +622,9 @@
           },
           "settings": {
             "$ref": "#/properties/settings"
+          },
+          "overrides": {
+            "$ref": "#/properties/overrides"
           }
         },
         "additionalProperties": false,

--- a/src/test/eslintrc/nestedOverrides.json
+++ b/src/test/eslintrc/nestedOverrides.json
@@ -1,0 +1,38 @@
+{
+  "rules": {
+    "array-bracket-spacing": [
+      "error",
+      "never",
+      {
+        "objectsInArrays": false
+      }
+    ]
+  },
+  "extends": "aaa",
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "parserOptions": {
+        "project": ["tsconfig.json"],
+        "createDefaultProgram": true
+      },
+      "extends": [
+        "plugin:@angular-eslint/recommended",
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+      ],
+      "overrides": [
+        {
+          "files": ["*.spec.ts"],
+          "plugins": ["jest"],
+          "extends": ["plugin:jest/recommended", "plugin:jest/style"],
+          "rules": {
+            "@typescript-eslint/no-floating-promises": "off",
+            "@typescript-eslint/unbound-method": "off",
+            "jest/unbound-method": "error"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
nested overrides are supported according to doc:
https://eslint.org/docs/user-guide/configuring/configuration-files#how-do-overrides-work


