### PR TITLE
New Schema: Drupal 8

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -643,6 +643,84 @@
       "url": "https://json.schemastore.org/dein.json"
     },
     {
+      "name": "Drupal Breakpoints Schema",
+      "description": "A Drupal schema for breakpoints",
+      "fileMatch": ["*.breakpoints.yml"],
+      "url": "https://json.schemastore.org/drupal-breakpoints.json"
+    },
+    {
+      "name": "Drupal Info Schema",
+      "description": "A Drupal schema for info",
+      "fileMatch": ["*.info.yml"],
+      "url": "https://json.schemastore.org/drupal-info.json"
+    },
+    {
+      "name": "Drupal Layouts Schema",
+      "description": "A Drupal schema for layouts",
+      "fileMatch": ["*.layouts.yml"],
+      "url": "https://json.schemastore.org/drupal-layouts.json"
+    },
+    {
+      "name": "Drupal Libraries Schema",
+      "description": "A Drupal schema for libraries",
+      "fileMatch": ["*.libraries.yml"],
+      "url": "https://json.schemastore.org/drupal-libraries.json"
+    },
+    {
+      "name": "Drupal Links Action Schema",
+      "description": "A Drupal schema for action links",
+      "fileMatch": ["*.links.action.yml"],
+      "url": "https://json.schemastore.org/drupal-links-action.json"
+    },
+    {
+      "name": "Drupal Links Contextual Schema",
+      "description": "A Drupal schema for contextual links",
+      "fileMatch": ["*.links.contextual.yml"],
+      "url": "https://json.schemastore.org/drupal-links-contextual.json"
+    },
+    {
+      "name": "Drupal Links Menu Schema",
+      "description": "A Drupal schema for menu links",
+      "fileMatch": ["*.links.menu.yml"],
+      "url": "https://json.schemastore.org/drupal-links-menu.json"
+    },
+    {
+      "name": "Drupal Links Task Schema",
+      "description": "A Drupal schema for task links",
+      "fileMatch": ["*.links.task.yml"],
+      "url": "https://json.schemastore.org/drupal-links-task.json"
+    },
+    {
+      "name": "Drupal Migration Schema",
+      "description": "A Drupal schema for migration",
+      "fileMatch": ["*.migration.*.yml", "*/migrations/*.yml"],
+      "url": "https://json.schemastore.org/drupal-migration.json"
+    },
+    {
+      "name": "Drupal Permissions Schema",
+      "description": "A Drupal schema for permissions",
+      "fileMatch": ["*.permissions.yml"],
+      "url": "https://json.schemastore.org/drupal-permissions.json"
+    },
+    {
+      "name": "Drupal Routing Schema",
+      "description": "A Drupal schema for routing",
+      "fileMatch": ["*.routing.yml"],
+      "url": "https://json.schemastore.org/drupal-routing.json"
+    },
+    {
+      "name": "Drupal Config Schema",
+      "description": "A Drupal schema for config",
+      "fileMatch": ["*/config/schema/*.schema.yml"],
+      "url": "https://json.schemastore.org/drupal-config.json"
+    },
+    {
+      "name": "Drupal Services Schema",
+      "description": "A Drupal schema for services",
+      "fileMatch": ["*.services.yml"],
+      "url": "https://json.schemastore.org/drupal-services.json"
+    },
+    {
       "name": "Helm Chart.yaml",
       "description": "The Chart.yaml file is required for a chart.",
       "fileMatch": ["Chart.yaml"],

--- a/src/schemas/json/drupal-breakpoints.json
+++ b/src/schemas/json/drupal-breakpoints.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal breakpoints file",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "label": {
+        "title": "A human readable label for the breakpoint",
+        "type": "string"
+      },
+      "mediaQuery": {
+        "title": "Media query text proper",
+        "examples": ["all and (min-width: 851px)"],
+        "type": "string"
+      },
+      "weight": {
+        "title": "Positional weight (order) for the breakpoint",
+        "type": "integer"
+      },
+      "multipliers": {
+        "title": " Supported pixel resolution multipliers",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)?x$"
+        },
+        "uniqueItems": true
+      },
+      "group": {
+        "title": "Breakpoint group",
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/schemas/json/drupal-breakpoints.json
+++ b/src/schemas/json/drupal-breakpoints.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal breakpoints file",
-  "type": "object",
   "additionalProperties": {
     "type": "object",
     "additionalProperties": false,
@@ -33,5 +31,7 @@
         "type": "string"
       }
     }
-  }
+  },
+  "title": "JSON schema for Drupal breakpoints file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-config.json
+++ b/src/schemas/json/drupal-config.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal configuration schema file",
-  "type": "object",
   "additionalProperties": {
     "title": "Configuration item",
     "$ref": "#/definitions/configItem"
@@ -72,5 +70,7 @@
       },
       "additionalProperties": false
     }
-  }
+  },
+  "title": "JSON schema for Drupal configuration schema file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-config.json
+++ b/src/schemas/json/drupal-config.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal configuration schema file",
+  "type": "object",
+  "additionalProperties": {
+    "title": "Configuration item",
+    "$ref": "#/definitions/configItem"
+  },
+  "definitions": {
+    "configItem": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "The type of the value",
+          "type": "string",
+          "examples": [
+            "boolean",
+            "integer",
+            "float",
+            "string",
+            "uri",
+            "email",
+            "mapping",
+            "sequence",
+            "label",
+            "text",
+            "config_object",
+            "config_entity"
+          ]
+        },
+        "label": {
+          "title": "User interface label for the value",
+          "type": "string"
+        },
+        "translatable": {
+          "title": "Whether the defined type is translatable",
+          "type": "boolean"
+        },
+        "translation context": {
+          "title": "The translation context the source string belongs to",
+          "type": "string"
+        },
+        "nullable": {
+          "title": "Whether the value can be empty",
+          "type": "boolean"
+        },
+        "class": {
+          "title": "The class implementing parsing",
+          "type": "string"
+        },
+        "definition_class": {
+          "title": "The definition class",
+          "type": "string"
+        },
+        "orderby": {
+          "title": "Determines how the sequence should be sorted",
+          "type": "string"
+        },
+        "constraints": {
+          "title": "Validation constrains",
+          "type": "object"
+        },
+        "sequence": {
+          "$ref": "#/definitions/configItem"
+        },
+        "mapping": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/configItem"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/schemas/json/drupal-info.json
+++ b/src/schemas/json/drupal-info.json
@@ -1,0 +1,244 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal extension info file",
+  "type": "object",
+  "required": ["type", "core_version_requirement", "name"],
+  "properties": {
+    "name": {
+      "title": "The human-readable name",
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["module", "theme", "profile", "theme_engine"]
+    },
+    "core": {
+      "type": "string",
+      "pattern": "^\\d\\.x$"
+    },
+    "core_version_requirement": {
+      "title": "Semantic core version requirement",
+      "type": "string"
+    },
+    "description": {
+      "title": "Extension description",
+      "type": "string"
+    },
+    "package": {
+      "title": "A key that allows to group extension together an administrative pages",
+      "type": "string"
+    },
+    "version": {
+      "title": "The version of the extension",
+      "type": "string"
+    },
+    "project": {
+      "title": "The machine name of extension project on drupal.org",
+      "type": "string"
+    },
+    "datestamp": {
+      "title": "The date and time when the extension was packaged",
+      "type": "integer"
+    },
+    "hidden": {
+      "title": "Do not the extension in admin interface",
+      "type": "boolean"
+    },
+    "php": {
+      "title": "The minimal PHP version that is required for this extension",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+(\\.\\d+)$"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "module" }
+        }
+      },
+      "then": {
+        "properties": {
+          "configure": {
+            "title": "A route name of the configuration form",
+            "type": "string"
+          },
+          "dependencies": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/dependency" }
+          },
+          "test_dependencies": {
+            "title": "Dependencies that are needed to run certain automated tests for this extension",
+            "type": "array",
+            "items": { "$ref": "#/definitions/dependency" }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "theme" }
+        }
+      },
+      "then": {
+        "properties": {
+          "base theme": {
+            "title": "Base theme",
+            "default": "classy",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "libraries": {
+            "title": "A list of libraries to add to all pages where the theme is active",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9_]+/[a-z0-9_-]+"
+            }
+          },
+          "libraries-override": {
+            "title": "A collection of libraries and assets to override",
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            }
+          },
+          "libraries-extend": {
+            "title": "A collection of libraries and assets to add whenever a library is attached",
+            "type": "object",
+            "additionalProperties": { "type": "array" }
+          },
+          "engine": {
+            "title": "The theme engine",
+            "default": "twig",
+            "type": "string"
+          },
+          "logo": {
+            "title": "The path to logo relative to the theme's .info.yml",
+            "type": "string"
+          },
+          "screenshot": {
+            "title": "The path to screenshot relative to the theme's .info.yml file",
+            "type": "string"
+          },
+          "regions": {
+            "title": "A list of theme regions",
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          },
+          "regions_hidden": {
+            "title": "A list of inherited regions to remove",
+            "type": "array",
+            "uniqueItems": true
+          },
+          "features": {
+            "title": "A list of features to expose on the theme 'Settings' page",
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true
+          },
+          "stylesheets-remove": {
+            "title": "A list of stylesheets from other modules or themes to remove from all pages where the theme is active",
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true
+          },
+          "ckeditor_stylesheets": {
+            "title": "A list of stylesheets to add to the CKEditor frame",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": { "const": "profile" }
+        }
+      },
+      "then": {
+        "properties": {
+          "distribution": {
+            "title": "Declare the installation profile as a distribution",
+            "type": "object",
+            "properties": {
+              "name": {
+                "title": "The distribution name",
+                "type": "string"
+              },
+              "install": {
+                "type": "object",
+                "properties": {
+                  "theme": {
+                    "title": "The theme for the distribution installation",
+                    "$ref": "#/definitions/machine_name"
+                  }
+                }
+              },
+              "langcode": {
+                "type": "string"
+              }
+            }
+          },
+          "dependencies": {
+            "title": "Required modules",
+            "type": "array",
+            "items": { "$ref": "#/definitions/machine_name" },
+            "uniqueItems": true
+          },
+          "install": {
+            "title": "Modules to install to support the profile",
+            "type": "array",
+            "items": { "$ref": "#/definitions/dependency" },
+            "uniqueItems": true
+          },
+          "theme": {
+            "title": "List any themes that should be installed as part of the profile installation",
+            "type": "array",
+            "items": { "$ref": "#/definitions/machine_name" },
+            "uniqueItems": true
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "dependency": {
+      "title": "Extension dependency",
+      "type": "string",
+      "pattern": "^[a-z0-9_]+:[a-z0-9_]+( \\(.+\\))?$"
+    },
+    "machine_name": {
+      "title": "Machine name",
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$"
+    }
+  }
+}

--- a/src/schemas/json/drupal-info.json
+++ b/src/schemas/json/drupal-info.json
@@ -1,8 +1,213 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal extension info file",
-  "type": "object",
-  "required": ["type", "core_version_requirement", "name"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "module"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "configure": {
+            "title": "A route name of the configuration form",
+            "type": "string"
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/dependency"
+            }
+          },
+          "test_dependencies": {
+            "title": "Dependencies that are needed to run certain automated tests for this extension",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/dependency"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "theme"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "base theme": {
+            "title": "Base theme",
+            "default": "classy",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "libraries": {
+            "title": "A list of libraries to add to all pages where the theme is active",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9_]+/[a-z0-9_-]+"
+            }
+          },
+          "libraries-override": {
+            "title": "A collection of libraries and assets to override",
+            "type": "object",
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            }
+          },
+          "libraries-extend": {
+            "title": "A collection of libraries and assets to add whenever a library is attached",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array"
+            }
+          },
+          "engine": {
+            "title": "The theme engine",
+            "default": "twig",
+            "type": "string"
+          },
+          "logo": {
+            "title": "The path to logo relative to the theme's .info.yml",
+            "type": "string"
+          },
+          "screenshot": {
+            "title": "The path to screenshot relative to the theme's .info.yml file",
+            "type": "string"
+          },
+          "regions": {
+            "title": "A list of theme regions",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "regions_hidden": {
+            "title": "A list of inherited regions to remove",
+            "type": "array",
+            "uniqueItems": true
+          },
+          "features": {
+            "title": "A list of features to expose on the theme 'Settings' page",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "stylesheets-remove": {
+            "title": "A list of stylesheets from other modules or themes to remove from all pages where the theme is active",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "ckeditor_stylesheets": {
+            "title": "A list of stylesheets to add to the CKEditor frame",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "profile"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "distribution": {
+            "title": "Declare the installation profile as a distribution",
+            "type": "object",
+            "properties": {
+              "name": {
+                "title": "The distribution name",
+                "type": "string"
+              },
+              "install": {
+                "type": "object",
+                "properties": {
+                  "theme": {
+                    "title": "The theme for the distribution installation",
+                    "$ref": "#/definitions/machine_name"
+                  }
+                }
+              },
+              "langcode": {
+                "type": "string"
+              }
+            }
+          },
+          "dependencies": {
+            "title": "Required modules",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/machine_name"
+            },
+            "uniqueItems": true
+          },
+          "install": {
+            "title": "Modules to install to support the profile",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/dependency"
+            },
+            "uniqueItems": true
+          },
+          "theme": {
+            "title": "List any themes that should be installed as part of the profile installation",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/machine_name"
+            },
+            "uniqueItems": true
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "dependency": {
+      "title": "Extension dependency",
+      "type": "string",
+      "pattern": "^[a-z0-9_]+:[a-z0-9_]+( \\(.+\\))?$"
+    },
+    "machine_name": {
+      "title": "Machine name",
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$"
+    }
+  },
   "properties": {
     "name": {
       "title": "The human-readable name",
@@ -57,188 +262,7 @@
       ]
     }
   },
-  "allOf": [
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "module" }
-        }
-      },
-      "then": {
-        "properties": {
-          "configure": {
-            "title": "A route name of the configuration form",
-            "type": "string"
-          },
-          "dependencies": {
-            "type": "array",
-            "items": { "$ref": "#/definitions/dependency" }
-          },
-          "test_dependencies": {
-            "title": "Dependencies that are needed to run certain automated tests for this extension",
-            "type": "array",
-            "items": { "$ref": "#/definitions/dependency" }
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "theme" }
-        }
-      },
-      "then": {
-        "properties": {
-          "base theme": {
-            "title": "Base theme",
-            "default": "classy",
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "boolean"
-              }
-            ]
-          },
-          "libraries": {
-            "title": "A list of libraries to add to all pages where the theme is active",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "pattern": "^[a-z0-9_]+/[a-z0-9_-]+"
-            }
-          },
-          "libraries-override": {
-            "title": "A collection of libraries and assets to override",
-            "type": "object",
-            "additionalProperties": {
-              "oneOf": [
-                {
-                  "type": "object"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "boolean"
-                }
-              ]
-            }
-          },
-          "libraries-extend": {
-            "title": "A collection of libraries and assets to add whenever a library is attached",
-            "type": "object",
-            "additionalProperties": { "type": "array" }
-          },
-          "engine": {
-            "title": "The theme engine",
-            "default": "twig",
-            "type": "string"
-          },
-          "logo": {
-            "title": "The path to logo relative to the theme's .info.yml",
-            "type": "string"
-          },
-          "screenshot": {
-            "title": "The path to screenshot relative to the theme's .info.yml file",
-            "type": "string"
-          },
-          "regions": {
-            "title": "A list of theme regions",
-            "type": "object",
-            "additionalProperties": { "type": "string" }
-          },
-          "regions_hidden": {
-            "title": "A list of inherited regions to remove",
-            "type": "array",
-            "uniqueItems": true
-          },
-          "features": {
-            "title": "A list of features to expose on the theme 'Settings' page",
-            "type": "array",
-            "items": { "type": "string" },
-            "uniqueItems": true
-          },
-          "stylesheets-remove": {
-            "title": "A list of stylesheets from other modules or themes to remove from all pages where the theme is active",
-            "type": "array",
-            "items": { "type": "string" },
-            "uniqueItems": true
-          },
-          "ckeditor_stylesheets": {
-            "title": "A list of stylesheets to add to the CKEditor frame",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "profile" }
-        }
-      },
-      "then": {
-        "properties": {
-          "distribution": {
-            "title": "Declare the installation profile as a distribution",
-            "type": "object",
-            "properties": {
-              "name": {
-                "title": "The distribution name",
-                "type": "string"
-              },
-              "install": {
-                "type": "object",
-                "properties": {
-                  "theme": {
-                    "title": "The theme for the distribution installation",
-                    "$ref": "#/definitions/machine_name"
-                  }
-                }
-              },
-              "langcode": {
-                "type": "string"
-              }
-            }
-          },
-          "dependencies": {
-            "title": "Required modules",
-            "type": "array",
-            "items": { "$ref": "#/definitions/machine_name" },
-            "uniqueItems": true
-          },
-          "install": {
-            "title": "Modules to install to support the profile",
-            "type": "array",
-            "items": { "$ref": "#/definitions/dependency" },
-            "uniqueItems": true
-          },
-          "theme": {
-            "title": "List any themes that should be installed as part of the profile installation",
-            "type": "array",
-            "items": { "$ref": "#/definitions/machine_name" },
-            "uniqueItems": true
-          }
-        }
-      }
-    }
-  ],
-  "definitions": {
-    "dependency": {
-      "title": "Extension dependency",
-      "type": "string",
-      "pattern": "^[a-z0-9_]+:[a-z0-9_]+( \\(.+\\))?$"
-    },
-    "machine_name": {
-      "title": "Machine name",
-      "type": "string",
-      "pattern": "^[a-z0-9_]+$"
-    }
-  }
+  "required": ["type", "core_version_requirement", "name"],
+  "title": "JSON schema for Drupal extension info file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-layouts.json
+++ b/src/schemas/json/drupal-layouts.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal layouts file",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "label": {
+        "title": "The human-readable name",
+        "type": "string"
+      },
+      "description": {
+        "title": "A description for advanced layouts",
+        "type": "string"
+      },
+      "category": {
+        "title": "The human-readable category name",
+        "type": "string"
+      },
+      "template": {
+        "title": "The template file to render this layout",
+        "type": "string"
+      },
+      "theme_hook": {
+        "title": "The theme hook used to render this layout",
+        "default": "layout",
+        "type": "string"
+      },
+      "path": {
+        "title": "Path to resources like icon or template",
+        "type": "string"
+      },
+      "library": {
+        "title": "The asset library",
+        "type": "string"
+      },
+      "icon": {
+        "title": "The path to the preview image",
+        "type": "string"
+      },
+      "icon_map": {
+        "title": "The icon map",
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "regions": {
+        "title": "List of regions in this layout",
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "title": "The human-readable name",
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "default_region": {
+        "title": "The default region",
+        "type": "string"
+      },
+      "class": {
+        "title": "Plugin class",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/schemas/json/drupal-layouts.json
+++ b/src/schemas/json/drupal-layouts.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal layouts file",
-  "type": "object",
   "additionalProperties": {
     "type": "object",
     "properties": {
@@ -43,7 +41,9 @@
         "type": "array",
         "items": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       },
       "regions": {
@@ -70,5 +70,7 @@
       }
     },
     "additionalProperties": false
-  }
+  },
+  "title": "JSON schema for Drupal layouts file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-libraries.json
+++ b/src/schemas/json/drupal-libraries.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal libraries file",
-  "type": "object",
   "additionalProperties": {
     "type": "object",
     "additionalProperties": false,
@@ -54,7 +52,9 @@
           "type": "object",
           "$ref": "#/definitions/file",
           "properties": {
-            "cache": { "type": "boolean" }
+            "cache": {
+              "type": "boolean"
+            }
           },
           "additionalProperties": false
         }
@@ -63,11 +63,21 @@
         "title": "List of CSS files to load",
         "type": "object",
         "properties": {
-          "base": { "$ref": "#/definitions/cssFiles" },
-          "layout": { "$ref": "#/definitions/cssFiles" },
-          "component": { "$ref": "#/definitions/cssFiles" },
-          "theme": { "$ref": "#/definitions/cssFiles" },
-          "state": { "$ref": "#/definitions/cssFiles" }
+          "base": {
+            "$ref": "#/definitions/cssFiles"
+          },
+          "layout": {
+            "$ref": "#/definitions/cssFiles"
+          },
+          "component": {
+            "$ref": "#/definitions/cssFiles"
+          },
+          "theme": {
+            "$ref": "#/definitions/cssFiles"
+          },
+          "state": {
+            "$ref": "#/definitions/cssFiles"
+          }
         }
       },
       "dependencies": {
@@ -96,7 +106,9 @@
           "title": "Whether the asset is already minified",
           "type": "boolean"
         },
-        "external": { "type": "boolean" },
+        "external": {
+          "type": "boolean"
+        },
         "type": {
           "title": "The source of the asset",
           "type": "string"
@@ -130,5 +142,7 @@
         "additionalProperties": false
       }
     }
-  }
+  },
+  "title": "JSON schema for Drupal libraries file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-libraries.json
+++ b/src/schemas/json/drupal-libraries.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal libraries file",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "version": {
+        "title": "The library version",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      },
+      "remote": {
+        "title": "The library repository URL",
+        "type": "string"
+      },
+      "license": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "title": "The human-readable name of the license",
+            "type": "string"
+          },
+          "url": {
+            "title": "The URL of the license file/information for the version of the library used",
+            "type": "string"
+          },
+          "gpl-compatible": {
+            "title": "A boolean for whether this library is GPL compatible",
+            "type": "boolean"
+          }
+        }
+      },
+      "header": {
+        "title": "A boolean for whether the script must be included in the header",
+        "type": "boolean"
+      },
+      "drupalSettings": {
+        "title": "Settings that needs to be attached to drupalSettings object in JavaScript",
+        "type": "object"
+      },
+      "js": {
+        "title": "List of JavaScript files to load",
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "$ref": "#/definitions/file",
+          "properties": {
+            "cache": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "css": {
+        "title": "List of CSS files to load",
+        "type": "object",
+        "properties": {
+          "base": { "$ref": "#/definitions/cssFiles" },
+          "layout": { "$ref": "#/definitions/cssFiles" },
+          "component": { "$ref": "#/definitions/cssFiles" },
+          "theme": { "$ref": "#/definitions/cssFiles" },
+          "state": { "$ref": "#/definitions/cssFiles" }
+        }
+      },
+      "dependencies": {
+        "title": "List libraries that should be loaded along with this library",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "^.+/.+$"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "file": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "title": "Optional attributes",
+          "type": "object"
+        },
+        "browsers": {
+          "title": "Load asset conditionally based on browser",
+          "type": "object"
+        },
+        "minified": {
+          "title": "Whether the asset is already minified",
+          "type": "boolean"
+        },
+        "external": { "type": "boolean" },
+        "type": {
+          "title": "The source of the asset",
+          "type": "string"
+        },
+        "preprocess": {
+          "title": "Whether the assets should be aggregated",
+          "type": "boolean"
+        },
+        "weight": {
+          "title": "The order relative to other assets",
+          "type": "integer"
+        }
+      }
+    },
+    "cssFiles": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "$ref": "#/definitions/file",
+        "properties": {
+          "group": {
+            "title": "The SMACSS group in which the asset is placed",
+            "type": "integer"
+          },
+          "media": {
+            "title": "Media type",
+            "type": "string",
+            "enum": ["all", "screen", "print", "speech"]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/src/schemas/json/drupal-links-action.json
+++ b/src/schemas/json/drupal-links-action.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal action links file",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "title": "The static title for the local action",
+        "type": "string"
+      },
+      "route_name": {
+        "title": "The route name used to generate a link",
+        "type": "string"
+      },
+      "route_parameters": {
+        "title": "Route parameters for generating a link",
+        "type": "object"
+      },
+      "weight": {
+        "title": "The weight of the local action",
+        "type": "integer"
+      },
+      "options": {
+        "title": "Array of link options",
+        "type": "object"
+      },
+      "appears_on": {
+        "title": "The route names where this local action appears",
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "class": {
+        "title": "Class for local action implementations",
+        "type": "string"
+      },
+      "deriver": {
+        "title": "Deriver class",
+        "type": "string"
+      },
+      "cache_tags": {
+        "title": "Cache tags",
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/schemas/json/drupal-links-action.json
+++ b/src/schemas/json/drupal-links-action.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal action links file",
-  "type": "object",
   "additionalProperties": {
     "type": "object",
     "properties": {
@@ -28,7 +26,9 @@
       "appears_on": {
         "title": "The route names where this local action appears",
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       },
       "class": {
         "title": "Class for local action implementations",
@@ -41,8 +41,12 @@
       "cache_tags": {
         "title": "Cache tags",
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       }
     }
-  }
+  },
+  "title": "JSON schema for Drupal action links file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-links-contextual.json
+++ b/src/schemas/json/drupal-links-contextual.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal contextual links file",
-  "type": "object",
   "additionalProperties": {
     "type": "object",
     "properties": {
@@ -40,9 +38,13 @@
       "cache_tags": {
         "title": "Cache tags",
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       }
     },
     "additionalProperties": false
-  }
+  },
+  "title": "JSON schema for Drupal contextual links file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-links-contextual.json
+++ b/src/schemas/json/drupal-links-contextual.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal contextual links file",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "title": "The static title for the local action",
+        "type": "string"
+      },
+      "route_name": {
+        "title": "The route name used to generate a link",
+        "type": "string"
+      },
+      "route_parameters": {
+        "title": "Route parameters for generating a link",
+        "type": "object"
+      },
+      "group": {
+        "title": "The contextual links group",
+        "type": "string"
+      },
+      "weight": {
+        "title": "The weight of the local action",
+        "type": "integer"
+      },
+      "options": {
+        "title": "Array of link options",
+        "type": "object"
+      },
+      "class": {
+        "title": "Class for local action implementations",
+        "type": "string"
+      },
+      "deriver": {
+        "title": "Deriver class",
+        "type": "string"
+      },
+      "cache_tags": {
+        "title": "Cache tags",
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/schemas/json/drupal-links-menu.json
+++ b/src/schemas/json/drupal-links-menu.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal menu links file",
-  "type": "object",
   "additionalProperties": {
     "type": "object",
     "properties": {
@@ -91,9 +89,13 @@
       "cache_tags": {
         "title": "Cache tags",
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       }
     },
     "additionalProperties": false
-  }
+  },
+  "title": "JSON schema for Drupal menu links file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-links-menu.json
+++ b/src/schemas/json/drupal-links-menu.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal menu links file",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "title": "The static title for the menu link",
+        "type": "string"
+      },
+      "description": {
+        "title": "The description",
+        "type": "string"
+      },
+      "route_name": {
+        "title": "The name of the route this links to, unless it's external",
+        "type": "string"
+      },
+      "route_parameters": {
+        "title": "Parameters for route variables when generating a link",
+        "type": "object"
+      },
+      "parent": {
+        "title": "The plugin ID of the parent tab",
+        "type": "string"
+      },
+      "menu_name": {
+        "title": "The name of the menu for this link",
+        "default": "tools",
+        "type": "string"
+      },
+      "url": {
+        "title": "The external URL if this link has one",
+        "type": "string"
+      },
+      "weight": {
+        "title": "The weight of the link",
+        "type": "integer"
+      },
+      "options": {
+        "title": "Array of link options",
+        "type": "object"
+      },
+      "class": {
+        "title": "Class for task implementations",
+        "type": "string"
+      },
+      "form_class": {
+        "title": "Class for task implementations",
+        "type": "string"
+      },
+      "provider": {
+        "title": "The name of the module providing this link",
+        "type": "string"
+      },
+      "metadata": {
+        "$comment": "@todo Add a title",
+        "type": "array"
+      },
+      "expanded": {
+        "title": "Show the link as expanded",
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "enabled": {
+        "title": "The status of the link",
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "deriver": {
+        "title": "Deriver class",
+        "type": "string"
+      },
+      "position": {
+        "$comment": "@todo Add a title and enum if needed",
+        "type": "string"
+      },
+      "cache_tags": {
+        "title": "Cache tags",
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/schemas/json/drupal-links-task.json
+++ b/src/schemas/json/drupal-links-task.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal task links file",
-  "type": "object",
   "additionalProperties": {
     "type": "object",
     "properties": {
@@ -44,9 +42,13 @@
       "cache_tags": {
         "title": "Cache tags",
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       }
     },
     "additionalProperties": false
-  }
+  },
+  "title": "JSON schema for Drupal task links file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-links-task.json
+++ b/src/schemas/json/drupal-links-task.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal task links file",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "title": "The static title for the local task",
+        "type": "string"
+      },
+      "route_name": {
+        "title": "The name of the route this task links to",
+        "type": "string"
+      },
+      "route_parameters": {
+        "title": "Parameters for route variables when generating a link",
+        "type": "object"
+      },
+      "base_route": {
+        "title": "The route name where the root tab appears",
+        "type": "string"
+      },
+      "parent_id": {
+        "title": "The plugin ID of the parent tab",
+        "type": "string"
+      },
+      "weight": {
+        "title": "The weight of the tab",
+        "type": "integer"
+      },
+      "options": {
+        "title": "Array of link options",
+        "type": "object"
+      },
+      "class": {
+        "title": "Class for task implementations",
+        "type": "string"
+      },
+      "deriver": {
+        "title": "Deriver class",
+        "type": "string"
+      },
+      "cache_tags": {
+        "title": "Cache tags",
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/schemas/json/drupal-migration.json
+++ b/src/schemas/json/drupal-migration.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal migration files",
+  "type": "object",
+  "properties": {
+    "id": {
+      "title": "The migration ID (machine name)",
+      "type": "string"
+    },
+    "label": {
+      "title": "The human-readable label for the migration",
+      "type": "string"
+    },
+    "audit": {
+      "title": "Whether the migration is auditable",
+      "type": "boolean"
+    },
+    "migration_tags": {
+      "title": "List of tags, used by the plugin manager for filtering",
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "deriver": {
+      "title": "Deriver class",
+      "type": "string"
+    },
+    "source": {
+      "title": "The source plugin configuration",
+      "type": "object",
+      "properties": {
+        "plugin": {
+          "title": "Source plugin ID",
+          "type": "string"
+        }
+      },
+      "required": ["plugin"]
+    },
+    "process": {
+      "title": "The configuration describing the process plugins",
+      "type": "object"
+    },
+    "destination": {
+      "title": "The destination plugin configuration",
+      "type": ["object"],
+      "properties": {
+        "plugin": {
+          "title": "Destination plugin ID",
+          "type": ["string", "null"]
+        }
+      },
+      "required": ["plugin"]
+    },
+    "migration_dependencies": {
+      "title": "Migrations to run before this migration",
+      "type": "object",
+      "properties": {
+        "required": {
+          "title": "List of migration IDs that must be run before this migration",
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "optional": {
+          "title": "List of migration IDs that, if they exist, must be run before",
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        }
+      }
+    },
+    "dependencies": {
+      "title": "The migration's dependencies",
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "module": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "theme": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "content": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "enforced": {
+          "type": "object",
+          "properties": {
+            "config": {
+              "type": "array",
+              "items": { "type": "string" },
+              "uniqueItems": true
+            },
+            "module": {
+              "type": "array",
+              "items": { "type": "string" },
+              "uniqueItems": true
+            },
+            "theme": {
+              "type": "array",
+              "items": { "type": "string" },
+              "uniqueItems": true
+            },
+            "content": {
+              "type": "array",
+              "items": { "type": "string" },
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "provider": {
+      "title": "List of plugin providers",
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "class": {
+      "title": "Class for migration implementation",
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/src/schemas/json/drupal-migration.json
+++ b/src/schemas/json/drupal-migration.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal migration files",
-  "type": "object",
   "properties": {
     "id": {
       "title": "The migration ID (machine name)",
@@ -18,7 +16,9 @@
     "migration_tags": {
       "title": "List of tags, used by the plugin manager for filtering",
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "uniqueItems": true
     },
     "deriver": {
@@ -58,13 +58,17 @@
         "required": {
           "title": "List of migration IDs that must be run before this migration",
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true
         },
         "optional": {
           "title": "List of migration IDs that, if they exist, must be run before",
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true
         }
       }
@@ -75,22 +79,30 @@
       "properties": {
         "config": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true
         },
         "module": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true
         },
         "theme": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true
         },
         "content": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true
         },
         "enforced": {
@@ -98,22 +110,30 @@
           "properties": {
             "config": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "uniqueItems": true
             },
             "module": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "uniqueItems": true
             },
             "theme": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "uniqueItems": true
             },
             "content": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "uniqueItems": true
             }
           },
@@ -125,12 +145,16 @@
     "provider": {
       "title": "List of plugin providers",
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "uniqueItems": true
     },
     "class": {
       "title": "Class for migration implementation",
       "type": ["string", "null"]
     }
-  }
+  },
+  "title": "JSON schema for Drupal migration files",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-permissions.json
+++ b/src/schemas/json/drupal-permissions.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal permissions file",
+  "type": "object",
+  "properties": {
+    "permission_callbacks": {
+      "title": "List of permission callbacks",
+      "type": "array",
+      "items": {
+        "title": "A callback that return array of permissions",
+        "type": "string"
+      },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": {
+    "title": "Permission definition",
+    "type": "object",
+    "required": ["title"],
+    "properties": {
+      "title": {
+        "title": "The human-readable name of the permission",
+        "type": "string"
+      },
+      "description": {
+        "title": "A description of what the permission does",
+        "type": "string"
+      },
+      "restrict access": {
+        "title": "Restrict access to this permission to trusted users",
+        "description": "This should be used for permissions that have inherent security risks across a variety of potential use cases (for example, the \"administer filters\" and \"bypass node access\" permissions provided by Drupal core).",
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/schemas/json/drupal-permissions.json
+++ b/src/schemas/json/drupal-permissions.json
@@ -1,18 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal permissions file",
-  "type": "object",
-  "properties": {
-    "permission_callbacks": {
-      "title": "List of permission callbacks",
-      "type": "array",
-      "items": {
-        "title": "A callback that return array of permissions",
-        "type": "string"
-      },
-      "uniqueItems": true
-    }
-  },
   "additionalProperties": {
     "title": "Permission definition",
     "type": "object",
@@ -33,5 +20,18 @@
       }
     },
     "additionalProperties": false
-  }
+  },
+  "properties": {
+    "permission_callbacks": {
+      "title": "List of permission callbacks",
+      "type": "array",
+      "items": {
+        "title": "A callback that return array of permissions",
+        "type": "string"
+      },
+      "uniqueItems": true
+    }
+  },
+  "title": "JSON schema for Drupal permissions file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-routing.json
+++ b/src/schemas/json/drupal-routing.json
@@ -1,15 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal routing file",
-  "type": "object",
-  "properties": {
-    "route_callbacks": {
-      "title": "List of callbacks to provide routes",
-      "type": "array",
-      "items": { "type": "string" },
-      "uniqueItems": true
-    }
-  },
   "additionalProperties": {
     "type": "object",
     "properties": {
@@ -25,30 +15,66 @@
             "title": "A controller to execute when the route is matched",
             "type": "string"
           },
-          "_form": { "type": "string" },
-          "_title": { "type": "string" },
-          "_title_callback": { "type": "string" },
-          "_access": { "type": "string" },
-          "_entity_list": { "type": "string" },
-          "_entity_form": { "type": "string" },
-          "_entity_view": { "type": "string" }
+          "_form": {
+            "type": "string"
+          },
+          "_title": {
+            "type": "string"
+          },
+          "_title_callback": {
+            "type": "string"
+          },
+          "_access": {
+            "type": "string"
+          },
+          "_entity_list": {
+            "type": "string"
+          },
+          "_entity_form": {
+            "type": "string"
+          },
+          "_entity_view": {
+            "type": "string"
+          }
         }
       },
       "requirements": {
         "title": "List of requirements that makes a specific route only match under specific conditions",
         "type": "object",
         "properties": {
-          "_access": { "type": "string" },
-          "_custom_access": { "type": "string" },
-          "_format": { "type": "string" },
-          "_entity_access": { "type": "string" },
-          "_entity_create_access": { "type": "string" },
-          "_entity_delete_multiple_access": { "type": "string" },
-          "_module_dependencies": { "type": "string" },
-          "_csrf_token": { "type": "string" },
-          "_user_is_logged_in": { "type": "string" },
-          "_access_theme": { "type": "string" },
-          "_permission": { "type": "string" }
+          "_access": {
+            "type": "string"
+          },
+          "_custom_access": {
+            "type": "string"
+          },
+          "_format": {
+            "type": "string"
+          },
+          "_entity_access": {
+            "type": "string"
+          },
+          "_entity_create_access": {
+            "type": "string"
+          },
+          "_entity_delete_multiple_access": {
+            "type": "string"
+          },
+          "_module_dependencies": {
+            "type": "string"
+          },
+          "_csrf_token": {
+            "type": "string"
+          },
+          "_user_is_logged_in": {
+            "type": "string"
+          },
+          "_access_theme": {
+            "type": "string"
+          },
+          "_permission": {
+            "type": "string"
+          }
         }
       },
       "methods": {
@@ -64,20 +90,46 @@
         "title": "Additional route options",
         "type": "object",
         "properties": {
-          "no_cache": { "type": "boolean" },
-          "_admin_route": { "type": "boolean" },
-          "_no_path": { "type": "boolean" },
-          "_maintenance_access": { "type": "boolean" },
-          "_node_operation_route": { "type": "boolean" },
-          "parameters": { "type": "object" },
+          "no_cache": {
+            "type": "boolean"
+          },
+          "_admin_route": {
+            "type": "boolean"
+          },
+          "_no_path": {
+            "type": "boolean"
+          },
+          "_maintenance_access": {
+            "type": "boolean"
+          },
+          "_node_operation_route": {
+            "type": "boolean"
+          },
+          "parameters": {
+            "type": "object"
+          },
           "_auth": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "uniqueItems": true
           }
         }
       }
     },
     "additionalProperties": false
-  }
+  },
+  "properties": {
+    "route_callbacks": {
+      "title": "List of callbacks to provide routes",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    }
+  },
+  "title": "JSON schema for Drupal routing file",
+  "type": "object"
 }

--- a/src/schemas/json/drupal-routing.json
+++ b/src/schemas/json/drupal-routing.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal routing file",
+  "type": "object",
+  "properties": {
+    "route_callbacks": {
+      "title": "List of callbacks to provide routes",
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "title": "Route path",
+        "type": "string"
+      },
+      "defaults": {
+        "title": "Default route parameters",
+        "type": "object",
+        "properties": {
+          "_controller": {
+            "title": "A controller to execute when the route is matched",
+            "type": "string"
+          },
+          "_form": { "type": "string" },
+          "_title": { "type": "string" },
+          "_title_callback": { "type": "string" },
+          "_access": { "type": "string" },
+          "_entity_list": { "type": "string" },
+          "_entity_form": { "type": "string" },
+          "_entity_view": { "type": "string" }
+        }
+      },
+      "requirements": {
+        "title": "List of requirements that makes a specific route only match under specific conditions",
+        "type": "object",
+        "properties": {
+          "_access": { "type": "string" },
+          "_custom_access": { "type": "string" },
+          "_format": { "type": "string" },
+          "_entity_access": { "type": "string" },
+          "_entity_create_access": { "type": "string" },
+          "_entity_delete_multiple_access": { "type": "string" },
+          "_module_dependencies": { "type": "string" },
+          "_csrf_token": { "type": "string" },
+          "_user_is_logged_in": { "type": "string" },
+          "_access_theme": { "type": "string" },
+          "_permission": { "type": "string" }
+        }
+      },
+      "methods": {
+        "title": "Method of the incoming request to match the route",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": ["GET", "POST", "PATCH", "PUT", "DELETE"]
+        },
+        "uniqueItems": true
+      },
+      "options": {
+        "title": "Additional route options",
+        "type": "object",
+        "properties": {
+          "no_cache": { "type": "boolean" },
+          "_admin_route": { "type": "boolean" },
+          "_no_path": { "type": "boolean" },
+          "_maintenance_access": { "type": "boolean" },
+          "_node_operation_route": { "type": "boolean" },
+          "parameters": { "type": "object" },
+          "_auth": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true
+          }
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/schemas/json/drupal-services.json
+++ b/src/schemas/json/drupal-services.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Drupal services file",
+  "type": "object",
+  "properties": {
+    "parameters": {
+      "title": "Service parameters",
+      "type": "object"
+    },
+    "services": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "title": "Service class",
+            "type": "string"
+          },
+          "parent": {
+            "title": "Parent service to extend",
+            "type": "string"
+          },
+          "factory": {
+            "title": "A factory to create the object",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array"
+              }
+            ]
+          },
+          "decorates": {
+            "title": "Service name to decorate",
+            "type": "string"
+          },
+          "deprecated": {
+            "title": "A flag indicating that the service is deprecated",
+            "type": "string"
+          },
+          "lazy": {
+            "title": "Lazy service instantiation",
+            "type": "boolean"
+          },
+          "shared": {
+            "title": "Shared service",
+            "type": "boolean"
+          },
+          "abstract": {
+            "title": "Abstract service",
+            "type": "boolean"
+          },
+          "public": {
+            "title": "A flag indication that the service cannot be accessed directly from the container object",
+            "type": "boolean"
+          },
+          "alias": {
+            "title": "A shortcut to access some services",
+            "type": "string"
+          },
+          "arguments": {
+            "title": "Service arguments",
+            "type": "array",
+            "uniqueItems": true
+          },
+          "configurator": {
+            "title": "A callable to configure a service after its instantiation",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "tags": {
+            "title": "List of tags tell Drupal that your service can be processed in some special way",
+            "examples": [
+              "event_subscriber",
+              "service_collector",
+              "theme_negotiator",
+              "twig.extension",
+              "access_check"
+            ],
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "call": { "type": "string" },
+                "alias": { "type": "string" },
+                "required": { "type": "boolean" },
+                "tag": { "type": "string" },
+                "priority": { "type": "integer" },
+                "default_backend": { "type": "string" },
+                "responder": { "type": "boolean" },
+                "format": { "type": "string" },
+                "applies_to": { "type": "string" },
+                "provider_id": { "type": "string" },
+                "needs_incoming_request": { "type": "boolean" },
+                "scheme": { "type": "string" }
+              }
+            }
+          },
+          "calls": {
+            "title": "Methods to set optional dependencies",
+            "type": "array",
+            "uniqueItems": true
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/schemas/json/drupal-services.json
+++ b/src/schemas/json/drupal-services.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "JSON schema for Drupal services file",
-  "type": "object",
+  "additionalProperties": false,
   "properties": {
     "parameters": {
       "title": "Service parameters",
@@ -67,7 +66,9 @@
           "configurator": {
             "title": "A callable to configure a service after its instantiation",
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+              "type": "string"
+            }
           },
           "tags": {
             "title": "List of tags tell Drupal that your service can be processed in some special way",
@@ -82,19 +83,45 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": { "type": "string" },
-                "call": { "type": "string" },
-                "alias": { "type": "string" },
-                "required": { "type": "boolean" },
-                "tag": { "type": "string" },
-                "priority": { "type": "integer" },
-                "default_backend": { "type": "string" },
-                "responder": { "type": "boolean" },
-                "format": { "type": "string" },
-                "applies_to": { "type": "string" },
-                "provider_id": { "type": "string" },
-                "needs_incoming_request": { "type": "boolean" },
-                "scheme": { "type": "string" }
+                "name": {
+                  "type": "string"
+                },
+                "call": {
+                  "type": "string"
+                },
+                "alias": {
+                  "type": "string"
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "tag": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "integer"
+                },
+                "default_backend": {
+                  "type": "string"
+                },
+                "responder": {
+                  "type": "boolean"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "applies_to": {
+                  "type": "string"
+                },
+                "provider_id": {
+                  "type": "string"
+                },
+                "needs_incoming_request": {
+                  "type": "boolean"
+                },
+                "scheme": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -107,5 +134,6 @@
       }
     }
   },
-  "additionalProperties": false
+  "title": "JSON schema for Drupal services file",
+  "type": "object"
 }

--- a/src/test/drupal-breakpoints/drupal-breakpoints.yml
+++ b/src/test/drupal-breakpoints/drupal-breakpoints.yml
@@ -1,0 +1,40 @@
+all:
+  label: All
+  mediaQuery: "only screen and (min-width: 0)"
+  weight: 0
+  group: MyWebsite
+  multipliers:
+    - 1x
+    - 2x
+xs:
+  label: Extra Small
+  mediaQuery: "only screen and (min-width: 480px)"
+  weight: 1
+  group: MyWebsite
+  multipliers:
+    - 1x
+    - 2x
+sm:
+  label: Small
+  mediaQuery: "only screen and (min-width: 768px)"
+  weight: 2
+  group: MyWebsite
+  multipliers:
+    - 1x
+    - 2x
+md:
+  label: Medium
+  mediaQuery: "only screen and (min-width: 992px)"
+  weight: 3
+  group: MyWebsite
+  multipliers:
+    - 1x
+    - 2x
+lg:
+  label: Large
+  mediaQuery: "only screen and (min-width: 1200px)"
+  weight: 4
+  group: MyWebsite
+  multipliers:
+    - 1x
+    - 2x

--- a/src/test/drupal-config/drupal-config.yml
+++ b/src/test/drupal-config/drupal-config.yml
@@ -1,0 +1,17 @@
+# Root of a configuration object.
+
+_core_config_info:
+  type: mapping
+  mapping:
+    default_config_hash:
+      type: string
+      label: "Default configuration hash"
+
+config_object:
+  type: mapping
+  mapping:
+    langcode:
+      type: string
+      label: "Language code"
+    _core:
+      type: _core_config_info

--- a/src/test/drupal-info/drupal-info.yml
+++ b/src/test/drupal-info/drupal-info.yml
@@ -1,0 +1,4 @@
+name: Hello World Special
+description: A special silly example module
+type: module
+core_version_requirement: ^9.1

--- a/src/test/drupal-layouts/drupal-layouts.yml
+++ b/src/test/drupal-layouts/drupal-layouts.yml
@@ -1,0 +1,18 @@
+one_column:
+  label: 'One column'
+  category: 'My Layouts'
+  template: templates/one-column
+  default_region: main
+  regions:
+    main:
+      label: Main content
+two_column:
+  label: 'Two column'
+  category: 'My Layouts'
+  template: templates/two-column
+  default_region: main
+  regions:
+    main:
+      label: Main content
+    sidebar:
+      label: Sidebar

--- a/src/test/drupal-layouts/drupal-layouts.yml
+++ b/src/test/drupal-layouts/drupal-layouts.yml
@@ -1,14 +1,14 @@
 one_column:
-  label: 'One column'
-  category: 'My Layouts'
+  label: "One column"
+  category: "My Layouts"
   template: templates/one-column
   default_region: main
   regions:
     main:
       label: Main content
 two_column:
-  label: 'Two column'
-  category: 'My Layouts'
+  label: "Two column"
+  category: "My Layouts"
   template: templates/two-column
   default_region: main
   regions:

--- a/src/test/drupal-libraries/drupal-libraries-2.yml
+++ b/src/test/drupal-libraries/drupal-libraries-2.yml
@@ -1,0 +1,11 @@
+global-styling:
+  version: 1.x
+  css:
+    theme:
+      css/layout.css: {}
+      css/style.css: {}
+      css/colors.css: {}
+global-scripts:
+  version: 1.x
+  js:
+    js/navmenu.js: {}

--- a/src/test/drupal-libraries/drupal-libraries.yml
+++ b/src/test/drupal-libraries/drupal-libraries.yml
@@ -1,0 +1,9 @@
+cuddly-slider:
+  version: 1.x
+  css:
+    layout:
+      css/cuddly-slider-layout.css: {}
+    theme:
+      css/cuddly-slider-theme.css: {}
+  js:
+    js/cuddly-slider.js: {}

--- a/src/test/drupal-links-action/drupal-links-action.yml
+++ b/src/test/drupal-links-action/drupal-links-action.yml
@@ -1,0 +1,10 @@
+node.type_add:
+  route_name: node.type_add
+  title: "Add content type"
+  appears_on:
+    - entity.node_type.collection
+node.add_page:
+  route_name: node.add_page
+  title: "Add content"
+  appears_on:
+    - system.admin_content

--- a/src/test/drupal-links-contextual/drupal-links-contextual.yml
+++ b/src/test/drupal-links-contextual/drupal-links-contextual.yml
@@ -1,0 +1,10 @@
+entity.node.edit_form:
+  route_name: entity.node.edit_form
+  group: node
+  title: Edit
+
+entity.node.delete_form:
+  route_name: entity.node.delete_form
+  group: node
+  title: Delete
+  weight: 10

--- a/src/test/drupal-links-menu/drupal-links-menu.yml
+++ b/src/test/drupal-links-menu/drupal-links-menu.yml
@@ -1,0 +1,19 @@
+example.admin:
+  title: "Example settings"
+  description: "Manage example settings for your site"
+  parent: system.admin_config_development
+  route_name: example.admin
+  weight: 100
+  # The menu link is enabled by default, we can override it with:
+  enabled: 0
+  route_parameters: { key: "value" }
+  # If menu_name is omitted, the "Tools" menu will be used.
+  menu_name: devel
+  options:
+    query:
+      uid: 1
+    attributes:
+      target: _blank
+      class:
+        - some-class
+        - anotherclass

--- a/src/test/drupal-links-task/drupal-links-task.yml
+++ b/src/test/drupal-links-task/drupal-links-task.yml
@@ -1,0 +1,70 @@
+system.rss_feeds_settings_tab:
+  route_name: system.rss_feeds_settings
+  title: Settings
+  base_route: system.rss_feeds_settings
+
+system.site_maintenance_mode_tab:
+  route_name: system.site_maintenance_mode
+  title: Settings
+  base_route: system.site_maintenance_mode
+
+system.site_information_settings_tab:
+  route_name: system.site_information_settings
+  title: Settings
+  base_route: system.site_information_settings
+
+system.themes_page:
+  route_name: system.themes_page
+  title: "List"
+  base_route: system.themes_page
+system.theme_settings:
+  route_name: system.theme_settings
+  title: "Settings"
+  base_route: system.themes_page
+  weight: 100
+
+system.theme_settings_global:
+  route_name: system.theme_settings
+  title: "Global settings"
+  parent_id: system.theme_settings
+  weight: -100
+system.theme_settings_theme:
+  route_name: system.theme_settings_theme
+  title: "Theme name"
+  parent_id: system.theme_settings
+  deriver: Drupal\system\Plugin\Derivative\ThemeLocalTask
+
+system.modules_list:
+  route_name: system.modules_list
+  base_route: system.modules_list
+  title: "List"
+system.modules_uninstall:
+  route_name: system.modules_uninstall
+  base_route: system.modules_list
+  title: "Uninstall"
+  weight: 20
+
+system.admin:
+  route_name: system.admin
+  base_route: system.admin
+  title: "Tasks"
+  weight: -20
+system.admin_index:
+  route_name: system.admin_index
+  base_route: system.admin
+  title: "Index"
+  weight: -18
+
+entity.date_format.collection:
+  route_name: entity.date_format.collection
+  base_route: entity.date_format.collection
+  title: "List"
+entity.date_format.edit_form:
+  title: "Edit"
+  route_name: entity.date_format.edit_form
+  base_route: entity.date_format.edit_form
+
+system.admin_content:
+  title: Content
+  route_name: system.admin_content
+  base_route: system.admin_content

--- a/src/test/drupal-migration/drupal-migration.yml
+++ b/src/test/drupal-migration/drupal-migration.yml
@@ -1,0 +1,15 @@
+id: d6_dblog_settings
+label: Database logging configuration
+migration_tags:
+  - Drupal 6
+  - Configuration
+source:
+  plugin: variable
+  variables:
+    - dblog_row_limit
+  source_module: dblog
+process:
+  row_limit: dblog_row_limit
+destination:
+  plugin: config
+  config_name: dblog.settings

--- a/src/test/drupal-permissions/drupal-permissions.yml
+++ b/src/test/drupal-permissions/drupal-permissions.yml
@@ -1,0 +1,29 @@
+bypass node access:
+  title: "Bypass content access control"
+  description: "View, edit and delete all content regardless of permission restrictions."
+  restrict access: true
+administer content types:
+  title: "Administer content types"
+  description: "Maintain the types of content available and the fields that are associated with those types."
+  restrict access: true
+administer nodes:
+  title: "Administer content"
+  description: "Promote, change ownership, edit revisions, and perform other tasks across all content types."
+  restrict access: true
+access content overview:
+  title: "Access the Content overview page"
+access content:
+  title: "View published content"
+view own unpublished content:
+  title: "View own unpublished content"
+view all revisions:
+  title: "View all revisions"
+revert all revisions:
+  title: "Revert all revisions"
+  description: "Role requires permission <em>view revisions</em> and <em>edit rights</em> for nodes in question or <em>administer nodes</em>."
+delete all revisions:
+  title: "Delete all revisions"
+  description: "Role requires permission to <em>view revisions</em> and <em>delete rights</em> for nodes in question or <em>administer nodes</em>."
+
+permission_callbacks:
+  - woof

--- a/src/test/drupal-routing/drupal-routing.yml
+++ b/src/test/drupal-routing/drupal-routing.yml
@@ -1,0 +1,26 @@
+# Each route is defined by a machine name, in the form of my_module_name.route_name.
+#
+book.render:
+  # The path always starts with a leading forward-slash.
+  path: "/book"
+  # Defines the default properties of a route.
+  defaults:
+    # For page callbacks that return a render array use _controller.
+    _controller: '\Drupal\book\Controller\BookController::bookRender'
+  # Require a permission to access this route.
+  requirements:
+    _permission: "access content"
+
+book.export:
+  # This path takes dynamic arguments, which are enclosed in { }.
+  path: "/book/export/{type}/{node}"
+  defaults:
+    # This route returns a Response object so also uses _controller
+    _controller: '\Drupal\book\Controller\BookController::bookExport'
+  requirements:
+    _permission: "access printer-friendly version"
+    # Ensure user has access to view the node passed in.
+    _entity_access: "node.view"
+  options:
+    # Enable the admin theme for this route.
+    _admin_route: TRUE

--- a/src/test/drupal-services/drupal-services.yml
+++ b/src/test/drupal-services/drupal-services.yml
@@ -1,0 +1,12 @@
+services:
+  # Defines a simple service which requires no parameter for its constructor.
+  example.simple:
+    class: Drupal\Example\Simple
+
+  # Defines a service which requires the module_handler for its constructor.
+  example.with_module_handler:
+    class: Drupal\Example\WithModuleHandler
+    arguments: ["@module_handler", "%example.parameter%"]
+
+parameters:
+  example.parameter: TRUE


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This adds Drupal 8 schemas. Closes #710

As per #710, this gets the schema files from an [external repository](https://github.com/5n00p4eg/Drupal-json-schemas). I had trouble getting the `if`s and `then`s validating under strict mode, so those were left out, for now. Test files were also added for every single added schema file.

cc @5n00p4eg