### PR TITLE
Add TSON schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3013,6 +3013,12 @@
       "url": "https://json.schemastore.org/tslint.json"
     },
     {
+      "name": "TSON",
+      "description": "Schema for TSON (Tuning-Spectrum Object Notation) data",
+      "fileMatch": ["*.tson", "*.tson.yaml", "*.tson.yml", "*.tson.json"],
+      "url": "https://raw.githubusercontent.com/spectral-discord/TSON/main/schema/tson.json"
+    },
+    {
       "name": "typewiz.json",
       "description": "Typewiz configuration file",
       "fileMatch": ["typewiz.json"],


### PR DESCRIPTION
A couple notes:
- I've set up automated testing in the repo that the `url` points to, so I didn't include tests here. That way I won't have to update tests in both places if changes are made to the schema.
- One of the file patterns I included is `*.tson`. This is for users who want their editors to associate files with a `.tson` extension with `.yaml`, rather than appending `.tson` to the filename as in the other patterns.

Lemme know if either of those is an issue!