### PR TITLE
Update skaffold.yaml schema to v2beta28

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3284,7 +3284,7 @@
       "name": "skaffold.yaml",
       "description": "Schema for the skaffold.yaml configuration file for Skaffold (https://skaffold.dev/)",
       "fileMatch": ["skaffold.yaml", "skaffold.yml"],
-      "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta22.json",
+      "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta28.json",
       "versions": {
         "v1alpha1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha1.json",
         "v1alpha2": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha2.json",


### PR DESCRIPTION
Skaffold v1.38.0 comes with skaffold.yaml v2beta28:
https://github.com/GoogleContainerTools/skaffold/releases/tag/v1.38.0

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
