### PR TITLE
GitHub Workflows fileMatch no-recurse

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1264,7 +1264,7 @@
     {
       "name": "GitHub Workflow",
       "description": "YAML schema for GitHub Workflow",
-      "fileMatch": [".github/workflows/**.yml", ".github/workflows/**.yaml"],
+      "fileMatch": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
       "url": "https://json.schemastore.org/github-workflow.json"
     },
     {


### PR DESCRIPTION
Workflows are found in `.github/workflows/` but not in subdirs thereof. This can easily be verified by creating a new repo and putting a hello-world workflow into such a dir, e.g. `.github/workflows/hello_world/runme.yaml`

Therefore, the fileMatch rule should be done with `*`, not `**`.

---

I had followed the `**` rule in my own code and then had a user report it incorrectly matching an action definition in a dir like `.github/workflows/foo/`. (There is no requirement that local action definitions go in `.github/actions/` even though this is a common convention.)