### PR TITLE
Allow multiline expressions @ GH Actions workflows

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -308,12 +308,12 @@
     "expressionSyntax": {
       "type": "string",
       "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
-      "pattern": "^\\$\\{\\{.*\\}\\}$"
+      "pattern": "^\\$\\{\\{(.|[\r\n])*\\}\\}$"
     },
     "stringContainingExpressionSyntax": {
       "type": "string",
       "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
-      "pattern": "^.*\\$\\{\\{.*\\}\\}.*$"
+      "pattern": "^.*\\$\\{\\{(.|[\r\n])*\\}\\}.*$"
     },
     "globs": {
       "type": "array",


### PR DESCRIPTION
Sometimes, conditional expressions in GHA are complex and spreading them across multiple lines is important to keep them easy to understand. It's perfectly legal to do so. Sadly, the current implementation demands single-line expressions and this hurts readability.

Here's an example of what I typically have:
```yaml
continue-on-error: >-
  ${{
      (
        needs.pre-setup.outputs.release-requested == 'true' &&
        !github.event.inputs.YOLO
      ) && true || false
  }}
```

This patch improves the regexp in the schema to allow just.