### PR TITLE
GitHub Workflows: Make more permissible and fix issue

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -222,8 +222,7 @@
                 "type": "boolean"
               }
             ]
-          },
-          "minProperties": 1
+          }
         },
         {
           "$ref": "#/definitions/expressionSyntax",
@@ -491,7 +490,7 @@
           "$ref": "#/definitions/jobNeeds"
         },
         "permissions": {
-          "$ref": "#/definitions/permissions-event"
+          "$ref": "#/definitions/permissions"
         },
         "runs-on": {
           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on",

--- a/src/test/github-workflow/permissions-string.yaml
+++ b/src/test/github-workflow/permissions-string.yaml
@@ -4,5 +4,6 @@ permissions: read-all
 jobs:
   one:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - run: echo 'Hello from ${{ runner.os }}'


### PR DESCRIPTION
## Fixes

- Allow env to include no properties (this is valid and mentioned specifically in the docs)
- Enable "write-all" etc. strings within a particular job (not just at the root)

Below image shows some of the current erroneous highlighting before this fix

![Graphically shows issues](https://user-images.githubusercontent.com/24364012/175833600-20a37ac9-0572-4d50-9eeb-73fea0e8c7e7.png)

