### PR TITLE
Add Plugin URL Link for Visual Studio Code

### DIFF
--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -80,7 +80,7 @@
         <li>Rider</li>
         <li>RubyMine</li>
         <li>Visual Studio 2013+</li>
-        <li>Visual Studio Code</li>
+        <li>Visual Studio Code with <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml" target="_blank">YAML Support</a> and <a href="https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore" target="_blank">JSON Support</a></li>
         <li>Visual Studio for Mac</li>
         <li>WebStorm</li>
     </ul>


### PR DESCRIPTION
Add a link to reduce the [question](https://github.com/SchemaStore/schemastore/issues/2438) about plugin needed for visual studio code