### PR TITLE
fix typo in yamllint.json

### DIFF
--- a/src/schemas/json/yamllint.json
+++ b/src/schemas/json/yamllint.json
@@ -477,8 +477,8 @@
                   ],
                   "default": "consistent"
                 },
-                "indent-sequence": {
-                  "title": "Indent Sequence",
+                "indent-sequences": {
+                  "title": "Indent Sequences",
                   "description": "Defines whether block sequences should be indented or not (when in a mapping, this indentation is not mandatory – some people perceive the - as part of the indentation).",
                   "anyOf": [
                     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

We had typo in `yamllint.json`. The change is only adding postfix `s` in `indent-sequence`. See valid configuration in https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.indentation