### PR TITLE
Add eksctl schema support

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1240,10 +1240,6 @@
     {
       "name": "eksctl",
       "description": "eksctl cluster configuration file",
-      "fileMatch": [
-        "cluster.yml",
-        "cluster.yaml"
-      ],
       "url": "https://raw.githubusercontent.com/weaveworks/eksctl/main/pkg/apis/eksctl.io/v1alpha5/assets/schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1238,6 +1238,15 @@
       "url": "https://json.schemastore.org/pm2-ecosystem.json"
     },
     {
+      "name": "eksctl",
+      "description": "eksctl cluster configuration file",
+      "fileMatch": [
+        "cluster.yml",
+        "cluster.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/weaveworks/eksctl/main/pkg/apis/eksctl.io/v1alpha5/assets/schema.json"
+    },
+    {
       "name": ".esmrc.json",
       "description": "Configuration files for the esm module/package in Node.js",
       "fileMatch": [


### PR DESCRIPTION
Basic support for the [eksctl](https://eksctl.io/) cluster configuration
schema. The file matches are based off the example in the documentation.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
