### PR TITLE
Allow specifying a single file to validate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To make sure that files are validated against your schema correctly (we strongly
 
 1. Create a subfolder in [`src/test`](src/test) named as your schema file
 2. Create one or more `.json, .yml or .yaml` files in that folder
-3. Run `npm run build`
+3. Run `npm run build` (to test a single schema, use `npm run build -- --SchemaName=<jsonFileName.json> default`)
 
 If the build succeeds, your changes are valid and you can safely create a PR.
 

--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -119,6 +119,11 @@ module.exports = function (grunt) {
       skipReadFile = true,
       processOnlyThisOneSchemaFile = undefined
     } = {}) {
+    const schemaNameOption = grunt.option('SchemaName')
+    if (processOnlyThisOneSchemaFile === undefined && schemaNameOption) {
+      processOnlyThisOneSchemaFile = schemaNameOption
+    }
+
     /**
      * @summary Check if the present json schema file must be tested or not
      * @param {string} jsonFilename


### PR DESCRIPTION
This is a preemptive PR that adds and document a shortcut to validate a single JSON file. I thought it would be good to do as it's very useful when testing as it closes the feedback loop between schema authoring and testing.

As the documentation states, it can be ran like so (sharing a flag with `local_coverage`):

```sh
npm run build -- --SchemaName=appveyor.json default
```
 

<details>
<summary>Command Output</summary>

```txt
❯ npm run build -- --SchemaName=appveyor.json default

> schemastore.org@1.0.0 build
> npm run eslint_check && grunt "--SchemaName=appveyor.json" "default"


> schemastore.org@1.0.0 eslint_check
> eslint Gruntfile.cjs

Running "local_check_duplicate_list_in_schema-validation.json" task
>> OK

Running "local_validate_directory_structure" task
>> OK

Running "local_check_filename_extension" task
>> All schema and test filename have the correct file extension. Total files scan: 3

Running "local_check_in_schema-validation.json_for_missing_schema_files" task
>> Total schema-validation.json items check: 345

Running "local_check_for_test_folders_without_schema_to_be_tested" task
>> Total test folders: 314

Running "local_tv4_validator_cannot_have_negative_test" task
>> OK

Running "local_catalog" task
>> catalog.json OK

Running "local_catalog-fileMatch-conflict" task
>> No new fileMatch conflict detected.

Running "local_url-present-in-catalog" task
>> All local url tested OK. Total: 390

Running "local_schema-present-in-catalog-list" task
>> All local schema files have URL link in catalog. Total: 1

Running "local_bom" task
>> no BOM file found in all schema files. Total files scan: 1

Running "local_find-duplicated-property-keys" task
>> No duplicated property key found in test files. Total files scan: 2

Running "local_check_for_schema_version_present" task
>> Total files scan: 1

Running "local_count_url_in_catalog" task
>> 390 SchemaStore URL
>> 292 External URL (43%)
>> 682 Total URL

Running "local_count_schema_versions" task
>> Schemas using (2020-12) Total files: 0
>> Schemas using (2019-09) Total files: 0
>> Schemas using (draft-07) Total files: 0
>> Schemas using (draft-06) Total files: 0
>> Schemas using (draft-04) Total files: 1
>> Schemas using (draft-03) Total files: 0
>> Schemas using (draft without version) Total files: 0
>> $schema unknown. Total files: 0

Running "local_search_for_schema_without_positive_test_files" task
>> (No positive test file present): BizTalkServerApplicationSchema.json
>> (No positive test file present): azure-deviceupdate-manifest-definitions-4.0.json
>> (No positive test file present): babelrc.json
>> (No positive test file present): backportrc.json
>> (No positive test file present): base.json
>> (No positive test file present): behat.json
>> (No positive test file present): block.json
>> (No positive test file present): bozr.json
>> (No positive test file present): clasp.json
>> (No positive test file present): cloudbuild.json
>> (No positive test file present): commands.json
>> (No positive test file present): cosmos-config.json
>> (No positive test file present): creatomic.json
>> (No positive test file present): cryproj.52.schema.json
>> (No positive test file present): cryproj.53.schema.json
>> (No positive test file present): cryproj.54.schema.json
>> (No positive test file present): cryproj.55.schema.json
>> (No positive test file present): cryproj.dev.schema.json
>> (No positive test file present): drush.site.yml.json
>> (No positive test file present): dss-2.0.0.json
>> (No positive test file present): electron-builder.json
>> (No positive test file present): expo-37.0.0.json
>> (No positive test file present): expo-38.0.0.json
>> (No positive test file present): expo-39.0.0.json
>> (No positive test file present): expo-41.0.0.json
>> (No positive test file present): fabric.mod.json
>> (No positive test file present): foundryvtt-manifest.json
>> (No positive test file present): foundryvtt-template.json
>> (No positive test file present): foxx-manifest.json
>> (No positive test file present): gitversion.json
>> (No positive test file present): grafana-dashboard-5.x.json
>> (No positive test file present): haxelib.json
>> (No positive test file present): htmlhint.json
>> (No positive test file present): hugo.json
>> (No positive test file present): ide.host.json
>> (No positive test file present): install.json
>> (No positive test file present): jasonette.json
>> (No positive test file present): jekyll.json
>> (No positive test file present): jsbeautifyrc-nested.json
>> (No positive test file present): jsbeautifyrc.json
>> (No positive test file present): jsdoc-1.0.0.json
>> (No positive test file present): json-api-1.0.json
>> (No positive test file present): kubernetes-definitions.json
>> (No positive test file present): lerna.json
>> (No positive test file present): licenses.1.json
>> (No positive test file present): lintstagedrc.schema.json
>> (No positive test file present): local.settings.json
>> (No positive test file present): lsdlschema-0.7.json
>> (No positive test file present): lsdlschema-1.0.json
>> (No positive test file present): lsdlschema-1.2.json
>> (No positive test file present): lsdlschema-2.0.json
>> (No positive test file present): lsdlschema-3.0.json
>> (No positive test file present): lsdlschema-3.1.json
>> (No positive test file present): lsdlschema-3.2.json
>> (No positive test file present): lsdlschema-3.3.json
>> (No positive test file present): lsdlschema-3.4.json
>> (No positive test file present): lsdlschema.json
>> (No positive test file present): markdownlint.json
>> (No positive test file present): mtad.json
>> (No positive test file present): mtaext.json
>> (No positive test file present): ninjs-1.0.json
>> (No positive test file present): nodehawkrc.json
>> (No positive test file present): nodemon.json
>> (No positive test file present): npm-link-up.json
>> (No positive test file present): nswag.json
>> (No positive test file present): nuget-project-3.3.0.json
>> (No positive test file present): omnisharp.json
>> (No positive test file present): openfin.json
>> (No positive test file present): opspec-io-0.1.7.json
>> (No positive test file present): package.manifest-7.0.0.json
>> (No positive test file present): package.manifest-8.0.0.json
>> (No positive test file present): pattern.json
>> (No positive test file present): pgap_yaml_input_reader.json
>> (No positive test file present): phraseapp.json
>> (No positive test file present): plagiarize-0.0.json
>> (No positive test file present): plagiarize-me-0.0.json
>> (No positive test file present): prettierrc-1.8.2.json
>> (No positive test file present): project-1.0.0-beta3.json
>> (No positive test file present): project-1.0.0-beta4.json
>> (No positive test file present): project-1.0.0-beta5.json
>> (No positive test file present): project-1.0.0-beta6.json
>> (No positive test file present): project-1.0.0-beta8.json
>> (No positive test file present): project-1.0.0-rc1.json
>> (No positive test file present): project-1.0.0-rc2.json
>> (No positive test file present): pyrseas-0.8.json
>> (No positive test file present): renovate.json
>> (No positive test file present): sarif-1.0.0.json
>> (No positive test file present): sarif-2.0.0-csd.2.beta.2018-10-10.json
>> (No positive test file present): sarif-2.0.0-csd.2.beta.2019-01-09.json
>> (No positive test file present): sarif-2.0.0-csd.2.beta.2019-01-24.json
>> (No positive test file present): sarif-2.0.0.json
>> (No positive test file present): sarif-2.1.0-rtm.0.json
>> (No positive test file present): sarif-2.1.0-rtm.1.json
>> (No positive test file present): sarif-2.1.0-rtm.2.json
>> (No positive test file present): sarif-2.1.0-rtm.3.json
>> (No positive test file present): sarif-2.1.0-rtm.4.json
>> (No positive test file present): sarif-2.1.0-rtm.5.json
>> (No positive test file present): sarif-2.1.0.json
>> (No positive test file present): sarif-external-property-file-2.1.0-rtm.0.json
>> (No positive test file present): sarif-external-property-file-2.1.0-rtm.1.json
>> (No positive test file present): sarif-external-property-file-2.1.0-rtm.2.json
>> (No positive test file present): sarif-external-property-file-2.1.0-rtm.3.json
>> (No positive test file present): sarif-external-property-file-2.1.0-rtm.4.json
>> (No positive test file present): sarif-external-property-file-2.1.0-rtm.5.json
>> (No positive test file present): sarif-external-property-file-2.1.0.json
>> (No positive test file present): sarif-external-property-file.json
>> (No positive test file present): schema-draft-v4.json
>> (No positive test file present): servicehub.config.schema.json
>> (No positive test file present): servicehub.service.schema.json
>> (No positive test file present): sourcehut-build-0.41.2.json
>> (No positive test file present): stylintrc.json
>> (No positive test file present): theme-v1.json
>> (No positive test file present): toolinfo.1.1.0.json
>> (No positive test file present): typewiz.json
>> (No positive test file present): up.json
>> (No positive test file present): vega-lite.json
>> (No positive test file present): vega.json
>> (No positive test file present): vsls.json
>> (No positive test file present): vss-extension.json
>> (No positive test file present): web-manifest-app-info.json
>> (No positive test file present): web-manifest-combined.json
>> (No positive test file present): winget-pkgs-singleton-0.1.json
>> (No positive test file present): workflows.json
>> (No positive test file present): xunit.runner.schema.json

31% of schemas do not have tests.
>> Schemas that have no positive test files. Total files: 124

Running "local_count_schema_tested_in_full_strict_mode" task
>> Schema in full strict mode to prevent any unexpected behaviours or silently ignored mistakes in user schemas.
>> -194 of 1 (-19400%)

Running "local_ajv_test" task

>> pass schema          | schemas/json/appveyor.json (draft-04)(NotStrictMode)
>> pass positive test   | test/appveyor/appveyor-matrix-config.json
>> pass positive test   | test/appveyor/reference.json

Total schemas validated with AJV: 1
>> local AJV schema passed

Running "local_tv4_only_for_non_compliance_schema" task

Total schemas validated with tv4: 0

Done.
```


</details>