### PR TITLE
pre-commit-config: Accept any string as a Git repo

### DIFF
--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -55,7 +55,7 @@
                 "repo": {
                     "$comment": "the repository url to git clone from",
                     "type": "string",
-                    "pattern": "^(((ssh)|(http[s]?)://)|(git@)).+"
+                    "pattern": "^(?!.*(local|meta)).*$"
                 },
                 "rev": {
                     "$comment": "the revision or tag to clone at (previously sha).",


### PR DESCRIPTION
https://git-scm.com/docs/git-clone#_git_urls documents all valid Git URL syntaxes. These are cumbersome to maintain as a regex.  I have reviewed many purported such regexes, and every single one of them at least omits some cases. False positives break builds, whereas false negatives are caught by running pre-commit.

Fixes #2172.