### PR TITLE
Add trailingSlash to staticwebapp.config.json

### DIFF
--- a/src/negative_test/staticwebapp.config/invalid_trailingslash_must_fail.json
+++ b/src/negative_test/staticwebapp.config/invalid_trailingslash_must_fail.json
@@ -1,0 +1,3 @@
+{
+    "trailingSlash": "invalid"
+}

--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -661,6 +661,15 @@
                 }
             },
             "additionalProperties": false
+        },
+        "trailingSlash": {
+            "type": "string",
+            "enum": [
+                "always",
+                "never",
+                "auto"
+            ],
+            "description": "Trailing slash configuration"
         }
     },
     "additionalProperties": false

--- a/src/test/staticwebapp.config/staticwebapp.config.json
+++ b/src/test/staticwebapp.config/staticwebapp.config.json
@@ -193,5 +193,6 @@
     },
     "platform": {
         "apiRuntime": "node:16"
-    }
+    },
+    "trailingSlash": "always"
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
Adding Azure Static Web Apps support for trailing slash configuration (https://docs.microsoft.com/azure/static-web-apps/configuration#trailing-slash).

cc @simonaco, @anthonychu, @miwebst

