### PR TITLE
Unrequire `required` field in GHA inputs

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -332,7 +332,7 @@
               "type": "string"
             }
           },
-          "required": ["description", "required"],
+          "required": ["description"],
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
The linked document https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_idrequired specifically says that it's **Optional**. It was probably required in 2019 per https://github.com/SchemaStore/schemastore/pull/872/files#r352372473, but today it is wrong to demand it in schema.