### PR TITLE
fix(pre-commit-hooks): add missing properties

### DIFF
--- a/src/negative_test/pre-commit-hooks/invalid-language.json
+++ b/src/negative_test/pre-commit-hooks/invalid-language.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "foo",
+    "name": "foo",
+    "entry": "foo",
+    "language": "haskell"
+  }
+]

--- a/src/negative_test/pre-commit-hooks/invalid-types.json
+++ b/src/negative_test/pre-commit-hooks/invalid-types.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "foo",
+    "name": "foo",
+    "entry": "foo",
+    "language": "python",
+    "types": ["js"]
+  }
+]

--- a/src/negative_test/pre-commit-hooks/missing-entry.json
+++ b/src/negative_test/pre-commit-hooks/missing-entry.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "foo",
+    "name": "boo",
+    "language": "python"
+  }
+]

--- a/src/schemas/json/pre-commit-hooks.json
+++ b/src/schemas/json/pre-commit-hooks.json
@@ -324,6 +324,10 @@
         "$comment": "language of the hook - tells pre-commit how to install the hook.",
         "$ref": "#/definitions/language"
       },
+      "alias": {
+        "$comment": "(optional) allows the hook to be referenced using an additional id.",
+        "type": "string"
+      },
       "files": {
         "$comment": "(optional) the pattern of files to run on.",
         "type": "string",
@@ -348,6 +352,13 @@
         "$comment": "(optional) pattern of files to exclude.",
         "$ref": "#/definitions/file_types",
         "default": []
+      },
+      "additional_dependencies": {
+        "$comment": "(optional) a list of dependencies that will be installed in the environment where this hook gets run. One useful application is to install plugins for hooks such as eslint.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       },
       "always_run": {
         "$comment": "(optional) if true this hook will run even if there are no matching files.",
@@ -383,6 +394,10 @@
         "$comment": "(optional) see Overriding language version at https://pre-commit.com/#overriding-language-version",
         "type": "string",
         "default": "default"
+      },
+      "log_file": {
+        "$comment": "(optional) if present, the hook output will additionally be written to a file.",
+        "type": "string"
       },
       "minimum_pre_commit_version": {
         "$comment": "(optional) allows one to indicate a minimum compatible pre-commit version.",


### PR DESCRIPTION
The [hook object](https://github.com/pre-commit/pre-commit/blob/v2.20.0/pre_commit/clientlib.py#L55-L84) is the same for both `.pre-commit-confg.yaml` and `.pre-commit-hooks.yaml`, even though a few keys are not documented for the later.