### PR TITLE
feature: Add "Common Catalog Schema" to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -743,10 +743,8 @@
       "fileMatch": [
         "*.cat.json",
         "*.catalog.json",
-        "catalog.json",
         "*.cat.yml",
-        "*.catalog.yml",
-        "catalog.yml"
+        "*.catalog.yml"
       ],
       "url": "https://raw.githubusercontent.com/howlowck/common-catalog-schema/main/schema-versions.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -738,6 +738,18 @@
       "url": "https://json.schemastore.org/commands.json"
     },
     {
+      "name": "Common Catalog Schema",
+      "description": "Universal schema for all catalog data focused on transformations and relationships",
+      "fileMatch": [
+        "*.cat.json",
+        "*.catalog.json",
+        "catalog.json",
+        "*.cat.yml",
+        "*.catalog.yml",
+        "catalog.yml"],
+      "url": "https://raw.githubusercontent.com/howlowck/common-catalog-schema/main/schema-versions.json"
+    },
+    {
       "name": "cosmos.config.json",
       "description": "React Cosmos configuration file",
       "fileMatch": ["cosmos.config.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -746,7 +746,8 @@
         "catalog.json",
         "*.cat.yml",
         "*.catalog.yml",
-        "catalog.yml"],
+        "catalog.yml"
+      ],
       "url": "https://raw.githubusercontent.com/howlowck/common-catalog-schema/main/schema-versions.json"
     },
     {


### PR DESCRIPTION
This PR adds [Common Catalog Schema](https://github.com/howlowck/common-catalog-schema) to the catalog. This is an externally hosted schema. Thank you!