### PR TITLE
Improve drupal-info.json libraries pattern to be stricter.

### DIFF
--- a/src/negative_test/drupal-info/theme-info-wrong-library-name.yml
+++ b/src/negative_test/drupal-info/theme-info-wrong-library-name.yml
@@ -1,0 +1,9 @@
+name: starterkit_theme
+type: theme
+"base theme": stable9
+hidden: true
+starterkit: true
+version: VERSION
+core_version_requirement: ^9
+libraries:
+  - foo/bar.baz###!&^%

--- a/src/schemas/json/drupal-info.json
+++ b/src/schemas/json/drupal-info.json
@@ -58,7 +58,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^[a-z0-9_]+/[a-z0-9_\\-.]+"
+              "pattern": "^[a-z0-9_]+/[a-z0-9_\\-.]+$"
             }
           },
           "libraries-override": {


### PR DESCRIPTION
This Pull Request makes pattern for `libraries` property stricter. Because it allows to use not allowed chars and treated in JetBrains IDE wrongly because of that. More info here #2466

Also, I've added a negative test for that case.