### PR TITLE
Fix(hws-config): Remove `hws*` from yaml fileMatch patterns

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3692,12 +3692,7 @@
     {
       "name": "Hardware Sentry Configuration",
       "description": "Hardware Sentry configuration file",
-      "fileMatch": [
-        "hws-config.yaml",
-        "hws-config.yml",
-        "hws*.yaml",
-        "hws*.yml"
-      ],
+      "fileMatch": ["*hws-config*.yaml", "*hws-config*.yml"],
       "url": "https://json.schemastore.org/hws-config.json"
     }
   ],


### PR DESCRIPTION
### Problem
Configuration files with names starting with `hws` are detected as a Hardware Sentry Configuration. Example: `hws-alert-manager-rules.yaml`.
### Update
This PR fixes the recently added fileMatch patterns for Hardware Sentry Schema `hws-config.json` by removing the `hws*` patterns. 
Only `*hws-config*.yaml` and `*hws-config*.yml` files are accepted.