### PR TITLE
fix: correct wildcard pattern for strmprivacy batchjob config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4091,7 +4091,7 @@
     {
       "name": "StrmPrivacy batch job configuration file",
       "description": "StrmPrivacy derived from the BatchJob protobuf definition",
-      "fileMatch": ["*batch-job-config.json*", "*batch-job-config*.yaml"],
+      "fileMatch": ["*batch-job-config*.json", "*batch-job-config*.yaml"],
       "url": "https://docs.strmprivacy.io/jsonschema/BatchJob.json",
       "versions": {
         "1.0": "https://docs.strmprivacy.io/jsonschema/BatchJob.json"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
