### PR TITLE
fix(asyncapi): add www. subdomain to URL to avoid 301

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -247,18 +247,18 @@
         "asyncapi.yaml",
         "*asyncapi.yaml"
       ],
-      "url": "https://asyncapi.com/schema-store/2.4.0.json",
+      "url": "https://www.asyncapi.com/schema-store/2.4.0.json",
       "versions": {
-        "1.0.0": "https://asyncapi.com/schema-store/1.0.0.json",
-        "1.1.0": "https://asyncapi.com/schema-store/1.1.0.json",
-        "1.2.0": "https://asyncapi.com/schema-store/1.2.0.json",
-        "2.0.0-rc1": "https://asyncapi.com/schema-store/2.0.0-rc1.json",
-        "2.0.0-rc2": "https://asyncapi.com/schema-store/2.0.0-rc2.json",
-        "2.0.0": "https://asyncapi.com/schema-store/2.0.0.json",
-        "2.1.0": "https://asyncapi.com/schema-store/2.1.0.json",
-        "2.2.0": "https://asyncapi.com/schema-store/2.2.0.json",
-        "2.3.0": "https://asyncapi.com/schema-store/2.3.0.json",
-        "2.4.0": "https://asyncapi.com/schema-store/2.4.0.json"
+        "1.0.0": "https://www.asyncapi.com/schema-store/1.0.0.json",
+        "1.1.0": "https://www.asyncapi.com/schema-store/1.1.0.json",
+        "1.2.0": "https://www.asyncapi.com/schema-store/1.2.0.json",
+        "2.0.0-rc1": "https://www.asyncapi.com/schema-store/2.0.0-rc1.json",
+        "2.0.0-rc2": "https://www.asyncapi.com/schema-store/2.0.0-rc2.json",
+        "2.0.0": "https://www.asyncapi.com/schema-store/2.0.0.json",
+        "2.1.0": "https://www.asyncapi.com/schema-store/2.1.0.json",
+        "2.2.0": "https://www.asyncapi.com/schema-store/2.2.0.json",
+        "2.3.0": "https://www.asyncapi.com/schema-store/2.3.0.json",
+        "2.4.0": "https://www.asyncapi.com/schema-store/2.4.0.json"
       }
     },
     {


### PR DESCRIPTION
My bad I didn't add the `www` subdomain prefix to all AsyncAPI URLs. WIthout it, a 301 redirect is happening.