### PR TITLE
NLog in appsettings with finalMinLevel

### DIFF
--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -376,7 +376,7 @@
           "default": false
         },
         "throwConfigExceptions": {
-          "type": [ "boolean", "null" ],
+          "type": ["boolean", "null"],
           "description": "Throws an exception when there is a config error? If not set, then throwExceptions will be used for this setting.",
           "default": false
         },
@@ -388,7 +388,7 @@
         "internalLogLevel": {
           "type": "string",
           "description": "The minimal log level for the internal logger.",
-          "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off" ],
+          "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off"],
           "default": "Off"
         },
         "internalLogFile": {
@@ -408,7 +408,7 @@
         "globalThreshold": {
           "type": "string",
           "description": "Log events below this threshold are not logged.",
-          "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off" ],
+          "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off"],
           "default": "Off"
         },
         "autoShutdown": {
@@ -450,7 +450,7 @@
           },
           "patternProperties": {
             ".*": {
-              "type": [ "number", "string", "boolean" ]
+              "type": ["number", "string", "boolean"]
             }
           }
         },
@@ -458,7 +458,7 @@
           "type": "object",
           "description": "Wrap all defined targets with this custom target wrapper.",
           "default": {},
-          "required": [ "type" ],
+          "required": ["type"],
           "properties": {
             "type": {
               "type": "string",
@@ -521,7 +521,7 @@
             {
               "type": "string",
               "description": "",
-              "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal" ]
+              "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal"]
             },
             {
               "type": "string"
@@ -537,7 +537,7 @@
             {
               "type": "string",
               "description": "",
-              "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal" ]
+              "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal"]
             },
             {
               "type": "string"
@@ -549,7 +549,7 @@
             {
               "type": "string",
               "description": "",
-              "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal" ]
+              "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal"]
             },
             {
               "type": "string"
@@ -561,7 +561,7 @@
             {
               "type": "string",
               "description": "",
-              "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal" ]
+              "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal"]
             },
             {
               "type": "string"
@@ -592,7 +592,7 @@
                 "type": "object",
                 "description": "",
                 "default": {},
-                "required": [ "type" ],
+                "required": ["type"],
                 "properties": {
                   "type": {
                     "type": "string",
@@ -601,7 +601,13 @@
                   "action": {
                     "type": "string",
                     "description": "Result action when filter matches logevent.",
-                    "enum": [ "Neutral", "Log", "Ignore", "LogFinal", "IgnoreFinal" ],
+                    "enum": [
+                      "Neutral",
+                      "Log",
+                      "Ignore",
+                      "LogFinal",
+                      "IgnoreFinal"
+                    ],
                     "default": "Neutral"
                   }
                 }
@@ -617,7 +623,7 @@
         "filterDefaultAction": {
           "type": "string",
           "description": "Default action if none of the filters match.",
-          "enum": [ "Neutral", "Log", "Ignore", "LogFinal", "IgnoreFinal" ],
+          "enum": ["Neutral", "Log", "Ignore", "LogFinal", "IgnoreFinal"],
           "default": "Ignore"
         }
       }

--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -376,7 +376,7 @@
           "default": false
         },
         "throwConfigExceptions": {
-          "type": ["boolean", "null"],
+          "type": [ "boolean", "null" ],
           "description": "Throws an exception when there is a config error? If not set, then throwExceptions will be used for this setting.",
           "default": false
         },
@@ -388,7 +388,7 @@
         "internalLogLevel": {
           "type": "string",
           "description": "The minimal log level for the internal logger.",
-          "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off"],
+          "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off" ],
           "default": "Off"
         },
         "internalLogFile": {
@@ -408,7 +408,7 @@
         "globalThreshold": {
           "type": "string",
           "description": "Log events below this threshold are not logged.",
-          "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off"],
+          "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal", "Off" ],
           "default": "Off"
         },
         "autoShutdown": {
@@ -450,15 +450,15 @@
           },
           "patternProperties": {
             ".*": {
-              "type": ["number", "string", "boolean"]
+              "type": [ "number", "string", "boolean" ]
             }
           }
         },
-        "default-wrapper": {
+        "targetDefaultWrapper": {
           "type": "object",
-          "description": "",
+          "description": "Wrap all defined targets with this custom target wrapper.",
           "default": {},
-          "required": ["type"],
+          "required": [ "type" ],
           "properties": {
             "type": {
               "type": "string",
@@ -521,7 +521,7 @@
             {
               "type": "string",
               "description": "",
-              "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal"]
+              "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal" ]
             },
             {
               "type": "string"
@@ -537,7 +537,7 @@
             {
               "type": "string",
               "description": "",
-              "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal"]
+              "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal" ]
             },
             {
               "type": "string"
@@ -549,7 +549,19 @@
             {
               "type": "string",
               "description": "",
-              "enum": ["Trace", "Debug", "Info", "Warn", "Error", "Fatal"]
+              "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal" ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "finalMinLevel": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "",
+              "enum": [ "Trace", "Debug", "Info", "Warn", "Error", "Fatal" ]
             },
             {
               "type": "string"
@@ -580,7 +592,7 @@
                 "type": "object",
                 "description": "",
                 "default": {},
-                "required": ["type"],
+                "required": [ "type" ],
                 "properties": {
                   "type": {
                     "type": "string",
@@ -589,13 +601,7 @@
                   "action": {
                     "type": "string",
                     "description": "Result action when filter matches logevent.",
-                    "enum": [
-                      "Neutral",
-                      "Log",
-                      "Ignore",
-                      "LogFinal",
-                      "IgnoreFinal"
-                    ],
+                    "enum": [ "Neutral", "Log", "Ignore", "LogFinal", "IgnoreFinal" ],
                     "default": "Neutral"
                   }
                 }
@@ -611,7 +617,7 @@
         "filterDefaultAction": {
           "type": "string",
           "description": "Default action if none of the filters match.",
-          "enum": ["Neutral", "Log", "Ignore", "LogFinal", "IgnoreFinal"],
+          "enum": [ "Neutral", "Log", "Ignore", "LogFinal", "IgnoreFinal" ],
           "default": "Ignore"
         }
       }


### PR DESCRIPTION
FinalMinLevel has been introduced with NLog 5.0

Also replace `"default-wrapper"` with `"targetDefaultWrapper"` since it has been available since NLog.Extensions.Logging v1.7.3 (Released a year ago). Because the option-name has better meaning.