### PR TITLE
kustomize adding includeTemplates to schema

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -449,6 +449,10 @@
           "description": "IncludeSelectors inidicates should transformer include the fieldSpecs for selectors",
           "type": "boolean"
         },
+        "includeTemplates": {
+          "description": "IncludeTemplates inidicates should transformer include the template labels",
+          "type": "boolean"
+        },
         "fields": {
           "description": "FieldSpec completely specifies a kustomizable field in a k8s API object. It helps define the operands of transformations",
           "items": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
`includeTemplates` was missing from the schema but is a valid flag.
[Upstream code.](https://github.com/kubernetes-sigs/kustomize/blob/master/api/types/labels.go#L18)