### PR TITLE
Add schema for the package configuration of OSS Review Toolkit

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1984,10 +1984,7 @@
     {
       "name": "OSS Review Toolkit package configuration",
       "description": "Schema for ORT's package configuration file",
-      "fileMatch": [
-        "vcs.yml",
-        "source-artifact.yml"
-      ],
+      "fileMatch": ["vcs.yml", "source-artifact.yml"],
       "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-configuration-schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1982,6 +1982,15 @@
       "url": "https://raw.githubusercontent.com/ory/kratos/master/.schema/version.schema.json"
     },
     {
+      "name": "OSS Review Toolkit package configuration",
+      "description": "Schema for ORT's package configuration file",
+      "fileMatch": [
+        "vcs.yml",
+        "source-artifact.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-configuration-schema.json"
+    },
+    {
       "name": "OSS Review Toolkit repository configuration",
       "description": "Schema for ORT's repository configuration file",
       "fileMatch": ["*.ort.yml"],


### PR DESCRIPTION
Add support for the package configuration file for OSS Review Toolkit.

See: https://github.com/oss-review-toolkit/ort

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
