### PR TITLE
New Schema: Serverless Workflow

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3729,6 +3729,18 @@
       "url": "https://raw.githubusercontent.com/lalcebo/json-schema/master/serverless/reference.json"
     },
     {
+      "name": "Serverless Workflow Schema",
+      "description": "Schema for serverless workflows",
+      "fileMatch": ["*.sw.json", "*.sw.yml"],
+      "url": "https://raw.githubusercontent.com/serverlessworkflow/specification/main/schema/workflow.json",
+      "versions": {
+        "v0.8": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.8.x/schema/workflow.json",
+        "v0.7": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.7.x/schema/workflow.json",
+        "v0.6": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.6.x/schema/workflow.json",
+        "v0.5": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.5.x/schema/workflow.json"
+      }
+    },
+    {
       "name": "Shopware 6 Configuration",
       "description": "Schema for Shopware 6 custom configurations",
       "fileMatch": ["shopware.yml", "shopware.yaml"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Building upon #1537, this adds the CNCF Serverless Workflow schema. As per CONTRIBUTING.md, it links to the external schema for a single source of truth (including multiple versions). Closes #2380