### PR TITLE
appsscript: fixed incorrect default type + added 'libraries' property to the test file

### DIFF
--- a/src/schemas/json/appsscript.json
+++ b/src/schemas/json/appsscript.json
@@ -95,7 +95,7 @@
               "version": {
                 "description": "The version of the library that is used by the script. This is either a version number or stable, meaning the last version created.",
                 "type": "string",
-                "default": 32
+                "default": "41"
               },
               "developmentMode": {
                 "description": "If true, version is ignored and the script uses the current library project saved code, even if that code has not been saved to a new version.",

--- a/src/test/appsscript/appsscript.json
+++ b/src/test/appsscript/appsscript.json
@@ -8,6 +8,14 @@
                 "userSymbol": "Sheets",
                 "version": "v4"
             }
+        ],
+        "libraries": [
+            {
+                "libraryId": "1B7FSrk5Zi6L1rSxxTDgDEUsPzlukDsi4KGuTMorsTQHhGBzBkMun4iDF",
+                "userSymbol": "OAuth2",
+                "version": "41",
+                "developmentMode": false
+            }
         ]
     },
     "exceptionLogging": "STACKDRIVER",


### PR DESCRIPTION
This minor PR fixes a small issue with `libraries` field default value `version` property - it should be a `string`, not a `number`.
It also adds the `libraries` field to the test file for the schema and updates the default number to the most recent version of the well-known library used as the default one.
