### PR TITLE
[BX CI]: add new major version

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -532,11 +532,12 @@
     {
       "name": "BX CI",
       "description": "CI configuration for Amdocs Bill Experience projects",
-      "url": "https://json.schemastore.org/bxci.schema-1.0.1.json",
+      "url": "https://json.schemastore.org/bxci.schema-2.0.0.json",
       "fileMatch": ["**/bxci.yaml", "**/bxci.yml"],
       "versions": {
         "1.0": "https://json.schemastore.org/bxci.schema-1.0.json",
-        "1.0.1": "https://json.schemastore.org/bxci.schema-1.0.1.json"
+        "1.0.1": "https://json.schemastore.org/bxci.schema-1.0.1.json",
+        "2.0.0": "https://json.schemastore.org/bxci.schema-2.0.0.json"
       }
     },
     {

--- a/src/negative_test/bxci.schema-2.0.0/bxci.yml
+++ b/src/negative_test/bxci.schema-2.0.0/bxci.yml
@@ -1,0 +1,29 @@
+project:
+  name: some-project
+  type: npm
+
+stages:
+  my stage:
+    steps:
+      - echo first
+
+output:
+  docker:
+    dockerfile: path/to/Dockerfile
+    image_name: my-image
+    publish:
+      branch: "^master$"
+      credentials: SECRET
+
+  helm:
+    path: k8s/project-name
+    updates:
+      - file: Chart.yaml
+        properties:
+          - key: chartVersion
+      - file: Another.yaml
+        properties:
+          - key: something
+    publish:
+      branch: "^master$|^release/.+$"
+      credentials: SECRET

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -29,6 +29,7 @@
     "bundleconfig.json",
     "bxci.schema-1.0.json",
     "bxci.schema-1.0.1.json",
+    "bxci.schema-2.0.0.json",
     "catalog-info.json",
     "chrome-manifest.json",
     "chutzpah.json",

--- a/src/schemas/json/bxci.schema-2.0.0.json
+++ b/src/schemas/json/bxci.schema-2.0.0.json
@@ -1,0 +1,429 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "definitions": {
+    "branchPattern": {
+      "description": "Regular expression for validating branch names",
+      "type": "string"
+    },
+    "timeout": {
+      "description": "Timeout in seconds",
+      "type": "integer"
+    },
+    "credentials": {
+      "description": "Jenkins credentials ID",
+      "type": "string"
+    },
+    "checkmarx": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "groupId": {
+          "type": "string",
+          "default": "55"
+        },
+        "preset": {
+          "type": "string",
+          "default": "36"
+        },
+        "projectName": {
+          "type": "string",
+          "default": "BSS_BB_Hybrid"
+        },
+        "branch_pattern": {
+          "$ref": "#/definitions/branchPattern",
+          "default": "^master$|.*[cC]heck[mM]arx.*"
+        },
+        "useOwnServerCredentials": {
+          "type": "boolean",
+          "default": true
+        },
+        "serverUrl": {
+          "type": "string",
+          "default": "http://cxpbgmgmtserver/"
+        },
+        "credentialsId": {
+          "type": "string",
+          "default": "BB-Checkmarx"
+        },
+        "generatePdfReport": {
+          "type": "boolean",
+          "default": true
+        },
+        "sourceEncoding": {
+          "type": "string",
+          "default": "5"
+        },
+        "isProxy": {
+          "type": "boolean",
+          "default": false
+        },
+        "waitForResultsEnabled": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "sonar": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "breaks_build": {
+          "type": "boolean",
+          "description": "Waits for analysis result and breaks the build when the project fails for some quality gates.",
+          "default": false
+        },
+        "timeout": {
+          "$ref": "#/definitions/timeout",
+          "description": "Seconds to wait for the result of the quality gate. Only applies when breaks_build is set to true",
+          "default": 120
+        }
+      },
+      "additionalProperties": false
+    },
+    "stage": {
+      "type": "object",
+      "properties": {
+        "steps": {
+          "type": "array",
+          "description": "List of steps to run"
+        },
+        "when": {
+          "type": "object",
+          "description": "Condition that should be met to run this step",
+          "properties": {
+            "branch": {
+              "$ref": "#/definitions/branchPattern",
+              "description": "Specifies in which branches this stage will be executed"
+            }
+          }
+        }
+      },
+      "required": ["steps"],
+      "additionalProperties": false
+    },
+    "releaseChannel": {
+      "type": "string",
+      "description": "Release channel name"
+    },
+    "releaseChannelBranch": {
+      "$ref": "#/definitions/branchPattern",
+      "description": "Indicates on which branches the artifact will be published."
+    },
+    "dockerfile": {
+      "description": "Dockerfile path",
+      "type": "string"
+    },
+    "outputDocker": {
+      "type": "object",
+      "properties": {
+        "dockerfile": {
+          "$ref": "#/definitions/dockerfile",
+          "description": "Path to Dockerfile used to generate the docker image"
+        },
+        "image_name": {
+          "type": "string",
+          "description": "Image name for the generated docker image. Cannot include tag. Tag will be automatically generated based on project version."
+        },
+        "publish": {
+          "$ref": "#/definitions/outputDockerPublish",
+          "description": "Docker publishing information. If not present, no images will be published"
+        }
+      },
+      "required": ["dockerfile", "image_name"]
+    },
+    "outputDockerPublish": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dockerReleaseChannel"
+      }
+    },
+    "dockerReleaseChannel": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "$ref": "#/definitions/releaseChannel"
+        },
+        "branch": {
+          "$ref": "#/definitions/releaseChannelBranch"
+        },
+        "registry": {
+          "type": "string",
+          "description": "Docker registry. Must include protocol (http|https) and port",
+          "format": "uri"
+        },
+        "credentials": {
+          "$ref": "#/definitions/credentials",
+          "description": "Jenkins credentials ID for publishing into the specified Docker registry"
+        }
+      },
+      "required": ["channel", "branch", "registry", "credentials"],
+      "additionalProperties": false
+    },
+    "outputHelm": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to the folder with all required chart config files"
+        },
+        "updates": {
+          "type": "array",
+          "description": "Updates that must be done before packing Helm chart. It's a list of objects that specifies which updates must be done on which files",
+          "items": {
+            "$ref": "#/definitions/outputHelmUpdates"
+          }
+        },
+        "publish": {
+          "$ref": "#/definitions/outputHelmPublish",
+          "description": "Helm chart publishing configuration. If not present, no charts will be published"
+        }
+      },
+      "required": ["path", "publish", "updates"],
+      "additionalProperties": false
+    },
+    "outputHelmUpdates": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Name (including path from Helm object path) of the file to be updated. Only supports yaml files"
+        },
+        "properties": {
+          "type": "array",
+          "description": "A list of properties to update. It can be updated with a fixed value or environment variable",
+          "items": {
+            "$ref": "#/definitions/outputHelmUpdatesProperties"
+          }
+        }
+      },
+      "required": ["file", "properties"]
+    },
+    "outputHelmUpdatesProperties": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Yaml property (full path) to be updated"
+        },
+        "env": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "description": "Environment variable whose value will be used to update the property"
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to update the given property"
+        }
+      },
+      "required": ["key"],
+      "oneOf": [
+        {
+          "required": ["env"],
+          "not": {
+            "required": ["value"]
+          }
+        },
+        {
+          "required": ["value"],
+          "not": {
+            "required": ["env"]
+          }
+        }
+      ]
+    },
+    "outputHelmPublish": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/helmReleaseChannel"
+      }
+    },
+    "helmReleaseChannel": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "$ref": "#/definitions/releaseChannel"
+        },
+        "branch": {
+          "$ref": "#/definitions/releaseChannelBranch"
+        },
+        "repository": {
+          "type": "string",
+          "format": "uri",
+          "description": "Helm chart repository. Must include protocol, host, port (if needed) and path"
+        },
+        "credentials": {
+          "$ref": "#/definitions/credentials",
+          "description": "Jenkins credentials Id for this repository for uploading the chart"
+        }
+      },
+      "required": ["channel", "branch", "repository", "credentials"],
+      "additionalProperties": false
+    }
+  },
+  "description": "CI configuration for Amdocs Bill Experience projects",
+  "properties": {
+    "project": {
+      "description": "Project properties",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Project's name (used by Jenkins, Docker and Sonar)",
+          "type": "string"
+        },
+        "type": {
+          "description": "Project type",
+          "enum": ["npm", "maven", "mvn"],
+          "default": "mvn"
+        },
+        "settings": {
+          "description": "ID of a managed maven or npm Jenkins file",
+          "type": "string",
+          "examples": ["bx-maven-settings", "bx-npm-settings"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "jenkins_runtime": {
+          "type": "object",
+          "properties": {
+            "docker": {
+              "type": "object",
+              "description": "Specifies how to build the Docker container (from an existing image or from a local Dockerfile)",
+              "properties": {
+                "image": {
+                  "description": "Prebuilt Docker image (has precedence over dockerfile)",
+                  "type": "string",
+                  "examples": ["remote-host.com/image-name:tag"]
+                },
+                "dockerfile": {
+                  "description": "Path to a local Dockerfile",
+                  "$ref": "#/definitions/dockerfile",
+                  "examples": [".ci/Dockerfile"]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false,
+          "required": ["docker"]
+        },
+        "branch": {
+          "type": "object",
+          "description": "Describes on which branch names a build will be run",
+          "properties": {
+            "branch_pattern": {
+              "$ref": "#/definitions/branchPattern"
+            },
+            "disable_validation": {
+              "description": "Disables branch name validation",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "build": {
+          "type": "object",
+          "properties": {
+            "clean_workspace_after_run": {
+              "type": "boolean",
+              "description": "Whether Jenkins workspace should be cleaned after the build",
+              "default": true
+            },
+            "checkmarx": {
+              "$ref": "#/definitions/checkmarx",
+              "description": "Adds a Static Analysis stage for CheckMarx. See https://www.jenkins.io/doc/pipeline/steps/checkmarx/ for all the configuration options."
+            },
+            "static_analysis": {
+              "$ref": "#/definitions/sonar",
+              "description": "Adds a Static Analysis stage for Sonar."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "services": {
+      "type": "array",
+      "description": "Additional services required by the project or application.",
+      "items": {
+        "enum": [
+          "Postgres",
+          "Postgis",
+          "Redis",
+          "Mssql",
+          "Mysql",
+          "Mongodb",
+          "Elasticsearch"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "environment": {
+      "type": "object",
+      "description": "Custom environment variables to be added to the pipeline",
+      "propertyNames": {
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      }
+    },
+    "jenkinsEnvironment": {
+      "type": "array",
+      "description": "Jenkins environment variables that are passed to the Docker container",
+      "uniqueItems": true,
+      "items": {
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+        "type": "string"
+      }
+    },
+    "stages": {
+      "type": "object",
+      "description": "Defines the stages and steps required to build the project.",
+      "patternProperties": {
+        "^\\w+( \\w+)*$": {
+          "$ref": "#/definitions/stage",
+          "description": "Stage name in the Jenkins pipeline"
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "description": "Describes artifacts generated after all the stages have been run",
+      "properties": {
+        "docker": {
+          "$ref": "#/definitions/outputDocker",
+          "description": "Configuration for generating a Docker image"
+        },
+        "helm": {
+          "$ref": "#/definitions/outputHelm",
+          "description": "Configuration for generating a Helm chart"
+        }
+      },
+      "additionalProperties": false
+    },
+    "archive": {
+      "type": "array",
+      "description": "List of artifacts to archive (wildcards allowed). Check out https://www.jenkins.io/doc/pipeline/steps/core/#archiveartifacts-archive-the-artifacts",
+      "examples": ["target/*.jar", "**/*.jar", "target/out.txt"]
+    },
+    "timeout": {
+      "$ref": "#/definitions/timeout",
+      "description": "Build timeout in seconds",
+      "default": 600
+    }
+  },
+  "required": ["project", "stages"],
+  "type": "object"
+}

--- a/src/test/bxci.schema-2.0.0/bxci.yml
+++ b/src/test/bxci.schema-2.0.0/bxci.yml
@@ -1,0 +1,84 @@
+project:
+  type: npm
+
+config:
+  jenkins_runtime:
+    docker:
+      image: remote-host.com/image-name:tag
+
+  build:
+    clean_workspace_after_run: false
+    static_analysis:
+      enabled: false
+
+  branch:
+    disable_validation: true
+
+services:
+  - Elasticsearch
+  - Mysql
+  - Mssql
+
+environment:
+  my_env_var: value
+  ANOTHER_VAR: value
+  __CFBundleIdentifier: some value
+
+jenkinsEnvironment:
+  - SOME_VALID_VALUE
+
+archive:
+  - some-file.txt
+  - target/*.jar
+
+stages:
+  my stage:
+    steps:
+      - echo first
+  another:
+    steps:
+      - npm run lint
+  Another step:
+    when:
+      branch: "^master$"
+    steps:
+      - echo last
+
+output:
+  docker:
+    dockerfile: path/to/Dockerfile
+    image_name: my-image
+
+    publish:
+      - channel: stable
+        branch: "^master$|^release/.+$"
+        registry: https://some-docker-registry.com:5008
+        credentials: MY_SECRET
+
+      - channel: dev
+        branch: "^(feature|bugfix)/.+$"
+        registry: https://some-docker-registry.com:5031
+        credentials: MY_SECRET
+
+  helm:
+    path: k8s/project-name
+    updates:
+      - file: Chart.yaml
+        properties:
+          - key: version
+            value: asdf
+      - file: values.yaml
+        properties:
+          - key: image.tag
+            env: SOME_VALID_VALUE
+
+    publish:
+      - channel: stable
+        branch: "^master$|^release/.+$"
+        repository: https://host.com/helm-repo/stable
+        credentials: MY_SECRET
+
+      - channel: dev
+        branch: "^(feature|bugfix)/.+$"
+        repository: https://host.com/helm-repo/snapshot
+        credentials: MY_SECRET


### PR DESCRIPTION
Add a new version for BX CI Schema (2.0.0) that includes support for multi-channel releases.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
