### PR TITLE
zuul: fix dependencies and provides

### DIFF
--- a/src/schemas/json/zuul.json
+++ b/src/schemas/json/zuul.json
@@ -56,6 +56,23 @@
           "title": "Description",
           "type": "string"
         },
+        "dependencies": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/JobDependencyModel"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Files"
+        },
         "failure-url": {
           "title": "Failure-Url",
           "type": "string"
@@ -148,8 +165,11 @@
           "title": "Pre-Run"
         },
         "provides": {
+          "items": {
+            "type": "string"
+          },
           "title": "Provides",
-          "type": "string"
+          "type": "array"
         },
         "required-projects": {
           "items": {
@@ -250,6 +270,25 @@
         "name"
       ],
       "title": "JobModel",
+      "type": "object"
+    },
+    "JobDependencyModel": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "soft": {
+          "default": false,
+          "title": "Soft",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "JobDependencyModel",
       "type": "object"
     },
     "JobSecretModel": {

--- a/src/test/zuul/jobs.yaml
+++ b/src/test/zuul/jobs.yaml
@@ -7,6 +7,8 @@
     description: ...
     pre-run: ...
     run: ...
+    dependencies:
+      - hard
     files:
       - foo
       - bar
@@ -23,6 +25,10 @@
     timeout: 3400
     description: ...
     run: ...
+    dependencies:
+      - name: hard
+      - name: soft
+        soft: true
     nodeset:
       nodes: []
     pre-run:
@@ -49,6 +55,11 @@
       - bar
       - name: foo
         override-checkout: branch-name
+    requires:
+      - vegetables
+    provides:
+      - salad
+      - food
     roles:
       - zuul: some_role_name
     final: false


### PR DESCRIPTION
There are a few aspects which were missing from the Zuul schema
which were dependencies that were added[1].  Also, provides is
expected to be a list of strings rather than a single string[2].

[1]: https://zuul-ci.org/docs/zuul/latest/config/job.html#attr-job.dependencies
[2]: https://zuul-ci.org/docs/zuul/latest/config/job.html#attr-job.provides

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
