### PR TITLE
fix(.swcrc) Add missing react configuration keys

### DIFF
--- a/src/schemas/json/swcrc.json
+++ b/src/schemas/json/swcrc.json
@@ -416,6 +416,15 @@
                       "type": "string",
                       "default": "React.Fragment"
                     },
+                    "refresh": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "runtime": {
+                      "type": "string",
+                      "enum": ["automatic", "classic"],
+                      "default": "classic"
+                    },
                     "throwIfNamespace": {
                       "type": "boolean",
                       "default": true

--- a/src/schemas/json/swcrc.json
+++ b/src/schemas/json/swcrc.json
@@ -405,6 +405,9 @@
                 "react": {
                   "type": "object",
                   "properties": {
+                    "development": {
+                      "type": "boolean"
+                    },
                     "pragma": {
                       "type": "string",
                       "default": "React.createElement"
@@ -416,9 +419,6 @@
                     "throwIfNamespace": {
                       "type": "boolean",
                       "default": true
-                    },
-                    "development": {
-                      "type": "boolean"
                     },
                     "useBuiltins": {
                       "type": "boolean"

--- a/src/test/swcrc/swcrc-test.json
+++ b/src/test/swcrc/swcrc-test.json
@@ -7,7 +7,14 @@
     "parser": {
       "syntax": "typescript"
     },
-    "transform": {},
+    "transform": {
+      "react": {
+        "development": false,
+        "refresh": false,
+        "runtime": "automatic",
+        "useBuiltins": false
+      }
+    },
     "externalHelpers": false,
     "target": "es3",
     "loose": false


### PR DESCRIPTION
Hello 👋🏻 
This PR adds missing fields `transform.react.refresh` and `transform.react.runtime` to [swc's configuration](https://swc.rs/docs/configuration/compilation#jsctransformreact).