### PR TITLE
build: Throw error a passed `--SchemaName` does not exist

### DIFF
--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -125,6 +125,10 @@ module.exports = function (grunt) {
     const schemaNameOption = grunt.option('SchemaName')
     if (processOnlyThisOneSchemaFile === undefined && schemaNameOption) {
       processOnlyThisOneSchemaFile = schemaNameOption
+      const file = pt.join(schemaDir, processOnlyThisOneSchemaFile)
+      if (!fs.existsSync(file)) {
+        throwWithErrorText([`Schema file ${processOnlyThisOneSchemaFile} does not exist`])
+      }
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This change is related to 040db01b6 - it simply shows an error message if the passed `SchemaName` file is not actually a file that exists. Typos are caught easier and time is saved.

