### PR TITLE
fix: codecov fix patch schema

### DIFF
--- a/src/schemas/json/codecov.json
+++ b/src/schemas/json/codecov.json
@@ -3,7 +3,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "default": {
-      "type": ["object", "boolean"],
       "$comment": "See https://docs.codecov.com/docs/commit-status#basic-configuration",
       "properties": {
         "target": {
@@ -491,17 +490,40 @@
             "project": {
               "properties": {
                 "default": {
+                  "type": [
+                    "object",
+                    "boolean"
+                  ],
                   "$ref": "#/definitions/default"
                 }
               },
               "additionalProperties": {
+                "type": [
+                  "object",
+                  "boolean"
+                ],
                 "$ref": "#/definitions/default"
               }
             },
             "patch": {
-              "$ref": "#/definitions/default"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "$ref": "#/definitions/default"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "off"
+                  ]
+                }
+              ]
             },
             "changes": {
+              "type": [
+                "object",
+                "boolean"
+              ],
               "$ref": "#/definitions/default"
             }
           }

--- a/src/schemas/json/codecov.json
+++ b/src/schemas/json/codecov.json
@@ -490,18 +490,12 @@
             "project": {
               "properties": {
                 "default": {
-                  "type": [
-                    "object",
-                    "boolean"
-                  ],
+                  "type": ["object", "boolean"],
                   "$ref": "#/definitions/default"
                 }
               },
               "additionalProperties": {
-                "type": [
-                  "object",
-                  "boolean"
-                ],
+                "type": ["object", "boolean"],
                 "$ref": "#/definitions/default"
               }
             },
@@ -513,17 +507,12 @@
                 },
                 {
                   "type": "string",
-                  "enum": [
-                    "off"
-                  ]
+                  "enum": ["off"]
                 }
               ]
             },
             "changes": {
-              "type": [
-                "object",
-                "boolean"
-              ],
+              "type": ["object", "boolean"],
               "$ref": "#/definitions/default"
             }
           }

--- a/src/test/codecov/jellyfin-vue.yml
+++ b/src/test/codecov/jellyfin-vue.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+        if_not_found: success # no commit found? still set a success
+    patch: off


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Ran into a project where apparently one of the properties were incorrect, but actually the schema is wrong.

According to the Codecov documentation, it can be an `object` or the literal string value, `off`.
It may be that `false` is a valid value as well, but the documentation does not clarify this.

See below for examples of the `patch` property from the docs.

> ```yml
> coverage:
>   status:
>     patch:
>       default:
>         # basic
>         target: auto
>         threshold: 0%
>         base: auto 
>         # advanced
>         branches: 
>           - master
>         if_ci_failed: error #success, failure, error, ignore
>         only_pulls: false
>         flags: 
>           - "unit"
>         paths: 
>           - "src"
> ```
> 
> ```yml
> coverage:
>   status:
>     project: off
>     patch: off
> ```
> 
> — https://docs.codecov.com/docs/commit-status#patch-status
