### PR TITLE
Added Qualisys Calqulus pipeline schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -528,6 +528,12 @@
       "url": "https://raw.githubusercontent.com/Kitware/CMake/master/Help/manual/presets/schema.json"
     },
     {
+      "name": "Calqulus pipeline",
+      "description": "Schema for Qualisys Calqulus pipeline",
+      "fileMatch": ["*.calqulus.yaml", "*.calqulus.yml"],
+      "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/calqulus-pipeline.schema.json"
+    },
+    {
       "name": "Camel YAML DSL",
       "description": "Schema for Camel YAML DSL",
       "fileMatch": ["*.camel.yaml", "*.camelk.yaml"],


### PR DESCRIPTION
This adds a schema validating [Calqulus pipelines](https://github.com/qualisys/Calqulus-Steps).