### PR TITLE
Correct and complete jscpd schema.

### DIFF
--- a/src/schemas/json/jscpd.json
+++ b/src/schemas/json/jscpd.json
@@ -1,42 +1,403 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "colorPreset": {
+      "enum": [
+        "green",
+        "blue",
+        "red",
+        "yellow",
+        "orange",
+        "purple",
+        "pink",
+        "grey",
+        "gray",
+        "cyan",
+        "black"
+      ]
+    },
+    "colorHex": {
+      "type": "string",
+      "pattern": "([0-9a-fA-F]{3}){1,2}"
+    },
+    "color": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/colorPreset"
+        },
+        {
+          "$ref": "#/definitions/colorHex"
+        }
+      ]
+    },
+    "format": {
+      "enum": [
+        "abap",
+        "actionscript",
+        "ada",
+        "apacheconf",
+        "apl",
+        "applescript",
+        "arduino",
+        "arff",
+        "asciidoc",
+        "asm6502",
+        "aspnet",
+        "autohotkey",
+        "autoit",
+        "bash",
+        "basic",
+        "batch",
+        "bison",
+        "brainfuck",
+        "bro",
+        "c",
+        "c-header",
+        "clike",
+        "clojure",
+        "coffeescript",
+        "comments",
+        "cpp",
+        "cpp-header",
+        "crystal",
+        "csharp",
+        "csp",
+        "css-extras",
+        "css",
+        "d",
+        "dart",
+        "diff",
+        "django",
+        "docker",
+        "eiffel",
+        "elixir",
+        "elm",
+        "erb",
+        "erlang",
+        "flow",
+        "fortran",
+        "fsharp",
+        "gedcom",
+        "gherkin",
+        "git",
+        "glsl",
+        "go",
+        "graphql",
+        "groovy",
+        "haml",
+        "handlebars",
+        "haskell",
+        "haxe",
+        "hpkp",
+        "hsts",
+        "http",
+        "ichigojam",
+        "icon",
+        "inform7",
+        "ini",
+        "io",
+        "j",
+        "java",
+        "javascript",
+        "jolie",
+        "json",
+        "jsx",
+        "julia",
+        "keymap",
+        "kotlin",
+        "latex",
+        "less",
+        "liquid",
+        "lisp",
+        "livescript",
+        "lolcode",
+        "lua",
+        "makefile",
+        "markdown",
+        "markup",
+        "matlab",
+        "mel",
+        "mizar",
+        "monkey",
+        "n4js",
+        "nasm",
+        "nginx",
+        "nim",
+        "nix",
+        "nsis",
+        "objectivec",
+        "ocaml",
+        "opencl",
+        "oz",
+        "parigp",
+        "pascal",
+        "perl",
+        "php",
+        "plsql",
+        "powershell",
+        "processing",
+        "prolog",
+        "properties",
+        "protobuf",
+        "pug",
+        "puppet",
+        "pure",
+        "python",
+        "q",
+        "qore",
+        "r",
+        "reason",
+        "renpy",
+        "rest",
+        "rip",
+        "roboconf",
+        "ruby",
+        "rust",
+        "sas",
+        "sass",
+        "scala",
+        "scheme",
+        "scss",
+        "smalltalk",
+        "smarty",
+        "soy",
+        "sql",
+        "stylus",
+        "swift",
+        "tap",
+        "tcl",
+        "textile",
+        "tsx",
+        "tt2",
+        "twig",
+        "typescript",
+        "vbnet",
+        "velocity",
+        "verilog",
+        "vhdl",
+        "vim",
+        "visual-basic",
+        "wasm",
+        "url",
+        "wiki",
+        "xeora",
+        "xojo",
+        "xquery",
+        "yaml"
+      ]
+    }
+  },
   "id": "https://json.schemastore.org/jscpd.json",
   "properties": {
     "minLines": {
-      "type": "number"
+      "type": "integer",
+      "default": 5,
+      "description": "minimum size of code block in lines to check for duplication"
     },
     "maxLines": {
-      "type": "string"
+      "type": "integer",
+      "default": 1000,
+      "description": "maximum size of source file in lines to check for duplication"
     },
     "maxSize": {
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ],
+      "default": "100kb",
+      "description": "maximum size of source file in bytes to check for duplication (e.g.,: 1kb, 1mb, 120kb)"
     },
     "minTokens": {
-      "type": "number"
+      "type": "integer",
+      "default": 50,
+      "description": "minimum size of code block in tokens to check for duplication"
+    },
+    "threshold": {
+      "type": "number",
+      "description": "maximum allowed duplicate lines expressed as a percentage; exit with error and exit code 1 when threshold exceeded"
+    },
+    "formatsExts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "default": {},
+      "description": "custom mapping from formats to file extensions (default: https://github.com/kucherenko/jscpd/blob/master/packages/tokenizer/src/formats.ts); see https://github.com/kucherenko/jscpd/blob/master/supported_formats.md"
     },
     "output": {
-      "type": "string"
+      "type": "string",
+      "default": "./report",
+      "description": "path to directory for non-console reports"
     },
-    "reporters": {
+    "path": {
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "description": "paths that should be included in duplicate detection (default: [process.cwd()])"
+    },
+    "pattern": {
+      "type": "string",
+      "default": "**/*",
+      "description": "glob pattern for files that should be included in duplicate detection (e.g., **/*.txt); only used to filter directories configured via path option"
+    },
+    "ignorePattern": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "ignore code blocks matching these regular expressions"
+    },
+    "mode": {
+      "enum": ["mild", "strict", "weak"],
+      "default": "mild",
+      "description": "mode of detection quality; see https://github.com/kucherenko/jscpd/blob/master/packages/jscpd/README.md#mode"
     },
     "ignore": {
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "default": [],
+      "description": "glob pattern for files that should be excluded from duplicate detection"
     },
-    "threshold": {
-      "type": "number"
+    "format": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/format"
+      },
+      "description": "list of formats for which to detect duplication (default: all); see https://github.com/kucherenko/jscpd/blob/master/supported_formats.md"
     },
-    "exitCode": {
-      "type": "number"
+    "store": {
+      "enum": ["leveldb", "redis"],
+      "description": "store used to collect information about code (default: in-memory store); install @jscpd/leveldb-store and use leveldb for big repositories"
+    },
+    "reporters": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "xml",
+          "json",
+          "csv",
+          "markdown",
+          "consoleFull",
+          "html",
+          "console",
+          "silent",
+          "threshold",
+          "xcode"
+        ]
+      },
+      "default": ["console"],
+      "description": "a list of reporters to use to output information about duplication; see https://github.com/kucherenko/jscpd/blob/master/packages/jscpd/README.md#reporters"
+    },
+    "blame": {
+      "type": "boolean",
+      "default": false,
+      "description": "get information about authors and dates of duplicated blocks from Git"
+    },
+    "silent": {
+      "type": "boolean",
+      "default": false,
+      "description": "do not write duplicate detection progress and result to console"
+    },
+    "verbose": {
+      "type": "boolean",
+      "default": false,
+      "description": "show full information during duplicate detection"
     },
     "absolute": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false,
+      "description": "use absolute paths in reports"
+    },
+    "noSymLinks": {
+      "type": "boolean",
+      "default": false,
+      "description": "do not follow symlinks"
+    },
+    "skipLocal": {
+      "type": "boolean",
+      "default": false,
+      "description": "skip duplicates within folders; just detect cross-folder duplicates"
+    },
+    "ignoreCase": {
+      "type": "boolean",
+      "default": false,
+      "description": "ignore case of symbols in code (experimental)"
+    },
+    "gitignore": {
+      "type": "boolean",
+      "default": false,
+      "description": "ignore all files from .gitignore file"
+    },
+    "reportersOptions": {
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "badge": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "output path for duplication level badge (default: path.join(output, 'jscpd-badge.svg'))"
+            },
+            "label": {
+              "type": "string",
+              "default": "Copy/Paste",
+              "description": "badge subject text (URL-encoding needed for spaces or special characters)"
+            },
+            "labelColor": {
+              "$ref": "#/definitions/color",
+              "default": "555",
+              "description": "badge label color (name or RGB code without #); see https://github.com/badgen/badgen/blob/master/src/color-presets.ts"
+            },
+            "status": {
+              "type": "string",
+              "description": "badge value text (URL-encoding needed for spaces or special characters, default: duplication %)"
+            },
+            "color": {
+              "$ref": "#/definitions/color",
+              "description": "badge color (name or RGB code without #, default: green if beneath threshold, red if above threshold, grey if threshold not set); see https://github.com/badgen/badgen/blob/master/src/color-presets.ts"
+            },
+            "style": {
+              "enum": ["flat", "classic"],
+              "default": "classic",
+              "description": "badge look: flat or classic"
+            },
+            "icon": {
+              "type": "string",
+              "description": "URL for icon to display in front of badge subject text (e.g., data:image/svg+xml;base64,...)"
+            },
+            "iconWidth": {
+              "type": "number",
+              "default": 13,
+              "description": "SVG width of icon to display in front of badge subject text; set this if icon is not square"
+            },
+            "scale": {
+              "type": "number",
+              "default": 1,
+              "description": "size of badge relative to default of 1"
+            }
+          }
+        }
+      }
+    },
+    "exitCode": {
+      "type": "integer",
+      "default": 0,
+      "description": "exit code to use when at least one duplicate code block is detected but threshold is not exceeded"
     }
   },
   "type": "object"

--- a/src/test/jscpd/jscpd.json
+++ b/src/test/jscpd/jscpd.json
@@ -1,6 +1,11 @@
 {
-  "absolute": false,
-  "format": "typescript",
+  "absolute": true,
+  "blame": true,
+  "exitCode": 1,
+  "format": ["typescript"],
+  "formatsExts": {
+    "typescript": ["ts", "tsx"]
+  },
   "gitignore": true,
   "ignore": [
     "**/node_modules/**",
@@ -13,7 +18,34 @@
     "**/report/**",
     "**/*.svg"
   ],
-  "include": ["src/**/*"],
-  "reporters": ["html", "markdown"],
-  "threshold": 0
+  "ignoreCase": true,
+  "ignorePattern": ["**/*.jsx?"],
+  "maxLines": 0,
+  "maxSize": "200kb",
+  "minLines": 0,
+  "minTokens": 0,
+  "mode": "strict",
+  "noSymLinks": true,
+  "output": "./report/jscpd",
+  "path": ["./src"],
+  "pattern": "**/*.tsx?",
+  "reporters": ["consoleFull", "console", "html", "markdown"],
+  "reportersOptions": {
+    "badge": {
+      "path": "./report/jscpd/badge.svg",
+      "label": "Duplication",
+      "labelColor": "0fA",
+      "status": "0%",
+      "color": "cyan",
+      "style": "flat",
+      "icon": "data:image/svg+xml;base64,...",
+      "iconWidth": 8,
+      "scale": 2
+    }
+  },
+  "silent": true,
+  "skipLocal": true,
+  "store": "redis",
+  "threshold": 0,
+  "verbose": true
 }


### PR DESCRIPTION
Fixes #2302.

[The build failed](https://github.com/Kurt-von-Laven/schemastore/runs/6952635320?check_suite_focus=true) when I tried to use draft-06, so I did as much as I could with draft-04. Upgrading to draft-06 would allow the use of `propertyNames` to enforce that the keys of `formatsExts` are of type `#/definitions/format`.

- Correct the type of `maxLines` from `string` to `integer`.
- Correct the types of `minLines`, `minTokens`, and `exitCode` from `number` to `integer`.
- Correct the type of `format` in test from `string` to `string[]`.
- Remove non-existent property `include` from test.
- Enumerate allowed `reporters`.
- Specify default values where appropriate.
- Add descriptions for all properties.
- Add all missing properties, and disallow additional properties.
- Exercise all properties in test.