### PR TITLE
Correct enum value in schema for .clang-format `AllowShortIfStatementsOnASingleLine`

### DIFF
--- a/src/schemas/json/clang-format.json
+++ b/src/schemas/json/clang-format.json
@@ -142,7 +142,7 @@
     "AllowShortIfStatementsOnASingleLine": {
       "type": "string",
       "description": "clang-format 9\r\r If true, if (a) return; can be put on a single line.",
-      "enum": ["AllIfAndElse", "Never", "WithoutElse", "OnlyFirstIf"]
+      "enum": ["AllIfsAndElse", "Never", "WithoutElse", "OnlyFirstIf"]
     },
     "AllowShortLoopsOnASingleLine": {
       "type": "boolean",


### PR DESCRIPTION
The `AllIfsAndElse` enum value had a typo in the schema for the `AllowShortIfStatementsOnASingleLine` property of the .clang-format configuration file.

References:

https://github.com/llvm/llvm-project/blob/llvmorg-14.0.6/clang/lib/Format/Format.cpp

```rst
  * ``SIS_AllIfsAndElse`` (in configuration: ``AllIfsAndElse``)
```

https://github.com/llvm/llvm-project/blob/llvmorg-14.0.6/clang/docs/ClangFormatStyleOptions.rst?plain=1#L883

```cpp
template <> struct ScalarEnumerationTraits<FormatStyle::ShortIfStyle> {
  static void enumeration(IO &IO, FormatStyle::ShortIfStyle &Value) {
    IO.enumCase(Value, "Never", FormatStyle::SIS_Never);
    IO.enumCase(Value, "WithoutElse", FormatStyle::SIS_WithoutElse);
    IO.enumCase(Value, "OnlyFirstIf", FormatStyle::SIS_OnlyFirstIf);
    IO.enumCase(Value, "AllIfsAndElse", FormatStyle::SIS_AllIfsAndElse);
```