### PR TITLE
New: Schema for `jscpd` 

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3654,6 +3654,12 @@
       "description": "Schema for Torque bluerpint",
       "fileMatch": ["blueprints/**.yaml"],
       "url": "https://raw.githubusercontent.com/QualiTorque/torque-vs-code-extensions/master/client/schemas/blueprint-spec2-schema.json"
+    },
+    {
+      "name": "jscpd Configuration Schema",
+      "description": "Copy/paste detector for programming source code",
+      "fileMatch": [".jscpd.json"],
+      "url": "https://json.schemastore.org/jscpd.json"
     }
   ],
   "version": 1

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -532,7 +532,8 @@
           "prettierrc.json",
           "ava.json",
           "stylelintrc.json",
-          "semantic-release.json"
+          "semantic-release.json",
+          "jscpd.json"
         ],
         "unknownKeywords": ["tsType", "x-intellij-language-injection"]
       }

--- a/src/schemas/json/jscpd.json
+++ b/src/schemas/json/jscpd.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/jscpd.json",
+  "type": "object",
+  "properties": {
+    "minLines": {
+      "type": "number"
+    },
+    "maxLines": {
+      "type": "string"
+    },
+    "maxSize": {
+      "type": "string"
+    },
+    "minTokens": {
+      "type": "number"
+    },
+    "output": {
+      "type": "string"
+    },
+    "reporters": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignore": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "threshold": {
+      "type": "number"
+    },
+    "exitCode": {
+      "type": "number"
+    },
+    "absolute": {
+      "type": "boolean"
+    }
+  }
+}

--- a/src/schemas/json/jscpd.json
+++ b/src/schemas/json/jscpd.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://json.schemastore.org/jscpd.json",
-  "type": "object",
   "properties": {
     "minLines": {
       "type": "number"
@@ -39,5 +38,6 @@
     "absolute": {
       "type": "boolean"
     }
-  }
+  },
+  "type": "object"
 }

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -766,6 +766,9 @@
     },
     "release": {
       "$ref": "https://json.schemastore.org/semantic-release.json"
+    },
+    "jscpd": {
+      "$ref": "https://json.schemastore.org/jscpd.json"
     }
   },
   "anyOf": [

--- a/src/test/jscpd/jscpd.json
+++ b/src/test/jscpd/jscpd.json
@@ -1,0 +1,19 @@
+{
+  "threshold": 0,
+  "reporters": ["html", "markdown"],
+  "ignore": [
+    "**/node_modules/**",
+    "**/.git/**",
+    "**/.rbenv/**",
+    "**/.venv/**",
+    "**/*cache*/**",
+    "**/.github/**",
+    "**/.idea/**",
+    "**/report/**",
+    "**/*.svg"
+  ],
+  "format": "typescript",
+  "include": ["src/**/*"],
+  "absolute": false,
+  "gitignore": true
+}

--- a/src/test/jscpd/jscpd.json
+++ b/src/test/jscpd/jscpd.json
@@ -1,6 +1,7 @@
 {
-  "threshold": 0,
-  "reporters": ["html", "markdown"],
+  "absolute": false,
+  "format": "typescript",
+  "gitignore": true,
   "ignore": [
     "**/node_modules/**",
     "**/.git/**",
@@ -12,8 +13,7 @@
     "**/report/**",
     "**/*.svg"
   ],
-  "format": "typescript",
   "include": ["src/**/*"],
-  "absolute": false,
-  "gitignore": true
+  "reporters": ["html", "markdown"],
+  "threshold": 0
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
As mentioned in #1885, this supports [jscpd](https://github.com/kucherenko/jscpd), a copy/paste detector for programming source code. This GitHub repository has over 2.6 thousand stars, so I thought it was reasonable to add support.

Closes #1885