### PR TITLE
Added GeoJSON.json latest

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4277,6 +4277,11 @@
         "updatecli.yaml"
       ],
       "url": "https://www.updatecli.io/schema/latest/config.json"
+    },
+    {
+      "name": "GeoJSON.json latest",
+      "description": "GeoJSON format for representing geographic data. Newest version from GeoJSON org.",
+      "url": "https://geojson.org/schema/GeoJSON.json"
     }
   ]
 }


### PR DESCRIPTION
This is the newest evolving schema of GeoJSON. Needed for defining a subset in another schema (Azure Cosmos DB Geospacial supported subset)

P.S. An older version using draft-04  has been added earlier
