### PR TITLE
Add schemas "ezd" and "docker-seq"

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1283,11 +1283,7 @@
     {
       "name": "ezd schema",
       "description": "Schema for ezd task runner.\n\nSee at: https://gitlab.com/sbenv/veroxis/ezd-rs",
-      "fileMatch": [
-        "ezd.yaml",
-        "ezd.json",
-        "ezd.yml"
-      ],
+      "fileMatch": ["ezd.yaml", "ezd.json", "ezd.yml"],
       "url": "https://gitlab.com/sbenv/veroxis/ezd-rs/-/raw/HEAD/ezd.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1092,6 +1092,19 @@
       "url": "https://json.schemastore.org/dockerd.json"
     },
     {
+      "name": "docker-seq schema",
+      "description": "Schema for docker-seq.\n\nSee at: https://gitlab.com/sbenv/veroxis/docker-seq",
+      "fileMatch": [
+        "docker-seq.yaml",
+        "docker-seq.json",
+        "docker-seq.yml",
+        "*.docker-seq.yaml",
+        "*.docker-seq.json",
+        "*.docker-seq.yml"
+      ],
+      "url": "https://gitlab.com/sbenv/veroxis/docker-seq/-/raw/HEAD/docker-seq.schema.json"
+    },
+    {
       "name": "docfx.json",
       "description": "A JSON schema for DocFx configuration files",
       "fileMatch": ["docfx.json"],
@@ -1266,6 +1279,16 @@
         "41.0.0": "https://json.schemastore.org/expo-41.0.0.json",
         "42.0.0": "https://json.schemastore.org/expo-42.0.0.json"
       }
+    },
+    {
+      "name": "ezd schema",
+      "description": "Schema for ezd task runner.\n\nSee at: https://gitlab.com/sbenv/veroxis/ezd-rs",
+      "fileMatch": [
+        "ezd.yaml",
+        "ezd.json",
+        "ezd.yml"
+      ],
+      "url": "https://gitlab.com/sbenv/veroxis/ezd-rs/-/raw/HEAD/ezd.schema.json"
     },
     {
       "name": ".eslintrc",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Schemas for [ezd](https://gitlab.com/sbenv/veroxis/ezd-rs) and [docker-seq](https://gitlab.com/sbenv/veroxis/docker-seq).

Since `docker-seq` is a part of `ezd` i'm adding both in the same commit.