### PR TITLE
update tsconfig.json with latest changes to ts-node options

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1083,13 +1083,25 @@
               "description": "Emit output files into `.ts-node` directory.",
               "type": "boolean"
             },
+            "esm": {
+              "description": "Enable native ESM support.\n\nFor details, see https://typestrong.org/ts-node/docs/imports#native-ecmascript-modules",
+              "type": "boolean"
+            },
             "experimentalReplAwait": {
               "description": "Allows the usage of top level await in REPL.\n\nUses node's implementation which accomplishes this with an AST syntax transformation.\n\nEnabled by default when tsconfig target is es2018 or above. Set to false to disable.\n\n**Note**: setting to `true` when tsconfig target is too low will throw an Error.  Leave as `undefined`\nto get default, automatic behavior.",
               "type": "boolean"
             },
-            "experimentalResolverFeatures": {
+            "experimentalResolver": {
               "description": "Enable experimental features that re-map imports and require calls to support:\n`baseUrl`, `paths`, `rootDirs`, `.js` to `.ts` file extension mappings,\n`outDir` to `rootDir` mappings for composite projects and monorepos.\n\nFor details, see https://github.com/TypeStrong/ts-node/issues/1514",
               "type": "boolean"
+            },
+            "experimentalSpecifierResolution": {
+              "description": "Like node's `--experimental-specifier-resolution`, , but can also be set in your `tsconfig.json` for convenience.\n\nFor details, see https://nodejs.org/dist/latest-v18.x/docs/api/esm.html#customizing-esm-specifier-resolution-algorithm",
+              "enum": [
+                "explicit",
+                "node"
+              ],
+              "type": "string"
             },
             "files": {
               "default": false,
@@ -1118,7 +1130,7 @@
             },
             "moduleTypes": {
               "$ref": "#/definitions/tsNodeModuleTypes",
-              "description": "Override certain paths to be compiled and executed as CommonJS or ECMAScript modules.\nWhen overridden, the tsconfig \"module\" and package.json \"type\" fields are overridden.\nThis is useful because TypeScript files cannot use the .cjs nor .mjs file extensions;\nit achieves the same effect.\n\nEach key is a glob pattern following the same rules as tsconfig's \"include\" array.\nWhen multiple patterns match the same file, the last pattern takes precedence.\n\n`cjs` overrides matches files to compile and execute as CommonJS.\n`esm` overrides matches files to compile and execute as native ECMAScript modules.\n`package` overrides either of the above to default behavior, which obeys package.json \"type\" and\ntsconfig.json \"module\" options."
+              "description": "Override certain paths to be compiled and executed as CommonJS or ECMAScript modules.\nWhen overridden, the tsconfig \"module\" and package.json \"type\" fields are overridden, and\nthe file extension is ignored.\nThis is useful if you cannot use .mts, .cts, .mjs, or .cjs file extensions;\nit achieves the same effect.\n\nEach key is a glob pattern following the same rules as tsconfig's \"include\" array.\nWhen multiple patterns match the same file, the last pattern takes precedence.\n\n`cjs` overrides matches files to compile and execute as CommonJS.\n`esm` overrides matches files to compile and execute as native ECMAScript modules.\n`package` overrides either of the above to default behavior, which obeys package.json \"type\" and\ntsconfig.json \"module\" options."
             },
             "preferTsExts": {
               "default": false,

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1097,10 +1097,7 @@
             },
             "experimentalSpecifierResolution": {
               "description": "Like node's `--experimental-specifier-resolution`, , but can also be set in your `tsconfig.json` for convenience.\n\nFor details, see https://nodejs.org/dist/latest-v18.x/docs/api/esm.html#customizing-esm-specifier-resolution-algorithm",
-              "enum": [
-                "explicit",
-                "node"
-              ],
+              "enum": ["explicit", "node"],
               "type": "string"
             },
             "files": {


### PR DESCRIPTION
Similar to https://github.com/SchemaStore/schemastore/pull/1785, this updates the tsconfig.json schema with new options as of the latest version, ts-node v10.8.

The schema is generated from our sources:

https://unpkg.com/browse/ts-node@10.8.2/tsconfig.schemastore-schema.json