### PR TITLE
Add cloud-init config-config userdata schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -774,6 +774,17 @@
       "url": "https://json.schemastore.org/cloudify.json"
     },
     {
+      "name": "cloud-init: cloud-config userdata JSON schema",
+      "description": "JSON schema for #cloud-config userdata YAML",
+      "fileMatch": [
+        "cloudconfig.yaml",
+        "cloud-config.yaml",
+        "*.cloudconfig.yaml",
+        "*.cloud-config.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/canonical/cloud-init/main/cloudinit/config/schemas/versions.schema.cloud-config.json"
+    },
+    {
       "name": "codemagic",
       "description": "JSON schema for Codemagic CI/CD file configuration",
       "fileMatch": [


### PR DESCRIPTION
Provide versioned schema for cloud-init's #cloud-config YAML files.

See https://cloudinit.readthedocs.io/en/latest