### PR TITLE
Update location of ansible-lint schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -150,7 +150,7 @@
     {
       "name": "Ansible-lint Configuration",
       "description": "Ansible-lint Configuration",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-lint.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json",
       "fileMatch": [".ansible-lint", ".config/ansible-lint.yml"]
     },
     {


### PR DESCRIPTION
As ansible-lint now has its JSON schema in its own repository, we change the database to point to it.

Related: https://github.com/ansible/ansible-lint/pull/2367

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
