### PR TITLE
Add JDownloader2 crawler rules schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1696,6 +1696,18 @@
       "url": "https://jenkins-x.io/schemas/jx-requirements.json"
     },
     {
+      "name": "JDownloader2 crawler single-rule schema",
+      "description": "A schema for validating a single jdownloader2 rule",
+      "fileMatch": ["*.jd2cr","*.jd2cr.json"],
+      "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2cr.schema.json"
+    },
+    {
+      "name": "JDownloader2 crawler multi-rule schema",
+      "description": "A schema for validating an array of jdownloader2 rules.",
+      "fileMatch": ["*.jd2mcr","*.jd2mcr.json"],
+      "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2mcr.schema.json"
+    },
+    {
       "name": "JFrog File Spec",
       "description": "JFrog File Spec schema definition",
       "fileMatch": ["**/filespecs/*.json", "*filespec*.json", "*.filespec"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1698,13 +1698,13 @@
     {
       "name": "JDownloader2 crawler single-rule schema",
       "description": "A schema for validating a single jdownloader2 rule",
-      "fileMatch": ["*.jd2cr","*.jd2cr.json"],
+      "fileMatch": ["*.jd2cr", "*.jd2cr.json"],
       "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2cr.schema.json"
     },
     {
       "name": "JDownloader2 crawler multi-rule schema",
       "description": "A schema for validating an array of jdownloader2 rules.",
-      "fileMatch": ["*.jd2mcr","*.jd2mcr.json", "*.linkcrawlerrules.json"],
+      "fileMatch": ["*.jd2mcr", "*.jd2mcr.json", "*.linkcrawlerrules.json"],
       "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2mcr.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1704,7 +1704,7 @@
     {
       "name": "JDownloader2 crawler multi-rule schema",
       "description": "A schema for validating an array of jdownloader2 rules.",
-      "fileMatch": ["*.jd2mcr","*.jd2mcr.json"],
+      "fileMatch": ["*.jd2mcr","*.jd2mcr.json", "*.linkcrawlerrules.json"],
       "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2mcr.schema.json"
     },
     {


### PR DESCRIPTION
Please, review and accept to add JDownloader2 website crawler rule schemas to the store. The single rule schema is for validating a single rule object. The multi-rule schema is for validating an array of rule objects, which is the format that JD2's input field uses.

I chose not to use versioning because JD2's versioning model is "autoupdate forward only", so the standard download is always the latest version. Any changes made to the program in the rule parsing will pretty much cause the schema to follow suit without dangling old schema versions.

I have tested the schemas myself but since I'm not including the files into the schemastore repo there's no point in adding the src/test or src/negative_test files. If the reviewer feels like giving it a manual go, my testfiles are [here](https://github.com/sergxerj/jdownloader2-crawler-rule-json-schema/tree/main/tests). The repo has instructions in the README.md and includes a .vscode/settings.json file to apply the schemas locally, so downloading the repo and opening all files in test/ should do for a quick way.

Thanks in advance for the approval/feedback.