### PR TITLE
fix: percentage is optional in codecov target

### DIFF
--- a/src/schemas/json/codecov.json
+++ b/src/schemas/json/codecov.json
@@ -14,13 +14,13 @@
       "properties": {
         "target": {
           "type": ["string", "number"],
-          "pattern": "^(([0-9]+\\.?[0-9]*|\\.[0-9]+)%|auto)$",
+          "pattern": "^(([0-9]+\\.?[0-9]*|\\.[0-9]+)%?|auto)$",
           "default": "auto"
         },
         "threshold": {
           "type": "string",
           "default": "0%",
-          "pattern": "^([0-9]+\\.?[0-9]*|\\.[0-9]+)%$"
+          "pattern": "^([0-9]+\\.?[0-9]*|\\.[0-9]+)%?$"
         },
         "base": {
           "type": "string",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

The `target`/`threshold` property in Codecov can be a string without a percentage (%) symbol.
This just makes it optional in the regular expression.