### PR TITLE
update: Add versioned xunit schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2964,8 +2964,13 @@
     {
       "name": "xunit.runner.json",
       "description": "xUnit.net runner configuration file",
-      "fileMatch": ["xunit.runner.json"],
-      "url": "https://json.schemastore.org/xunit.runner.schema.json"
+      "fileMatch": ["xunit.runner.json", "*.xunit.runner.json"],
+      "url": "https://json.schemastore.org/xunit.runner.schema.json",
+      "versions": {
+        "v2.2": "https://json.schemastore.org/xunit-2.2.json",
+        "v2.3": "https://json.schemastore.org/xunit-2.3.json",
+        "v2.4": "https://json.schemastore.org/xunit.runner.schema.json"
+      }
     },
     {
       "name": "servicehub.service.json",

--- a/src/schemas/json/xunit-2.2.json
+++ b/src/schemas/json/xunit-2.2.json
@@ -1,16 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "id": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "id": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
   "title": "xUnit.net Runner Configuration",
-  "$comment": "This schema was last updated for v2.4.1",
   "description": "Configuration file for unit test projects using xUnit.net",
   "type": "object",
   "properties": {
-    "$schema": {
-      "description": "The document schema",
-      "default": "https://xunit.net/schema/current/xunit.runner.schema.json",
-      "type": "string"
-    },
     "appDomain": {
       "description": "Determines whether the runner will use an app domain to discover and run tests. If you choose 'required', app domains will be required (only desktop tests can be run); if you choose 'denied', then tests will not use app domains; if you choose 'ifAvailable', then app domains use is left to the discretion of the runner. Defaults to 'ifAvailable'. Note that not all runners support app domains, so the 'required' value may not always be valid.",
       "default": "ifAvailable",
@@ -21,30 +15,20 @@
       "default": false,
       "type": "boolean"
     },
-    "internalDiagnosticMessages": {
-      "description": "Enables or disables internal diagnostic information during test discovery and execution.",
-      "default": false,
-      "type": "boolean"
-    },
     "longRunningTestSeconds": {
       "description": "Enables reporting of tests which take longer than the configured time to complete (set to 0 to disable).",
       "type": "integer",
       "minimum": 0
     },
     "maxParallelThreads": {
-      "description": "Configures the maximum number of threads to be used when parallelizing tests within this assembly. Use a value of 0 to indicate that you would like the default behavior; use a value of -1 to indicate that you do not wish to limit the number of threads used for parallelization.",
+      "description": "Configures the maximum number of threads to be used when parallelizing tests within this assembly.",
       "type": "integer",
-      "minimum": -1
+      "minimum": 1
     },
     "methodDisplay": {
       "description": "Configures the default display name for test cases. If you choose 'method', the display name will be just the method (without the class name); if you choose 'classAndMethod', the default display name will be the fully qualified class name and method name.",
       "default": "classAndMethod",
       "enum": ["method", "classAndMethod"]
-    },
-    "methodDisplayOptions": {
-      "description": "Configures one or more automatic transformations of test names. Flag names should be combined with a comma (i.e., flag1,flag2). Valid flags are: 'replaceUnderscoreWithSpace', 'useOperatorMonikers', 'useEscapeSequences', 'replacePeriodWithComma'. There are special flags named 'all' and 'none'.",
-      "default": "none",
-      "type": "string"
     },
     "parallelizeAssembly": {
       "description": "Instructs the test runner that this assembly is willing to run in parallel with other assemblies.",

--- a/src/schemas/json/xunit-2.2.json
+++ b/src/schemas/json/xunit-2.2.json
@@ -1,9 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "id": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
-  "title": "xUnit.net Runner Configuration",
+  "additionalProperties": false,
   "description": "Configuration file for unit test projects using xUnit.net",
-  "type": "object",
+  "id": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
   "properties": {
     "appDomain": {
       "description": "Determines whether the runner will use an app domain to discover and run tests. If you choose 'required', app domains will be required (only desktop tests can be run); if you choose 'denied', then tests will not use app domains; if you choose 'ifAvailable', then app domains use is left to the discretion of the runner. Defaults to 'ifAvailable'. Note that not all runners support app domains, so the 'required' value may not always be valid.",
@@ -51,5 +50,6 @@
       "type": "boolean"
     }
   },
-  "additionalProperties": false
+  "title": "xUnit.net Runner Configuration",
+  "type": "object"
 }

--- a/src/schemas/json/xunit-2.3.json
+++ b/src/schemas/json/xunit-2.3.json
@@ -1,9 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "id": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
-  "title": "xUnit.net Runner Configuration",
+  "additionalProperties": false,
   "description": "Configuration file for unit test projects using xUnit.net",
-  "type": "object",
+  "id": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
   "properties": {
     "appDomain": {
       "description": "Determines whether the runner will use an app domain to discover and run tests. If you choose 'required', app domains will be required (only desktop tests can be run); if you choose 'denied', then tests will not use app domains; if you choose 'ifAvailable', then app domains use is left to the discretion of the runner. Defaults to 'ifAvailable'. Note that not all runners support app domains, so the 'required' value may not always be valid.",
@@ -56,5 +55,6 @@
       "type": "boolean"
     }
   },
-  "additionalProperties": false
+  "title": "xUnit.net Runner Configuration",
+  "type": "object"
 }

--- a/src/schemas/json/xunit-2.3.json
+++ b/src/schemas/json/xunit-2.3.json
@@ -1,16 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "id": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "id": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
   "title": "xUnit.net Runner Configuration",
-  "$comment": "This schema was last updated for v2.4.1",
   "description": "Configuration file for unit test projects using xUnit.net",
   "type": "object",
   "properties": {
-    "$schema": {
-      "description": "The document schema",
-      "default": "https://xunit.net/schema/current/xunit.runner.schema.json",
-      "type": "string"
-    },
     "appDomain": {
       "description": "Determines whether the runner will use an app domain to discover and run tests. If you choose 'required', app domains will be required (only desktop tests can be run); if you choose 'denied', then tests will not use app domains; if you choose 'ifAvailable', then app domains use is left to the discretion of the runner. Defaults to 'ifAvailable'. Note that not all runners support app domains, so the 'required' value may not always be valid.",
       "default": "ifAvailable",
@@ -32,19 +26,14 @@
       "minimum": 0
     },
     "maxParallelThreads": {
-      "description": "Configures the maximum number of threads to be used when parallelizing tests within this assembly. Use a value of 0 to indicate that you would like the default behavior; use a value of -1 to indicate that you do not wish to limit the number of threads used for parallelization.",
+      "description": "Configures the maximum number of threads to be used when parallelizing tests within this assembly.",
       "type": "integer",
-      "minimum": -1
+      "minimum": 1
     },
     "methodDisplay": {
       "description": "Configures the default display name for test cases. If you choose 'method', the display name will be just the method (without the class name); if you choose 'classAndMethod', the default display name will be the fully qualified class name and method name.",
       "default": "classAndMethod",
       "enum": ["method", "classAndMethod"]
-    },
-    "methodDisplayOptions": {
-      "description": "Configures one or more automatic transformations of test names. Flag names should be combined with a comma (i.e., flag1,flag2). Valid flags are: 'replaceUnderscoreWithSpace', 'useOperatorMonikers', 'useEscapeSequences', 'replacePeriodWithComma'. There are special flags named 'all' and 'none'.",
-      "default": "none",
-      "type": "string"
     },
     "parallelizeAssembly": {
       "description": "Instructs the test runner that this assembly is willing to run in parallel with other assemblies.",

--- a/src/schemas/json/xunit.runner.schema.json
+++ b/src/schemas/json/xunit.runner.schema.json
@@ -1,10 +1,9 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
-  "id": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "title": "xUnit.net Runner Configuration",
   "$comment": "This schema was last updated for v2.4.1",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "additionalProperties": false,
   "description": "Configuration file for unit test projects using xUnit.net",
-  "type": "object",
+  "id": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "properties": {
     "$schema": {
       "description": "The document schema",
@@ -67,5 +66,6 @@
       "type": "boolean"
     }
   },
-  "additionalProperties": false
+  "title": "xUnit.net Runner Configuration",
+  "type": "object"
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This adds more xUnit schemas for versions `v2.2`, `v2.3`, and "current" (which is v2.4.1 as of now). The primary schema file, `xuint.runner.schema.json` has been updated to the latest (v2.4.1), and has the same name for URL backwards-compatibility (i am unsure about the policy for changing the name of schema files, so I decided to be safe)

Closes #681