### PR TITLE
add grunt task: "local_check_for_schema_version_too_high"

### DIFF
--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -1035,6 +1035,27 @@ module.exports = function (grunt) {
     grunt.log.ok(`Total files scan: ${countScan}`)
   })
 
+  grunt.registerTask('local_check_for_schema_version_too_high', 'Dynamically load schema file for $schema version check', function () {
+    let countScan = 0
+    localSchemaFileAndTestFile({
+      schemaOnlyScan (callbackParameter) {
+        countScan++
+        if (schemaValidation.highSchemaVersion.includes(callbackParameter.jsonName)) {
+          return // skip the verification for this schema file
+        }
+        const schemaName = showSchemaVersions().getObj(callbackParameter.jsonObj).schemaName
+        if (schemaName === '2019-09' || schemaName === '2020-12') {
+          throwWithErrorText([`Schema version is too high => "${schemaName}" in file ${callbackParameter.jsonName}`])
+        }
+      }
+    },
+    {
+      fullScanAllFiles: true,
+      skipReadFile: false
+    })
+    grunt.log.ok(`Total files scan: ${countScan}`)
+  })
+
   grunt.registerTask('local_check_duplicate_list_in_schema-validation.json', 'Check if options list is unique in schema-validation.json', function () {
     function checkForDuplicateInList (list, listName) {
       if (list) {
@@ -1048,6 +1069,7 @@ module.exports = function (grunt) {
     checkForDuplicateInList(schemaValidation.skiptest, 'skiptest[]')
     checkForDuplicateInList(schemaValidation.missingcatalogurl, 'missingcatalogurl[]')
     checkForDuplicateInList(schemaValidation.fileMatchConflict, 'fileMatchConflict[]')
+    checkForDuplicateInList(schemaValidation.highSchemaVersion, 'highSchemaVersion[]')
 
     // Check for duplicate in options[]
     const checkList = []
@@ -1137,6 +1159,7 @@ module.exports = function (grunt) {
     x(schemaValidation.ajvNotStrictMode)
     x(schemaValidation.skiptest)
     x(schemaValidation.missingcatalogurl)
+    x(schemaValidation.highSchemaVersion)
 
     for (const item of schemaValidation.options) {
       const schemaName = Object.keys(item).pop()
@@ -1165,6 +1188,7 @@ module.exports = function (grunt) {
     x(schemaValidation.tv4test, 'tv4test')
     x(schemaValidation.ajvNotStrictMode, 'ajvNotStrictMode')
     x(schemaValidation.missingcatalogurl, 'missingcatalogurl')
+    x(schemaValidation.highSchemaVersion, 'highSchemaVersion')
 
     for (const item of schemaValidation.options) {
       const schemaName = Object.keys(item).pop()
@@ -1383,6 +1407,7 @@ module.exports = function (grunt) {
       'local_bom',
       'local_find-duplicated-property-keys',
       'local_check_for_schema_version_present',
+      'local_check_for_schema_version_too_high',
       'local_count_url_in_catalog',
       'local_count_schema_versions',
       'local_search_for_schema_without_positive_test_files',

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -206,6 +206,14 @@
     "manifest.json",
     "*.cryproj"
   ],
+  "highSchemaVersion": [
+    "---> JSON schema 2019-09 and 2020-12 are not well supported by many IDEs and should not be used <---",
+    "jsone.json",
+    "license-report-config.json",
+    "openweather.current.json",
+    "openweather.roadrisk.json",
+    "specif-1.1.json"
+  ],
   "missingcatalogurl": [
     "---> below this line are schema, that are included from other schema<---",
     "azure-deviceupdate-manifest-definitions-4.0.json",


### PR DESCRIPTION
Using JSON schema 2019-09 and 2020-12 should be discouraged. There is a list of exceptions for this 'too high' version schema 'highSchemaVersion' in src/schema-validation.json
