### PR TITLE
Remove windows-2016 from GitHub Workflow schema

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -514,7 +514,6 @@
                 "ubuntu-20.04",
                 "ubuntu-22.04",
                 "ubuntu-latest",
-                "windows-2016",
                 "windows-2019",
                 "windows-2022",
                 "windows-latest"


### PR DESCRIPTION
The `windows-2016` target for `runs-on` was removed earlier this year in March: https://github.com/actions/runner-images/issues/4312