### PR TITLE
Updated 'match_pattern' with 'urn:*' for chrome-manifest.json

### DIFF
--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -168,7 +168,7 @@
     "match_pattern": {
       "type": "string",
       "format": "match-pattern",
-      "pattern": "^((\\*|http|https|file|ftp|chrome-extension):\\/\\/(\\*|\\*\\.[^\\/\\*]+|[^\\/\\*]+)?(\\/.*))|<all_urls>$"
+      "pattern": "^((\\*|http|https|file|ftp|chrome-extension):\\/\\/(\\*|\\*\\.[^\\/\\*]+|[^\\/\\*]+)?(\\/.*))|urn:(\\*|.*)|<all_urls>$"
     },
     "mime_type": {
       "type": "string",


### PR DESCRIPTION
https://developer.chrome.com/docs/extensions/mv3/match_patterns/

See **urn:\***

### Example in Webstorm:
![Example Webstorm](https://user-images.githubusercontent.com/36635504/184054333-071aff99-eb4b-44a4-9240-7df73878f8cc.png)

### [Visual Regex](https://regexper.com):
![Visual Regex](https://user-images.githubusercontent.com/36635504/184054458-4f89e249-e521-43b0-809a-875778dbee42.png)

