### PR TITLE
Update schema for Dart's `build.yaml` files

### DIFF
--- a/src/schemas/json/dart-build.json
+++ b/src/schemas/json/dart-build.json
@@ -17,12 +17,18 @@
             "type": "object",
             "additionalProperties": {
               "$ref": "#/definitions/buildTarget"
+            },
+            "propertyNames": {
+              "$ref": "#/definitions/targetKey"
             }
           },
           "builders": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/definitions/builderDefinition"
+            },
+            "propertyNames": {
+              "$ref": "#/definitions/builderKey"
             }
           },
           "post_process_builders": {
@@ -257,8 +263,8 @@
       "targetKey": {
         "type": "string",
         "title": "An identifier for a target",
-        "description": "A target key has two parts, a package and a name.",
-        "pattern": "^(?:\\w+:)?\\w+\\$default$"
+        "description": "A target key has two parts, a package and a name. They are separated by a `|`.",
+        "pattern": "^(?:\\w+\\|)?\\w+|\\$default$"
       },
       "builderKey": {
         "type": "string",

--- a/src/schemas/json/dart-build.json
+++ b/src/schemas/json/dart-build.json
@@ -263,14 +263,14 @@
       "targetKey": {
         "type": "string",
         "title": "An identifier for a target",
-        "description": "A target key has two parts, a package and a name. They are separated by a `|`.",
-        "pattern": "^(?:\\w+\\|)?\\w+|\\$default$"
+        "description": "A target key has two parts, a package and a name. They are separated by a colon.",
+        "pattern": "^(?:\\w+:)?\\w+|\\$default$"
       },
       "builderKey": {
         "type": "string",
         "title": "An identifier for a builder",
-        "description": "To construct a key, you join the package name and the builder name with a |.",
-        "pattern": "^(?:\\w*\\|)?\\w+$"
+        "description": "To construct a key, you join the package name and the builder name with a colon.",
+        "pattern": "^(?:\\w*:)?\\w+$"
       }
     },
     "$ref": "#/definitions/buildConfig"

--- a/src/test/dart-build/sample.json
+++ b/src/test/dart-build/sample.json
@@ -2,12 +2,12 @@
     "targets": {
       "$default": {
         "dependencies": [
-          "foo|bar",
+          "foo:bar",
           "foo",
           "$default"
         ],
         "builders": {
-          "build_web_compilers|entrypoint": {
+          "build_web_compilers:entrypoint": {
             "options": {
               "compiler": "dart2js",
               "dart2js_args": [
@@ -19,13 +19,13 @@
               "web/stack_trace_mapper.dart"
             ]
           },
-          "build_web_compilers|_stack_trace_mapper_copy": {
+          "build_web_compilers:_stack_trace_mapper_copy": {
             "enabled": true
           },
-          "build_web_compilers|sdk_js_copy": {
+          "build_web_compilers:sdk_js_copy": {
             "enabled": true
           },
-          "build_web_compilers|sdk_js_cleanup": {
+          "build_web_compilers:sdk_js_cleanup": {
             "enabled": true
           }
         }
@@ -46,10 +46,10 @@
         "is_optional": false,
         "auto_apply": "none",
         "applies_builders": [
-          "build_web_compilers|sdk_js_cleanup"
+          "build_web_compilers:sdk_js_cleanup"
         ],
         "runs_before": [
-          "build_web_compilers|entrypoint"
+          "build_web_compilers:entrypoint"
         ]
       },
       "dart2js_modules": {
@@ -75,7 +75,7 @@
           ".module.library"
         ],
         "applies_builders": [
-          "build_modules|module_cleanup"
+          "build_modules:module_cleanup"
         ]
       },
       "ddc_modules": {
@@ -101,7 +101,7 @@
           ".module.library"
         ],
         "applies_builders": [
-          "build_modules|module_cleanup"
+          "build_modules:module_cleanup"
         ]
       },
       "ddc": {
@@ -124,9 +124,9 @@
           ".ddc.module"
         ],
         "applies_builders": [
-          "build_web_compilers|ddc_modules",
-          "build_web_compilers|dart2js_modules",
-          "build_web_compilers|dart_source_cleanup"
+          "build_web_compilers:ddc_modules",
+          "build_web_compilers:dart2js_modules",
+          "build_web_compilers:dart_source_cleanup"
         ]
       },
       "entrypoint": {
@@ -179,7 +179,7 @@
           }
         },
         "applies_builders": [
-          "build_web_compilers|dart2js_archive_extractor"
+          "build_web_compilers:dart2js_archive_extractor"
         ]
       },
       "_stack_trace_mapper_copy": {

--- a/src/test/dart-build/sample.json
+++ b/src/test/dart-build/sample.json
@@ -1,6 +1,11 @@
 {
     "targets": {
       "$default": {
+        "dependencies": [
+          "foo|bar",
+          "foo",
+          "$default"
+        ],
         "builders": {
           "build_web_compilers|entrypoint": {
             "options": {


### PR DESCRIPTION
As per https://github.com/dart-lang/build/issues/3293, the suggestion is to use `:` instead of `|` for target and builder keys. This PR implements these changes in the schema and adapts the test file.