### PR TITLE
Partial interpolation in GitHub Workflow runs-on

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -307,6 +307,11 @@
       "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
       "pattern": "^\\$\\{\\{.*\\}\\}$"
     },
+    "stringContainingExpressionSyntax": {
+      "type": "string",
+      "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
+      "pattern": "^.*\\$\\{\\{.*\\}\\}.*$"
+    },
     "globs": {
       "type": "array",
       "items": {
@@ -596,7 +601,7 @@
               ]
             },
             {
-              "$ref": "#/definitions/expressionSyntax"
+              "$ref": "#/definitions/stringContainingExpressionSyntax"
             }
           ]
         },

--- a/src/test/github-workflow/runs-on-interpolated.yaml
+++ b/src/test/github-workflow/runs-on-interpolated.yaml
@@ -1,0 +1,12 @@
+on:
+  push:
+jobs:
+  macos:
+    strategy:
+      matrix:
+        include:
+          - macos-version: "10.15"
+          - macos-version: "11"
+    runs-on: macos-${{ matrix.macos-version }}
+    steps:
+      - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Workflows have an expression syntax covered by a well-defined regex in the current schema. However, the expression syntax is not necessarily the full content of a field. In addition to
```
foo: ${{ expr }}
```
the schema should support
```
foo: bar-${{ expr }}
```
in certain contexts.

This PR introduces a new variant of the established regex which allows for arbitrary prefix and suffix strings. The only requirement is that a valid expression-syntax-block appear somewhere within the field.

Apply `stringContainingExpressionSyntax` in lieu of `expressionSyntax` to the `runs-on` field in workflows. This fixes #2311

The `stringContainingExpressionSyntax` may turn out to be desirable in all locations which use `expressionSyntax`, but this change is not made here, only in `runs-on`.

Additionally, the `stringContainingExpressionSyntax` block used for `runs-on` could be made more restrictive. For example, `allOf` could be used to enforce that if there is a string prefix, it must match one of the known classes of runners. However, such logic would be error-prone, and is omitted for now.

---

Since this originated as a bug report on `check-jsonschema`, I've validated that with the updated schema, the new test-case passes validation with that tool. That means that the regex here is correctly interpreted both under python and under javascript.