### PR TITLE
fix: Add `continue-on-error` to composite GHA step

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -3,6 +3,11 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "additionalProperties": false,
   "definitions": {
+    "expressionSyntax": {
+      "type": "string",
+      "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
+      "pattern": "^\\$\\{\\{.*\\}\\}$"
+    },
     "pre-if": {
       "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#pre-if",
       "description": "Allows you to define conditions for the `pre:` action execution. The `pre:` action will only run if the conditions in `pre-if` are met. If not set, then `pre-if` defaults to `always()`. Note that the `step` context is unavailable, as no steps have run yet.",
@@ -122,6 +127,19 @@
                 "additionalProperties": {
                   "type": "string"
                 }
+              },
+              "continue-on-error": {
+                "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error",
+                "description": "Prevents a job from failing when a step fails. Set to true to allow a job to pass when this step fails.",
+                "oneOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "$ref": "#/definitions/expressionSyntax"
+                  }
+                ],
+                "default": false
               },
               "working-directory": {
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsworking-directory",


### PR DESCRIPTION
This was added in actions/runner#1757