### PR TITLE
feat: update AsyncAPI schema URLs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -239,7 +239,14 @@
     {
       "name": "AsyncAPI",
       "description": "A JSON Schema for validating AsyncAPI documentation files",
-      "fileMatch": ["asyncapi.json", "*.asyncapi.json", "asyncapi.yml", ".asyncapi.yml", "asyncapi.yaml", ".asyncapi.yaml"],
+      "fileMatch": [
+        "asyncapi.json",
+        "*.asyncapi.json",
+        "asyncapi.yml",
+        ".asyncapi.yml",
+        "asyncapi.yaml",
+        ".asyncapi.yaml"
+      ],
       "url": "https://asyncapi.com/schema-store/2.4.0.json",
       "versions": {
         "1.0.0": "https://asyncapi.com/schema-store/1.0.0.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -237,19 +237,21 @@
       "url": "https://json.schemastore.org/asconfig-schema.json"
     },
     {
-      "name": "asyncapi.json",
-      "description": "A JSON schema for AsyncAPI documentation files",
-      "fileMatch": ["asyncapi.json", "asyncapi.yml", "asyncapi.yaml"],
-      "url": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/2.4.0.json",
+      "name": "AsyncAPI",
+      "description": "A JSON Schema for validating AsyncAPI documentation files",
+      "fileMatch": ["asyncapi.json", "*.asyncapi.json", "asyncapi.yml", ".asyncapi.yml", "asyncapi.yaml", ".asyncapi.yaml"],
+      "url": "https://asyncapi.com/schema-store/2.4.0.json",
       "versions": {
-        "1.0.0": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/1.0.0.json",
-        "1.1.0": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/1.1.0.json",
-        "1.2.0": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/1.2.0.json",
-        "2.0.0": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/2.0.0.json",
-        "2.1.0": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/2.1.0.json",
-        "2.2.0": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/2.2.0.json",
-        "2.3.0": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/2.3.0.json",
-        "2.4.0": "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/2.4.0.json"
+        "1.0.0": "https://asyncapi.com/schema-store/1.0.0.json",
+        "1.1.0": "https://asyncapi.com/schema-store/1.1.0.json",
+        "1.2.0": "https://asyncapi.com/schema-store/1.2.0.json",
+        "2.0.0-rc1": "https://asyncapi.com/schema-store/2.0.0-rc1.json",
+        "2.0.0-rc2": "https://asyncapi.com/schema-store/2.0.0-rc2.json",
+        "2.0.0": "https://asyncapi.com/schema-store/2.0.0.json",
+        "2.1.0": "https://asyncapi.com/schema-store/2.1.0.json",
+        "2.2.0": "https://asyncapi.com/schema-store/2.2.0.json",
+        "2.3.0": "https://asyncapi.com/schema-store/2.3.0.json",
+        "2.4.0": "https://asyncapi.com/schema-store/2.4.0.json"
       }
     },
     {


### PR DESCRIPTION
This PR updates the following data from the AsyncAPI catalog entry:

- The name, from `asyncapi.json` to `AsyncAPI` as it is more readable, as `asyncapi.json` is not any standard name known in the community.
- Improved a bit the description.
- Added more file patterns into `fileMatch` field.
- Changed all the URLs to point to asyncapi.com/schema-store site, as per AsyncAPI documentation recommends: https://github.com/asyncapi/spec-json-schemas/tree/master/schemas#json-schema-store
