### PR TITLE
Update Architect.io schema to new url.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -263,7 +263,7 @@
         "*.architect.yml",
         "*.architect.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/architect-team/architect-cli/master/src/dependency-manager/schema/architect.schema.json"
+      "url": "https://raw.githubusercontent.com/architect-team/architect-cli/main/src/dependency-manager/schema/architect.schema.json"
     },
     {
       "name": "arc.json",
@@ -4291,7 +4291,9 @@
     {
       "name": "Butane config schema",
       "description": "Schema to validate butane files for Fedora CoreOS",
-      "fileMatch": ["*.bu"],
+      "fileMatch": [
+        "*.bu"
+      ],
       "url": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/Butane-Schema.json"
     },
     {
@@ -4313,7 +4315,9 @@
     {
       "name": ".clang-format",
       "description": "yaml schema for clang-format config",
-      "fileMatch": [".clang-format"],
+      "fileMatch": [
+        ".clang-format"
+      ],
       "url": "https://json.schemastore.org/clang-format.json"
     }
   ]


### PR DESCRIPTION
The Architect.io team has recently updated our github repository to use `main` instead of `master`. With this change the current schema url no longer pulls from our production branch. 

## Tests
Ran `make` and all tests passed. Verified the new URL also worked.
https://raw.githubusercontent.com/architect-team/architect-cli/main/src/dependency-manager/schema/architect.schema.json