### PR TITLE
fix: add missing editorconfig option in prettierrc schema

### DIFF
--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -33,6 +33,11 @@
           "default": -1,
           "type": "integer"
         },
+        "editorconfig": {
+          "description": "Whether parse the .editorconfig file in your project and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by .prettierrc, etc.",
+          "default": false,
+          "type": "boolean"
+        },
         "embeddedLanguageFormatting": {
           "description": "Control how Prettier formats quoted code embedded in the file.",
           "default": "auto",


### PR DESCRIPTION
Add `editorconfig` property

https://prettier.io/docs/en/configuration.html#editorconfig