### PR TITLE
github-workflow: allow concurrency in reusable workflow call

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -488,6 +488,18 @@
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idsecrets",
           "description": "When a job is used to call a reusable workflow, you can use 'secrets' to provide a map of secrets that are passed to the called workflow. Any secrets that you pass must match the names defined in the called workflow.",
           "$ref": "#/definitions/env"
+        },
+        "concurrency": {
+          "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency",
+          "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/concurrency"
+            }
+          ]
         }
       },
       "required": [

--- a/src/test/github-workflow/call-reusable-workflow.json
+++ b/src/test/github-workflow/call-reusable-workflow.json
@@ -12,7 +12,8 @@
       "uses": "exampleowner/example/.github/workflows/build_and_publish.yaml@v1",
       "secrets": {
         "api_token": "${{ secrets.API_TOKEN }}"
-      }
+      },
+      "concurrency": "build-${{ github.ref }}"
     }
   }
 }


### PR DESCRIPTION
 Allow concurrency in reusable Github Actions workflow call. Concurrency is already defined in `normalJob` but was missing from `reusableWorkflowCallJob`.

For reference:
- https://docs.github.com/en/actions/using-jobs/using-concurrency
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idconcurrency