### PR TITLE
github-workflow-template-properties: remove extension from `iconName`

### DIFF
--- a/src/schemas/json/github-workflow-template-properties.json
+++ b/src/schemas/json/github-workflow-template-properties.json
@@ -18,8 +18,8 @@
     "iconName": {
       "description": "A workflow template icon\nMust be a .svg image\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "string",
-      "pattern": ".+\\.svg$",
-      "examples": ["Sample icon.svg"]
+      "minLength": 1,
+      "examples": ["Sample icon"]
     },
     "categories": {
       "description": "A workflow category\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",

--- a/src/schemas/json/github-workflow-template-properties.json
+++ b/src/schemas/json/github-workflow-template-properties.json
@@ -16,7 +16,7 @@
       "examples": ["Sample description"]
     },
     "iconName": {
-      "description": "A workflow template iconMust be the name of an SVG file, without the file name extension, stored in the workflow-templates directory\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
+      "description": "A workflow template icon\nMust be the name of an SVG file, without the file name extension, stored in the workflow-templates directory\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "string",
       "minLength": 1,
       "examples": ["Sample icon"]

--- a/src/schemas/json/github-workflow-template-properties.json
+++ b/src/schemas/json/github-workflow-template-properties.json
@@ -16,7 +16,7 @@
       "examples": ["Sample description"]
     },
     "iconName": {
-      "description": "A workflow template icon\Must be the name of an SVG file, without the file name extension, stored in the workflow-templates directory\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
+      "description": "A workflow template iconMust be the name of an SVG file, without the file name extension, stored in the workflow-templates directory\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "string",
       "minLength": 1,
       "examples": ["Sample icon"]

--- a/src/schemas/json/github-workflow-template-properties.json
+++ b/src/schemas/json/github-workflow-template-properties.json
@@ -16,7 +16,7 @@
       "examples": ["Sample description"]
     },
     "iconName": {
-      "description": "A workflow template icon\nMust be a .svg image\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
+      "description": "A workflow template icon\Must be the name of an SVG file, without the file name extension, stored in the workflow-templates directory\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "string",
       "minLength": 1,
       "examples": ["Sample icon"]

--- a/src/test/github-workflow-template-properties/blank.json
+++ b/src/test/github-workflow-template-properties/blank.json
@@ -1,5 +1,5 @@
 {
   "description": "Start with a file with the minimum necessary structure.",
-  "iconName": "blank.svg",
+  "iconName": "blank",
   "name": "Simple workflow"
 }

--- a/src/test/github-workflow-template-properties/c-cpp.json
+++ b/src/test/github-workflow-template-properties/c-cpp.json
@@ -1,6 +1,6 @@
 {
   "categories": ["C", "C++"],
   "description": "Build and test a C/C++ project using Make.",
-  "iconName": "c-cpp.svg",
+  "iconName": "c-cpp",
   "name": "C/C++ with Make"
 }


### PR DESCRIPTION
Per the GitHub documentation:

> The `iconName` must be the name of an SVG file, without the file name extension, stored in the `workflow-templates` directory. For example, an SVG file named `example-icon.svg` is referenced as `example-icon`.

This was a regression introduced in #2065.