### PR TITLE
pyproject: backport Poetry changes 2020 – 2022

### DIFF
--- a/src/negative_test/pyproject/poetry-bad-multiline.toml
+++ b/src/negative_test/pyproject/poetry-bad-multiline.toml
@@ -1,0 +1,4 @@
+[tool.poetry]
+name = "bad-multiline"
+version = "1.2.3"
+description = "Some multi-\nline string"

--- a/src/negative_test/pyproject/poetry-bad-multiline.toml
+++ b/src/negative_test/pyproject/poetry-bad-multiline.toml
@@ -2,3 +2,4 @@
 name = "bad-multiline"
 version = "1.2.3"
 description = "Some multi-\nline string"
+authors = ["Poetry <poet@example.com>"]

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -400,33 +400,6 @@
         }
       }
     },
-    "poetry-repository": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the repository"
-        },
-        "url": {
-          "type": "string",
-          "description": "The url of the repository",
-          "format": "uri"
-        },
-        "default": {
-          "type": "boolean",
-          "description": "Make this repository the default (disable PyPI)"
-        },
-        "secondary": {
-          "type": "boolean",
-          "description": "Declare this repository as secondary, i.e. it will only be looked up last for packages."
-        },
-        "links": {
-          "type": "boolean",
-          "description": "Declare this as a link source. Links at uri/path can point to sdist or bdist archives."
-        }
-      }
-    },
     "poetry-build-script": {
       "type": "string",
       "description": "The python script file used to build extensions."
@@ -520,7 +493,7 @@
       "properties": {
         "poetry": {
           "type": "object",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "required": ["name", "version", "description"],
           "properties": {
             "name": {
@@ -704,13 +677,6 @@
             },
             "build": {
               "$ref": "#/definitions/poetry-build-section"
-            },
-            "source": {
-              "type": "array",
-              "description": "A set of additional repositories where packages can be found.",
-              "items": {
-                "$ref": "#/definitions/poetry-repository"
-              }
             },
             "scripts": {
               "type": "object",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -494,7 +494,7 @@
         "poetry": {
           "type": "object",
           "additionalProperties": true,
-          "required": ["name", "version", "description"],
+          "required": ["name", "version", "description", "authors"],
           "properties": {
             "name": {
               "type": "string",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -170,6 +170,10 @@
           "type": "string",
           "description": "The revision to checkout."
         },
+        "subdirectory": {
+          "type": "string",
+          "description": "The relative path to the directory where the package is located."
+        },
         "python": {
           "type": "string",
           "description": "The python versions for which the dependency should be installed."

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -658,6 +658,34 @@
                 }
               }
             },
+            "group": {
+              "type": "object",
+              "description": "This represents groups of dependencies",
+              "patternProperties": {
+                "^[a-zA-Z-_.0-9]+$": {
+                  "type": "object",
+                  "description": "This represents a single dependency group",
+                  "required": ["dependencies"],
+                  "properties": {
+                    "optional": {
+                      "type": "boolean",
+                      "description": "Whether the dependency group is optional or not"
+                    },
+                    "dependencies": {
+                      "type": "object",
+                      "description": "The dependencies of this dependency group",
+                      "patternProperties": {
+                        "^[a-zA-Z-_.0-9]+$": {
+                          "$ref": "#/definitions/poetry-dependency-any"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
             "build": {
               "$ref": "#/definitions/poetry-build-section"
             },

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -569,8 +569,19 @@
               "$ref": "#/definitions/poetry-maintainers"
             },
             "readme": {
-              "type": "string",
-              "description": "The path to the README file"
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "The path to the README file."
+                },
+                {
+                  "type": "array",
+                  "description": "A list of paths to the readme files.",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "classifiers": {
               "type": "array",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -379,6 +379,31 @@
         }
       }
     },
+    "poetry-build-script": {
+      "type": "string",
+      "description": "The python script file used to build extensions."
+    },
+    "poetry-build-config": {
+      "type": "object",
+      "description": "Build specific configurations.",
+      "additionalProperties": false,
+      "properties": {
+        "generate-setup-file": {
+          "type": "boolean",
+          "description": "Generate and include a setup.py file in sdist.",
+          "default": true
+        },
+        "script": {
+          "$ref": "#/definitions/poetry-build-script"
+        }
+      }
+    },
+    "poetry-build-section": {
+      "oneOf": [
+        { "$ref": "#/definitions/poetry-build-script" },
+        { "$ref": "#/definitions/poetry-build-config" }
+      ]
+    },
     "BuildSystem": {
       "title": "Project build system configuration",
       "$comment": "see PEP 517 (https://peps.python.org/pep-0517/) and PEP 518 (https://peps.python.org/pep-0518/)",
@@ -582,8 +607,7 @@
               }
             },
             "build": {
-              "type": "string",
-              "description": "The file used to build extensions."
+              "$ref": "#/definitions/poetry-build-section"
             },
             "source": {
               "type": "array",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -533,7 +533,8 @@
             },
             "description": {
               "type": "string",
-              "description": "Short package description."
+              "description": "Short package description.",
+              "pattern": "^[^\n]*$"
             },
             "keywords": {
               "type": "array",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -181,6 +181,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "develop": {
+          "type": "boolean",
+          "description": "Whether to install the dependency in development mode."
         }
       }
     },

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -395,6 +395,10 @@
         "secondary": {
           "type": "boolean",
           "description": "Declare this repository as secondary, i.e. it will only be looked up last for packages."
+        },
+        "links": {
+          "type": "boolean",
+          "description": "Declare this as a link source. Links at uri/path can point to sdist or bdist archives."
         }
       }
     },

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -52,6 +52,25 @@
         "$ref": "#/definitions/poetry-author-pattern"
       }
     },
+    "poetry-include-path": {
+      "type": "string",
+      "description": "Path to file or directory to include."
+    },
+    "poetry-package-format": {
+      "type": "string",
+      "enum": ["sdist", "wheel"],
+      "description": "A Python packaging format."
+    },
+    "poetry-package-formats": {
+      "oneOf": [
+        { "$ref": "#/definitions/poetry-package-format" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/definitions/poetry-package-format" }
+        }
+      ],
+      "description": "The format(s) for which the package must be included."
+    },
     "poetry-dependency-any": {
       "oneOf": [
         {
@@ -537,33 +556,41 @@
                 "required": ["include"],
                 "properties": {
                   "include": {
-                    "type": "string",
-                    "description": "What to include in the package."
+                    "$ref": "#/definitions/poetry-include-path"
                   },
                   "from": {
                     "type": "string",
                     "description": "Where the source directory of the package resides."
                   },
                   "format": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    ],
-                    "description": "The format(s) for which the package must be included."
+                    "$ref": "#/definitions/poetry-package-formats"
                   }
                 }
               }
             },
             "include": {
               "type": "array",
-              "description": "A list of files and folders to include."
+              "description": "A list of files and folders to include.",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/poetry-include-path"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["path"],
+                    "properties": {
+                      "path": {
+                        "$ref": "#/definitions/poetry-include-path"
+                      },
+                      "format": {
+                        "$ref": "#/definitions/poetry-package-formats"
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "exclude": {
               "type": "array",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -63,10 +63,14 @@
     },
     "poetry-package-formats": {
       "oneOf": [
-        { "$ref": "#/definitions/poetry-package-format" },
+        {
+          "$ref": "#/definitions/poetry-package-format"
+        },
         {
           "type": "array",
-          "items": { "$ref": "#/definitions/poetry-package-format" }
+          "items": {
+            "$ref": "#/definitions/poetry-package-format"
+          }
         }
       ],
       "description": "The format(s) for which the package must be included."
@@ -421,8 +425,12 @@
     },
     "poetry-build-section": {
       "oneOf": [
-        { "$ref": "#/definitions/poetry-build-script" },
-        { "$ref": "#/definitions/poetry-build-config" }
+        {
+          "$ref": "#/definitions/poetry-build-script"
+        },
+        {
+          "$ref": "#/definitions/poetry-build-config"
+        }
       ]
     },
     "BuildSystem": {

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -339,32 +339,53 @@
         ]
       }
     },
-    "poetry-scripts": {
+    "poetry-script-table": {
       "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z-_.0-9]+$": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/poetry-script"
-            },
-            {
-              "$ref": "#/definitions/poetry-extra-script"
-            }
-          ]
+      "oneOf": [
+        {
+          "$ref": "#/definitions/poetry-extra-script-legacy"
+        },
+        {
+          "$ref": "#/definitions/poetry-extra-scripts"
         }
-      }
+      ]
     },
-    "poetry-script": {
+    "poetry-script-legacy": {
       "type": "string",
       "description": "A simple script pointing to a callable object."
     },
-    "poetry-extra-script": {
+    "poetry-extra-scripts": {
+      "type": "object",
+      "description": "Either a console entry point or a script file that'll be included in the distribution package.",
+      "additionalProperties": false,
+      "properties": {
+        "reference": {
+          "type": "string",
+          "description": "If type is file this is the relative path of the script file, if console it is the module name."
+        },
+        "type": {
+          "description": "Value can be either file or console.",
+          "type": "string",
+          "enum": ["file", "console"]
+        },
+        "extras": {
+          "type": "array",
+          "description": "The required extras for this script. Only applicable if type is console.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["reference", "type"]
+    },
+    "poetry-extra-script-legacy": {
       "type": "object",
       "description": "A script that should be installed only if extras are activated.",
       "additionalProperties": false,
       "properties": {
         "callable": {
-          "$ref": "#/definitions/poetry-script"
+          "$ref": "#/definitions/poetry-script-legacy",
+          "description": "The entry point of the script. Deprecated in favour of reference."
         },
         "extras": {
           "type": "array",
@@ -651,8 +672,15 @@
               "type": "object",
               "description": "A hash of scripts to be installed.",
               "patternProperties": {
-                "^.+$": {
-                  "type": "string"
+                "^[a-zA-Z-_.0-9]+$": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/poetry-script-legacy"
+                    },
+                    {
+                      "$ref": "#/definitions/poetry-script-table"
+                    }
+                  ]
                 }
               }
             },

--- a/src/test/pyproject/poetry-complete.toml
+++ b/src/test/pyproject/poetry-complete.toml
@@ -27,6 +27,9 @@ cleo = { git = "https://github.com/sdispater/cleo.git", branch = "master" }
 # Optional dependencies (extras)
 pendulum = { version = "^1.4", optional = true }
 
+[tool.poetry."this key is not in the schema"]
+"but that’s" = "ok"
+
 [tool.poetry.extras]
 time = ["pendulum"]
 

--- a/src/test/pyproject/poetry-complete.toml
+++ b/src/test/pyproject/poetry-complete.toml
@@ -1,0 +1,45 @@
+[tool.poetry]
+name = "poetry"
+version = "0.5.0"
+description = "Python dependency management and packaging made easy."
+authors = ["Sébastien Eustace <sebastien@eustace.io>"]
+license = "MIT"
+
+readme = "README.rst"
+
+homepage = "https://python-poetry.org/"
+repository = "https://github.com/python-poetry/poetry"
+documentation = "https://python-poetry.org/docs"
+
+keywords = ["packaging", "dependency", "poetry"]
+
+# Requirements
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.2" # Compatible python versions must be declared here
+toml = "^0.9"
+# Dependencies with extras
+requests = { version = "^2.13", extras = ["security"] }
+# Python specific dependencies with prereleases allowed
+pathlib2 = { version = "^2.2", python = "~2.7", allows-prereleases = true }
+# Git dependencies
+cleo = { git = "https://github.com/sdispater/cleo.git", branch = "master" }
+
+# Optional dependencies (extras)
+pendulum = { version = "^1.4", optional = true }
+
+[tool.poetry.extras]
+time = ["pendulum"]
+
+[tool.poetry.dev-dependencies]
+pytest = "^3.0"
+pytest-cov = "^2.4"
+
+[tool.poetry.scripts]
+my-script = 'my_package:main'
+sample_pyscript = { reference = "script-files/sample_script.py", type = "file" }
+sample_shscript = { reference = "script-files/sample_script.sh", type = "file" }
+
+
+[[tool.poetry.source]]
+name = "foo"
+url = "https://bar.com"

--- a/src/test/pyproject/poetry-inline-table.toml
+++ b/src/test/pyproject/poetry-inline-table.toml
@@ -1,0 +1,42 @@
+[tool.poetry]
+name = "with-include"
+version = "1.2.3"
+description = "Some description."
+authors = ["Sébastien Eustace <sebastien@eustace.io>"]
+license = "MIT"
+
+homepage = "https://python-poetry.org/"
+repository = "https://github.com/python-poetry/poetry"
+documentation = "https://python-poetry.org/docs"
+
+keywords = ["packaging", "dependency", "poetry"]
+
+classifiers = [
+  "Topic :: Software Development :: Build Tools",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+packages = [{ include = "src_package", from = "src" }]
+
+include = [
+  { path = "tests", format = "sdist" },
+  { path = "wheel_only.txt", format = "wheel" },
+]
+
+# Requirements
+[tool.poetry.dependencies]
+python = "^3.6"
+cleo = "^0.6"
+cachy = { version = "^0.2.0", extras = ["msgpack"] }
+
+pendulum = { version = "^1.4", optional = true }
+
+[tool.poetry.dev-dependencies]
+pytest = "~3.4"
+
+[tool.poetry.extras]
+time = ["pendulum"]
+
+[tool.poetry.scripts]
+my-script = "my_package:main"
+my-2nd-script = "my_package:main2"

--- a/src/test/pyproject/poetry-readme-files.toml
+++ b/src/test/pyproject/poetry-readme-files.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "single-python"
+version = "0.1"
+description = "Some description."
+authors = ["Wagner Macedo <wagnerluis1982@gmail.com>"]
+license = "MIT"
+
+readme = ["README-1.rst", "README-2.rst"]
+
+homepage = "https://python-poetry.org/"
+
+
+[tool.poetry.dependencies]
+python = "2.7.15"

--- a/src/test/pyproject/poetry-sample-project.toml
+++ b/src/test/pyproject/poetry-sample-project.toml
@@ -1,0 +1,60 @@
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "Some description."
+authors = ["Sébastien Eustace <sebastien@eustace.io>"]
+license = "MIT"
+
+readme = "README.rst"
+
+homepage = "https://python-poetry.org"
+repository = "https://github.com/python-poetry/poetry"
+documentation = "https://python-poetry.org/docs"
+
+keywords = ["packaging", "dependency", "poetry"]
+
+classifiers = [
+  "Topic :: Software Development :: Build Tools",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+# Requirements
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+cleo = "^0.6"
+pendulum = { git = "https://github.com/sdispater/pendulum.git", branch = "2.0" }
+tomlkit = { git = "https://github.com/sdispater/tomlkit.git", rev = "3bff550", develop = false }
+requests = { version = "^2.18", optional = true, extras = ["security"] }
+pathlib2 = { version = "^2.2", python = "~2.7" }
+
+orator = { version = "^0.9", optional = true }
+
+# File dependency
+demo = { path = "../distributions/demo-0.1.0-py2.py3-none-any.whl" }
+
+# Dir dependency with setup.py
+my-package = { path = "../project_with_setup/" }
+
+# Dir dependency with pyproject.toml
+simple-project = { path = "../simple_project/" }
+
+# Dependency with markers
+functools32 = { version = "^3.2.3", markers = "python_version ~= '2.7' and sys_platform == 'win32' or python_version in '3.4 3.5'" }
+
+# Dependency with python constraint
+dataclasses = { version = "^0.7", python = ">=3.6.1,<3.7" }
+
+
+[tool.poetry.extras]
+db = ["orator"]
+
+[tool.poetry.group.dev.dependencies]
+pytest = "~3.4"
+
+
+[tool.poetry.scripts]
+my-script = "my_package:main"
+
+
+[tool.poetry.plugins."blogtool.parsers"]
+".rst" = "some_module::SomeClass"

--- a/src/test/pyproject/pyproject.json
+++ b/src/test/pyproject/pyproject.json
@@ -7,7 +7,11 @@
       "name": "datathing",
       "license": "other",
       "version": "0.1.0",
-      "description": "desc"
+      "description": "desc",
+      "build": {
+        "script": "build.py",
+        "generate-setup-file": true
+      }
     }
   }
 }

--- a/src/test/pyproject/pyproject.json
+++ b/src/test/pyproject/pyproject.json
@@ -8,6 +8,7 @@
       "license": "other",
       "version": "0.1.0",
       "description": "desc",
+      "authors": ["Poetry <poet@example.com>"],
       "build": {
         "script": "build.py",
         "generate-setup-file": true


### PR DESCRIPTION
With Poetry 1.2 [just around the corner](https://github.com/python-poetry/poetry/issues/5586#issuecomment-1223937688), now is a good time to backport a couple of `pyproject.toml` schema changes from poetry-core.

- python-poetry/poetry-core@fc4ae2d (Allow the develop property for git dependencies)
- python-poetry/poetry-core@08964d5 (allow disabling setup.py for sdist)
- python-poetry/poetry-core@356de20 (Add support of inline tables for include)
- python-poetry/poetry-core@f3e3792 (schema: add support for source.links boolean)
- python-poetry/poetry-core@8b1cc5e (masonry: support file scripts)
- python-poetry/poetry-core@f3215b7 (Add support for dependency groups)
- python-poetry/poetry-core@3144f1f (Add support for subdirectories for VCS dependencies)
- python-poetry/poetry-core@5994fa8 (Require that package descriptions not include newlines)
- python-poetry/poetry-core@6215dd1 (Add support for multiple README files)
- python-poetry/poetry-core@9e3796b (support indexed legacy repositories)
- python-poetry/poetry-core@3bf7ad0 (schema: relax validation to allow additional props)
- python-poetry/poetry-core@c9348e8 (Make `poetry check` detect missing `authors` property)

Looks like some projects depend on the pyproject schema in the store, for example the [Even Better TOML extension](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) for VS Code: https://github.com/tamasfe/taplo/issues/204

This PR might help such projects get ready for Poetry 1.2.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
