### PR TITLE
Add support for global command keyword to chrome-manifest.json

### DIFF
--- a/src/negative_test/chrome-manifest/v3_global_command_key_must_end_in_number.json
+++ b/src/negative_test/chrome-manifest/v3_global_command_key_must_end_in_number.json
@@ -1,0 +1,13 @@
+{
+  "commands": {
+    "must-be-a-number": {
+      "global": true,
+      "suggested_key": {
+        "default": "Command+Shift+A"
+      }
+    }
+  },
+  "manifest_version": 3,
+  "name": "v3-test-global-command-key-must-end-in-number",
+  "version": "0.0.1"
+}

--- a/src/negative_test/chrome-manifest/v3_global_command_key_must_include_shift.json
+++ b/src/negative_test/chrome-manifest/v3_global_command_key_must_include_shift.json
@@ -1,0 +1,13 @@
+{
+  "commands": {
+    "must-include-shift": {
+      "global": true,
+      "suggested_key": {
+        "default": "Command+1"
+      }
+    }
+  },
+  "manifest_version": 3,
+  "name": "v3-test-global-command-key-must-include-shift",
+  "version": "0.0.1"
+}

--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -98,18 +98,51 @@
     },
     "command": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "suggested_key": {
-          "type": "object",
-          "additionalProperties": false,
-          "patternProperties": {
-            "^(default|mac|windows|linux|chromeos)$": {
-              "type": "string",
-              "pattern": "^(Ctrl|Command|MacCtrl|Alt|Option)\\+(Shift\\+)?[A-Z]"
+      "if": {
+        "$comment": "Global shortcuts change the acceptable pattern for the suggested_key.",
+        "properties": { "global": { "const": true } },
+        "required": ["global"]
+      },
+      "then": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "global": {
+            "type": "boolean",
+            "description": "Whether this command should work while Chrome does not have focus. Keyboard shortcut suggestions for global commands are limited to Ctrl+Shift+[0..9]"
+          },
+          "suggested_key": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "^(default|mac|windows|linux|chromeos)$": {
+                "type": "string",
+                "pattern": "^(Ctrl|Command|MacCtrl)\\+Shift\\+[0-9]"
+              }
+            }
+          }
+        }
+      },
+      "else": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "global": {
+            "type": "boolean",
+            "description": "Whether this command should work while Chrome does not have focus. Keyboard shortcut suggestions for global commands are limited to Ctrl+Shift+[0..9]"
+          },
+          "suggested_key": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "^(default|mac|windows|linux|chromeos)$": {
+                "type": "string",
+                "pattern": "^(Ctrl|Command|MacCtrl|Alt|Option)\\+(Shift\\+)?[A-Z]"
+              }
             }
           }
         }

--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -100,7 +100,11 @@
       "type": "object",
       "if": {
         "$comment": "Global shortcuts change the acceptable pattern for the suggested_key.",
-        "properties": { "global": { "const": true } },
+        "properties": {
+          "global": {
+            "const": true
+          }
+        },
         "required": ["global"]
       },
       "then": {

--- a/src/test/chrome-manifest/v3.json
+++ b/src/test/chrome-manifest/v3.json
@@ -43,5 +43,18 @@
       "resources": ["html/chrome_oauth_receiver.html"],
       "matches": ["http://localhost/*"]
     }
-  ]
+  ],
+  "commands": {
+    "a-global-command": {
+      "global": true,
+      "suggested_key": {
+        "default": "Command+Shift+1"
+      }
+    },
+    "a-non-global-command": {
+      "suggested_key": {
+        "default": "Command+Shift+A"
+      }
+    }
+  }
 }

--- a/src/test/chrome-manifest/v3.json
+++ b/src/test/chrome-manifest/v3.json
@@ -20,6 +20,19 @@
   "chrome_url_overrides": {
     "newtab": "html/tab.html"
   },
+  "commands": {
+    "a-global-command": {
+      "global": true,
+      "suggested_key": {
+        "default": "Command+Shift+1"
+      }
+    },
+    "a-non-global-command": {
+      "suggested_key": {
+        "default": "Command+Shift+A"
+      }
+    }
+  },
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'",
     "sandbox": "script-src 'self'; object-src 'self'"
@@ -43,18 +56,5 @@
       "resources": ["html/chrome_oauth_receiver.html"],
       "matches": ["http://localhost/*"]
     }
-  ],
-  "commands": {
-    "a-global-command": {
-      "global": true,
-      "suggested_key": {
-        "default": "Command+Shift+1"
-      }
-    },
-    "a-non-global-command": {
-      "suggested_key": {
-        "default": "Command+Shift+A"
-      }
-    }
-  }
+  ]
 }


### PR DESCRIPTION
The `"global"` keyword is listed down the page a bit at https://developer.chrome.com/docs/extensions/reference/commands/#scope.

Thanks for maintaining the store, it's super helpful 🙂