### PR TITLE
Add V2Ray schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4330,6 +4330,18 @@
         "*.flow.json"
       ],
       "url": "https://raw.githubusercontent.com/estuary/flow/master/flow.schema.json"
+    },
+    {
+      "name": "V2Ray",
+      "description": "JSON schema for V2Ray jsonv4/jsonv5 configuration format",
+      "fileMatch": [
+        "**/v2ray/*.json"
+      ],
+      "url": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v4-config.schema.json",
+      "versions": {
+        "jsonv4": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v4-config.schema.json",
+        "jsonv5-preview": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v5-config.schema.json"
+      }
     }
   ]
 }


### PR DESCRIPTION
Schemas are generated from https://github.com/EHfive/v2ray-jsonschema

This add schemas for [V2Ray](https://github.com/v2fly/v2ray-core) configuration files.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
