### PR TITLE
fix: Update Meltano schema URLs to point to GitHub

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1716,13 +1716,13 @@
       "name": "Meltano project definition",
       "description": "JSON schema for Meltano project definition files",
       "fileMatch": ["*meltano.yml"],
-      "url": "https://gitlab.com/meltano/meltano/-/raw/master/schema/meltano.schema.json"
+      "url": "https://raw.githubusercontent.com/meltano/meltano/main/schema/meltano.schema.json"
     },
     {
       "name": "Meltano plugin discovery definition",
       "description": "JSON schema for Meltano plugin discovery definition file",
       "fileMatch": ["*discovery.yml"],
-      "url": "https://gitlab.com/meltano/meltano/-/raw/master/schema/discovery.schema.json"
+      "url": "https://raw.githubusercontent.com/meltano/meltano/main/schema/discovery.schema.json"
     },
     {
       "name": "Microsoft Band Web Tile",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Edit the schema URLs to point to GitHub.

Closes https://github.com/meltano/meltano/issues/6316