### PR TITLE
Update CircleCI schema for allowed & default setup_remote_docker versions

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -620,16 +620,16 @@
             "version": {
               "description": "If your build requires a specific docker image, you can set it as an image attribute",
               "enum": [
+		"20.10.17",
                 "20.10.14",
                 "20.10.12",
                 "20.10.11",
                 "20.10.7",
                 "20.10.6",
                 "20.10.2",
-                "19.03.13",
-                "17.09.0-ce"
+                "19.03.13"
               ],
-              "default": "17.09.0-ce"
+              "default": "20.10.17"
             }
           }
         },

--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -620,7 +620,7 @@
             "version": {
               "description": "If your build requires a specific docker image, you can set it as an image attribute",
               "enum": [
-		"20.10.17",
+                "20.10.17",
                 "20.10.14",
                 "20.10.12",
                 "20.10.11",


### PR DESCRIPTION
Issue I am seeing in vs code:


![Screenshot 2022-09-20 at 13 32 12](https://user-images.githubusercontent.com/171002/191261188-01856579-12f4-4f20-b991-e1b6336b320e.png)


Updating schema for CirclCI as per docs: https://circleci.com/docs/building-docker-images#docker-version