### PR TITLE
Add Jasmine JSON config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1818,6 +1818,14 @@
       "url": "https://json.schemastore.org/io-package.json"
     },
     {
+      "name": "Jasmine",
+      "description": "Schema for jasmine JSON config file",
+      "fileMatch": [
+          "jasmine.json"
+      ],
+      "url": "https://json.schemastore.org/jasmine.json"
+    },
+    {
       "name": "Jekyll",
       "description": "Jekyll static site generator config file schema",
       "fileMatch": [

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1820,9 +1820,7 @@
     {
       "name": "Jasmine",
       "description": "Schema for jasmine JSON config file",
-      "fileMatch": [
-          "jasmine.json"
-      ],
+      "fileMatch": ["jasmine.json"],
       "url": "https://json.schemastore.org/jasmine.json"
     },
     {

--- a/src/negative_test/jasmine/camel-case-prop.json
+++ b/src/negative_test/jasmine/camel-case-prop.json
@@ -1,0 +1,3 @@
+{
+  "specDir": "spec"
+}

--- a/src/negative_test/jasmine/wrong-value.json
+++ b/src/negative_test/jasmine/wrong-value.json
@@ -1,0 +1,3 @@
+{
+  "spec_files": "**/*.spec.js"
+}

--- a/src/schemas/json/jasmine.json
+++ b/src/schemas/json/jasmine.json
@@ -1,30 +1,39 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://json.schemastore.org/jasmine.json",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "id": "https://json.schemastore.org/jasmine.json",
   "title": "Schema for jasmine JSON config file",
   "definitions": {
-    "spec_dir": {
-      "description": "Spec directory path relative to the current working dir when jasmine is executed.",
-      "type": "string",
-      "default": ""
+    "root-items": {
+      "type": "object",
+      "required": [
+        "spec_dir",
+        "spec_files"
+      ],
+      "properties": {
+        "spec_dir": {
+          "description": "Spec directory path relative to the current working dir when jasmine is executed.",
+          "type": "string",
+          "default": ""
+        },
+        "spec_files": {
+          "description": "Array of filepaths (and globs) relative to spec_dir to include and exclude.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "helpers": {
+          "description": "Array of filepaths (and globs) relative to spec_dir to include before jasmine specs",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      }
     },
-    "spec_files": {
-      "description": "Array of filepaths (and globs) relative to spec_dir to include and exclude.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "default": []
-    },
-    "helpers": {
-      "description": "Array of filepaths (and globs) relative to spec_dir to include before jasmine specs",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "default": []
-    },
-    "env": {
+    "env-items": {
       "description": "Configuration of the Jasmine environment",
       "type": "object",
       "properties": {
@@ -50,10 +59,16 @@
         },
         "seed": {
           "description": "Seed to use as the basis of randomization. Null causes the seed to be determined randomly at the start of execution.",
-          "type": [
-            "string",
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
           ],
           "default": null
         },
@@ -74,5 +89,21 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/root-items"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "env": {
+          "$ref": "#/definitions/env-items"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/env-items"
+    }
+  ]
 }

--- a/src/schemas/json/jasmine.json
+++ b/src/schemas/json/jasmine.json
@@ -1,14 +1,25 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "id": "https://json.schemastore.org/jasmine.json",
-  "title": "Schema for jasmine JSON config file",
+  "allOf": [
+    {
+      "$ref": "#/definitions/root-items"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "env": {
+          "$ref": "#/definitions/env-items"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/env-items"
+    }
+  ],
   "definitions": {
     "root-items": {
       "type": "object",
-      "required": [
-        "spec_dir",
-        "spec_files"
-      ],
+      "required": ["spec_dir", "spec_files"],
       "properties": {
         "spec_dir": {
           "description": "Spec directory path relative to the current working dir when jasmine is executed.",
@@ -90,20 +101,6 @@
       }
     }
   },
-  "allOf": [
-    {
-      "$ref": "#/definitions/root-items"
-    },
-    {
-      "type": "object",
-      "properties": {
-        "env": {
-          "$ref": "#/definitions/env-items"
-        }
-      }
-    },
-    {
-      "$ref": "#/definitions/env-items"
-    }
-  ]
+  "id": "https://json.schemastore.org/jasmine.json",
+  "title": "Schema for jasmine JSON config file"
 }

--- a/src/schemas/json/jasmine.json
+++ b/src/schemas/json/jasmine.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://json.schemastore.org/jasmine.json",
+  "title": "Schema for jasmine JSON config file",
+  "definitions": {
+    "spec_dir": {
+      "description": "Spec directory path relative to the current working dir when jasmine is executed.",
+      "type": "string",
+      "default": ""
+    },
+    "spec_files": {
+      "description": "Array of filepaths (and globs) relative to spec_dir to include and exclude.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "helpers": {
+      "description": "Array of filepaths (and globs) relative to spec_dir to include before jasmine specs",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "env": {
+      "description": "Configuration of the Jasmine environment",
+      "type": "object",
+      "properties": {
+        "autoCleanClosure": {
+          "description": "Clean closures when a suite is done running (done by clearing the stored function reference). This prevents memory leaks, but you won't be able to run jasmine multiple times.",
+          "type": "boolean",
+          "default": false
+        },
+        "failSpecWithNoExpectations": {
+          "description": "Whether to fail the spec if it ran no expectations. By default a spec that ran no expectations is reported as passed. Setting this to true will report such spec as a failure.",
+          "type": "boolean",
+          "default": false
+        },
+        "hideDisbaled": {
+          "description": "Whether or not reporters should hide disabled specs from their output. Currently only supported by Jasmine's HTMLReporter.",
+          "type": "boolean",
+          "default": false
+        },
+        "random": {
+          "description": "Whether to randomize spec execution order.",
+          "type": "boolean",
+          "default": true
+        },
+        "seed": {
+          "description": "Seed to use as the basis of randomization. Null causes the seed to be determined randomly at the start of execution.",
+          "type": [
+            "string",
+            "number",
+            "null"
+          ],
+          "default": null
+        },
+        "stopOnSpecFailure": {
+          "description": "Whether to stop execution of the suite after the first spec failure.",
+          "type": "boolean",
+          "default": false
+        },
+        "stopSpecOnExpectationFailure": {
+          "description": "Whether to cause specs to only have one expectation failure.",
+          "type": "boolean",
+          "default": false
+        },
+        "verboseDeprication": {
+          "description": "Whether or not to issue warnings for certain deprecated functionality every time it's used. If not set or set to false, deprecation warnings for methods that tend to be called frequently will be issued only once or otherwise throttled to to prevent the suite output from being flooded with warnings.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  }
+}

--- a/src/test/jasmine/jasmine.json
+++ b/src/test/jasmine/jasmine.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/jasmine.json",
+  "spec_dir": "specs",
+  "spec_files": [
+    "**/*.spec.js"
+  ],
+  "helpers": [
+    "helpers/*.js"
+  ],
+  "env": {
+    "failSpecWithNoExpectations": true,
+    "stopSpecOnExpectationFailure": false,
+    "stopOnSpecFailure": true,
+    "random": false
+  }
+}

--- a/src/test/jasmine/jasmine.json
+++ b/src/test/jasmine/jasmine.json
@@ -1,16 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/jasmine.json",
-  "spec_dir": "specs",
-  "spec_files": [
-    "**/*.spec.js"
-  ],
-  "helpers": [
-    "helpers/*.js"
-  ],
   "env": {
     "failSpecWithNoExpectations": true,
     "stopSpecOnExpectationFailure": false,
     "stopOnSpecFailure": true,
     "random": false
-  }
+  },
+  "helpers": ["helpers/*.js"],
+  "spec_dir": "specs",
+  "spec_files": ["**/*.spec.js"]
 }


### PR DESCRIPTION
Hey :wave: 
I'd like to add a schema for Jasmines json config to this awesome project :heart: 

### Resources

There's a [Node.js Setup Configuration example](https://jasmine.github.io/setup/nodejs.html#configuration) where most of the options are listed. I took the defaults for the _top-level options_ from the [source code](https://github.com/jasmine/jasmine-npm/blob/cff54c268770cbfd9a6f5bbd9c5c755658f7d935/lib/jasmine.js#L56-L58). Furthermore, the [Configureation Interface](https://jasmine.github.io/api/edge/Configuration.html) reveals all options for the _Jasmine Environment_.

I hope I didn't miss some options here!

### Known issues

1. As far as I know, all options that live in `env` can also be placed on the top level of the configuration; see [this](https://github.com/jasmine/jasmine-npm/blob/cff54c268770cbfd9a6f5bbd9c5c755658f7d935/lib/jasmine.js#L276-L278) part of the source code, where `failSpecWithNoExpectations` is looked up on the toplevel and if found, assigned to env config. I'm not sure how to properly put a reference (or anything like this) to the schema to be able to make this work.

1. The negative test passes, when `spec_files` is given a string but defined as an array of strings :upside_down_face: 

1. I tried to add another negative test that check the spelling of the properties, so that:
    ```json
    {
        "specDir": "specs"
    }
    ```
    fails. But this does not work :confused: 

I'm thankful for any feedback or advice :pray: 
