### PR TITLE
Add schema for Xstate statecharts

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4247,6 +4247,12 @@
         "conf.yaml"
       ],
       "url": "https://json.schemastore.org/cheatsheets.json"
+    },
+    {
+      "name": "Xstate Machine Schema",
+      "description": "Schema for making statecharts",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/statelyai/xstate/main/packages/core/src/machine.schema.json"
     }
   ]
 }


### PR DESCRIPTION
Schema for xstate statecharts. The schema is retained in the xstate repository to avoid dublicate versions