### PR TITLE
CodeQL should only run on JavaScript changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,11 @@ name: "CodeQL"
 
 on:
   push:
+    paths:
+      - "**.c?js"
   pull_request:
+    paths:
+      - "**.c?js"
   schedule:
     - cron: "41 3 * * 4"
 

--- a/src/package.json
+++ b/src/package.json
@@ -8,6 +8,9 @@
   "bugs": {
     "url": "https://github.com/schemastore/SchemaStore/issues"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "license": "Apache 2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
CodeQL is quite a long build process. Need to keep this to a minimum.
