### PR TITLE
Add support for Semantic Release

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2387,6 +2387,12 @@
       "url": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json"
     },
     {
+      "name": "Semantic Release",
+      "description": "Schema for Semantic Seleases, a project for automated versioning and releases",
+      "fileMatch": [".releaserc.yaml", ".releaserc.yml", ".releaserc.json"],
+      "url": "https://json.schemastore.org/semantic-release.json"
+    },
+    {
       "name": "Semgrep Rule",
       "description": "Semgrep code scanning patterns and rules",
       "fileMatch": [

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -527,7 +527,7 @@
     },
     {
       "package.json": {
-        "externalSchema": ["eslintrc.json", "prettierrc.json", "ava.json"],
+        "externalSchema": ["eslintrc.json", "prettierrc.json", "ava.json", "semantic-release.json"],
         "unknownKeywords": ["tsType", "x-intellij-language-injection"]
       }
     },

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -527,7 +527,12 @@
     },
     {
       "package.json": {
-        "externalSchema": ["eslintrc.json", "prettierrc.json", "ava.json", "semantic-release.json"],
+        "externalSchema": [
+          "eslintrc.json",
+          "prettierrc.json",
+          "ava.json",
+          "semantic-release.json"
+        ],
         "unknownKeywords": ["tsType", "x-intellij-language-injection"]
       }
     },

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -760,6 +760,9 @@
     },
     "ava": {
       "$ref": "https://json.schemastore.org/ava.json"
+    },
+    "release": {
+      "$ref": "https://json.schemastore.org/semantic-release.json"
     }
   },
   "anyOf": [

--- a/src/schemas/json/semantic-release.json
+++ b/src/schemas/json/semantic-release.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Semantic Release Schema",
-  "type": "object",
   "additionalProperties": false,
   "definitions": {
     "branch-object": {
@@ -67,8 +65,14 @@
         "master",
         "next",
         "next-major",
-        { "name": "beta", "prerelease": true },
-        { "name": "alpha", "prerelease": true }
+        {
+          "name": "beta",
+          "prerelease": true
+        },
+        {
+          "name": "alpha",
+          "prerelease": true
+        }
       ]
     },
     "repositoryUrl": {
@@ -109,5 +113,7 @@
       "description": "Set to false to skip Continuous Integration environment verifications. This allows for making releases from a local machine",
       "default": true
     }
-  }
+  },
+  "title": "Semantic Release Schema",
+  "type": "object"
 }

--- a/src/schemas/json/semantic-release.json
+++ b/src/schemas/json/semantic-release.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://json.schemastore.org/semantic-release.json",
   "additionalProperties": false,
   "definitions": {
     "branch-object": {
@@ -23,6 +22,7 @@
       }
     }
   },
+  "id": "https://json.schemastore.org/semantic-release.json",
   "properties": {
     "extends": {
       "description": "List of modules or file paths containing a shareable configuration. If multiple shareable configurations are set, they will be imported in the order defined with each configuration option taking precedence over the options defined in a previous shareable configuration",

--- a/src/schemas/json/semantic-release.json
+++ b/src/schemas/json/semantic-release.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Semantic Release Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "branch-object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "prerelease"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "range": {
+          "type": "string"
+        },
+        "prerelease": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+    "extends": {
+      "description": "List of modules or file paths containing a shareable configuration. If multiple shareable configurations are set, they will be imported in the order defined with each configuration option taking precedence over the options defined in a previous shareable configuration",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "branches": {
+      "description": "The branches on which releases should happen.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/branch-object"
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        }
+      ],
+      "default": [
+        "+([0-9])?(.{+([0-9]),x}).x",
+        "master",
+        "next",
+        "next-major",
+        { "name": "beta", "prerelease": true },
+        { "name": "alpha", "prerelease": true }
+      ]
+    },
+    "repositoryUrl": {
+      "type": "string",
+      "description": "The git repository URL"
+    },
+    "tagFormat": {
+      "type": "string",
+      "description": "The Git tag format used by semantic-release to identify releases. The tag name is generated with Lodash template and will be compiled with the version variable.",
+      "default": "v${version}"
+    },
+    "plugins": {
+      "type": "array",
+      "description": "Define the list of plugins to use. Plugins will run in series, in the order defined",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array"
+          }
+        ]
+      },
+      "default": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/npm",
+        "@semantic-release/github"
+      ]
+    },
+    "dryRun": {
+      "type": "boolean",
+      "description": "The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following steps: prepare, publish, success and fail. In addition to this it prints the next version and release notes to the console"
+    },
+    "ci": {
+      "type": "boolean",
+      "description": "Set to false to skip Continuous Integration environment verifications. This allows for making releases from a local machine",
+      "default": true
+    }
+  }
+}

--- a/src/schemas/json/semantic-release.json
+++ b/src/schemas/json/semantic-release.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/semantic-release.json",
   "additionalProperties": false,
   "definitions": {
     "branch-object": {

--- a/src/test/semantic-release/example1.json
+++ b/src/test/semantic-release/example1.json
@@ -1,0 +1,27 @@
+{
+  "branches": [
+    "master",
+    {
+      "name": "a",
+      "channel": "b",
+      "range": "c",
+      "prerelease": "d"
+    }
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"]
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Hai ^w^ :wave:  

This Closes #2266, adding support for [semantic release](https://github.com/semantic-release/semantic-release)

- For future purposes, I referenced [this](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md) document was references when creating the schemas

This config also can go in `releases` property of `package.json`. I didn't add that because [it seems](https://github.com/SchemaStore/schemastore/blob/03dd32e7205e37a25148c274865ff6c48f5d63e3/src/schemas/json/package.json#L761) the current method is to link to the schemastore website. Since adding a currently-unresolvable link would fail the test suite, excluding it seemed the best option