### PR TITLE
fix(pre-commit): use `description` keyword instead of `$comment`

### DIFF
--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -53,16 +53,16 @@
       "type": "object",
       "properties": {
         "repo": {
-          "$comment": "the repository url to git clone from",
+          "description": "the repository url to git clone from",
           "type": "string",
           "pattern": "^(?!.*(local|meta)).*$"
         },
         "rev": {
-          "$comment": "the revision or tag to clone at (previously sha).",
+          "description": "the revision or tag to clone at (previously sha).",
           "type": "string"
         },
         "hooks": {
-          "$comment": "A list of hook mappings. See https://pre-commit.com/#pre-commit-configyaml---hooks.",
+          "description": "A list of hook mappings. See https://pre-commit.com/#pre-commit-configyaml---hooks.",
           "type": "array",
           "items": {
             "type": "object",
@@ -75,81 +75,81 @@
       "type": "object",
       "properties": {
         "id": {
-          "$comment": "which hook from the repository to use.",
+          "description": "which hook from the repository to use.",
           "type": "string"
         },
         "alias": {
-          "$comment": "(optional) allows the hook to be referenced using an additional id when using pre-commit run <hookid>.",
+          "description": "(optional) allows the hook to be referenced using an additional id when using pre-commit run <hookid>.",
           "type": "string"
         },
         "name": {
-          "$comment": "(optional) override the name of the hook - shown during hook execution.",
+          "description": "(optional) override the name of the hook - shown during hook execution.",
           "type": "string"
         },
         "language": {
-          "$comment": "(optional) Tells pre-commit on how to install the hook. See https://pre-commit.com/#supported-languages",
+          "description": "(optional) Tells pre-commit on how to install the hook. See https://pre-commit.com/#supported-languages",
           "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/language"
         },
         "language_version": {
-          "$comment": "(optional) override the language version for the hook. See https://pre-commit.com/#overriding-language-version.",
+          "description": "(optional) override the language version for the hook. See https://pre-commit.com/#overriding-language-version.",
           "type": "string"
         },
         "files": {
-          "$comment": "(optional) override the default pattern for files to run on.",
+          "description": "(optional) override the default pattern for files to run on.",
           "type": "string"
         },
         "entry": {
-          "$comment": "(optional) Override default command to execute for the hook.",
+          "description": "(optional) Override default command to execute for the hook.",
           "type": "string"
         },
         "exclude": {
-          "$comment": "(optional) file exclude pattern.",
+          "description": "(optional) file exclude pattern.",
           "type": "string"
         },
         "types": {
-          "$comment": "(optional) override the default file types to run on. See https://pre-commit.com/#filtering-files-with-types.",
+          "description": "(optional) override the default file types to run on. See https://pre-commit.com/#filtering-files-with-types.",
           "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/file_types"
         },
         "types_or": {
-          "$comment": "(optional) override the default file types to run on (OR). See Filtering files with types. new in 2.9.0.",
+          "description": "(optional) override the default file types to run on (OR). See Filtering files with types. new in 2.9.0.",
           "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/file_types"
         },
         "exclude_types": {
-          "$comment": "(optional) file types to exclude.",
+          "description": "(optional) file types to exclude.",
           "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/file_types"
         },
         "args": {
-          "$comment": "(optional) list of additional parameters to pass to the hook.",
+          "description": "(optional) list of additional parameters to pass to the hook.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "stages": {
-          "$comment": "(optional) confines the hook to the commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit or manual stage. See https://pre-commit.com/#confining-hooks-to-run-at-certain-stages.",
+          "description": "(optional) confines the hook to the commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit or manual stage. See https://pre-commit.com/#confining-hooks-to-run-at-certain-stages.",
           "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/stages"
         },
         "additional_dependencies": {
-          "$comment": "(optional) a list of dependencies that will be installed in the environment where this hook gets run. One useful application is to install plugins for hooks such as eslint.",
+          "description": "(optional) a list of dependencies that will be installed in the environment where this hook gets run. One useful application is to install plugins for hooks such as eslint.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "always_run": {
-          "$comment": "(optional) if true, this hook will run even if there are no matching files.",
+          "description": "(optional) if true, this hook will run even if there are no matching files.",
           "type": "boolean"
         },
         "verbose": {
-          "$comment": "(optional) if true, forces the output of the hook to be printed even when the hook passes.",
+          "description": "(optional) if true, forces the output of the hook to be printed even when the hook passes.",
           "type": "boolean"
         },
         "log_file": {
-          "$comment": "(optional) if present, the hook output will additionally be written to a file.",
+          "description": "(optional) if present, the hook output will additionally be written to a file.",
           "type": "string"
         },
         "pass_filenames": {
-          "$comment": "(optional) if false, this hook will be called only once without being called for each matching file.",
+          "description": "(optional) if false, this hook will be called only once without being called for each matching file.",
           "type": "boolean",
           "default": false
         }
@@ -158,51 +158,51 @@
   },
   "properties": {
     "ci": {
-      "$comment": "pre-commit.ci specific settings. See https://pre-commit.ci/#configuration",
+      "description": "pre-commit.ci specific settings. See https://pre-commit.ci/#configuration",
       "type": "object",
       "properties": {
         "autofix_commit_msg": {
-          "$comment": "custom commit message for PR autofixes",
+          "description": "custom commit message for PR autofixes",
           "default": "[pre-commit.ci] auto fixes from pre-commit.com hooks\n\nfor more information, see https://pre-commit.ci",
           "type": "string"
         },
         "autofix_prs": {
-          "$comment": "whether to autofix pull requests. when disabled, comment \"pre-commit.ci autofix\" on a pull request to manually trigger auto-fixing",
+          "description": "whether to autofix pull requests. when disabled, comment \"pre-commit.ci autofix\" on a pull request to manually trigger auto-fixing",
           "default": true,
           "type": "boolean"
         },
         "autoupdate_branch": {
-          "$comment": "branch to send autoupdate PRs to. by default, pre-commit.ci will update the default branch of the repository.",
+          "description": "branch to send autoupdate PRs to. by default, pre-commit.ci will update the default branch of the repository.",
           "default": "",
           "type": "string"
         },
         "autoupdate_commit_msg": {
-          "$comment": "custom commit message for autoupdate PRs",
+          "description": "custom commit message for autoupdate PRs",
           "default": "[pre-commit.ci] pre-commit autoupdate",
           "type": "string"
         },
         "autoupdate_schedule": {
-          "$comment": "control when the autoupdate runs",
+          "description": "control when the autoupdate runs",
           "type": "string",
           "default": "weekly",
           "enum": ["weekly", "monthly", "quarterly"]
         },
         "skip": {
-          "$comment": "which hook ids to be skipped when running under pre-commit.ci",
+          "description": "which hook ids to be skipped when running under pre-commit.ci",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "submodules": {
-          "$comment": "whether to recursive check out submodules",
+          "description": "whether to recursive check out submodules",
           "default": false,
           "type": "boolean"
         }
       }
     },
     "repos": {
-      "$comment": "A list of repository mappings. See https://pre-commit.com/#pre-commit-configyaml---repos.",
+      "description": "A list of repository mappings. See https://pre-commit.com/#pre-commit-configyaml---repos.",
       "type": "array",
       "items": {
         "anyOf": [
@@ -219,33 +219,33 @@
       }
     },
     "default_language_version": {
-      "$comment": "(optional: default {}) a mapping from language to the default language_version that should be used for that language. This will only override individual hooks that do not set language_version.",
+      "description": "(optional: default {}) a mapping from language to the default language_version that should be used for that language. This will only override individual hooks that do not set language_version.",
       "type": "object",
       "additionalProperties": {
         "type": "string"
       }
     },
     "default_stages": {
-      "$comment": "(optional: default (all stages)) a configuration-wide default for the stages property of hooks. This will only override individual hooks that do not set stages.",
+      "description": "(optional: default (all stages)) a configuration-wide default for the stages property of hooks. This will only override individual hooks that do not set stages.",
       "$ref": "https://json.schemastore.org/pre-commit-hooks.json#/definitions/stages"
     },
     "files": {
-      "$comment": "(optional: default '') global file include pattern.",
+      "description": "(optional: default '') global file include pattern.",
       "type": "string",
       "default": ""
     },
     "exclude": {
-      "$comment": "(optional: default ^$) global file exclude pattern.",
+      "description": "(optional: default ^$) global file exclude pattern.",
       "type": "string",
       "default": "^$"
     },
     "fail_fast": {
-      "$comment": "(optional: default false) set to true to have pre-commit stop running hooks after the first failure.",
+      "description": "(optional: default false) set to true to have pre-commit stop running hooks after the first failure.",
       "type": "boolean",
       "default": false
     },
     "minimum_pre_commit_version": {
-      "$comment": "(optional: default '0') require a minimum version of pre-commit.",
+      "description": "(optional: default '0') require a minimum version of pre-commit.",
       "type": "string",
       "default": "0"
     }

--- a/src/schemas/json/pre-commit-hooks.json
+++ b/src/schemas/json/pre-commit-hooks.json
@@ -309,103 +309,103 @@
     "additionalProperties": false,
     "properties": {
       "id": {
-        "$comment": "id of the hook - used in pre-commit-config.yaml.",
+        "description": "id of the hook - used in pre-commit-config.yaml.",
         "type": "string"
       },
       "name": {
-        "$comment": "name of the hook - shown during hook execution.",
+        "description": "name of the hook - shown during hook execution.",
         "type": "string"
       },
       "entry": {
-        "$comment": "entry point - the executable to run. Can also contain arguments that will not be overridden such as `entry: autopep8 -i`.",
+        "description": "entry point - the executable to run. Can also contain arguments that will not be overridden such as `entry: autopep8 -i`.",
         "type": "string"
       },
       "language": {
-        "$comment": "language of the hook - tells pre-commit how to install the hook.",
+        "description": "language of the hook - tells pre-commit how to install the hook.",
         "$ref": "#/definitions/language"
       },
       "alias": {
-        "$comment": "(optional) allows the hook to be referenced using an additional id.",
+        "description": "(optional) allows the hook to be referenced using an additional id.",
         "type": "string"
       },
       "files": {
-        "$comment": "(optional) the pattern of files to run on.",
+        "description": "(optional) the pattern of files to run on.",
         "type": "string",
         "default": ""
       },
       "exclude": {
-        "$comment": "(optional) exclude files that were matched by files.",
+        "description": "(optional) exclude files that were matched by files.",
         "type": "string",
         "default": "^$"
       },
       "types": {
-        "$comment": "(optional) list of file types to run on (AND).",
+        "description": "(optional) list of file types to run on (AND).",
         "$ref": "#/definitions/file_types",
         "default": ["file"]
       },
       "types_or": {
-        "$comment": "(optional) list of file types to run on (OR).",
+        "description": "(optional) list of file types to run on (OR).",
         "$ref": "#/definitions/file_types",
         "default": []
       },
       "exclude_types": {
-        "$comment": "(optional) pattern of files to exclude.",
+        "description": "(optional) pattern of files to exclude.",
         "$ref": "#/definitions/file_types",
         "default": []
       },
       "additional_dependencies": {
-        "$comment": "(optional) a list of dependencies that will be installed in the environment where this hook gets run. One useful application is to install plugins for hooks such as eslint.",
+        "description": "(optional) a list of dependencies that will be installed in the environment where this hook gets run. One useful application is to install plugins for hooks such as eslint.",
         "type": "array",
         "items": {
           "type": "string"
         }
       },
       "always_run": {
-        "$comment": "(optional) if true this hook will run even if there are no matching files.",
+        "description": "(optional) if true this hook will run even if there are no matching files.",
         "type": "boolean",
         "default": false
       },
       "fail_fast": {
-        "$comment": "(optional) if true this hook will run even if there are no matching files.",
+        "description": "(optional) if true this hook will run even if there are no matching files.",
         "type": "boolean",
         "default": false
       },
       "verbose": {
-        "$comment": "(optional) if true, forces the output of the hook to be printed even when the hook passes.",
+        "description": "(optional) if true, forces the output of the hook to be printed even when the hook passes.",
         "type": "boolean",
         "default": false
       },
       "pass_filenames": {
-        "$comment": "(optional) if false no filenames will be passed to the hook.",
+        "description": "(optional) if false no filenames will be passed to the hook.",
         "type": "boolean",
         "default": true
       },
       "require_serial": {
-        "$comment": "(optional) if true this hook will execute using a single process instead of in parallel.",
+        "description": "(optional) if true this hook will execute using a single process instead of in parallel.",
         "type": "boolean",
         "default": false
       },
       "description": {
-        "$comment": "(optional) description of the hook. Used for metadata purposes only.",
+        "description": "(optional) description of the hook. Used for metadata purposes only.",
         "type": "string",
         "default": ""
       },
       "language_version": {
-        "$comment": "(optional) see Overriding language version at https://pre-commit.com/#overriding-language-version",
+        "description": "(optional) see Overriding language version at https://pre-commit.com/#overriding-language-version",
         "type": "string",
         "default": "default"
       },
       "log_file": {
-        "$comment": "(optional) if present, the hook output will additionally be written to a file.",
+        "description": "(optional) if present, the hook output will additionally be written to a file.",
         "type": "string"
       },
       "minimum_pre_commit_version": {
-        "$comment": "(optional) allows one to indicate a minimum compatible pre-commit version.",
+        "description": "(optional) allows one to indicate a minimum compatible pre-commit version.",
         "type": "string",
         "default": "0"
       },
       "args": {
-        "$comment": "(optional) list of additional parameters to pass to the hook.",
+        "description": "(optional) list of additional parameters to pass to the hook.",
         "type": "array",
         "items": {
           "type": "string"
@@ -413,7 +413,7 @@
         "default": []
       },
       "stages": {
-        "$comment": "(optional) confines the hook to the commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite, or manual stage. See Confining hooks to run at certain stages in https://pre-commit.com/#confining-hooks-to-run-at-certain-stages",
+        "description": "(optional) confines the hook to the commit, merge-commit, push, prepare-commit-msg, commit-msg, post-checkout, post-commit, post-merge, post-rewrite, or manual stage. See Confining hooks to run at certain stages in https://pre-commit.com/#confining-hooks-to-run-at-certain-stages",
         "$ref": "#/definitions/stages"
       }
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

The information is useful to the end-user and can be used by integrations:

![image](https://user-images.githubusercontent.com/32458727/182220777-ae0a0e6e-bd4d-4cff-988d-318e2ebf83cc.png)

https://json-schema.org/understanding-json-schema/reference/generic.html#comments
https://json-schema.org/draft-07/json-schema-core.html#rfc.section.9