### PR TITLE
Fixed using the wrong type for timeout_in in cirrus.json

### DIFF
--- a/src/schemas/json/cirrus.json
+++ b/src/schemas/json/cirrus.json
@@ -627,7 +627,7 @@
         },
         "timeout_in": {
           "description": "Task timeout in minutes",
-          "type": "number"
+          "type": "string"
         },
         "trigger_type": {
           "description": "Trigger type",
@@ -1282,7 +1282,7 @@
         },
         "timeout_in": {
           "description": "Task timeout in minutes",
-          "type": "number"
+          "type": "string"
         },
         "trigger_type": {
           "description": "Trigger type",
@@ -1958,7 +1958,7 @@
         },
         "timeout_in": {
           "description": "Task timeout in minutes",
-          "type": "number"
+          "type": "string"
         },
         "trigger_type": {
           "description": "Trigger type",
@@ -3512,7 +3512,7 @@
         },
         "timeout_in": {
           "description": "Task timeout in minutes",
-          "type": "number"
+          "type": "string"
         },
         "trigger_type": {
           "description": "Trigger type",
@@ -4537,7 +4537,7 @@
     },
     "timeout_in": {
       "description": "Task timeout in minutes",
-      "type": "number"
+      "type": "string"
     },
     "trigger_type": {
       "description": "Trigger type",


### PR DESCRIPTION
According to https://cirrus-ci.org/faq/#instance-timed-out,
`timeout_in` should be a string, not a number.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
