### PR TITLE
Add VCPKG to Component Detection Manifest

### DIFF
--- a/src/schemas/json/component-detection-manifest.json
+++ b/src/schemas/json/component-detection-manifest.json
@@ -73,6 +73,9 @@
         },
         {
           "$ref": "#/definitions/RubyGems"
+        },
+        {
+          "$ref": "#/definitions/VCPKG"
         }
       ]
     },
@@ -354,6 +357,44 @@
         }
       },
       "required": ["type", "rubygems"]
+    },
+    "VCPKG": {
+      "title": "VCPKG",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["vcpkg"]
+        },
+        "vcpkg": {
+          "type": "object",
+          "properties": {
+            "spdxId": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "downloadLocation": {
+              "type": "string"
+            },
+            "triplet": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "portVersion": {
+              "type": "integer"
+            }
+          },
+          "required": ["spdxId", "name"]
+        }
+      },
+      "required": ["type", "vcpkg"]
     }
   },
   "title": "Component Detection manifest"

--- a/src/test/component-detection-manifest/cgmanifest.json
+++ b/src/test/component-detection-manifest/cgmanifest.json
@@ -114,7 +114,7 @@
           "name": "nlohmann-json",
           "version": "3.10.4",
           "portVersion": 5,
-          "downloadLocation": "git+https://github.com/Microsoft/vcpkg#ports/nlohmann-json",
+          "downloadLocation": "git+https://github.com/Microsoft/vcpkg#ports/nlohmann-json"
         }
       }
     }

--- a/src/test/component-detection-manifest/cgmanifest.json
+++ b/src/test/component-detection-manifest/cgmanifest.json
@@ -105,6 +105,18 @@
           "version": "1.11.2"
         }
       }
+    },
+    {
+      "component": {
+        "type": "vcpkg",
+        "vcpkg": {
+          "spdxId": "SPDXRef-port",
+          "name": "nlohmann-json",
+          "version": "3.10.4",
+          "portVersion": 5,
+          "downloadLocation": "git+https://github.com/Microsoft/vcpkg#ports/nlohmann-json",
+        }
+      }
     }
   ],
   "version": 1


### PR DESCRIPTION
This PR adds VCPKG[^1] components to the Component Detection Manifest JSON Schema. 

[^1]: https://github.com/microsoft/vcpkg