### PR TITLE
Correct erroneous and outdated configurations in .clangformat schema

### DIFF
--- a/src/schemas/json/clang-format.json
+++ b/src/schemas/json/clang-format.json
@@ -320,7 +320,7 @@
     "BreakConstructorInitializers": {
       "type": "string",
       "description": "clang-format 5\r\r The constructor initializers style to use.",
-      "enum": ["BeforeColon", "BeforeComma", "AfterColon", "AfterComma"]
+      "enum": ["BeforeColon", "BeforeComma", "AfterColon"]
     },
     "BreakInheritanceList": {
       "type": "string",

--- a/src/schemas/json/clang-format.json
+++ b/src/schemas/json/clang-format.json
@@ -822,7 +822,7 @@
       "enum": [
         "ControlStatements",
         "Never",
-        "ConctrolStatementsExceptControlMacros",
+        "ControlStatementsExceptControlMacros",
         "NonEmptyParentheses",
         "Always",
         "Custom"
@@ -840,7 +840,7 @@
           "description": "bool AfterForeachMacros If true, put space between foreach macros and opening parentheses.",
           "type": "boolean"
         },
-        "AfterFunctionDelcarationName": {
+        "AfterFunctionDeclarationName": {
           "description": "bool AfterFunctionDeclarationName If true, put a space between function declaration name and opening parentheses.",
           "type": "boolean"
         },
@@ -864,7 +864,7 @@
           "description": "bool AfterRequiresInExpression If true, put space between requires keyword in a requires expression and opening parentheses.",
           "type": "boolean"
         },
-        "BeforeNonEmptyParenthese": {
+        "BeforeNonEmptyParentheses": {
           "description": "bool BeforeNonEmptyParentheses If true, put a space before opening parentheses only if the parentheses are not empty.",
           "type": "boolean"
         }

--- a/src/schemas/json/clang-format.json
+++ b/src/schemas/json/clang-format.json
@@ -508,7 +508,7 @@
     "JavaScriptQuotes": {
       "description": "clang-fromat 3.9\r\r The JavaScriptQuoteStyle to use for JavaScript strings.",
       "type": "string",
-      "enum": ["Leave"]
+      "enum": ["Leave", "Single", "Double"]
     },
     "JavaScriptWrapImports": {
       "description": "clang-format 3.9\r\r Whether to wrap JavaScript import/export statements.",

--- a/src/schemas/json/clang-format.json
+++ b/src/schemas/json/clang-format.json
@@ -21,13 +21,15 @@
         "WebKit",
         "Microsoft",
         "GNU",
+        "InheritParentConfig",
         "chromium",
         "google",
         "llvm",
         "mozilla",
         "webkit",
         "microsoft",
-        "gnu"
+        "gnu",
+        "inheritparentconfig"
       ]
     },
     "AccessModifierOffset": {


### PR DESCRIPTION
Some of the enums were missing values supported by the current versions of ClangFormat.

There were several errors in the schema.

It is now updated to be valid for the most recent release of ClangFormat (14.0.6) as well as the current development version.

See the individual commit messages for reference links for each individual proposed change.