### PR TITLE
Add Component Detection manifest schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -850,6 +850,12 @@
       "url": "https://json.schemastore.org/component.json"
     },
     {
+      "name": "component-detection-manifest.json",
+      "description": "Component Detection manifest",
+      "fileMatch": ["cdmanifest.json", "cgmanifest.json"],
+      "url": "https://json.schemastore.org/component-detection-manifest.json"
+    },
+    {
       "name": "config.json",
       "description": "ASP.NET project config file",
       "fileMatch": ["config.json"],

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -46,6 +46,7 @@
     "commitlintrc.json",
     "compile-commands.json",
     "compilerconfig.json",
+    "component-detection-manifest.json",
     "creatomic.json",
     "crowdin.json",
     "dart-test.json",

--- a/src/schemas/json/component-detection-manifest.json
+++ b/src/schemas/json/component-detection-manifest.json
@@ -1,0 +1,762 @@
+{
+  "$ref": "#/definitions/CGManifest",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "definitions": {
+    "CGManifest": {
+      "properties": {
+        "registrations": {
+          "items": {
+            "$ref": "#/definitions/Registration"
+          },
+          "type": "array"
+        },
+        "version": {
+          "type": "integer"
+        }
+      },
+      "required": ["registrations", "version"],
+      "title": "CGManifest",
+      "type": "object"
+    },
+    "Registration": {
+      "properties": {
+        "component": {
+          "$ref": "#/definitions/Component"
+        },
+        "dependencyRoots": {
+          "items": {
+            "$ref": "#/definitions/Component"
+          },
+          "type": "array"
+        },
+        "developmentDependency": {
+          "type": "boolean"
+        }
+      },
+      "required": ["component"],
+      "title": "Registration",
+      "type": "object"
+    },
+    "Component": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "cargo",
+            "git",
+            "go",
+            "linux",
+            "maven",
+            "npm",
+            "nuget",
+            "other",
+            "pip",
+            "pod",
+            "rubygems"
+          ]
+        },
+        "cargo": {
+          "$ref": "#/definitions/Cargo"
+        },
+        "git": {
+          "$ref": "#/definitions/Git"
+        },
+        "go": {
+          "$ref": "#/definitions/Go"
+        },
+        "linux": {
+          "$ref": "#/definitions/Linux"
+        },
+        "maven": {
+          "$ref": "#/definitions/Maven"
+        },
+        "npm": {
+          "$ref": "#/definitions/Npm"
+        },
+        "nuget": {
+          "$ref": "#/definitions/NuGet"
+        },
+        "other": {
+          "$ref": "#/definitions/Other"
+        },
+        "pip": {
+          "$ref": "#/definitions/Pip"
+        },
+        "pod": {
+          "$ref": "#/definitions/Pod"
+        },
+        "rubygems": {
+          "$ref": "#/definitions/RubyGems"
+        }
+      },
+      "required": ["type"],
+      "anyOf": [
+        {
+          "properties": {
+            "type": {
+              "const": "cargo"
+            }
+          },
+          "required": ["cargo"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "git"
+            }
+          },
+          "required": ["git"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "go"
+            }
+          },
+          "required": ["go"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "linux"
+            }
+          },
+          "required": ["linux"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "maven"
+            }
+          },
+          "required": ["maven"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "npm"
+            }
+          },
+          "required": ["npm"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "nuget"
+            }
+          },
+          "required": ["nuget"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "other"
+            }
+          },
+          "required": ["other"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "other"
+            }
+          },
+          "required": ["other"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "pip"
+            }
+          },
+          "required": ["pip"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "pod"
+            }
+          },
+          "required": ["pod"]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "rubygems"
+            }
+          },
+          "required": ["rubygems"]
+        }
+      ],
+      "dependencies": {
+        "cargo": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "git": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "go": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "linux": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "maven": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "npm": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "nuget": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "other": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "pip": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pod"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "pod": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["rubygems"]
+              }
+            ]
+          }
+        },
+        "rubygems": {
+          "not": {
+            "anyOf": [
+              {
+                "required": ["cargo"]
+              },
+              {
+                "required": ["git"]
+              },
+              {
+                "required": ["go"]
+              },
+              {
+                "required": ["linux"]
+              },
+              {
+                "required": ["maven"]
+              },
+              {
+                "required": ["npm"]
+              },
+              {
+                "required": ["nuget"]
+              },
+              {
+                "required": ["other"]
+              },
+              {
+                "required": ["pip"]
+              },
+              {
+                "required": ["pod"]
+              }
+            ]
+          }
+        }
+      },
+      "title": "Component",
+      "type": "object"
+    },
+    "Cargo": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "Cargo",
+      "type": "object"
+    },
+    "Git": {
+      "properties": {
+        "commitHash": {
+          "type": "string"
+        },
+        "repositoryUrl": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": ["commitHash", "repositoryUrl"],
+      "title": "Git",
+      "type": "object"
+    },
+    "Go": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "Go",
+      "type": "object"
+    },
+    "Linux": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "distribution": {
+          "type": "string"
+        },
+        "release": {
+          "type": "string"
+        },
+        "key-URL": {
+          "type": "string",
+          "format": "uri"
+        },
+        "pool-URL": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": ["name", "version", "distribution", "release"],
+      "title": "Linux",
+      "type": "object"
+    },
+    "Maven": {
+      "properties": {
+        "groupId": {
+          "type": "string"
+        },
+        "artifactId": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["groupId", "artifactId", "version"],
+      "title": "Maven",
+      "type": "object"
+    },
+    "Npm": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "Npm",
+      "type": "object"
+    },
+    "NuGet": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "NuGet",
+      "type": "object"
+    },
+    "Other": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "downloadUrl": {
+          "format": "uri",
+          "type": "string"
+        },
+        "hash": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version", "downloadUrl"],
+      "title": "Other",
+      "type": "object"
+    },
+    "Pip": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "Pip",
+      "type": "object"
+    },
+    "Pod": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "Pod",
+      "type": "object"
+    },
+    "RubyGems": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "RubyGems",
+      "type": "object"
+    }
+  },
+  "title": "Component Detection manifest"
+}

--- a/src/test/component-detection-manifest/cgmanifest.json
+++ b/src/test/component-detection-manifest/cgmanifest.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "../../schemas/json/component-detection-manifest.json",
+  "registrations": [
+    {
+      "component": {
+        "type": "cargo",
+        "cargo": {
+          "name": "rand",
+          "version": "0.7.3"
+        }
+      },
+      "developmentDependency": false
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/lodash/lodash",
+          "commitHash": "86a852fe763935bb64c12589df5391fd7d3bb14d"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "go",
+        "go": {
+          "name": "github.com/golang/protobuf",
+          "version": "1.2.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "linux",
+        "linux": {
+          "name": "bash",
+          "version": "2.2.2",
+          "distribution": "Ubuntu",
+          "release": "18.04"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "maven",
+        "maven": {
+          "groupId": "junit",
+          "artifactId": "junit",
+          "version": "4.13"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "npm",
+        "npm": {
+          "name": "lodash",
+          "version": "4.17.15"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "nuget",
+        "nuget": {
+          "name": "Newtonsoft.Json",
+          "version": "12.0.3"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "Libgcrypt",
+          "version": "1.8.5",
+          "downloadUrl": "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.5.tar.bz2",
+          "hash": "3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "pip",
+        "pip": {
+          "name": "standalone",
+          "version": "1.0.1"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "pod",
+        "pod": {
+          "name": "Log",
+          "version": "2.0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "rubygems",
+        "rubygems": {
+          "name": "bundler",
+          "version": "1.11.2"
+        }
+      }
+    }
+  ],
+  "version": 1
+}


### PR DESCRIPTION
[Component Detection](https://github.com/microsoft/component-detection/) is a software composition analysis tool. This schema is used as a fallback. When Component Detection is unable to parse a file from a package manager, users can add a file to their repository to track a dependency.

Strict mode is disabled due to ajv-validator/ajv#1571, which causes issues with `required` properties used inside `anyOf`

For existing examples in the wild, see [this GitHub search](https://github.com/search?l=&q=filename%3Acgmanifest.json&type=code)