### PR TITLE
Add schema for Datahub ingestion recipe

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3600,11 +3600,7 @@
     {
       "name": "Datahub Ingestion Recipe Schema",
       "description": "Schema for Datahub Ingestion recipe. \n\nSee also at https://datahubproject.io/docs/metadata-ingestion\n\n",
-      "fileMatch": [
-        "*.dhub.yml",
-        "*.dhub.yaml",
-        "*.dhub.json"
-      ],
+      "fileMatch": ["*.dhub.yml", "*.dhub.yaml", "*.dhub.json"],
       "url": "https://datahubproject.io/schemas/datahub_ingestion_schema.json"
     }
   ],


### PR DESCRIPTION
It adds schema for [Datahub's](https://datahubproject.io/) ingestion recipe -> https://datahubproject.io/docs/metadata-ingestion 