### PR TITLE
Update semantic-release schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2428,9 +2428,9 @@
       "url": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json"
     },
     {
-      "name": "Semantic Release",
-      "description": "Schema for Semantic Seleases, a project for automated versioning and releases",
-      "fileMatch": [".releaserc.yaml", ".releaserc.yml", ".releaserc.json"],
+      "name": "semantic-release",
+      "description": "Configuration for semantic-release",
+      "fileMatch": [".releaserc", ".releaserc.yaml", ".releaserc.yml", ".releaserc.json"],
       "url": "https://json.schemastore.org/semantic-release.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2430,7 +2430,12 @@
     {
       "name": "semantic-release",
       "description": "Configuration for semantic-release",
-      "fileMatch": [".releaserc", ".releaserc.yaml", ".releaserc.yml", ".releaserc.json"],
+      "fileMatch": [
+        ".releaserc",
+        ".releaserc.yaml",
+        ".releaserc.yml",
+        ".releaserc.json"
+      ],
       "url": "https://json.schemastore.org/semantic-release.json"
     },
     {

--- a/src/schemas/json/semantic-release.json
+++ b/src/schemas/json/semantic-release.json
@@ -5,7 +5,7 @@
     "branch-object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "prerelease"],
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string"
@@ -17,7 +17,14 @@
           "type": "string"
         },
         "prerelease": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
         }
       }
     }
@@ -115,6 +122,6 @@
       "default": true
     }
   },
-  "title": "Semantic Release Schema",
+  "title": "semantic-release Schema",
   "type": "object"
 }

--- a/src/test/semantic-release/example1.json
+++ b/src/test/semantic-release/example1.json
@@ -6,6 +6,10 @@
       "channel": "b",
       "range": "c",
       "prerelease": "d"
+    },
+    {
+      "name": "e",
+      "prerelease": true
     }
   ],
   "plugins": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
After noticing the semantic-release schema (added in #2273; updated in #2282) was incorrect for the `branch-object.prerelease` property:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/831617/174506325-1f1bc4e5-8cf6-48e2-ba67-03bd4960167d.png">

I checked the sematic-release [Configuration](https://github.com/semantic-release/semantic-release/blob/9589a96239826abe9b07e8deffcc7d8aeb9c2e40/docs/usage/configuration.md) and [Workflow configuration](https://github.com/semantic-release/semantic-release/blob/9589a96239826abe9b07e8deffcc7d8aeb9c2e40/docs/usage/workflow-configuration.md) docs. This PR does the following:
- `prerelease` is made optional (it is required if the branch spec is for a prerelease branch, which is implied)
- `prerelease` can either be a boolean or string
- Add a example block with a boolean `prerelease` value
- Rename "Semantic Release" to "semantic-release" globally
- Add the extensionless (either YAML or JSON) `.releaserc` to matched files