### PR TITLE
feat: add dashlord configuration to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -889,6 +889,12 @@
       "url": "https://json.schemastore.org/dart-test.json"
     },
     {
+      "name": "DashLord configuration",
+      "description": "Configuration for DashLord",
+      "fileMatch": ["dashlord.yaml", "dashlord.yml"],
+      "url": "https://raw.githubusercontent.com/socialgouv/dashlord/main/schema.json"
+    },
+    {
       "name": "datalogic-scan2deploy-android",
       "description": "Datalogic Scan2Deploy Android file",
       "fileMatch": [".dla.json"],


### PR DESCRIPTION
Hello, is it possible please to add a schema in the catalog for the [dashlord.yaml](https://github.com/SocialGouv/dashlord) configuration file ?

thanks !