### PR TITLE
Add additional file matches for Datadog Service Catalog Definition

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1640,7 +1640,11 @@
     {
       "name": "Datadog Service Catalog Definition",
       "description": "Datadog service catalog definition file",
-      "fileMatch": ["service.datadog.yaml"],
+      "fileMatch": [
+        "service.datadog.yaml",
+        "service.datadog.yml",
+        "service.datadog.json"
+      ],
       "url": "https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/version.schema.json"
     },
     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
It is recommended to add tests.
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
