### PR TITLE
Update saucectl url

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3467,7 +3467,7 @@
       "name": "SauceCTL Configuration",
       "description": "JSON Schema for SauceCTL configuration files.",
       "fileMatch": ["**/.sauce/*.yml"],
-      "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/v1alpha/generated/saucectl.schema.json"
+      "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/saucectl.schema.json"
     },
     {
       "name": "fulibWorkflows",


### PR DESCRIPTION
Saucectl schema file has found a new home. Update URL to reflect changes in https://github.com/saucelabs/saucectl/pull/574