### PR TITLE
add top level type to github schemas

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions",
+  "type": "object",
   "definitions": {
     "pre-if": {
       "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#pre-if",

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions",
+  "type": "object",
   "definitions": {
     "architecture": {
       "type": "string",


### PR DESCRIPTION
Currently there is a top level `"properties"` field, but no
associated `"type": "object"` field to restrict the type to be
an object. This allows the value to be JSON types other than
object, which is probably not intended. For example the workflow
specification currently allows `42`, `true`, or `["not a workflow"]` as values.

For reference, see section 7.6.1 of the [JSONSchema specification](https://json-schema.org/draft/2020-12/json-schema-core.html):

> Most assertions only constrain values within a certain primitive type. When the type of the instance is not of the type targeted by the keyword, the instance is considered to conform to the assertion.

In this case, the keyword in question is `properties` which targets the `object` type, so anything that's not an object is deemed to conform.

It's easy to verify this assumption using an [online JSONSchema validator](https://jsonschemalint.com/#!/version/draft-07/markup/json)

I've only updated two schemas here, but a quick scan shows that there are a number of other schemas which might well suffer from the same issue, specifically these ones:

- [commitlintrc.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/commitlintrc.json)
- [esmrc.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/esmrc.json)
- [github-action.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/github-action.json)
- [github-workflow.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/github-workflow.json)
- [helmfile.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/helmfile.json)
- [minecraft-loot-table.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/minecraft-loot-table.json)
- [nswag.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/nswag.json)
- [opspec-io-0.1.7.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/opspec-io-0.1.7.json)
- [phraseapp.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/phraseapp.json)
- [prisma.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/prisma.json)
- [prometheus.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/prometheus.json)
- [prometheus.rules.json](https://github.com/SchemaStore/schemastore/blob/2d4f6159d123a0a3b8e85bb983d3c4d2b5ca3684/src/schemas/json/prometheus.rules.json)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
