### PR TITLE
Add Ubuntu 22.04 support to the github-workflow schema

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -547,6 +547,7 @@
                 "self-hosted",
                 "ubuntu-18.04",
                 "ubuntu-20.04",
+                "ubuntu-22.04",
                 "ubuntu-latest",
                 "windows-2016",
                 "windows-2019",

--- a/src/test/github-workflow/runs-on.yaml
+++ b/src/test/github-workflow/runs-on.yaml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo 'Hello from ${{ runner.os }}'
+  ubuntu-22:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo 'Hello from ${{ runner.os }}'
   ubuntu-20:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
The `ubuntu-22.04` virtual environment has been made available per https://github.com/actions/virtual-environments/issues/5490.
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
