### PR TITLE
feat: Update JSON Schema for AVA

### DIFF
--- a/src/schemas/json/ava.json
+++ b/src/schemas/json/ava.json
@@ -23,16 +23,16 @@
   "id": "https://json.schemastore.org/ava.json",
   "properties": {
     "files": {
-      "$ref": "#/definitions/array-of-strings",
-      "description": "An array of glob patterns to select test files. Files with an underscore prefix are ignored. By default only selects files with `cjs`, `mjs` & `js` extensions, even if the pattern matches other files. Specify extensions to allow other file extensions"
-    },
-    "match": {
       "$ref": "#/definitions/array-of-paths",
-      "description": "Not typically useful in the package.json configuration, but equivalent to specifying `--match` on the CLI"
+      "description": "An array of glob patterns to select test files. Files with an underscore prefix are ignored. By default only selects files with `cjs`, `mjs` & `js` extensions, even if the pattern matches other files. Specify `extensions` to allow other file extensions"
     },
     "ignoredByWatcher": {
       "$ref": "#/definitions/array-of-paths",
       "description": "An array of glob patterns to match files that, even if changed, are ignored by the watcher"
+    },
+    "match": {
+      "$ref": "#/definitions/array-of-paths",
+      "description": "Not typically useful in the `package.json` configuration, but equivalent to specifying `--match` on the CLI"
     },
     "cache": {
       "type": "boolean",
@@ -55,6 +55,7 @@
     },
     "failWithoutAssertions": {
       "type": "boolean",
+      "default": true,
       "description": "If `false`, does not fail a test if it doesn't run assertions"
     },
     "environmentVariables": {
@@ -72,16 +73,31 @@
     "verbose": {
       "type": "boolean",
       "default": false,
-      "description": "If `true`, enables verbose output (though there currently non-verbose output is not supported)"
+      "description": "If `true`, enables verbose output (though currently non-verbose output is not supported)"
     },
     "snapshotDir": {
       "$ref": "#/definitions/path",
       "description": "Specifies a fixed location for storing snapshot files. Use this if your snapshots are ending up in the wrong location"
     },
     "extensions": {
-      "$ref": "#/definitions/array-of-strings",
-      "default": ["js", "mjs", "cjs"],
-      "description": "Extensions of test files. Setting this overrides the default [cjs, mjs, js] value, so make sure to include those extensions in the list"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/array-of-strings"
+        },
+        {
+          "type": "object",
+          "patternProperties": {
+            "^(c|m)?js$": {
+              "enum": [true]
+            }
+          },
+          "additionalProperties": {
+            "enum": ["commonjs", "module"]
+          }
+        }
+      ],
+      "default": ["cjs", "mjs", "js"],
+      "description": "Extensions of test files. Setting this overrides the default `[\"cjs\", \"mjs\", \"js\"]` value, so make sure to include those extensions in the list. Experimentally you can configure how files are loaded"
     },
     "require": {
       "$ref": "#/definitions/array-of-paths",
@@ -95,7 +111,7 @@
         },
         {
           "type": "string",
-          "pattern": "(\\d+)(s|m)$"
+          "pattern": "^(\\d+)(s|m)$"
         }
       ],
       "default": "10s",
@@ -109,6 +125,32 @@
       "type": "boolean",
       "default": true,
       "description": "If `false`, disable parallel builds (default: `true`)"
+    },
+    "typescript": {
+      "type": "object",
+      "description": "Configures @ava/typescript for projects that precompile TypeScript. Alternatively, you can use `ts-node` to do live testing without transpiling, in which case you shouldn't use the `typescript` property",
+      "properties": {
+        "extensions": {
+          "$ref": "#/definitions/array-of-paths",
+          "default": ["ts"],
+          "description": "You can configure AVA to recognize additional file extensions as TypeScript (e.g., `[\"ts\", \"tsx\"]` to add partial JSX support). Note that the preserve mode for JSX is not (yet) supported. See also AVA's `extensions` object"
+        },
+        "rewritePaths": {
+          "type": "object",
+          "description": "AVA searches your entire project for `*.js`, `*.cjs`, `*.mjs` and `*.ts` files (or other extensions you've configured). It will ignore such files found in the `rewritePaths` targets (e.g. `build/`). If you use more specific paths, for instance `build/main/`, you may need to change AVA's `files` configuration to ignore other directories. Paths are relative to your project directory",
+          "patternProperties": {
+            "/$": {
+              "type": "string",
+              "pattern": "/$"
+            }
+          }
+        },
+        "compile": {
+          "enum": [false, "tsc"],
+          "default": false,
+          "description": "If `false`, AVA will assume you have already compiled your project. If set to `'tsc'`, AVA will run the TypeScript compiler before running your tests. This can be inefficient when using AVA in watch mode"
+        }
+      }
     }
   },
   "title": "AVA Config Schema",


### PR DESCRIPTION
- Add `typescript` property
- Allow configuration of file loading via `extensions` property
- Reorder values in default `extensions` array to match AVA docs
- Disallow arbitrary prefixes in `timeout` property
- Specify that `failWithoutAssertions` property defaults to `true`
- Correct `files` property type from array of strings to array of paths
- Reorder `match` property to match AVA documentation for convenience
- Update and correct typos in documentation