### PR TITLE
Mark *.schema.json as JSON schema draft 7 file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1615,7 +1615,6 @@
     {
       "name": "JSON-API",
       "description": "JSON API document",
-      "fileMatch": ["*.schema.json"],
       "url": "https://jsonapi.org/schema"
     },
     {
@@ -3023,6 +3022,7 @@
     {
       "name": "JSON Schema Draft 7",
       "description": "Meta-validation schema for JSON Schema Draft 7",
+      "fileMatch": ["*.schema.json"],
       "url": "https://json-schema.org/draft-07/schema"
     },
     {


### PR DESCRIPTION
It was registered as JSON-API, but the spec doesn’t appear to define this file pattern.

https://github.com/json-api/json-api/search?q=schema.json

VSCode defines `*.schema.json` as a file match for JSON schema draft 7 files. It’s probably a good idea to match this.

https://github.com/microsoft/vscode/blob/1.70.0/extensions/json-language-features/package.json#L143
