### PR TITLE
Fix prometheus buckets validation

### DIFF
--- a/src/schemas/json/traefik-v2.json
+++ b/src/schemas/json/traefik-v2.json
@@ -434,7 +434,7 @@
             "buckets": {
               "type": "array",
               "items": {
-                "type": "integer"
+                "type": "number"
               }
             },
             "addEntryPointsLabels": {

--- a/src/test/traefik-v2/example.json
+++ b/src/test/traefik-v2/example.json
@@ -183,7 +183,7 @@
   },
   "metrics": {
     "prometheus": {
-      "buckets": [42, 42],
+      "buckets": [4.2, 42, 42],
       "addEntryPointsLabels": true,
       "addRoutersLabels": true,
       "addServicesLabels": true,


### PR DESCRIPTION
According to the [Traefik source code](https://github.com/traefik/traefik/blob/master/pkg/types/metrics.go#L21), Prometheus buckets can be float numbers to. Not only integers. Defaults are 0.1, 0.3, 1.2, 5