### PR TITLE
Add @factorial/drupal-breakpoints-css schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -17,6 +17,12 @@
       }
     },
     {
+      "name": "@factorial/drupal-breakpoints-css",
+      "description": "JSON Schema for @factorial/drupal-breakpoints-css config file",
+      "fileMatch": ["breakpoints.config.yml"],
+      "url": "https://raw.githubusercontent.com/factorial-io/drupal-breakpoints-css/main/schema/drupal-breakpoints-css.json"
+    },
+    {
       "name": ".adonisrc.json",
       "description": "AdonisJS configuration file",
       "fileMatch": [".adonisrc.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -20,7 +20,7 @@
       "name": "@factorial/drupal-breakpoints-css",
       "description": "JSON Schema for @factorial/drupal-breakpoints-css config file",
       "fileMatch": ["breakpoints.config.yml"],
-      "url": "https://raw.githubusercontent.com/factorial-io/drupal-breakpoints-css/main/schema/drupal-breakpoints-css.json"
+      "url": "https://json.schemastore.org/factorial-drupal-breakpoints-css-0.1.0.json"
     },
     {
       "name": ".adonisrc.json",

--- a/src/schemas/json/factorial-drupal-breakpoints-css-0.1.0.json
+++ b/src/schemas/json/factorial-drupal-breakpoints-css-0.1.0.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/drupal-breakpoints-css",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "drupal-breakpoints-css": {
       "title": "Drupal breakpoints to CSS configuration",

--- a/src/schemas/json/factorial-drupal-breakpoints-css-0.1.0.json
+++ b/src/schemas/json/factorial-drupal-breakpoints-css-0.1.0.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/drupal-breakpoints-css",
+  "definitions": {
+    "drupal-breakpoints-css": {
+      "title": "Drupal breakpoints to CSS configuration",
+      "description": "https://github.com/factorial-io/drupal-breakpoints-css",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "drupal": {
+          "$ref": "#/definitions/drupal"
+        },
+        "js": {
+          "$ref": "#/definitions/js"
+        },
+        "css": {
+          "$ref": "#/definitions/css"
+        },
+        "options": {
+          "$ref": "#/definitions/options"
+        },
+        "prettier": {
+          "$ref": "#/definitions/prettier"
+        }
+      },
+      "required": ["drupal"]
+    },
+    "drupal": {
+      "title": "Drupal configuration",
+      "description": "https://github.com/factorial-io/drupal-breakpoints-css",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "breakpointsPath": {
+          "type": "string"
+        },
+        "themeName": {
+          "type": "string"
+        }
+      },
+      "required": ["breakpointsPath", "themeName"]
+    },
+    "js": {
+      "title": "JavaScript configuration",
+      "description": "https://github.com/factorial-io/drupal-breakpoints-css",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": ["module", "commonjs"]
+        }
+      }
+    },
+    "css": {
+      "title": "CSS configuration",
+      "description": "https://github.com/factorial-io/drupal-breakpoints-css",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "element": {
+          "type": "string"
+        }
+      }
+    },
+    "options": {
+      "title": "Toggle available extraction options",
+      "description": "https://github.com/factorial-io/drupal-breakpoints-css",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mediaQuery": {
+          "type": "boolean"
+        },
+        "resolution": {
+          "type": "boolean"
+        },
+        "minWidth": {
+          "type": "boolean"
+        },
+        "maxWidth": {
+          "type": "boolean"
+        }
+      }
+    },
+    "prettier": {
+      "title": "Prettier options",
+      "description": "https://github.com/factorial-io/drupal-breakpoints-css",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "configPath": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/test/factorial-drupal-breakpoints-css-0.1.0/mandatory.json
+++ b/src/test/factorial-drupal-breakpoints-css-0.1.0/mandatory.json
@@ -1,0 +1,6 @@
+{
+  "drupal": {
+    "breakpointsPath": "breakpoints.yml",
+    "themeName": "themeName"
+  }
+}

--- a/src/test/factorial-drupal-breakpoints-css-0.1.0/optional.json
+++ b/src/test/factorial-drupal-breakpoints-css-0.1.0/optional.json
@@ -1,25 +1,25 @@
 {
+  "css": {
+    "enabled": true,
+    "path": "./breakpoints.css",
+    "element": ":root"
+  },
   "drupal": {
     "breakpointsPath": "breakpoints.yml",
     "themeName": "themeName"
-  },
-  "prettier": {
-    "configPath": "./.prettierrc"
   },
   "js": {
     "enabled": true,
     "path": "./breakpoints.js",
     "type": "commonjs"
   },
-  "css": {
-    "enabled": true,
-    "path": "./breakpoints.css",
-    "element": ":root"
-  },
   "options": {
     "mediaQuery": true,
     "resolution": false,
     "minWidth": false,
     "maxWidth": false
+  },
+  "prettier": {
+    "configPath": "./.prettierrc"
   }
 }

--- a/src/test/factorial-drupal-breakpoints-css-0.1.0/optional.json
+++ b/src/test/factorial-drupal-breakpoints-css-0.1.0/optional.json
@@ -1,0 +1,25 @@
+{
+  "drupal": {
+    "breakpointsPath": "breakpoints.yml",
+    "themeName": "themeName"
+  },
+  "prettier": {
+    "configPath": "./.prettierrc"
+  },
+  "js": {
+    "enabled": true,
+    "path": "./breakpoints.js",
+    "type": "commonjs"
+  },
+  "css": {
+    "enabled": true,
+    "path": "./breakpoints.css",
+    "element": ":root"
+  },
+  "options": {
+    "mediaQuery": true,
+    "resolution": false,
+    "minWidth": false,
+    "maxWidth": false
+  }
+}


### PR DESCRIPTION
"Drupal breakpoints css" is a small script to parse a custom theme Drupal breakpoints file and generate custom properties as well as a JavaScript object to reduce the amount of points of failure and to reduce inconsistencies between the frontend and backend. 

Read more about @factorial/drupal-breakpoints-css here: https://github.com/factorial-io/drupal-breakpoints-css

Thanks for adding!
Greetings,
Dennis