### PR TITLE
Add templates to Drone schema

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -259,6 +259,18 @@
         }
       }
     },
+    "kind_template": {
+      "type": "object",
+      "required": ["load"],
+      "properties": {
+        "load": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object"
+        }
+      }
+    },
     "kind_pipeline": {
       "type": "object",
       "required": ["type", "name", "steps"],
@@ -746,6 +758,9 @@
       "$ref": "#/definitions/kind_secret"
     },
     {
+      "$ref": "#/definitions/kind_template"
+    },
+    {
       "allOf": [
         {
           "$ref": "#/definitions/kind_pipeline"
@@ -777,7 +792,7 @@
   ],
   "properties": {
     "kind": {
-      "enum": ["signature", "secret", "pipeline"]
+      "enum": ["signature", "secret", "template", "pipeline"]
     }
   },
   "required": ["kind"],

--- a/src/test/drone/template.json
+++ b/src/test/drone/template.json
@@ -1,0 +1,5 @@
+{
+  "data": {},
+  "kind": "template",
+  "load": "plugin.starlark"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

:wave:  Hai!

This adds support for [Drone Templates](https://docs.drone.io/template/yaml) to the Drone schema. Closes #2167 
