### PR TITLE
Update Schema: pyproject

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -591,8 +591,10 @@
             "scripts": {
               "type": "object",
               "description": "A hash of scripts to be installed.",
-              "items": {
-                "type": "string"
+              "patternProperties": {
+                "^.+$": {
+                  "type": "string"
+                }
               }
             },
             "plugins": {

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -589,7 +589,7 @@
               }
             },
             "scripts": {
-              "type": "array",
+              "type": "object",
               "description": "A hash of scripts to be installed.",
               "items": {
                 "type": "string"


### PR DESCRIPTION
This is a very small change, but I'm fairly certain that `poetry.scripts` is supposed to be of type `object` instead of type `array` like it's currently configured in the schema.

I'm not certain whether or not `items` is still suitable here, or if `patternProperties` is necessary.

Link to Poetry documentation regarding `poetry.scripts`: https://python-poetry.org/docs/pyproject/#scripts