### PR TITLE
Add schema for Hardware Sentry configuration file (hws-config.yaml)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3682,6 +3682,12 @@
       "description": "Copy/paste detector for programming source code",
       "fileMatch": [".jscpd.json"],
       "url": "https://json.schemastore.org/jscpd.json"
+    },
+    {
+      "name": "Hardware Sentry Configuration",
+      "description": "Hardware Sentry configuration file",
+      "fileMatch": ["hws-config.yaml", "hws-config.yml", "hws*.yaml", "hws*.yml"],
+      "url": "https://json.schemastore.org/hws-config.json"
     }
   ],
   "version": 1

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3692,7 +3692,12 @@
     {
       "name": "Hardware Sentry Configuration",
       "description": "Hardware Sentry configuration file",
-      "fileMatch": ["hws-config.yaml", "hws-config.yml", "hws*.yaml", "hws*.yml"],
+      "fileMatch": [
+        "hws-config.yaml",
+        "hws-config.yml",
+        "hws*.yaml",
+        "hws*.yml"
+      ],
       "url": "https://json.schemastore.org/hws-config.json"
     }
   ],

--- a/src/negative_test/hws-config/hws-config.yaml
+++ b/src/negative_test/hws-config/hws-config.yaml
@@ -34,7 +34,7 @@ extraMetrics:
   # Source: https://app.electricitymap.org/map
 
   hw.site.electricity_cost_dollars: 0.12 # in $/kWh
-  # Electricity cost per kilowatt-hour. 
+  # Electricity cost per kilowatt-hour.
   # The average is $0.12/kWh for non-household in Europe.
   # The average is $0.159/kWh for non-household in the USA.
   # The average is $0.117/kWh for non-household in Canada.

--- a/src/negative_test/hws-config/hws-config.yaml
+++ b/src/negative_test/hws-config/hws-config.yaml
@@ -32,7 +32,7 @@ extraMetrics:
   # The average is 40g/kWh for Ontario, Canada.
   # The average is 712g/kWh for Queensland, Australia.
   # Source: https://app.electricitymap.org/map
-  
+
   hw.site.electricity_cost_dollars: 0.12 # in $/kWh
   # Electricity cost per kilowatt-hour. 
   # The average is $0.12/kWh for non-household in Europe.
@@ -40,7 +40,7 @@ extraMetrics:
   # The average is $0.117/kWh for non-household in Canada.
   # The average is $0.225/kWh for non-household in Australia.
   # Source: https://www.globalpetrolprices.com/electricity_prices/
-  
+
   hw.site.pue_ratio: 1.8
   # Power Usage Effectiveness. A ratio describing how efficiently a computer data center uses energy. The ideal ratio is 1.
 

--- a/src/negative_test/hws-config/hws-config.yaml
+++ b/src/negative_test/hws-config/hws-config.yaml
@@ -1,0 +1,51 @@
+# Hardware Sentry
+
+# Number of jobs that Hardware Sentry can run simultaneously.
+jobPoolSize: 30
+
+# Discovery cycle.
+discoveryCycle: 20
+
+# Internal collect interval.
+collectPeriod: 1m
+
+# Debug mode of the core engine.
+loggerLevel: debug
+
+# Display the configured hostname in the Host Resource `host.name` attribute instead of the resolved FQDN.
+resolveHostnameToFqdn: true
+
+# Forces all the network calls to be executed in sequential order.
+sequential: false
+
+# Disable hardware alerts.
+disableAlerts: false
+
+extraLabels:
+  site: Datacenter 1 # Customize this value with your own site naming convention. (Dedicating 1 collector to 1 site is a good practice.)
+
+extraMetrics:
+  hw.site.carbon_density_grams: 230 # in g/kWh
+  # Carbon dioxide produced per kilowatt-hour.
+  # The average is 230g/kWh for Europe.
+  # The average is 309g/kWh for Texas, USA.
+  # The average is 40g/kWh for Ontario, Canada.
+  # The average is 712g/kWh for Queensland, Australia.
+  # Source: https://app.electricitymap.org/map
+  
+  hw.site.electricity_cost_dollars: 0.12 # in $/kWh
+  # Electricity cost per kilowatt-hour. 
+  # The average is $0.12/kWh for non-household in Europe.
+  # The average is $0.159/kWh for non-household in the USA.
+  # The average is $0.117/kWh for non-household in Canada.
+  # The average is $0.225/kWh for non-household in Australia.
+  # Source: https://www.globalpetrolprices.com/electricity_prices/
+  
+  hw.site.pue_ratio: 1.8
+  # Power Usage Effectiveness. A ratio describing how efficiently a computer data center uses energy. The ideal ratio is 1.
+
+exporter:
+  otlp:
+
+# Missing hosts!
+hosts:

--- a/src/schemas/json/hws-config.json
+++ b/src/schemas/json/hws-config.json
@@ -18,24 +18,12 @@
     },
     "loggerLevel": {
       "type": "string",
-      "enum": [
-        "all",
-        "trace",
-        "debug",
-        "info",
-        "warn",
-        "error",
-        "fatal",
-        "off"
-      ],
+      "enum": ["all", "trace", "debug", "info", "warn", "error", "fatal", "off"],
       "default": "off"
     },
     "transportProtocols": {
       "type": "string",
-      "enum": [
-        "http",
-        "https"
-      ]
+      "enum": ["http", "https"]
     },
     "namespace": {
       "description": "Forces a specific namespace for connectors that perform namespace auto-detection (Advanced).",
@@ -76,10 +64,7 @@
       "properties": {
         "otlp": {
           "description": "Overrides Hardware Sentry's internal OTLP Exporter configuration.",
-          "type": [
-            "object",
-            "null"
-          ],
+          "type": ["object", "null"],
           "properties": {
             "headers": {
               "description": "Sets Hardware Sentry's OTLP Exporter headers, such as the `Authorization` header used to authenticate the Exporter with the OTLP gRPC Receiver.",
@@ -178,10 +163,7 @@
                 ]
               }
             },
-            "required": [
-              "hostname",
-              "type"
-            ]
+            "required": ["hostname", "type"]
           },
           "http": {
             "description": "Configures the HTTP protocol to access the host.",
@@ -303,11 +285,7 @@
               "privacy": {
                 "description": "SNMP v3 only - Sets the type of encryption protocol.",
                 "type": "string",
-                "enum": [
-                  "none",
-                  "aes",
-                  "des"
-                ]
+                "enum": ["none", "aes", "des"]
               },
               "privacyPassword": {
                 "description": "SNMP v3 only - Sets the password associated to the privacy protocol.",
@@ -325,13 +303,7 @@
               "version": {
                 "description": "Sets the version of the SNMP protocol (Default: v1).",
                 "type": "string",
-                "enum": [
-                  "v1",
-                  "v2c",
-                  "v3-no-auth",
-                  "v3-md5",
-                  "v3-sha"
-                ],
+                "enum": ["v1", "v2c", "v3-no-auth", "v3-md5", "v3-sha"],
                 "default": "v1"
               }
             }
@@ -417,14 +389,9 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": [
-                    "ntlm",
-                    "kerberos"
-                  ]
+                  "enum": ["ntlm", "kerberos"]
                 },
-                "default": [
-                  "ntlm"
-                ]
+                "default": ["ntlm"]
               },
               "namespace": {
                 "$ref": "#/definitions/namespace"
@@ -476,9 +443,7 @@
             }
           }
         },
-        "required": [
-          "host"
-        ]
+        "required": ["host"]
       }
     },
     "jobPoolSize": {

--- a/src/schemas/json/hws-config.json
+++ b/src/schemas/json/hws-config.json
@@ -1,9 +1,6 @@
 {
-  "id": "https://json.schemastore.org/hws-config.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
-  "title": "Hardware Sentry configuration file",
-  "type": "object",
   "definitions": {
     "duration": {
       "oneOf": [
@@ -51,6 +48,7 @@
       "default": "Hardware problem on \\${FQDN\\} with \\${MONITOR_NAME\\}.\\${NEWLINE\\}\\${NEWLINE\\}\\${ALERT_DETAILS\\}\\${NEWLINE\\}\\${NEWLINE\\}\\${FULLREPORT\\}"
     }
   },
+  "id": "https://json.schemastore.org/hws-config.json",
   "properties": {
     "collectPeriod": {
       "description": "Sets the collect period that Hardware Sentry uses to collects metrics from the monitored hosts (Default: 2m).",
@@ -477,5 +475,7 @@
       "description": "Forces all the network calls to be executed in sequential order for all the monitored hosts - NOT RECOMMENDED (Default: false).",
       "$ref": "#/definitions/sequential"
     }
-  }
+  },
+  "title": "Hardware Sentry configuration file",
+  "type": "object"
 }

--- a/src/schemas/json/hws-config.json
+++ b/src/schemas/json/hws-config.json
@@ -1,0 +1,507 @@
+{
+  "id": "https://json.schemastore.org/hws-config.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "title": "Hardware Sentry configuration file",
+  "type": "object",
+  "definitions": {
+    "duration": {
+      "oneOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+\\s*[years|yrs|y|weeks|wks|w|days|d|hours|hrs|h|minutes|mins|m!seconds|secs|s|milliseconds|ms]*$"
+        }
+      ]
+    },
+    "loggerLevel": {
+      "type": "string",
+      "enum": [
+        "all",
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal",
+        "off"
+      ],
+      "default": "off"
+    },
+    "transportProtocols": {
+      "type": "string",
+      "enum": [
+        "http",
+        "https"
+      ]
+    },
+    "namespace": {
+      "description": "Forces a specific namespace for connectors that perform namespace auto-detection (Advanced).",
+      "type": "string"
+    },
+    "outputDirectory": {
+      "type": "string",
+      "default": "logs"
+    },
+    "sequential": {
+      "type": "boolean",
+      "default": false
+    },
+    "hardwareProblemTemplate": {
+      "type": "string",
+      "default": "Hardware problem on \\${FQDN\\} with \\${MONITOR_NAME\\}.\\${NEWLINE\\}\\${NEWLINE\\}\\${ALERT_DETAILS\\}\\${NEWLINE\\}\\${NEWLINE\\}\\${FULLREPORT\\}"
+    }
+  },
+  "properties": {
+    "collectPeriod": {
+      "description": "Sets the collect period that Hardware Sentry uses to collects metrics from the monitored hosts (Default: 2m).",
+      "$ref": "#/definitions/duration",
+      "default": "2m"
+    },
+    "disableAlerts": {
+      "description": "Disables Hardware Sentry's alerts for all the monitored hosts (Default: false).",
+      "type": "boolean",
+      "default": false
+    },
+    "discoveryCycle": {
+      "description": "Sets the cycle that Hardware Sentry uses to perform discoveries and detect new components in your monitored environment. By default, Hardware Sentry runs a discovery after 30 collects.",
+      "type": "integer",
+      "default": "30"
+    },
+    "exporter": {
+      "description": "Sets Hardware Sentry's internal Exporter configuration.",
+      "type": "object",
+      "properties": {
+        "otlp": {
+          "description": "Overrides Hardware Sentry's internal OTLP Exporter configuration.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "headers": {
+              "description": "Sets Hardware Sentry's OTLP Exporter headers, such as the `Authorization` header used to authenticate the Exporter with the OTLP gRPC Receiver.",
+              "type": "object"
+            },
+            "trustedCertificatesFile": {
+              "description": "Sets Hardware Sentry's OTLP Exporter trusted certificates file (Default: security/otel.crt).",
+              "type": "string",
+              "default": "security/otel.crt"
+            }
+          }
+        }
+      }
+    },
+    "extraLabels": {
+      "description": "Adds or overrides the attributes for all the monitored hosts. It is recommended to specify a different `site` label value for each OpenTelemetry Collector running the Hardware Sentry Agent.",
+      "type": "object"
+    },
+    "extraMetrics": {
+      "description": "Adds additional static metrics to be exposed by Hardware Sentry.",
+      "type": "object"
+    },
+    "hardwareProblemTemplate": {
+      "description": "Overrides the default hardware problem template used to build the alert body for all the monitored hosts.",
+      "$ref": "#/definitions/hardwareProblemTemplate"
+    },
+    "hosts": {
+      "description": "Configures the hosts to monitor.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "collectPeriod": {
+            "description": "Sets the default collect period that Hardware Sentry uses to collects metrics from the monitored host (Default: 2m).",
+            "$ref": "#/definitions/duration",
+            "default": "2m"
+          },
+          "disableAlerts": {
+            "description": "Disables Hardware Sentry's alerts for the monitored host (Default: false).",
+            "type": "boolean",
+            "default": false
+          },
+          "discoveryCycle": {
+            "description": "Sets the cycle that Hardware Sentry uses to perform discoveries and detect new components for the specific host. By default, Hardware Sentry runs a discovery after 30 collects.",
+            "type": "integer",
+            "default": "30"
+          },
+          "excludedConnectors": {
+            "description": "Sets the Connector(s) that must be excluded from the automatic detection.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "extraLabels": {
+            "description": "Adds or overrides the attributes of the monitored host.",
+            "type": "object"
+          },
+          "hardwareProblemTemplate": {
+            "description": "Overrides the default hardware problem template used to build the alert body for the monitored host.",
+            "$ref": "#/definitions/hardwareProblemTemplate"
+          },
+          "host": {
+            "description": "Configures a new host to be monitored.",
+            "type": "object",
+            "properties": {
+              "hostname": {
+                "description": "Configures the hostname of the host to be monitored.",
+                "type": "string"
+              },
+              "id": {
+                "description": "Configures the identifier of the host to be monitored (Optional). By default, the host identifier is the hostname property value.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Configures the type of the host to be monitored.",
+                "type": "string",
+                "anyOf": [
+                  {
+                    "pattern": "^lin|^lnx$|^win|^ms.*win|^microsoft.*w|^oob$|^out|^vmware|^mgmt|^management|^esx|^blade|^net|^switch|^sto|^san|vms|tru64|osf|hp.*ux|aix|rs6000|^sun|^ora|sol"
+                  },
+                  {
+                    "enum": [
+                      "win",
+                      "linux",
+                      "network",
+                      "oob",
+                      "storage",
+                      "aix",
+                      "hpux",
+                      "solaris",
+                      "tru64",
+                      "vmx"
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": [
+              "hostname",
+              "type"
+            ]
+          },
+          "http": {
+            "description": "Configures the HTTP protocol to access the host.",
+            "type": "object",
+            "properties": {
+              "https": {
+                "description": "Enables HTTPS to access the host (Default: true).",
+                "type": "boolean",
+                "default": true
+              },
+              "password": {
+                "description": "Sets the password used to establish the connection with the host through the HTTP protocol.",
+                "type": "string"
+              },
+              "port": {
+                "description": "Sets the HTTPS port number used to perform HTTP requests (Default: 443).",
+                "type": "integer",
+                "default": 443
+              },
+              "timeout": {
+                "description": "Sets how long until the HTTP request times out (Default: 120s).",
+                "$ref": "#/definitions/duration",
+                "default": "120s"
+              },
+              "username": {
+                "description": "Sets the username used to establish the connection with the host through the HTTP protocol.",
+                "type": "string"
+              }
+            }
+          },
+          "ipmi": {
+            "description": "Configures the IPMI protocol to access the host.",
+            "type": "object",
+            "properties": {
+              "password": {
+                "description": "Sets the password used to establish the connection with the host through the IPMI protocol.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Sets how long until the IPMI request times out (Default: 120s).",
+                "$ref": "#/definitions/duration",
+                "default": "120s"
+              },
+              "username": {
+                "description": "Sets the username used to establish the connection with the host through the IPMI protocol.",
+                "type": "string"
+              }
+            }
+          },
+          "loggerLevel": {
+            "description": "Enables the debug mode of the core engine on the specific host (Default: off).",
+            "$ref": "#/definitions/loggerLevel"
+          },
+          "operationTimeout": {
+            "description": "Sets how long until the engine's discovery and collect operations time out.",
+            "type": "integer"
+          },
+          "osCommand": {
+            "description": "Configures the OS Command protocol to access the host.",
+            "type": "object",
+            "properties": {
+              "sudoCommand": {
+                "description": "Sets the sudo command to be used for the host to be monitored (Default: sudo).",
+                "type": "string",
+                "default": "sudo"
+              },
+              "timeout": {
+                "description": "Sets how long until the local OS Command times out (Default: 120s).",
+                "$ref": "#/definitions/duration",
+                "default": "120s"
+              },
+              "useSudo": {
+                "description": "Sets if sudo needs to be used for the local OS Command (Default: false).",
+                "type": "boolean",
+                "default": false
+              },
+              "useSudoCommands": {
+                "description": "Sets the list of commands for which sudo is required.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "outputDirectory": {
+            "description": "Sets the debug output directory for the monitored host. By default, the debug output file is saved in the `logs` directory under the Hardware Sentry's home directory.",
+            "$ref": "#/definitions/outputDirectory"
+          },
+          "selectedConnectors": {
+            "description": "Sets the Connector(s) to use to monitor the host. No automatic detection will be performed.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sequential": {
+            "description": "Forces all the network calls to be executed in sequential order for the monitored host - NOT RECOMMENDED (Default: false).",
+            "$ref": "#/definitions/sequential"
+          },
+          "snmp": {
+            "description": "Configures the SNMP protocol to access the host.",
+            "type": "object",
+            "properties": {
+              "community": {
+                "description": "Sets the SNMP Community string to use to perform SNMP v1 queries (Default: public).",
+                "type": "string",
+                "default": "public"
+              },
+              "password": {
+                "description": "SNMP v3 only - Sets the password to use for performing the SNMP query.",
+                "type": "string"
+              },
+              "port": {
+                "description": "Sets the SNMP port number used to perform SNMP queries (Default: 161).",
+                "type": "integer",
+                "default": 161
+              },
+              "privacy": {
+                "description": "SNMP v3 only - Sets the type of encryption protocol.",
+                "type": "string",
+                "enum": [
+                  "none",
+                  "aes",
+                  "des"
+                ]
+              },
+              "privacyPassword": {
+                "description": "SNMP v3 only - Sets the password associated to the privacy protocol.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Sets how long until the SNMP request times out (Default: 120s).",
+                "$ref": "#/definitions/duration",
+                "default": "120s"
+              },
+              "username": {
+                "description": "SNMP v3 only - Sets the username to use for performing the SNMP query.",
+                "type": "string"
+              },
+              "version": {
+                "description": "Sets the version of the SNMP protocol (Default: v1).",
+                "type": "string",
+                "enum": [
+                  "v1",
+                  "v2c",
+                  "v3-no-auth",
+                  "v3-md5",
+                  "v3-sha"
+                ],
+                "default": "v1"
+              }
+            }
+          },
+          "ssh": {
+            "description": "Configures the SSH protocol to access the host.",
+            "type": "object",
+            "properties": {
+              "password": {
+                "description": "Sets the password to use for performing the SSH query.",
+                "type": "string"
+              },
+              "privateKey": {
+                "description": "Sets the private Key File to use to establish the connection to the host through the SSH protocol.",
+                "type": "string"
+              },
+              "sudoCommand": {
+                "description": "Sets the sudo command to be used.",
+                "type": "string",
+                "default": "sudo"
+              },
+              "timeout": {
+                "description": "Sets how long until the command times out (Default: 120s).",
+                "$ref": "#/definitions/duration",
+                "default": "120s"
+              },
+              "useSudo": {
+                "description": "Sets if sudo needs to be used for the SSH Command (Default: false).",
+                "type": "boolean",
+                "default": false
+              },
+              "useSudoCommands": {
+                "description": "Sets the list of commands for which sudo is required.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "username": {
+                "description": "Sets the username to use for performing the SSH query.",
+                "type": "string"
+              }
+            }
+          },
+          "wbem": {
+            "description": "Configures the WBEM protocol to access the host.",
+            "type": "object",
+            "properties": {
+              "namespace": {
+                "$ref": "#/definitions/namespace"
+              },
+              "password": {
+                "description": "Sets the password used to establish the connection with the host through the WBEM protocol.",
+                "type": "string"
+              },
+              "port": {
+                "description": "Sets the HTTPS port number used to perform WBEM queries (Default: 5989 for HTTPS or 5988 for HTTP).",
+                "type": "integer",
+                "default": 5989
+              },
+              "protocol": {
+                "description": "Sets the protocol used to access the host (Default: https).",
+                "$ref": "#/definitions/transportProtocols",
+                "default": "https"
+              },
+              "timeout": {
+                "description": "Sets how long until the WBEM request times out (Default: 120s).",
+                "$ref": "#/definitions/duration",
+                "default": "120s"
+              },
+              "username": {
+                "description": "Sets the username used to establish the connection with the host through the WBEM protocol.",
+                "type": "string"
+              }
+            }
+          },
+          "winrm": {
+            "description": "Configures the WinRM protocol to access the host.",
+            "type": "object",
+            "properties": {
+              "authentications": {
+                "description": "Sets an ordered list of authentication schemes (Default: [\"ntlm\"]).",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "ntlm",
+                    "kerberos"
+                  ]
+                },
+                "default": [
+                  "ntlm"
+                ]
+              },
+              "namespace": {
+                "$ref": "#/definitions/namespace"
+              },
+              "password": {
+                "description": "Sets the password used to establish the connection with the host through the WinRM protocol.",
+                "type": "string"
+              },
+              "port": {
+                "description": "Sets the port number used to perform WQL queries and commands (Default: 5985 for HTTP or 5986 for HTTPS).",
+                "type": "integer"
+              },
+              "protocol": {
+                "description": "Sets the protocol used to access the host (Default: http).",
+                "$ref": "#/definitions/transportProtocols",
+                "default": "http"
+              },
+              "timeout": {
+                "description": "Sets how long until the WinRM request times out (Default: 120s).",
+                "$ref": "#/definitions/duration",
+                "default": "120s"
+              },
+              "username": {
+                "description": "Sets the username used to establish the connection with the host through the WinRM protocol.",
+                "type": "string"
+              }
+            }
+          },
+          "wmi": {
+            "description": "Configures the WMI protocol to access the host.",
+            "type": "object",
+            "properties": {
+              "namespace": {
+                "$ref": "#/definitions/namespace"
+              },
+              "password": {
+                "description": "Sets the password used to establish the connection with the host through the WMI protocol.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Sets how long until the WMI request times out (Default: 120s).",
+                "$ref": "#/definitions/duration",
+                "default": "120s"
+              },
+              "username": {
+                "description": "Sets the username used to establish the connection with the host through the WMI protocol.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "host"
+        ]
+      }
+    },
+    "jobPoolSize": {
+      "description": "Sets the number of jobs that Hardware Sentry can run simultaneously (Default: 20).",
+      "type": "integer",
+      "default": "20"
+    },
+    "loggerLevel": {
+      "description": "Enables the debug mode of the core engine (Default: off).",
+      "$ref": "#/definitions/loggerLevel"
+    },
+    "outputDirectory": {
+      "description": "Sets the debug output directory for all the monitored hosts. By default, the debug output files are saved in the `logs` directory under the Hardware Sentry's home directory.",
+      "$ref": "#/definitions/outputDirectory"
+    },
+    "resolveHostnameToFqdn": {
+      "description": "Displays the configured hostname in the Host Resource `host.name` attribute instead of the resolved FQDN (Default: false).",
+      "type": "boolean",
+      "default": false
+    },
+    "sequential": {
+      "description": "Forces all the network calls to be executed in sequential order for all the monitored hosts - NOT RECOMMENDED (Default: false).",
+      "$ref": "#/definitions/sequential"
+    }
+  }
+}

--- a/src/schemas/json/hws-config.json
+++ b/src/schemas/json/hws-config.json
@@ -18,12 +18,24 @@
     },
     "loggerLevel": {
       "type": "string",
-      "enum": ["all", "trace", "debug", "info", "warn", "error", "fatal", "off"],
+      "enum": [
+        "all",
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal",
+        "off"
+      ],
       "default": "off"
     },
     "transportProtocols": {
       "type": "string",
-      "enum": ["http", "https"]
+      "enum": [
+        "http",
+        "https"
+      ]
     },
     "namespace": {
       "description": "Forces a specific namespace for connectors that perform namespace auto-detection (Advanced).",
@@ -64,7 +76,10 @@
       "properties": {
         "otlp": {
           "description": "Overrides Hardware Sentry's internal OTLP Exporter configuration.",
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "properties": {
             "headers": {
               "description": "Sets Hardware Sentry's OTLP Exporter headers, such as the `Authorization` header used to authenticate the Exporter with the OTLP gRPC Receiver.",
@@ -163,7 +178,10 @@
                 ]
               }
             },
-            "required": ["hostname", "type"]
+            "required": [
+              "hostname",
+              "type"
+            ]
           },
           "http": {
             "description": "Configures the HTTP protocol to access the host.",
@@ -285,7 +303,11 @@
               "privacy": {
                 "description": "SNMP v3 only - Sets the type of encryption protocol.",
                 "type": "string",
-                "enum": ["none", "aes", "des"]
+                "enum": [
+                  "none",
+                  "aes",
+                  "des"
+                ]
               },
               "privacyPassword": {
                 "description": "SNMP v3 only - Sets the password associated to the privacy protocol.",
@@ -303,7 +325,13 @@
               "version": {
                 "description": "Sets the version of the SNMP protocol (Default: v1).",
                 "type": "string",
-                "enum": ["v1", "v2c", "v3-no-auth", "v3-md5", "v3-sha"],
+                "enum": [
+                  "v1",
+                  "v2c",
+                  "v3-no-auth",
+                  "v3-md5",
+                  "v3-sha"
+                ],
                 "default": "v1"
               }
             }
@@ -389,9 +417,14 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": ["ntlm", "kerberos"]
+                  "enum": [
+                    "ntlm",
+                    "kerberos"
+                  ]
                 },
-                "default": ["ntlm"]
+                "default": [
+                  "ntlm"
+                ]
               },
               "namespace": {
                 "$ref": "#/definitions/namespace"
@@ -443,7 +476,9 @@
             }
           }
         },
-        "required": ["host"]
+        "required": [
+          "host"
+        ]
       }
     },
     "jobPoolSize": {

--- a/src/schemas/json/hws-config.json
+++ b/src/schemas/json/hws-config.json
@@ -32,10 +32,7 @@
     },
     "transportProtocols": {
       "type": "string",
-      "enum": [
-        "http",
-        "https"
-      ]
+      "enum": ["http", "https"]
     },
     "namespace": {
       "description": "Forces a specific namespace for connectors that perform namespace auto-detection (Advanced).",
@@ -76,10 +73,7 @@
       "properties": {
         "otlp": {
           "description": "Overrides Hardware Sentry's internal OTLP Exporter configuration.",
-          "type": [
-            "object",
-            "null"
-          ],
+          "type": ["object", "null"],
           "properties": {
             "headers": {
               "description": "Sets Hardware Sentry's OTLP Exporter headers, such as the `Authorization` header used to authenticate the Exporter with the OTLP gRPC Receiver.",
@@ -178,10 +172,7 @@
                 ]
               }
             },
-            "required": [
-              "hostname",
-              "type"
-            ]
+            "required": ["hostname", "type"]
           },
           "http": {
             "description": "Configures the HTTP protocol to access the host.",
@@ -303,11 +294,7 @@
               "privacy": {
                 "description": "SNMP v3 only - Sets the type of encryption protocol.",
                 "type": "string",
-                "enum": [
-                  "none",
-                  "aes",
-                  "des"
-                ]
+                "enum": ["none", "aes", "des"]
               },
               "privacyPassword": {
                 "description": "SNMP v3 only - Sets the password associated to the privacy protocol.",
@@ -325,13 +312,7 @@
               "version": {
                 "description": "Sets the version of the SNMP protocol (Default: v1).",
                 "type": "string",
-                "enum": [
-                  "v1",
-                  "v2c",
-                  "v3-no-auth",
-                  "v3-md5",
-                  "v3-sha"
-                ],
+                "enum": ["v1", "v2c", "v3-no-auth", "v3-md5", "v3-sha"],
                 "default": "v1"
               }
             }
@@ -417,14 +398,9 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": [
-                    "ntlm",
-                    "kerberos"
-                  ]
+                  "enum": ["ntlm", "kerberos"]
                 },
-                "default": [
-                  "ntlm"
-                ]
+                "default": ["ntlm"]
               },
               "namespace": {
                 "$ref": "#/definitions/namespace"
@@ -476,9 +452,7 @@
             }
           }
         },
-        "required": [
-          "host"
-        ]
+        "required": ["host"]
       }
     },
     "jobPoolSize": {

--- a/src/test/hws-config/hws-config.yaml
+++ b/src/test/hws-config/hws-config.yaml
@@ -32,7 +32,7 @@ extraMetrics:
   # The average is 40g/kWh for Ontario, Canada.
   # The average is 712g/kWh for Queensland, Australia.
   # Source: https://app.electricitymap.org/map
-  
+
   hw.site.electricity_cost_dollars: 0.12 # in $/kWh
   # Electricity cost per kilowatt-hour. 
   # The average is $0.12/kWh for non-household in Europe.
@@ -40,7 +40,7 @@ extraMetrics:
   # The average is $0.117/kWh for non-household in Canada.
   # The average is $0.225/kWh for non-household in Australia.
   # Source: https://www.globalpetrolprices.com/electricity_prices/
-  
+
   hw.site.pue_ratio: 1.8
   # Power Usage Effectiveness. A ratio describing how efficiently a computer data center uses energy. The ideal ratio is 1.
 

--- a/src/test/hws-config/hws-config.yaml
+++ b/src/test/hws-config/hws-config.yaml
@@ -34,7 +34,7 @@ extraMetrics:
   # Source: https://app.electricitymap.org/map
 
   hw.site.electricity_cost_dollars: 0.12 # in $/kWh
-  # Electricity cost per kilowatt-hour. 
+  # Electricity cost per kilowatt-hour.
   # The average is $0.12/kWh for non-household in Europe.
   # The average is $0.159/kWh for non-household in the USA.
   # The average is $0.117/kWh for non-household in Canada.
@@ -51,158 +51,157 @@ exporter:
     trustedCertificatesFile: security/otel.crt
 
 hosts:
+  # Some templates can be found below:
 
-# Some templates can be found below:
+  #═══════════════════════════════════════════════════
+  # IPMI protocol configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# IPMI protocol configuration                      
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-1
+      type: oob
+    ipmi:
+      username: username
+      password: password
+      timeout: 120s
 
- - host:
-     hostname: server-1
-     type: oob
-   ipmi:
-     username: username
-     password: password
-     timeout: 120s
+  #═══════════════════════════════════════════════════
+  # WMI protocol configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# WMI protocol configuration                       
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-2
+      type: win
+    wmi:
+      timeout: 120s
 
- - host:
-     hostname: server-2
-     type: win
-   wmi:
-     timeout: 120s
+  #═══════════════════════════════════════════════════
+  # WMI protocol configuration with credentials
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# WMI protocol configuration with credentials      
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-3
+      type: win
+    wmi:
+      username: server-3\username
+      password: password
+      timeout: 120s
 
- - host:
-     hostname: server-3
-     type: win
-   wmi:
-     username: server-3\username
-     password: password
-     timeout: 120s
+  #═══════════════════════════════════════════════════
+  # SNMP v1 protocol configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# SNMP v1 protocol configuration                  
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-4
+      type: network
+    snmp:
+      version: v1
+      community: public
+      port: 161
+      timeout: 120s
+    excludedConnectors: [SunF15K]
 
- - host:
-     hostname: server-4
-     type: network
-   snmp:
-     version: v1
-     community: public
-     port: 161
-     timeout: 120s
-   excludedConnectors: [ SunF15K ]
+  #═══════════════════════════════════════════════════
+  # SNMP v2c protocol configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# SNMP v2c protocol configuration                  
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-5
+      type: oob
+    snmp:
+      version: v2c
+      community: public
+      port: 161
+      timeout: 120s
 
- - host:
-     hostname: server-5
-     type: oob
-   snmp:
-     version: v2c
-     community: public
-     port: 161
-     timeout: 120s
+  #═══════════════════════════════════════════════════
+  # SNMP v3 MD5 protocol configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# SNMP v3 MD5 protocol configuration               
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-6
+      type: oob
+    snmp:
+      version: v3-md5
+      community: public
+      port: 161
+      timeout: 120
+      privacy: des
+      privacyPassword: privacy_password
+      username: username
+      password: password
 
- - host:
-     hostname: server-6
-     type: oob
-   snmp:
-     version: v3-md5
-     community: public
-     port: 161
-     timeout: 120
-     privacy: des
-     privacyPassword: privacy_password
-     username: username
-     password: password
+  #═══════════════════════════════════════════════════
+  # WBEM protocol configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# WBEM protocol configuration                      
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-7
+      type: storage
+    wbem:
+      protocol: https
+      port: 5989
+      timeout: 120s
+      username: username
+      password: password
+    excludedConnectors:
+      - PureStorageREST
 
- - host:
-     hostname: server-7
-     type: storage
-   wbem:
-     protocol: https
-     port: 5989
-     timeout: 120s
-     username: username
-     password: password
-   excludedConnectors:
-   - PureStorageREST
+  #═══════════════════════════════════════════════════
+  # HTTP protocol configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# HTTP protocol configuration                      
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-8
+      type: storage
+    http:
+      https: true
+      port: 443
+      username: username
+      password: password
+    selectedConnectors:
+      - PureStorageREST
 
- - host:
-     hostname: server-8
-     type: storage
-   http:
-     https: true
-     port: 443
-     username: username
-     password: password
-   selectedConnectors:
-   - PureStorageREST
+  #═══════════════════════════════════════════════════
+  # SSH protocol configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# SSH protocol configuration                       
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-9
+      type: linux
+    ssh:
+      timeout: 120
+      useSudo: true
+      useSudoCommands: [isi, isi_for_array]
+      sudoCommand: sudo
+      username: username
+      password: password
+      privateKey: /tmp/ssh-key.txt
 
- - host:
-     hostname: server-9
-     type: linux
-   ssh:
-     timeout: 120
-     useSudo: true
-     useSudoCommands: [ isi, isi_for_array ]
-     sudoCommand: sudo
-     username: username
-     password: password
-     privateKey: /tmp/ssh-key.txt
+  #═══════════════════════════════════════════════════
+  # OSCommand configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# OSCommand configuration                          
-#═══════════════════════════════════════════════════
+  - host:
+      hostname: server-10
+      type: linux
+    osCommand:
+      timeout: 120
+      useSudo: true
+      useSudoCommands: []
+      sudoCommand: sudo
 
- - host:
-     hostname: server-10
-     type: linux
-   osCommand:
-     timeout: 120
-     useSudo: true
-     useSudoCommands: [ ]
-     sudoCommand: sudo
+  #═══════════════════════════════════════════════════
+  # WinRM configuration
+  #═══════════════════════════════════════════════════
 
-#═══════════════════════════════════════════════════
-# WinRM configuration                              
-#═══════════════════════════════════════════════════
-
- - host:
-     hostname: server-11
-     type: win
-   winrm:
-     timeout: 120
-     username: username
-     password: password
-     port: 5985
-     protocol: http
-     authentications: [ntlm, kerberos]
+  - host:
+      hostname: server-11
+      type: win
+    winrm:
+      timeout: 120
+      username: username
+      password: password
+      port: 5985
+      protocol: http
+      authentications: [ntlm, kerberos]

--- a/src/test/hws-config/hws-config.yaml
+++ b/src/test/hws-config/hws-config.yaml
@@ -1,0 +1,208 @@
+# Hardware Sentry
+
+# Number of jobs that Hardware Sentry can run simultaneously.
+jobPoolSize: 30
+
+# Discovery cycle.
+discoveryCycle: 20
+
+# Internal collect interval.
+collectPeriod: 1m
+
+# Debug mode of the core engine.
+loggerLevel: debug
+
+# Display the configured hostname in the Host Resource `host.name` attribute instead of the resolved FQDN.
+resolveHostnameToFqdn: true
+
+# Forces all the network calls to be executed in sequential order.
+sequential: false
+
+# Disable hardware alerts.
+disableAlerts: false
+
+extraLabels:
+  site: Datacenter 1 # Customize this value with your own site naming convention. (Dedicating 1 collector to 1 site is a good practice.)
+
+extraMetrics:
+  hw.site.carbon_density_grams: 230 # in g/kWh
+  # Carbon dioxide produced per kilowatt-hour.
+  # The average is 230g/kWh for Europe.
+  # The average is 309g/kWh for Texas, USA.
+  # The average is 40g/kWh for Ontario, Canada.
+  # The average is 712g/kWh for Queensland, Australia.
+  # Source: https://app.electricitymap.org/map
+  
+  hw.site.electricity_cost_dollars: 0.12 # in $/kWh
+  # Electricity cost per kilowatt-hour. 
+  # The average is $0.12/kWh for non-household in Europe.
+  # The average is $0.159/kWh for non-household in the USA.
+  # The average is $0.117/kWh for non-household in Canada.
+  # The average is $0.225/kWh for non-household in Australia.
+  # Source: https://www.globalpetrolprices.com/electricity_prices/
+  
+  hw.site.pue_ratio: 1.8
+  # Power Usage Effectiveness. A ratio describing how efficiently a computer data center uses energy. The ideal ratio is 1.
+
+exporter:
+  otlp:
+    headers:
+      Authorization: token
+    trustedCertificatesFile: security/otel.crt
+
+hosts:
+
+# Some templates can be found below:
+
+#═══════════════════════════════════════════════════
+# IPMI protocol configuration                      
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-1
+     type: oob
+   ipmi:
+     username: username
+     password: password
+     timeout: 120s
+
+#═══════════════════════════════════════════════════
+# WMI protocol configuration                       
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-2
+     type: win
+   wmi:
+     timeout: 120s
+
+#═══════════════════════════════════════════════════
+# WMI protocol configuration with credentials      
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-3
+     type: win
+   wmi:
+     username: server-3\username
+     password: password
+     timeout: 120s
+
+#═══════════════════════════════════════════════════
+# SNMP v1 protocol configuration                  
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-4
+     type: network
+   snmp:
+     version: v1
+     community: public
+     port: 161
+     timeout: 120s
+   excludedConnectors: [ SunF15K ]
+
+#═══════════════════════════════════════════════════
+# SNMP v2c protocol configuration                  
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-5
+     type: oob
+   snmp:
+     version: v2c
+     community: public
+     port: 161
+     timeout: 120s
+
+#═══════════════════════════════════════════════════
+# SNMP v3 MD5 protocol configuration               
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-6
+     type: oob
+   snmp:
+     version: v3-md5
+     community: public
+     port: 161
+     timeout: 120
+     privacy: des
+     privacyPassword: privacy_password
+     username: username
+     password: password
+
+#═══════════════════════════════════════════════════
+# WBEM protocol configuration                      
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-7
+     type: storage
+   wbem:
+     protocol: https
+     port: 5989
+     timeout: 120s
+     username: username
+     password: password
+   excludedConnectors:
+   - PureStorageREST
+
+#═══════════════════════════════════════════════════
+# HTTP protocol configuration                      
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-8
+     type: storage
+   http:
+     https: true
+     port: 443
+     username: username
+     password: password
+   selectedConnectors:
+   - PureStorageREST
+
+#═══════════════════════════════════════════════════
+# SSH protocol configuration                       
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-9
+     type: linux
+   ssh:
+     timeout: 120
+     useSudo: true
+     useSudoCommands: [ isi, isi_for_array ]
+     sudoCommand: sudo
+     username: username
+     password: password
+     privateKey: /tmp/ssh-key.txt
+
+#═══════════════════════════════════════════════════
+# OSCommand configuration                          
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-10
+     type: linux
+   osCommand:
+     timeout: 120
+     useSudo: true
+     useSudoCommands: [ ]
+     sudoCommand: sudo
+
+#═══════════════════════════════════════════════════
+# WinRM configuration                              
+#═══════════════════════════════════════════════════
+
+ - host:
+     hostname: server-11
+     type: win
+   winrm:
+     timeout: 120
+     username: username
+     password: password
+     port: 5985
+     protocol: http
+     authentications: [ntlm, kerberos]


### PR DESCRIPTION
This PR adds a JSON schema for Hardware Sentry configuration file. This configuration file is needed when running [Hardware Sentry OpenTelemetry Collector](https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html).
