### PR TITLE
Specify pattern for `maxSize` in jscpd schema.

### DIFF
--- a/src/schemas/json/jscpd.json
+++ b/src/schemas/json/jscpd.json
@@ -203,7 +203,8 @@
     "maxSize": {
       "anyOf": [
         {
-          "type": "string"
+          "type": "string",
+          "pattern": "^\\+?[0-9]+(\\.[0-9]+)? *[kKmMgGtTpP][bB]$"
         },
         {
           "type": "integer"

--- a/src/test/jscpd/jscpd.json
+++ b/src/test/jscpd/jscpd.json
@@ -21,7 +21,7 @@
   "ignoreCase": true,
   "ignorePattern": ["**/*.jsx?"],
   "maxLines": 0,
-  "maxSize": "200kb",
+  "maxSize": "0.00000000001 PB",
   "minLines": 0,
   "minTokens": 0,
   "mode": "strict",


### PR DESCRIPTION
Disallow arbitrary strings that don't correspond to a non-negative file size in bytes as defined by the npm package bytes.