### PR TITLE
Added  ize.toml schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4124,6 +4124,16 @@
         "18.0.0": "https://raw.githubusercontent.com/dahag-ag/keycloak-openapi/main/OpenApiDefinitions/keycloak-18.0.0.json",
         "19.0.0": "https://raw.githubusercontent.com/dahag-ag/keycloak-openapi/main/OpenApiDefinitions/keycloak-19.0.0.json"
       }
+    },
+    {
+      "name": "ize.toml",
+      "description": "TOML Schema ❯ize Infra Tool",
+      "fileMatch": ["ize.toml"],
+      "url": "https://raw.githubusercontent.com/hazelops/ize/1.1.5/internal/schema/ize-spec.json",
+      "versions": {
+        "1.1.5": "https://raw.githubusercontent.com/hazelops/ize/1.1.5/internal/schema/ize-spec.json",
+        "1.1.4": "https://raw.githubusercontent.com/hazelops/ize/1.1.4/internal/schema/ize-spec.json"
+      }
     }
   ],
   "version": 1


### PR DESCRIPTION
Adds support of ize.toml schema for the https://github.com/hazelops/ize infra tool.
