### PR TITLE
Remove UmbracoPath from appsettings

### DIFF
--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -921,11 +921,6 @@
           "type": "integer",
           "default": 7
         },
-        "UmbracoPath": {
-          "description": "Umbraco back-office path",
-          "type": "string",
-          "default": "~/umbraco"
-        },
         "IconsPath": {
           "description": "Path to Umbraco Icons for backoffice",
           "type": "string",

--- a/src/test/appsettings/umbraco-more-settings.json
+++ b/src/test/appsettings/umbraco-more-settings.json
@@ -23,7 +23,6 @@
         "TimeOut": "00:20:00",
         "UmbracoCssPath": "~/css",
         "UmbracoMediaPath": "~/media",
-        "UmbracoPath": "~/umbraco",
         "UseHttps": false,
         "VersionCheckPeriod": 7,
         "Smtp": {

--- a/src/test/appsettings/umbraco.json
+++ b/src/test/appsettings/umbraco.json
@@ -10,7 +10,6 @@
       "Global": {
         "DefaultUILanguage": "en-us",
         "HideTopLevelNodeFromPath": true,
-        "UmbracoPath": "~/umbraco",
         "TimeOutInMinutes": 20,
         "UseHttps": false
       },


### PR DESCRIPTION
This PR removes the Umbraco CMS configuration `UmbracoPath` from appsettings.

`UmbracoPath` is no longer considered configurable in Umbraco CMS, as the feature is broken and about to be removed entirely from the CMS (see https://github.com/umbraco/Umbraco-CMS/pull/13032 and https://github.com/umbraco/UmbracoDocs/pull/4389)
