### PR TITLE
swcrc: add jsc.preserveAllComments

### DIFF
--- a/src/schemas/json/swcrc.json
+++ b/src/schemas/json/swcrc.json
@@ -502,6 +502,10 @@
               "type": "boolean",
               "description": "If true, this option will reduce the filesize by importing from an external module"
             },
+            "preserveAllComments": {
+              "type": "boolean",
+              "description": "If true, all comments will be preserved during compilation"
+            },
             "target": {
               "type": "string",
               "description": "Specifies the target environment",


### PR DESCRIPTION
Adds [jsc.preserveAllComments](https://swc.rs/docs/configuration/compilation#jscpreserveallcomments) to the schema for `.swcrc` files.