### PR TITLE
Fixed annotations definition for apibuilder

### DIFF
--- a/src/schemas/json/apibuilder.json
+++ b/src/schemas/json/apibuilder.json
@@ -110,6 +110,25 @@
       "required": ["name", "type"],
       "additionalProperties": false
     },
+    "annotation": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_]*$": {
+          "type": "object",
+          "description": "An annotation is just a short key that can be used to tag any field in any model of this API.",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Describes what the annotation is used for."
+            },
+            "deprecation": {
+              "$ref": "#/definitions/deprecation"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
     "attribute": {
       "type": "object",
       "properties": {
@@ -686,11 +705,8 @@
       }
     },
     "annotations": {
-      "type": "array",
-      "description": "JSON Array defining additional meta data about this service. Attributes are used to add custom extensions to API Builder and are typically used by generators to enable advanced code generation.",
-      "items": {
-        "type": "string"
-      }
+      "description": "JSON object defining all of the annotations in this API. The key of each object is the annotation name.",
+      "$ref": "#/definitions/annotation"
     }
   },
   "required": ["name"],

--- a/src/test/apibuilder/apibuilder-api.json
+++ b/src/test/apibuilder/apibuilder-api.json
@@ -110,6 +110,11 @@
       "url": "http://opensource.org/licenses/MIT"
     }
   },
+  "annotations": {
+    "personal_data": {
+      "description": "Identifies a field that contains personal data, as defined by GDPR."
+    }
+  },
   "models": {
     "validation": {
       "description": "Used only to validate json files - used as a resource where http status code defines success",
@@ -219,7 +224,8 @@
         },
         {
           "name": "email",
-          "type": "string"
+          "type": "string",
+          "annotations": [ "personal_data" ]
         },
         {
           "name": "nickname",

--- a/src/test/apibuilder/apibuilder-api.json
+++ b/src/test/apibuilder/apibuilder-api.json
@@ -1,5 +1,10 @@
 {
   "$schema": "../../schemas/json/apibuilder.json",
+  "annotations": {
+    "personal_data": {
+      "description": "Identifies a field that contains personal data, as defined by GDPR."
+    }
+  },
   "base_url": "https://api.apibuilder.io",
   "description": "Host API documentation for applications providing REST APIs, facilitating the design of good resource first APIs.",
   "enums": {
@@ -108,11 +113,6 @@
     "license": {
       "name": "MIT",
       "url": "http://opensource.org/licenses/MIT"
-    }
-  },
-  "annotations": {
-    "personal_data": {
-      "description": "Identifies a field that contains personal data, as defined by GDPR."
     }
   },
   "models": {
@@ -225,7 +225,7 @@
         {
           "name": "email",
           "type": "string",
-          "annotations": [ "personal_data" ]
+          "annotations": ["personal_data"]
         },
         {
           "name": "nickname",


### PR DESCRIPTION
According to APIBuilder's spec `annotations` is a map of objects, not an array.
Ref: https://app.apibuilder.io/doc/apiJson#annotation

This PR updates the definition and adds a test case for it. 