### PR TITLE
Add Butane schema for Fedora CoreOS

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4260,6 +4260,7 @@
       "fileMatch": ["*.bu"],
       "url": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/Butane-Schema.json"
     },
+    {
       "name": "Updatecli",
       "description": "Schema for Updatecli manifest",
       "fileMatch": [

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4253,6 +4253,12 @@
       "description": "Schema for making statecharts",
       "fileMatch": [],
       "url": "https://raw.githubusercontent.com/statelyai/xstate/main/packages/core/src/machine.schema.json"
+    },
+    {
+      "name": "Butane config schema",
+      "description": "Schema to validate butane files for Fedora CoreOS",
+      "fileMatch": ["*.bu"],
+      "url": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/Butane-Schema.json"
     }
   ]
 }


### PR DESCRIPTION
Adding [butane](https://coreos.github.io/butane/specs/) v1.4.0 and higher validation schema for Fedora CoreOS