### PR TITLE
feat: Add Argo Events schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -220,6 +220,11 @@
       "url": "https://raw.githubusercontent.com/architect/parser/v2.3.0/arc-schema.json"
     },
     {
+      "name": "Argo Events",
+      "description": "Argo Events Event Sources and Sensors",
+      "url": "https://raw.githubusercontent.com/argoproj/argo-events/master/api/jsonschema/schema.json"
+    },
+    {
       "name": "Argo Workflows",
       "description": "Argo Workflow configuration file",
       "url": "https://raw.githubusercontent.com/argoproj/argo-workflows/master/api/jsonschema/schema.json"


### PR DESCRIPTION
Argo Events is a CNCF project from ArgoProj.io for managing an eventbus.

They manage their own schemas.
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
