### PR TITLE
Add the JSON schema for Quilt's mod metadata

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3682,6 +3682,12 @@
       "description": "Copy/paste detector for programming source code",
       "fileMatch": [".jscpd.json"],
       "url": "https://json.schemastore.org/jscpd.json"
+    },
+    {
+      "name": "quilt.mod.json",
+      "description": "Schema for the metadata used by Quilt mods.",
+      "fileMatch": ["quilt.mod.json"],
+      "url": "https://raw.githubusercontent.com/QuiltMC/quilt-json-schemas/main/quilt.mod.json/schemas/main.json"
     }
   ],
   "version": 1


### PR DESCRIPTION
This PR adds a JSON schema for [QuiltMC](https://quiltmc.org)'s mod metadata, `quilt.mod.json`. This schema is an adaptation of the format specification described [here](https://github.com/QuiltMC/rfcs/blob/master/specification/0002-quilt.mod.json.md), with its prototype having aided with the development of the specification itself.