### PR TITLE
Update: Stylelint schema

### DIFF
--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -1,6 +1,95 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
+    "allRules": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/atRule"
+        },
+        {
+          "$ref": "#/definitions/block"
+        },
+        {
+          "$ref": "#/definitions/color"
+        },
+        {
+          "$ref": "#/definitions/comment"
+        },
+        {
+          "$ref": "#/definitions/customMedia"
+        },
+        {
+          "$ref": "#/definitions/customProperty"
+        },
+        {
+          "$ref": "#/definitions/declaration"
+        },
+        {
+          "$ref": "#/definitions/declarationBlock"
+        },
+        {
+          "$ref": "#/definitions/font"
+        },
+        {
+          "$ref": "#/definitions/function"
+        },
+        {
+          "$ref": "#/definitions/generalSheet"
+        },
+        {
+          "$ref": "#/definitions/keyframeDeclaration"
+        },
+        {
+          "$ref": "#/definitions/length"
+        },
+        {
+          "$ref": "#/definitions/mediaFeature"
+        },
+        {
+          "$ref": "#/definitions/mediaQueryList"
+        },
+        {
+          "$ref": "#/definitions/number"
+        },
+        {
+          "$ref": "#/definitions/property"
+        },
+        {
+          "$ref": "#/definitions/rootRule"
+        },
+        {
+          "$ref": "#/definitions/rule"
+        },
+        {
+          "$ref": "#/definitions/selector"
+        },
+        {
+          "$ref": "#/definitions/selectorList"
+        },
+        {
+          "$ref": "#/definitions/shorthandProperty"
+        },
+        {
+          "$ref": "#/definitions/string"
+        },
+        {
+          "$ref": "#/definitions/stylelintDisableComment"
+        },
+        {
+          "$ref": "#/definitions/time"
+        },
+        {
+          "$ref": "#/definitions/unit"
+        },
+        {
+          "$ref": "#/definitions/value"
+        },
+        {
+          "$ref": "#/definitions/valueList"
+        }
+      ]
+    },
     "alwaysMultiLineRule": {
       "type": ["null", "string", "array"],
       "oneOf": [
@@ -122,9 +211,15 @@
     },
     "coreRule": {
       "properties": {
+        "disableFix": {
+          "type": "boolean"
+        },
         "message": {
           "description": "Custom message that will be used in errors and warnings",
           "type": "string"
+        },
+        "reportDisables": {
+          "type": "boolean"
         },
         "severity": {
           "description": "Message status",
@@ -3048,6 +3143,31 @@
       "description": "Plugins are rules or sets of rules built by the community that support methodologies, toolsets, non-standard CSS features, or very specific use cases",
       "$ref": "#/definitions/simpleArrayStringRule"
     },
+    "customSyntax": {
+      "description": "Specify a custom syntax to use on your code.",
+      "type": "string"
+    },
+    "overrides": {
+      "description": "Provide rule and behavior overrides for files that match particular glob patterns.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "customSyntax": {
+            "type": "string"
+          },
+          "rules": {
+            "$ref": "#/definitions/allRules"
+          }
+        }
+      }
+    },
     "processors": {
       "description": "Processors are functions that hook into stylelint's pipeline, modifying code on its way into stylelint and modifying results on their way out",
       "type": "array",
@@ -3070,6 +3190,10 @@
         ]
       }
     },
+    "ignoreDisables": {
+      "description": "Ignore stylelint-disable (e.g. /* stylelint-disable block-no-empty */) comments.",
+      "type": "boolean"
+    },
     "ignoreFiles": {
       "description": "Provide a glob or array of globs to ignore specific files",
       "$ref": "#/definitions/simpleStringOrArrayStringRule"
@@ -3079,94 +3203,20 @@
       "type": "string",
       "enum": ["warning", "error"]
     },
+    "reportDescriptionlessDisables": {
+      "description": "Report stylelint-disable comments without a description.",
+      "$ref": "#/definitions/booleanRule"
+    },
+    "reportInvalidScopeDisables": {
+      "description": "Report stylelint-disable comments that don't match rules that are specified in the configuration object.",
+      "$ref": "#/definitions/booleanRule"
+    },
+    "reportNeedlessDisables": {
+      "description": "Report stylelint-disable comments that don't actually match any lints that need to be disabled",
+      "$ref": "#/definitions/booleanRule"
+    },
     "rules": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/atRule"
-        },
-        {
-          "$ref": "#/definitions/block"
-        },
-        {
-          "$ref": "#/definitions/color"
-        },
-        {
-          "$ref": "#/definitions/comment"
-        },
-        {
-          "$ref": "#/definitions/customMedia"
-        },
-        {
-          "$ref": "#/definitions/customProperty"
-        },
-        {
-          "$ref": "#/definitions/declaration"
-        },
-        {
-          "$ref": "#/definitions/declarationBlock"
-        },
-        {
-          "$ref": "#/definitions/font"
-        },
-        {
-          "$ref": "#/definitions/function"
-        },
-        {
-          "$ref": "#/definitions/generalSheet"
-        },
-        {
-          "$ref": "#/definitions/keyframeDeclaration"
-        },
-        {
-          "$ref": "#/definitions/length"
-        },
-        {
-          "$ref": "#/definitions/mediaFeature"
-        },
-        {
-          "$ref": "#/definitions/mediaQueryList"
-        },
-        {
-          "$ref": "#/definitions/number"
-        },
-        {
-          "$ref": "#/definitions/property"
-        },
-        {
-          "$ref": "#/definitions/rootRule"
-        },
-        {
-          "$ref": "#/definitions/rule"
-        },
-        {
-          "$ref": "#/definitions/selector"
-        },
-        {
-          "$ref": "#/definitions/selectorList"
-        },
-        {
-          "$ref": "#/definitions/shorthandProperty"
-        },
-        {
-          "$ref": "#/definitions/string"
-        },
-        {
-          "$ref": "#/definitions/stylelintDisableComment"
-        },
-        {
-          "$ref": "#/definitions/time"
-        },
-        {
-          "$ref": "#/definitions/unit"
-        },
-        {
-          "$ref": "#/definitions/value"
-        },
-        {
-          "$ref": "#/definitions/valueList"
-        }
-      ]
+      "$ref": "#/definitions/allRules"
     }
   },
   "title": "JSON schema for the Stylelint configuration files",

--- a/src/test/stylelintrc/stylelintrc-test.json
+++ b/src/test/stylelintrc/stylelintrc-test.json
@@ -6,6 +6,35 @@
         "except": ["first-nested"],
         "ignore": ["after-comment", "stylelint-commands"]
       }
-    ]
-  }
+    ],
+    "color-function-notation": ["modern", { "disableFix": true }],
+    "custom-property-pattern": [
+      "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
+      {
+        "message": "Expected custom property name to be kebab-case"
+      }
+    ],
+    "color-no-invalid-hex": [true, { "reportDisables": true }]
+  },
+  "customSyntax": "blah",
+  "overrides": [
+    {
+      "files": ["*.scss", "**/*.scss"],
+      "customSyntax": "postcss-scss"
+    },
+    {
+      "files": ["components/**/*.css", "pages/**/*.css"],
+      "rules": {
+        "alpha-value-notation": "percentage"
+      }
+    }
+  ],
+  "reportNeedlessDisables": true,
+  "reportDescriptionlessDisables": [
+    false,
+    {
+      "except": ["unit-allowed-list"],
+      "severity": "warning"
+    }
+  ]
 }

--- a/src/test/stylelintrc/stylelintrc-test.json
+++ b/src/test/stylelintrc/stylelintrc-test.json
@@ -1,21 +1,4 @@
 {
-  "rules": {
-    "comment-empty-line-before": [
-      "always",
-      {
-        "except": ["first-nested"],
-        "ignore": ["after-comment", "stylelint-commands"]
-      }
-    ],
-    "color-function-notation": ["modern", { "disableFix": true }],
-    "custom-property-pattern": [
-      "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
-      {
-        "message": "Expected custom property name to be kebab-case"
-      }
-    ],
-    "color-no-invalid-hex": [true, { "reportDisables": true }]
-  },
   "customSyntax": "blah",
   "overrides": [
     {
@@ -29,12 +12,39 @@
       }
     }
   ],
-  "reportNeedlessDisables": true,
   "reportDescriptionlessDisables": [
     false,
     {
       "except": ["unit-allowed-list"],
       "severity": "warning"
     }
-  ]
+  ],
+  "reportNeedlessDisables": true,
+  "rules": {
+    "comment-empty-line-before": [
+      "always",
+      {
+        "except": ["first-nested"],
+        "ignore": ["after-comment", "stylelint-commands"]
+      }
+    ],
+    "color-function-notation": [
+      "modern",
+      {
+        "disableFix": true
+      }
+    ],
+    "custom-property-pattern": [
+      "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
+      {
+        "message": "Expected custom property name to be kebab-case"
+      }
+    ],
+    "color-no-invalid-hex": [
+      true,
+      {
+        "reportDisables": true
+      }
+    ]
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Update Stylelint schema. Notably, this includes:

- Supporting [overrides](https://stylelint.io/user-guide/configure#overrides)
- Explicitly specifying [rules](https://stylelint.io/user-guide/configure#rules) to include the new properties `disablefix` and `reportDisables`
- Supporting extra properties of the root configuration
