### PR TITLE
Use github URL for deno schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1044,7 +1044,7 @@
       "name": "Deno",
       "description": "A JSON representation of a Deno configuration file.",
       "fileMatch": ["deno.json", "deno.jsonc"],
-      "url": "https://deno.land/x/deno/cli/schemas/config-file.v1.json"
+      "url": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json"
     },
     {
       "name": "dependabot.json",


### PR DESCRIPTION
Some integrations don't follow the link to the resolved URL.

See: #2160

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
