### PR TITLE
Add Schema: tizen_workspace.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2893,6 +2893,12 @@
       }
     },
     {
+      "name": "tizen_workspace.json",
+      "description": "Tizen project workspace configuration file",
+      "fileMatch": ["tizen_workspace.yaml"],
+      "url": "https://json.schemastore.org/tizen_workspace.json"
+    },
+    {
       "name": "tmLanguage",
       "description": "Language grammar description files in Textmate and compatible editors",
       "fileMatch": ["*.tmLanguage.json"],

--- a/src/schemas/json/tizen_workspace.json
+++ b/src/schemas/json/tizen_workspace.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
   "properties": {
     "auto_gen_build_files": {
       "type": "boolean"
@@ -14,7 +13,7 @@
     },
     "api_version": {
       "type": "number",
-	  "multipleOf": 0.1
+      "multipleOf": 0.1
     },
     "profiles_xml_path": {
       "type": "string"
@@ -24,7 +23,7 @@
     },
     "build_type": {
       "type": "string",
-	  "pattern": "^(test|debug|release)$"
+      "pattern": "^(test|debug|release)$"
     },
     "rootstrap": {
       "type": "string"
@@ -44,39 +43,39 @@
     },
     "dotnet_build_tool": {
       "type": "string",
-	  "pattern": "^(dotnet-cli|msbuild)$"
+      "pattern": "^(dotnet-cli|msbuild)$"
     },
     "tizen_net_version": {
       "type": "string",
-	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+      "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
     },
     "tizen_net_sdk_verison": {
       "type": "string",
-	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+      "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
     },
     "xamarin_forms_version": {
       "type": "string",
-	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+      "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
     },
     "msbuild_tasks_version": {
       "type": "string",
-	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+      "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
     },
     "tizen_wearable_circleui_version": {
       "type": "string",
-	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+      "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
     },
     "tizen_opentk_version": {
       "type": "string",
-	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+      "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
     },
     "tizen_nuixaml_version": {
       "type": "string",
-	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+      "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
     },
     "tizen_hotreload_version": {
       "type": "string",
-	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+      "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
     },
     "working_folder": {
       "type": ["string", "null"]
@@ -87,8 +86,8 @@
     "chrome_simulator_options": {
       "type": "array",
       "items": {
-          "type": "string"
-        }
+        "type": "string"
+      }
     },
     "chrome_simulator_data_path": {
       "type": "string"
@@ -98,17 +97,16 @@
     },
     "chrome_inspector_options": {
       "type": "array",
-	  "items": {
-          "type": "string"
-        }
-
+      "items": {
+        "type": "string"
+      }
     },
     "chrome_inspector_data_path": {
       "type": "string"
     },
     "arch": {
       "type": "string",
-	  "pattern": "^(x86|x86_64|arm|aarch64)$"
+      "pattern": "^(x86|x86_64|arm|aarch64)$"
     },
     "opt": {
       "type": "boolean"
@@ -116,23 +114,23 @@
     "src_file_patterns": {
       "type": "array",
       "items": {
-		  "type": "string"
-        }
+        "type": "string"
+      }
     },
     "test_file_patterns": {
       "type": "array",
       "items": {
-          "type": "string"
-        }
+        "type": "string"
+      }
     },
     "projects": {
       "type": "object",
       "additionalProperties": {
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		}
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
     }
   },
   "required": [
@@ -169,5 +167,6 @@
     "src_file_patterns",
     "test_file_patterns",
     "projects"
-  ]
+  ],
+  "type": "object"
 }

--- a/src/schemas/json/tizen_workspace.json
+++ b/src/schemas/json/tizen_workspace.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "auto_gen_build_files": {
+      "type": "boolean"
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^(native|web|dotnet|hybrid)$"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "api_version": {
+      "type": "number",
+	  "multipleOf": 0.1
+    },
+    "profiles_xml_path": {
+      "type": "string"
+    },
+    "signing_profile": {
+      "type": "string"
+    },
+    "build_type": {
+      "type": "string",
+	  "pattern": "^(test|debug|release)$"
+    },
+    "rootstrap": {
+      "type": "string"
+    },
+    "compiler": {
+      "type": "string",
+      "pattern": "^(llvm|gcc)$"
+    },
+    "skip_vs_files": {
+      "type": "boolean"
+    },
+    "dotnet_cli_path": {
+      "type": "string"
+    },
+    "msbuild_path": {
+      "type": "string"
+    },
+    "dotnet_build_tool": {
+      "type": "string",
+	  "pattern": "^(dotnet-cli|msbuild)$"
+    },
+    "tizen_net_version": {
+      "type": "string",
+	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+    },
+    "tizen_net_sdk_verison": {
+      "type": "string",
+	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+    },
+    "xamarin_forms_version": {
+      "type": "string",
+	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+    },
+    "msbuild_tasks_version": {
+      "type": "string",
+	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+    },
+    "tizen_wearable_circleui_version": {
+      "type": "string",
+	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+    },
+    "tizen_opentk_version": {
+      "type": "string",
+	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+    },
+    "tizen_nuixaml_version": {
+      "type": "string",
+	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+    },
+    "tizen_hotreload_version": {
+      "type": "string",
+	  "pattern": "^((?:.?[0-9]+){3,}(?:[-a-z]+)?)$"
+    },
+    "working_folder": {
+      "type": ["string", "null"]
+    },
+    "chrome_path": {
+      "type": "string"
+    },
+    "chrome_simulator_options": {
+      "type": "array",
+      "items": {
+          "type": "string"
+        }
+    },
+    "chrome_simulator_data_path": {
+      "type": "string"
+    },
+    "tv_simulator_path": {
+      "type": "string"
+    },
+    "chrome_inspector_options": {
+      "type": "array",
+	  "items": {
+          "type": "string"
+        }
+
+    },
+    "chrome_inspector_data_path": {
+      "type": "string"
+    },
+    "arch": {
+      "type": "string",
+	  "pattern": "^(x86|x86_64|arm|aarch64)$"
+    },
+    "opt": {
+      "type": "boolean"
+    },
+    "src_file_patterns": {
+      "type": "array",
+      "items": {
+		  "type": "string"
+        }
+    },
+    "test_file_patterns": {
+      "type": "array",
+      "items": {
+          "type": "string"
+        }
+    },
+    "projects": {
+      "type": "object",
+      "additionalProperties": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		}
+    }
+  },
+  "required": [
+    "auto_gen_build_files",
+    "type",
+    "profile",
+    "api_version",
+    "profiles_xml_path",
+    "signing_profile",
+    "build_type",
+    "rootstrap",
+    "compiler",
+    "skip_vs_files",
+    "dotnet_cli_path",
+    "msbuild_path",
+    "dotnet_build_tool",
+    "tizen_net_version",
+    "tizen_net_sdk_verison",
+    "xamarin_forms_version",
+    "msbuild_tasks_version",
+    "tizen_wearable_circleui_version",
+    "tizen_opentk_version",
+    "tizen_nuixaml_version",
+    "tizen_hotreload_version",
+    "working_folder",
+    "chrome_path",
+    "chrome_simulator_options",
+    "chrome_simulator_data_path",
+    "tv_simulator_path",
+    "chrome_inspector_options",
+    "chrome_inspector_data_path",
+    "arch",
+    "opt",
+    "src_file_patterns",
+    "test_file_patterns",
+    "projects"
+  ]
+}


### PR DESCRIPTION
Adds a schema for Tizen project workspace configuration file.

Signed-off-by: Om Prakash/IoT Hubcore /SRI-Bangalore/Engineer/Samsung Electronics <om90.prakash@samsung.com>

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
