### PR TITLE
feat: add openrpc metaschema to schema catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1977,6 +1977,12 @@
       }
     },
     {
+      "name": "openrpc.json",
+      "description": "A JSON schema for OpenRPC documents. See https://open-rpc.org for more information.",
+      "fileMatch": ["openrpc.json", "openrpc.yml", "openrpc.yaml", "open-rpc.json", "open-rpc.yml", "open-rpc.yaml"],
+      "url": "https://meta.open-rpc.org/"
+    },
+    {
       "name": "openfin.json",
       "description": "OpenFin application configuration file",
       "url": "https://json.schemastore.org/openfin.json"

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1979,7 +1979,14 @@
     {
       "name": "openrpc.json",
       "description": "A JSON schema for OpenRPC documents. See https://open-rpc.org for more information.",
-      "fileMatch": ["openrpc.json", "openrpc.yml", "openrpc.yaml", "open-rpc.json", "open-rpc.yml", "open-rpc.yaml"],
+      "fileMatch": [
+        "openrpc.json",
+        "openrpc.yml",
+        "openrpc.yaml",
+        "open-rpc.json",
+        "open-rpc.yml",
+        "open-rpc.yaml"
+      ],
       "url": "https://meta.open-rpc.org/"
     },
     {


### PR DESCRIPTION
homepage: https://open-rpc.org/

Schemas are regularly tested using these example OpenRPC documents: https://github.com/open-rpc/examples/tree/master/service-descriptions

Versioned URL support coming soon for meta.open-rpc.org, and I'll come back here to add the versions once thats out.