### PR TITLE
Add support for Drupal's 'title_context' and 'description_context' properties

### DIFF
--- a/src/schemas/json/drupal-links-action.json
+++ b/src/schemas/json/drupal-links-action.json
@@ -7,6 +7,10 @@
         "title": "The static title for the local action",
         "type": "string"
       },
+      "title_context": {
+        "title": "The translation context for the title value.",
+        "type": "string"
+      },
       "route_name": {
         "title": "The route name used to generate a link",
         "type": "string"

--- a/src/schemas/json/drupal-links-contextual.json
+++ b/src/schemas/json/drupal-links-contextual.json
@@ -7,6 +7,10 @@
         "title": "The static title for the local action",
         "type": "string"
       },
+      "title_context": {
+        "title": "The translation context for the title value.",
+        "type": "string"
+      },
       "route_name": {
         "title": "The route name used to generate a link",
         "type": "string"

--- a/src/schemas/json/drupal-links-menu.json
+++ b/src/schemas/json/drupal-links-menu.json
@@ -7,8 +7,16 @@
         "title": "The static title for the menu link",
         "type": "string"
       },
+      "title_context": {
+        "title": "The translation context for the title value.",
+        "type": "string"
+      },
       "description": {
         "title": "The description",
+        "type": "string"
+      },
+      "description_context": {
+        "title": "The translation context for the description value.",
         "type": "string"
       },
       "route_name": {

--- a/src/schemas/json/drupal-links-task.json
+++ b/src/schemas/json/drupal-links-task.json
@@ -7,6 +7,10 @@
         "title": "The static title for the local task",
         "type": "string"
       },
+      "title_context": {
+        "title": "The translation context for the title value.",
+        "type": "string"
+      },
       "route_name": {
         "title": "The name of the route this task links to",
         "type": "string"

--- a/src/test/drupal-links-action/drupal-links-action.yml
+++ b/src/test/drupal-links-action/drupal-links-action.yml
@@ -8,3 +8,8 @@ node.add_page:
   title: "Add content"
   appears_on:
     - system.admin_content
+link_with_context:
+  title: "The link title"
+  title_context: "context"
+  appears_on:
+    - system.admin_content

--- a/src/test/drupal-links-contextual/drupal-links-contextual.yml
+++ b/src/test/drupal-links-contextual/drupal-links-contextual.yml
@@ -8,3 +8,9 @@ entity.node.delete_form:
   group: node
   title: Delete
   weight: 10
+
+link_with_context:
+  title: "The link title"
+  title_context: "context"
+  route_name: foo.bar
+  group: foo

--- a/src/test/drupal-links-menu/drupal-links-menu.yml
+++ b/src/test/drupal-links-menu/drupal-links-menu.yml
@@ -1,6 +1,8 @@
 example.admin:
   title: "Example settings"
+  title_context: "context"
   description: "Manage example settings for your site"
+  description_context: "context"
   parent: system.admin_config_development
   route_name: example.admin
   weight: 100

--- a/src/test/drupal-links-task/drupal-links-task.yml
+++ b/src/test/drupal-links-task/drupal-links-task.yml
@@ -68,3 +68,7 @@ system.admin_content:
   title: Content
   route_name: system.admin_content
   base_route: system.admin_content
+
+link_with_context:
+  title: "The link title"
+  title_context: "context"


### PR DESCRIPTION
Drupal `*.links.*.yml` files supports for translation context properties. This Pull Requests add them into schemas.

- `*.links.contextual.yml` supports for `title_context` ([source](https://github.com/drupal/drupal/blob/7512b901723e0a404e6b74539b198fb320c57289/core/lib/Drupal/Core/Menu/ContextualLinkManager.php#L117))
- `*.links.action.yml` supports for `title_context` ([source](https://github.com/drupal/drupal/blob/7512b901723e0a404e6b74539b198fb320c57289/core/lib/Drupal/Core/Menu/LocalActionManager.php#L142))
- `*.links.task.yml` supports for `title_context` ([source](https://github.com/drupal/drupal/blob/7512b901723e0a404e6b74539b198fb320c57289/core/lib/Drupal/Core/Menu/LocalTaskManager.php#L150))
- `*.links.menu.yml` supports for `title_context` and `description_context` ([source](https://github.com/drupal/drupal/blob/7512b901723e0a404e6b74539b198fb320c57289/core/lib/Drupal/Core/Menu/MenuLinkManager.php#L140-L141))
