### PR TITLE
fix(semantic-release): Allow additionalProperties at the root

### DIFF
--- a/src/schemas/json/semantic-release.json
+++ b/src/schemas/json/semantic-release.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "additionalProperties": false,
   "definitions": {
     "branch-object": {
       "type": "object",

--- a/src/test/semantic-release/example1.json
+++ b/src/test/semantic-release/example1.json
@@ -27,5 +27,6 @@
         "assets": ["CHANGELOG.md"]
       }
     ]
-  ]
+  ],
+  "someOptionUsedByPlugins": {}
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Additional properties are allowed at the root of the semantic-release configuration, they can be used as global options, and avoids having to repeat them in each plugin config.

For example, the [commit-analyzer](https://github.com/semantic-release/commit-analyzer) and [release-notes-generator](https://github.com/semantic-release/release-notes-generator) plugins both depend on the [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) library, and use the same options to configure it (e.g. `preset`, `presetConfig`, `parserOpts`...)