### PR TITLE
Add command highlight from npm scripts

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -697,7 +697,8 @@
     {
       "package.json": {
         "unknownKeywords": [
-          "tsType"
+          "tsType",
+          "x-intellij-language-injection"
         ]
       }
     },

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -34,35 +34,43 @@
     },
     "scriptsInstallAfter": {
       "description": "Run AFTER the package is installed.",
-      "type": "string"
+      "type": "string",
+      "x-intellij-language-injection": "Shell Script"
     },
     "scriptsPublishAfter": {
       "description": "Run AFTER the package is published.",
-      "type": "string"
+      "type": "string",
+      "x-intellij-language-injection": "Shell Script"
     },
     "scriptsRestart": {
       "description": "Run by the 'npm restart' command. Note: 'npm restart' will run the stop and start scripts if no restart script is provided.",
-      "type": "string"
+      "type": "string",
+      "x-intellij-language-injection": "Shell Script"
     },
     "scriptsStart": {
       "description": "Run by the 'npm start' command.",
-      "type": "string"
+      "type": "string",
+      "x-intellij-language-injection": "Shell Script"
     },
     "scriptsStop": {
       "description": "Run by the 'npm stop' command.",
-      "type": "string"
+      "type": "string",
+      "x-intellij-language-injection": "Shell Script"
     },
     "scriptsTest": {
       "description": "Run by the 'npm test' command.",
-      "type": "string"
+      "type": "string",
+      "x-intellij-language-injection": "Shell Script"
     },
     "scriptsUninstallBefore": {
       "description": "Run BEFORE the package is uninstalled.",
-      "type": "string"
+      "type": "string",
+      "x-intellij-language-injection": "Shell Script"
     },
     "scriptsVersionBefore": {
       "description": "Run BEFORE bump the package version.",
-      "type": "string"
+      "type": "string",
+      "x-intellij-language-injection": "Shell Script"
     },
     "packageExportsEntryPath": {
       "type": [
@@ -534,7 +542,8 @@
       },
       "additionalProperties": {
         "type": "string",
-        "tsType": "string | undefined"
+        "tsType": "string | undefined",
+        "x-intellij-language-injection": "Shell Script"
       }
     },
     "config": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Add command highlight from npm scripts like this:
before:
<img width="1113" alt="image" src="https://user-images.githubusercontent.com/16346984/163771840-043f4026-343f-48ca-a2c1-2c1dcc76f938.png">
after:
<img width="773" alt="image" src="https://user-images.githubusercontent.com/16346984/163772054-e88ff506-4244-4f97-945e-f560b719adff.png">

