### PR TITLE
Add a `git-hyper-blame` ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,24 @@
+# git hyper-blame main ignore list.
+#
+# This file contains a list of git hashes of revisions to be ignored by git
+# hyper-blame (in Git itself and on GitHub). These revisions are considered
+# "unimportant" in that they are unlikely to be what you are interested in
+# when blaming.
+#
+# Instructions:
+# - Only large (generally automated) reformatting or renaming PRs should be
+#   added to this list. Do not put things here just because you feel they are
+#   trivial or unimportant. If in doubt, do not put it on this list.
+# - Precede each revision with a comment containing the first line of its log.
+#   For bulk work over many commits, place all commits in a block with a single
+#   comment at the top describing the work done in those commits.
+# - Only put full 40-character hashes on this list (not short hashes or any
+#   other revision reference).
+# - Append to the bottom of the file (revisions should be in chronological order
+#   from oldest to newest).
+# - Because you must use a hash, you need to append to this list in a follow-up
+#   PR to the actual reformatting PR that you are trying to ignore.
+
+# Mass-formatting with prettier via
+# https://github.com/SchemaStore/schemastore/pull/2255
+6049f681741399cf73aea088680f58375c12592a


### PR DESCRIPTION
This file can be used locally via `git hyper-blame --ignore-file .git-blame-ignore-revs`
and it is now supported by GitHub web UI natively[1] [2] and is being picked up automatically.

[1]: https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/
[2]: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view