### PR TITLE
Add stripe-app.json schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2792,6 +2792,12 @@
       "url": "https://raw.githubusercontent.com/Konafets/statamic-blueprint-validation/main/statamic.blueprint.schema.json"
     },
     {
+      "name": "stripe-app.json",
+      "description": "Stripe Apps manifest file",
+      "fileMatch": ["stripe-app.json"],
+      "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app.schema.json"
+    },
+    {
       "name": "Stryker Mutator",
       "description": "Configuration file for Stryker Mutator, the mutation testing framework for JavaScript and friends. See https://stryker-mutator.io.",
       "fileMatch": ["stryker.conf.json", "stryker-*.conf.json"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
Add schema file for `stripe-app.json`.

Thanks for reviewing 🙂 
