### PR TITLE
traefik: updates schemas to v2.9 requirements

### DIFF
--- a/src/schemas/json/traefik-v2-file-provider.json
+++ b/src/schemas/json/traefik-v2-file-provider.json
@@ -53,10 +53,12 @@
                 "type": "object",
                 "properties": {
                   "main": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Main defines the main domain name."
                   },
                   "sans": {
                     "type": "array",
+                    "description": "SANs defines the subject alternative domain names.",
                     "items": {
                       "type": "string"
                     }
@@ -121,6 +123,10 @@
           "type": "object",
           "description": "Configure health check to remove unhealthy servers from the load balancing rotation. Traefik will consider your servers healthy as long as they return status codes between 2XX and 3XX to the health check requests (carried out every interval). Traefik keeps monitoring the health of unhealthy servers. If a server has recovered (returning 2xx -> 3xx responses again), it will be added back to the load balancer rotation pool.",
           "properties": {
+            "method": {
+              "type": "string",
+              "description": "If defined, will apply this Method for the health check request."
+            },
             "path": {
               "type": "string",
               "description": "path is appended to the server URL to set the health check endpoint."
@@ -1302,10 +1308,12 @@
                 "type": "object",
                 "properties": {
                   "main": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Main defines the main domain name."
                   },
                   "sans": {
                     "type": "array",
+                    "description": "SANs defines the subject alternative domain names.",
                     "items": {
                       "type": "string"
                     }
@@ -1531,6 +1539,7 @@
     },
     "udp": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "routers": {
           "type": "object",
@@ -1551,6 +1560,7 @@
     "tls": {
       "type": "object",
       "description": "Configures the TLS connection, TLS options, and certificate stores.",
+      "additionalProperties": false,
       "properties": {
         "certificates": {
           "type": "array",
@@ -1576,52 +1586,55 @@
         "options": {
           "type": "object",
           "description": "The TLS options allow one to configure some parameters of the TLS connection.",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "minVersion": {
-                "type": "string",
-                "description": "Minimum TLS Version"
-              },
-              "maxVersion": {
-                "type": "string",
-                "description": "Maximum TLS Version. It is discouraged to use of this setting to disable TLS1.3. The recommended approach is to update the clients to support TLS1.3."
-              },
-              "cipherSuites": {
-                "type": "array",
-                "description": "Cipher suites defined for TLS 1.2 and below cannot be used in TLS 1.3, and vice versa. With TLS 1.3, the cipher suites are not configurable (all supported cipher suites are safe in this case).",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "curvePreferences": {
-                "type": "array",
-                "description": "This option allows to set the preferred elliptic curves in a specific order.\n\nThe names of the curves defined by crypto (e.g. CurveP521) and the RFC defined names (e.g. secp521r1) can be used.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "sniStrict": {
-                "type": "boolean",
-                "description": "With strict SNI checking enabled, Traefik won't allow connections from clients that do not specify a server_name extension or don't match any certificate configured on the tlsOption."
-              },
-              "preferServerCipherSuites": {
-                "type": "boolean",
-                "description": "This option allows the server to choose its most preferred cipher suite instead of the client's. Please note that this is enabled automatically when minVersion or maxVersion are set."
-              },
-              "clientAuth": {
-                "type": "object",
-                "description": "Traefik supports mutual authentication, through the clientAuth section.",
-                "properties": {
-                  "caFiles": {
-                    "type": "array",
-                    "description": "For authentication policies that require verification of the client certificate, the certificate authority for the certificate should be set here.",
-                    "items": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "[a-zA-Z0-9-_]+": {
+              "type": "object",
+              "properties": {
+                "minVersion": {
+                  "type": "string",
+                  "description": "Minimum TLS Version"
+                },
+                "maxVersion": {
+                  "type": "string",
+                  "description": "Maximum TLS Version. It is discouraged to use of this setting to disable TLS1.3. The recommended approach is to update the clients to support TLS1.3."
+                },
+                "cipherSuites": {
+                  "type": "array",
+                  "description": "Cipher suites defined for TLS 1.2 and below cannot be used in TLS 1.3, and vice versa. With TLS 1.3, the cipher suites are not configurable (all supported cipher suites are safe in this case).",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "curvePreferences": {
+                  "type": "array",
+                  "description": "This option allows to set the preferred elliptic curves in a specific order.\n\nThe names of the curves defined by crypto (e.g. CurveP521) and the RFC defined names (e.g. secp521r1) can be used.",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sniStrict": {
+                  "type": "boolean",
+                  "description": "With strict SNI checking enabled, Traefik won't allow connections from clients that do not specify a server_name extension or don't match any certificate configured on the tlsOption."
+                },
+                "preferServerCipherSuites": {
+                  "type": "boolean",
+                  "description": "This option allows the server to choose its most preferred cipher suite instead of the client's. Please note that this is enabled automatically when minVersion or maxVersion are set."
+                },
+                "clientAuth": {
+                  "type": "object",
+                  "description": "Traefik supports mutual authentication, through the clientAuth section.",
+                  "properties": {
+                    "caFiles": {
+                      "type": "array",
+                      "description": "For authentication policies that require verification of the client certificate, the certificate authority for the certificate should be set here.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "clientAuthType": {
                       "type": "string"
                     }
-                  },
-                  "clientAuthType": {
-                    "type": "string"
                   }
                 }
               }
@@ -1631,18 +1644,50 @@
         "stores": {
           "type": "object",
           "description": "Any store definition other than the default one (named default) will be ignored, and there is therefore only one globally available TLS store.",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "defaultCertificate": {
-                "type": "object",
-                "description": "Traefik can use a default certificate for connections without a SNI, or without a matching domain. If no default certificate is provided, Traefik generates and uses a self-signed certificate.",
-                "properties": {
-                  "certFile": {
-                    "type": "string"
-                  },
-                  "keyFile": {
-                    "type": "string"
+          "patternProperties": {
+            "[a-zA-Z0-9-_]+": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "defaultCertificate": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Traefik can use a default certificate for connections without a SNI, or without a matching domain. If no default certificate is provided, Traefik generates and uses a self-signed certificate.",
+                  "properties": {
+                    "certFile": {
+                      "type": "string"
+                    },
+                    "keyFile": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "defaultGeneratedCert": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "GeneratedCert defines the default generated certificate configuration.",
+                  "properties": {
+                    "resolver": {
+                      "type": "string",
+                      "description": "Resolver is the name of the resolver that will be used to issue the DefaultCertificate."
+                    },
+                    "domain": {
+                      "type": "object",
+                      "description": "Domain is the domain definition for the DefaultCertificate.",
+                      "properties": {
+                        "main": {
+                          "type": "string",
+                          "description": "Main defines the main domain name."
+                        },
+                        "sans": {
+                          "type": "array",
+                          "description": "SANs defines the subject alternative domain names.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/src/schemas/json/traefik-v2.json
+++ b/src/schemas/json/traefik-v2.json
@@ -37,7 +37,7 @@
             "names": {
               "type": "object",
               "patternProperties": {
-                "[a-zA-Z0-9-_]*": {
+                "[a-zA-Z0-9-_]+": {
                   "type": "string"
                 }
               }
@@ -51,7 +51,7 @@
                 "names": {
                   "type": "object",
                   "patternProperties": {
-                    "[a-zA-Z0-9-_]*": {
+                    "[a-zA-Z0-9-_]+": {
                       "type": "string"
                     }
                   }
@@ -84,7 +84,7 @@
     "certificatesResolvers": {
       "type": "object",
       "patternProperties": {
-        "[a-zA-Z0-9-_]*": {
+        "[a-zA-Z0-9-_]+": {
           "type": "object",
           "properties": {
             "acme": {
@@ -160,7 +160,7 @@
     "entryPoints": {
       "type": "object",
       "patternProperties": {
-        "[a-zA-Z0-9-_]*": {
+        "[a-zA-Z0-9-_]+": {
           "type": "object",
           "properties": {
             "address": {
@@ -329,7 +329,7 @@
         "plugins": {
           "type": "object",
           "patternProperties": {
-            "[a-zA-Z0-9-_]*": {
+            "[a-zA-Z0-9-_]+": {
               "type": "object",
               "properties": {
                 "moduleName": {
@@ -346,7 +346,7 @@
         "localPlugins": {
           "type": "object",
           "patternProperties": {
-            "[a-zA-Z0-9-_]*": {
+            "[a-zA-Z0-9-_]+": {
               "type": "object",
               "properties": {
                 "moduleName": {
@@ -1102,6 +1102,9 @@
             "exposedByDefault": {
               "type": "boolean"
             },
+            "ecsAnywhere": {
+              "type": "boolean"
+            },
             "refreshSeconds": {
               "type": "integer"
             },
@@ -1140,12 +1143,6 @@
               "items": {
                 "type": "string"
               }
-            },
-            "username": {
-              "type": "string"
-            },
-            "password": {
-              "type": "string"
             },
             "token": {
               "type": "string"
@@ -1201,9 +1198,6 @@
             "password": {
               "type": "string"
             },
-            "token": {
-              "type": "string"
-            },
             "tls": {
               "type": "object",
               "properties": {
@@ -1245,30 +1239,6 @@
             },
             "password": {
               "type": "string"
-            },
-            "token": {
-              "type": "string"
-            },
-            "tls": {
-              "type": "object",
-              "properties": {
-                "ca": {
-                  "type": "string"
-                },
-                "caOptional": {
-                  "type": "boolean"
-                },
-                "cert": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "string"
-                },
-                "insecureSkipVerify": {
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -1291,8 +1261,8 @@
             "password": {
               "type": "string"
             },
-            "token": {
-              "type": "string"
+            "db": {
+              "type": "integer"
             },
             "tls": {
               "type": "object",
@@ -1357,7 +1327,7 @@
         "plugin": {
           "type": "object",
           "patternProperties": {
-            "[a-zA-Z0-9-_]*": {
+            "[a-zA-Z0-9-_]+": {
               "type": "object"
             }
           }
@@ -1477,6 +1447,15 @@
             },
             "globalTag": {
               "type": "string"
+            },
+            "globalTags": {
+              "type": "object",
+              "description": "Sets a list of key:value tags on all spans.",
+              "patternProperties": {
+                "[a-zA-Z0-9-_]+": {
+                  "type": "string"
+                }
+              }
             },
             "debug": {
               "type": "boolean"

--- a/src/test/traefik-v2-file-provider/example.json
+++ b/src/test/traefik-v2-file-provider/example.json
@@ -565,12 +565,26 @@
         "defaultCertificate": {
           "certFile": "foobar",
           "keyFile": "foobar"
+        },
+        "defaultGeneratedCert": {
+          "resolver": "foobar",
+          "domain": {
+            "main": "foobar",
+            "sans": ["foobar", "foobar"]
+          }
         }
       },
       "Store1": {
         "defaultCertificate": {
           "certFile": "foobar",
           "keyFile": "foobar"
+        },
+        "defaultGeneratedCert": {
+          "resolver": "foobar",
+          "domain": {
+            "main": "foobar",
+            "sans": ["foobar", "foobar"]
+          }
         }
       }
     }

--- a/src/test/traefik-v2/example.json
+++ b/src/test/traefik-v2/example.json
@@ -218,7 +218,8 @@
       "addRoutersLabels": true,
       "addServicesLabels": true,
       "additionalLabels": {
-        "foobar": "foobar"
+        "name0": "foobar",
+        "name1": "foobar"
       }
     },
     "influxDB2": {
@@ -231,7 +232,8 @@
       "addRoutersLabels": true,
       "addServicesLabels": true,
       "additionalLabels": {
-        "foobar": "foobar"
+        "name0": "foobar",
+        "name1": "foobar"
       }
     }
   },
@@ -359,9 +361,9 @@
       "connectAware": true,
       "connectByDefault": true,
       "serviceName": "foobar",
+      "watch": true,
       "namespace": "foobar",
       "namespaces": ["foobar", "foobar"],
-      "watch": true,
       "endpoint": {
         "address": "foobar",
         "scheme": "foobar",
@@ -382,13 +384,13 @@
       }
     },
     "nomad": {
+      "defaultRule": "foobar",
       "constraints": "foobar",
       "prefix": "foobar",
-      "refreshInterval": "42s",
       "stale": true,
-      "exposedByDefault": true,
-      "defaultRule": "foobar",
       "namespace": "foobar",
+      "exposedByDefault": true,
+      "refreshInterval": "42s",
       "endpoint": {
         "address": "foobar",
         "region": "foobar",
@@ -412,13 +414,12 @@
       "autoDiscoverClusters": true,
       "region": "foobar",
       "accessKeyID": "foobar",
-      "secretAccessKey": "foobar"
+      "secretAccessKey": "foobar",
+      "ecsAnywhere": true
     },
     "consul": {
       "rootKey": "foobar",
       "endpoints": ["foobar", "foobar"],
-      "username": "foobar",
-      "password": "foobar",
       "token": "foobar",
       "namespace": "foobar",
       "namespaces": ["foobar", "foobar"],
@@ -435,7 +436,6 @@
       "endpoints": ["foobar", "foobar"],
       "username": "foobar",
       "password": "foobar",
-      "token": "foobar",
       "tls": {
         "ca": "foobar",
         "caOptional": true,
@@ -448,22 +448,14 @@
       "rootKey": "foobar",
       "endpoints": ["foobar", "foobar"],
       "username": "foobar",
-      "password": "foobar",
-      "token": "foobar",
-      "tls": {
-        "ca": "foobar",
-        "caOptional": true,
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      }
+      "password": "foobar"
     },
     "redis": {
       "rootKey": "foobar",
       "endpoints": ["foobar", "foobar"],
       "username": "foobar",
       "password": "foobar",
-      "token": "foobar",
+      "db": 42,
       "tls": {
         "ca": "foobar",
         "caOptional": true,
@@ -526,6 +518,10 @@
     "datadog": {
       "localAgentHostPort": "foobar",
       "globalTag": "foobar",
+      "globalTags": {
+        "tag1": "foobar",
+        "tag2": "foobar"
+      },
       "debug": true,
       "prioritySampling": true,
       "traceIDHeaderName": "foobar",


### PR DESCRIPTION
This PR updates Traefik schemas to satisfy [v2.9](https://github.com/traefik/traefik/releases/tag/v2.9.0-rc2) static and dynamic configuration requirements.