### PR TITLE
Update schema for Dart's build.yaml files

### DIFF
--- a/src/schemas/json/dart-build.json
+++ b/src/schemas/json/dart-build.json
@@ -108,10 +108,7 @@
           }
         },
         "runs_before": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/builderKey"
-          }
+          "$ref": "#/definitions/runsBefore"
         },
         "applies_builders": {
           "type": "array",
@@ -231,6 +228,9 @@
         },
         "release_options": {
           "$ref": "#/definitions/builderOptions"
+        },
+        "runs_before": {
+          "$ref": "#/definitions/runsBefore"
         }
       },
       "additionalProperties": false
@@ -262,6 +262,12 @@
       "title": "An identifier for a builder",
       "description": "To construct a key, you join the package name and the builder name with a colon.",
       "pattern": "^(?:\\w*:)?\\w+$"
+    },
+    "runsBefore": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/builderKey"
+      }
     }
   },
   "description": "Configuration for Dart's build system",


### PR DESCRIPTION
Adds support for `runs_before` to global builder configuration.