### PR TITLE
Allow specifying secrets or inputs as env

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -226,6 +226,10 @@
         },
         {
           "$ref": "#/definitions/expressionSyntax",
+          "pattern": "^\\$\\{\\{\\s*(secrets|inputs)\\s*\\}\\}$"
+        },
+        {
+          "$ref": "#/definitions/expressionSyntax",
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson",
           "pattern": "^\\$\\{\\{\\s*fromJSON\\(.*\\)\\s*\\}\\}$"
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Rationale of this PR is to pass validation for the following syntax (which works in GitHub Actions):

<img width="560" alt="Screen Shot 2022-09-03 at 6 34 05 PM" src="https://user-images.githubusercontent.com/37664182/188265182-a9edf637-436b-41dd-bae3-554ead5d6c7a.png">

I also considered adding [this link](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) as the `$comment` property,
but omitted it for now hoping there's a better link for the `$comment`..

Seemed like a simple & intuitive case, but I can add test code if necessary!!