### PR TITLE
Allow additional props and fix `theme`/`menus` props in Hugo schema

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -2819,7 +2819,8 @@
     },
     "theme": {
       "description": "\nhttps://gohugo.io/hugo-modules/configuration/#module-config-imports",
-      "type": "boolean"
+      "type": "string",
+      "minLength": 1
     },
     "themesDir": {
       "description": "The directory where themes are stored\nhttps://gohugo.io/getting-started/configuration/#themesdir",
@@ -3433,6 +3434,5 @@
       "type": "boolean",
       "default": false
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -1964,7 +1964,7 @@
       },
       "additionalProperties": false
     },
-    "menus": {
+    "menu": {
       "title": "media menu options",
       "description": "The menu options\nhttps://gohugo.io/content-management/menus/#add-non-content-entries-to-a-menu",
       "type": "object",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
