### PR TITLE
circleciconfig.json - Remove `2.0` from Docs URLs

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "logical": {
-      "description": "https://circleci.com/docs/2.0/configuration-reference/#logic-statements \n\nA logical statement to be used in dynamic configuration",
+      "description": "https://circleci.com/docs/configuration-reference#logic-statements \n\nA logical statement to be used in dynamic configuration",
       "oneOf": [
         {
           "type": ["string", "boolean", "integer", "number"]
@@ -14,29 +14,29 @@
           "maxProperties": 1,
           "properties": {
             "and": {
-              "description": "https://circleci.com/docs/2.0/configuration-reference/#logic-statements \n\nLogical and: true when all statements in the list are true",
+              "description": "https://circleci.com/docs/configuration-reference#logic-statements \n\nLogical and: true when all statements in the list are true",
               "type": "array",
               "items": {
                 "$ref": "#/definitions/logical"
               }
             },
             "or": {
-              "description": "https://circleci.com/docs/2.0/configuration-reference/#logic-statements \n\nLogical or: true when at least one statements in the list is true",
+              "description": "https://circleci.com/docs/configuration-reference#logic-statements \n\nLogical or: true when at least one statements in the list is true",
               "type": "array",
               "items": {
                 "$ref": "#/definitions/logical"
               }
             },
             "not": {
-              "description": "https://circleci.com/docs/2.0/configuration-reference/#logic-statements \n\nLogical not: true when statement is false",
+              "description": "https://circleci.com/docs/configuration-reference#logic-statements \n\nLogical not: true when statement is false",
               "$ref": "#/definitions/logical"
             },
             "equal": {
-              "description": "https://circleci.com/docs/2.0/configuration-reference/#logic-statements \n\nTrue when all elements in the list are equal",
+              "description": "https://circleci.com/docs/configuration-reference#logic-statements \n\nTrue when all elements in the list are equal",
               "type": "array"
             },
             "matches": {
-              "description": "https://circleci.com/docs/2.0/configuration-reference/#logic-statements \n\nTrue when value matches the pattern",
+              "description": "https://circleci.com/docs/configuration-reference#logic-statements \n\nTrue when value matches the pattern",
               "type": "object",
               "additionalProperties": false,
               "properties": {
@@ -88,17 +88,17 @@
       }
     },
     "orbs": {
-      "description": "https://circleci.com/docs/2.0/configuration-reference/#orbs-requires-version-21\n\nOrbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.",
+      "description": "https://circleci.com/docs/configuration-reference#orbs-requires-version-21\n\nOrbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.",
       "type": "object",
       "additionalProperties": {
         "oneOf": [
           {
-            "description": "https://circleci.com/docs/2.0/creating-orbs/#semantic-versioning-in-orbs\n\nAn orb to depend on and its semver range, or volatile for the most recent release.",
+            "description": "https://circleci.com/docs/creating-orbs#semantic-versioning-in-orbs\n\nAn orb to depend on and its semver range, or volatile for the most recent release.",
             "type": "string",
             "pattern": "^[a-z][a-z0-9_-]+/[a-z][a-z0-9_-]+@(dev:[\\.a-z0-9_-]+|\\d+|\\d+\\.\\d+|\\d+\\.\\d+\\.\\d+|volatile)$"
           },
           {
-            "description": "https://circleci.com/docs/2.0/creating-orbs/#creating-inline-orbs\n\nInline orbs can be handy during development of an orb or as a convenience for name-spacing jobs and commands in lengthy configurations, particularly if you later intend to share the orb with others.",
+            "description": "https://circleci.com/docs/creating-orbs#creating-inline-orbs\n\nInline orbs can be handy during development of an orb or as a convenience for name-spacing jobs and commands in lengthy configurations, particularly if you later intend to share the orb with others.",
             "type": "object",
             "properties": {
               "orbs": {
@@ -119,10 +119,10 @@
       }
     },
     "commands": {
-      "description": "https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21\n\nA command definition defines a sequence of steps as a map to be executed in a job, enabling you to reuse a single command definition across multiple jobs.",
+      "description": "https://circleci.com/docs/configuration-reference#commands-requires-version-21\n\nA command definition defines a sequence of steps as a map to be executed in a job, enabling you to reuse a single command definition across multiple jobs.",
       "type": "object",
       "additionalProperties": {
-        "description": "https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21\n\nDefinition of a custom command.",
+        "description": "https://circleci.com/docs/configuration-reference#commands-requires-version-21\n\nDefinition of a custom command.",
         "type": "object",
         "required": ["steps"],
         "properties": {
@@ -134,13 +134,13 @@
             }
           },
           "parameters": {
-            "description": "https://circleci.com/docs/2.0/reusing-config/#using-the-parameters-declaration\n\nA map of parameter keys.",
+            "description": "https://circleci.com/docs/reusing-config#using-the-parameters-declaration\n\nA map of parameter keys.",
             "type": "object",
             "patternProperties": {
               "^[a-z][a-z0-9_-]+$": {
                 "oneOf": [
                   {
-                    "description": "https://circleci.com/docs/2.0/reusing-config/#string\n\nA string parameter.",
+                    "description": "https://circleci.com/docs/reusing-config#string\n\nA string parameter.",
                     "type": "object",
                     "required": ["type"],
                     "properties": {
@@ -156,7 +156,7 @@
                     }
                   },
                   {
-                    "description": "https://circleci.com/docs/2.0/reusing-config/#boolean\n\nA boolean parameter.",
+                    "description": "https://circleci.com/docs/reusing-config#boolean\n\nA boolean parameter.",
                     "type": "object",
                     "required": ["type"],
                     "properties": {
@@ -172,7 +172,7 @@
                     }
                   },
                   {
-                    "description": "https://circleci.com/docs/2.0/reusing-config/#integer\n\nAn integer parameter.",
+                    "description": "https://circleci.com/docs/reusing-config#integer\n\nAn integer parameter.",
                     "type": "object",
                     "required": ["type"],
                     "properties": {
@@ -188,7 +188,7 @@
                     }
                   },
                   {
-                    "description": "https://circleci.com/docs/2.0/reusing-config/#enum\n\nThe `enum` parameter may be a list of any values. Use the `enum` parameter type when you want to enforce that the value must be one from a specific set of string values.",
+                    "description": "https://circleci.com/docs/reusing-config#enum\n\nThe `enum` parameter may be a list of any values. Use the `enum` parameter type when you want to enforce that the value must be one from a specific set of string values.",
                     "type": "object",
                     "required": ["type", "enum"],
                     "properties": {
@@ -211,7 +211,7 @@
                     }
                   },
                   {
-                    "description": "https://circleci.com/docs/2.0/reusing-config/#executor\n\nUse an `executor` parameter type to allow the invoker of a job to decide what executor it will run on.",
+                    "description": "https://circleci.com/docs/reusing-config#executor\n\nUse an `executor` parameter type to allow the invoker of a job to decide what executor it will run on.",
                     "type": "object",
                     "required": ["type"],
                     "properties": {
@@ -227,7 +227,7 @@
                     }
                   },
                   {
-                    "description": "https://circleci.com/docs/2.0/reusing-config/#steps\n\nSteps are used when you have a job or command that needs to mix predefined and user-defined steps. When passed in to a command or job invocation, the steps passed as parameters are always defined as a sequence, even if only one step is provided.",
+                    "description": "https://circleci.com/docs/reusing-config#steps\n\nSteps are used when you have a job or command that needs to mix predefined and user-defined steps. When passed in to a command or job invocation, the steps passed as parameters are always defined as a sequence, even if only one step is provided.",
                     "type": "object",
                     "required": ["type"],
                     "properties": {
@@ -246,7 +246,7 @@
                     }
                   },
                   {
-                    "description": "https://circleci.com/docs/2.0/reusing-config/#environment-variable-name\n\nThe environment variable name parameter is a string that must match a POSIX_NAME regexp (e.g. no spaces or special characters) and is a more meaningful parameter type that enables additional checks to be performed. ",
+                    "description": "https://circleci.com/docs/reusing-config#environment-variable-name\n\nThe environment variable name parameter is a string that must match a POSIX_NAME regexp (e.g. no spaces or special characters) and is a more meaningful parameter type that enables additional checks to be performed. ",
                     "type": "object",
                     "required": ["type"],
                     "properties": {
@@ -274,7 +274,7 @@
       }
     },
     "dockerExecutor": {
-      "description": "Options for the [docker executor](https://circleci.com/docs/2.0/configuration-reference/#docker)",
+      "description": "Options for the [docker executor](https://circleci.com/docs/configuration-reference#docker)",
       "type": "array",
       "items": {
         "type": "object",
@@ -358,31 +358,31 @@
       }
     },
     "machineExecutor": {
-      "description": "Options for the [machine executor](https://circleci.com/docs/2.0/configuration-reference/#machine)",
+      "description": "Options for the [machine executor](https://circleci.com/docs/configuration-reference#machine)",
       "type": "object",
       "required": ["image"],
       "additionalProperties": false,
       "properties": {
         "image": {
-          "description": "The VM image to use. View [available images](https://circleci.com/docs/2.0/configuration-reference/#available-machine-images). **Note:** This key is **not** supported on the installable CircleCI. For information about customizing machine executor images on CircleCI installed on your servers, see our [VM Service documentation](https://circleci.com/docs/2.0/vm-service).",
+          "description": "The VM image to use. View [available images](https://circleci.com/docs/configuration-reference#available-machine-images). **Note:** This key is **not** supported on the installable CircleCI. For information about customizing machine executor images on CircleCI installed on your servers, see our [VM Service documentation](https://circleci.com/docs/vm-service).",
           "type": "string",
           "default": "ubuntu-2004:current"
         },
         "docker_layer_caching": {
-          "description": "Set to `true` to enable [Docker Layer Caching](https://circleci.com/docs/2.0/docker-layer-caching). Note: If you haven't already, you must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.",
+          "description": "Set to `true` to enable [Docker Layer Caching](https://circleci.com/docs/docker-layer-caching). Note: If you haven't already, you must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.",
           "type": "boolean",
           "default": "true"
         }
       }
     },
     "macosExecutor": {
-      "description": "Options for the [macOS executor](https://circleci.com/docs/2.0/configuration-reference/#macos)",
+      "description": "Options for the [macOS executor](https://circleci.com/docs/configuration-reference#macos)",
       "type": "object",
       "additionalProperties": false,
       "required": ["xcode"],
       "properties": {
         "xcode": {
-          "description": "The version of Xcode that is installed on the virtual machine, see the [Supported Xcode Versions section of the Testing iOS](https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions) document for the complete list.",
+          "description": "The version of Xcode that is installed on the virtual machine, see the [Supported Xcode Versions section of the Testing iOS](https://circleci.com/docs/testing-ios#supported-xcode-versions) document for the complete list.",
           "oneOf": [
             {
               "type": "number"
@@ -463,7 +463,7 @@
             ]
           },
           "shell": {
-            "description": "Shell to use for execution command in all steps. Can be overridden by shell in each step (default: See [Default Shell Options](https://circleci.com/docs/2.0/configuration-reference/#default-shell-options)",
+            "description": "Shell to use for execution command in all steps. Can be overridden by shell in each step (default: See [Default Shell Options](https://circleci.com/docs/configuration-reference#default-shell-options)",
             "type": "string"
           },
           "working_directory": {
@@ -483,43 +483,43 @@
     "builtinSteps": {
       "documentation": {
         "run": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#run\n\nUsed for invoking all command-line programs, taking either a map of configuration values, or, when called in its short-form, a string that will be used as both the `command` and `name`. Run commands are executed using non-login shells by default, so you must explicitly source any dotfiles as part of the command."
+          "description": "https://circleci.com/docs/configuration-reference#run\n\nUsed for invoking all command-line programs, taking either a map of configuration values, or, when called in its short-form, a string that will be used as both the `command` and `name`. Run commands are executed using non-login shells by default, so you must explicitly source any dotfiles as part of the command."
         },
         "checkout": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#checkout\n\nSpecial step used to check out source code to the configured `path` (defaults to the `working_directory`). The reason this is a special step is because it is more of a helper function designed to make checking out code easy for you. If you require doing git over HTTPS you should not use this step as it configures git to checkout over ssh."
+          "description": "https://circleci.com/docs/configuration-reference#checkout\n\nSpecial step used to check out source code to the configured `path` (defaults to the `working_directory`). The reason this is a special step is because it is more of a helper function designed to make checking out code easy for you. If you require doing git over HTTPS you should not use this step as it configures git to checkout over ssh."
         },
         "setup_remote_docker": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#setup_remote_docker\n\nCreates a remote Docker environment configured to execute Docker commands."
+          "description": "https://circleci.com/docs/configuration-reference#setup_remote_docker\n\nCreates a remote Docker environment configured to execute Docker commands."
         },
         "save_cache": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#save_cache\n\nGenerates and stores a cache of a file or directory of files such as dependencies or source code in our object storage. Later jobs can restore this cache using the `restore_cache` step."
+          "description": "https://circleci.com/docs/configuration-reference#save_cache\n\nGenerates and stores a cache of a file or directory of files such as dependencies or source code in our object storage. Later jobs can restore this cache using the `restore_cache` step."
         },
         "restore_cache": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#restore_cache\n\nRestores a previously saved cache based on a `key`. Cache needs to have been saved first for this key using the `save_cache` step."
+          "description": "https://circleci.com/docs/configuration-reference#restore_cache\n\nRestores a previously saved cache based on a `key`. Cache needs to have been saved first for this key using the `save_cache` step."
         },
         "deploy": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#deploy\n\nSpecial step for deploying artifacts. `deploy` uses the same configuration map and semantics as run step. Jobs may have more than one deploy step. In general deploy step behaves just like run with two exceptions:\n* In a job with parallelism, the deploy step will only be executed by node #0 and only if all nodes succeed. Nodes other than #0 will skip this step.\n* In a job that runs with SSH, the deploy step will not execute"
+          "description": "https://circleci.com/docs/configuration-reference#deploy\n\nSpecial step for deploying artifacts. `deploy` uses the same configuration map and semantics as run step. Jobs may have more than one deploy step. In general deploy step behaves just like run with two exceptions:\n* In a job with parallelism, the deploy step will only be executed by node #0 and only if all nodes succeed. Nodes other than #0 will skip this step.\n* In a job that runs with SSH, the deploy step will not execute"
         },
         "store_artifacts": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#store_artifacts\n\nStep to store artifacts (for example logs, binaries, etc) to be available in the web app or through the API."
+          "description": "https://circleci.com/docs/configuration-reference#store_artifacts\n\nStep to store artifacts (for example logs, binaries, etc) to be available in the web app or through the API."
         },
         "store_test_results": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#store_test_results\n\nSpecial step used to upload test results so they display in builds’ Test Summary section and can be used for timing analysis. To also see test result as build artifacts, please use the `store_artifacts` step."
+          "description": "https://circleci.com/docs/configuration-reference#storetestresults\n\nSpecial step used to upload test results so they display in builds’ Test Summary section and can be used for timing analysis. To also see test result as build artifacts, please use the `store_artifacts` step."
         },
         "persist_to_workspace": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#persist_to_workspace\n\nSpecial step used to persist a temporary file to be used by another job in the workflow"
+          "description": "https://circleci.com/docs/configuration-reference#persist_to_workspace\n\nSpecial step used to persist a temporary file to be used by another job in the workflow"
         },
         "attach_workspace": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#attach_workspace\n\nSpecial step used to attach the workflow's workspace to the current container. The full contents of the workspace are downloaded and copied into the directory the workspace is being attached at."
+          "description": "https://circleci.com/docs/configuration-reference#attach_workspace\n\nSpecial step used to attach the workflow's workspace to the current container. The full contents of the workspace are downloaded and copied into the directory the workspace is being attached at."
         },
         "add_ssh_keys": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#add_ssh_keys\n\nSpecial step that adds SSH keys from a project’s settings to a container. Also configures SSH to use these keys."
+          "description": "https://circleci.com/docs/configuration-reference#add_ssh_keys\n\nSpecial step that adds SSH keys from a project’s settings to a container. Also configures SSH to use these keys."
         },
         "when": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#the-when-step-requires-version-21 \n\nConditional step to run on custom conditions (determined at config-compile time) that are checked before a workflow runs"
+          "description": "https://circleci.com/docs/configuration-reference#the-when-step-requires-version-21 \n\nConditional step to run on custom conditions (determined at config-compile time) that are checked before a workflow runs"
         },
         "unless": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#the-when-step-requires-version-21 \n\nConditional step to run when custom conditions aren't met (determined at config-compile time) that are checked before a workflow runs"
+          "description": "https://circleci.com/docs/configuration-reference#the-when-step-requires-version-21 \n\nConditional step to run when custom conditions aren't met (determined at config-compile time) that are checked before a workflow runs"
         }
       },
       "configuration": {
@@ -890,12 +890,12 @@
           "enum": ["add_ssh_keys"]
         },
         {
-          "description": "https://circleci.com/docs/2.0/reusing-config/#invoking-reusable-commands\n\nA custom command defined via the top level commands key",
+          "description": "https://circleci.com/docs/reusing-config#invoking-reusable-commands\n\nA custom command defined via the top level commands key",
           "type": "string",
           "pattern": "^[a-z][a-z0-9_-]+$"
         },
         {
-          "description": "https://circleci.com/docs/2.0/using-orbs/#commands\n\nA custom command defined via an orb.",
+          "description": "https://circleci.com/docs/using-orbs#commands\n\nA custom command defined via an orb.",
           "type": "string",
           "pattern": "^[a-z][a-z0-9_-]+/[a-z][a-z0-9_-]+$"
         },
@@ -946,10 +946,10 @@
           },
           "patternProperties": {
             "^[a-z][a-z0-9_-]+$": {
-              "description": "https://circleci.com/docs/2.0/reusing-config/#invoking-reusable-commands\n\nA custom command defined via the top level commands key"
+              "description": "https://circleci.com/docs/reusing-config#invoking-reusable-commands\n\nA custom command defined via the top level commands key"
             },
             "^[a-z][a-z0-9_-]+/[a-z][a-z0-9_-]+$": {
-              "description": "https://circleci.com/docs/2.0/using-orbs/#commands\n\nA custom command defined via an orb."
+              "description": "https://circleci.com/docs/using-orbs#commands\n\nA custom command defined via an orb."
             }
           }
         }
@@ -1000,7 +1000,7 @@
           }
         },
         "matrix": {
-          "description": "https://circleci.com/docs/2.0/configuration-reference/#matrix-requires-version-21\n\nThe matrix stanza allows you to run a parameterized job multiple times with different arguments.",
+          "description": "https://circleci.com/docs/configuration-reference#matrix-requires-version-21\n\nThe matrix stanza allows you to run a parameterized job multiple times with different arguments.",
           "type": "object",
           "additionalProperties": false,
           "required": ["parameters"],


### PR DESCRIPTION
Hi there! 👋 

I am part of the Docs team at CircleCI and I am making this PR to slightly improve the schema.

We recently went through an overhaul of our URLs and the `2.0` is not needed anymore. This PR updates all the links to our docs to ensure users can still reach the content without issues.

Thanks!