### PR TITLE
tsconfig.json and jsconfig.json: add ES2022 to lib enum and pattern

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -816,7 +816,13 @@
                       "ES2021.String",
                       "ES2021.WeakRef",
                       "ESNext.WeakRef",
-                      "es2021.intl"
+                      "es2021.intl",
+                      "ES2022",
+                      "ES2022.Array",
+                      "ES2022.Error",
+                      "ES2022.Intl",
+                      "ES2022.Object",
+                      "ES2022.String"
                     ]
                   },
                   {
@@ -842,6 +848,9 @@
                   },
                   {
                     "pattern": "^[Ee][Ss]2021(\\.([Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ww][Ee][Aa][Kk][Rr][Ee][Ff]))?$"
+                  },
+                  {
+                    "pattern": "^[Ee][Ss]2022(\\.([Aa][Rr][Rr][Aa][Yy]|[Ee][Rr][Rr][Oo][Rr]|[Ii][Nn][Tt][Ll]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Tt][Rr][Ii][Nn][Gg]))?$"
                   },
                   {
                     "pattern": "^[Ee][Ss][Nn][Ee][Xx][Tt](\\.([Aa][Rr][Rr][Aa][Yy]|[Aa][Ss][Yy][Nn][Cc][Ii][Tt][Ee][Rr][Aa][Bb][Ll][Ee]|[Bb][Ii][Gg][Ii][Nn][Tt]|[Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll]|[Ww][Ee][Aa][Kk][Rr][Ee][Ff]))?$"

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -813,14 +813,19 @@
                       "Webworker.Iterable",
                       "ES7",
                       "ES2021",
-                      "ES2022",
                       "ES2020.SharedMemory",
                       "ES2020.Intl",
                       "ES2021.Promise",
                       "ES2021.String",
                       "ES2021.WeakRef",
                       "ESNext.WeakRef",
-                      "es2021.intl"
+                      "es2021.intl",
+                      "ES2022",
+                      "ES2022.Array",
+                      "ES2022.Error",
+                      "ES2022.Intl",
+                      "ES2022.Object",
+                      "ES2022.String"
                     ]
                   },
                   {
@@ -848,7 +853,7 @@
                     "pattern": "^[Ee][Ss]2021(\\.([Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ww][Ee][Aa][Kk][Rr][Ee][Ff]))?$"
                   },
                   {
-                    "pattern": "^[Ee][Ss]2022$"
+                    "pattern": "^[Ee][Ss]2022(\\.([Aa][Rr][Rr][Aa][Yy]|[Ee][Rr][Rr][Oo][Rr]|[Ii][Nn][Tt][Ll]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Tt][Rr][Ii][Nn][Gg]))?$"
                   },
                   {
                     "pattern": "^[Ee][Ss][Nn][Ee][Xx][Tt](\\.([Aa][Rr][Rr][Aa][Yy]|[Aa][Ss][Yy][Nn][Cc][Ii][Tt][Ee][Rr][Aa][Bb][Ll][Ee]|[Bb][Ii][Gg][Ii][Nn][Tt]|[Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll]|[Ww][Ee][Aa][Kk][Rr][Ee][Ff]))?$"

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -813,6 +813,7 @@
                       "Webworker.Iterable",
                       "ES7",
                       "ES2021",
+                      "ES2022",
                       "ES2020.SharedMemory",
                       "ES2020.Intl",
                       "ES2021.Promise",
@@ -845,6 +846,9 @@
                   },
                   {
                     "pattern": "^[Ee][Ss]2021(\\.([Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ww][Ee][Aa][Kk][Rr][Ee][Ff]))?$"
+                  },
+                  {
+                    "pattern": "^[Ee][Ss]2022$"
                   },
                   {
                     "pattern": "^[Ee][Ss][Nn][Ee][Xx][Tt](\\.([Aa][Rr][Rr][Aa][Yy]|[Aa][Ss][Yy][Nn][Cc][Ii][Tt][Ee][Rr][Aa][Bb][Ll][Ee]|[Bb][Ii][Gg][Ii][Nn][Tt]|[Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll]|[Ww][Ee][Aa][Kk][Rr][Ee][Ff]))?$"


### PR DESCRIPTION
Thanks for maintaining this project!

I see `es2022` was already added to target, but didn't see it for lib.

Let me know if this is a reasonable change or if it needs any tweaks.

For reference, the TS 4.6 announcement mentions using `es2022` with `lib`: https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/#target-es2022