### PR TITLE
Correct fly.toml env type

### DIFF
--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -341,7 +341,9 @@
     "env": {
       "description": "Set non-sensitive information as environment variables in the application's [runtime environment](https://fly.io/docs/reference/runtime-environment/).\nFor sensitive information, such as credentials or passwords, use the [secrets command](https://fly.io/docs/reference/secrets). For anything else though, the `env` section provides a simple way to set environment variables. Here's an example:\n```toml\n[env]\n  LOG_LEVEL = \"debug\"\n  S3_BUCKET = \"my-bucket\"\n```",
       "type": "object",
-      "additionalProperties": { "type": "string" }
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "build": {
       "description": "Build configuration options. See docs at https://fly.io/docs/reference/builders.",

--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -340,10 +340,8 @@
     },
     "env": {
       "description": "Set non-sensitive information as environment variables in the application's [runtime environment](https://fly.io/docs/reference/runtime-environment/).\nFor sensitive information, such as credentials or passwords, use the [secrets command](https://fly.io/docs/reference/secrets). For anything else though, the `env` section provides a simple way to set environment variables. Here's an example:\n```toml\n[env]\n  LOG_LEVEL = \"debug\"\n  S3_BUCKET = \"my-bucket\"\n```",
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
+      "type": "object",
+      "additionalProperties": { "type": "string" }
     },
     "build": {
       "description": "Build configuration options. See docs at https://fly.io/docs/reference/builders.",


### PR DESCRIPTION
[fly.toml's [env] section](https://fly.io/docs/reference/configuration/#the-env-variables-section) should be key-value, so an object, not an array.