### PR TITLE
Add Ansible Argument Specs Schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -82,19 +82,19 @@
     {
       "name": "Ansible Execution Environment",
       "description": "Ansible execution-environment.yml file",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-ee.json",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-ee.json",
       "fileMatch": ["**/execution-environment.yml"]
     },
     {
       "name": "Ansible Meta",
       "description": "Ansible meta/main.yml file",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-meta.json",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-meta.json",
       "fileMatch": ["**/meta/main.yml"]
     },
     {
       "name": "Ansible Meta Runtime",
       "description": "Ansible meta/runtime.yml file",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-meta-runtime.json",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-meta-runtime.json",
       "fileMatch": ["**/meta/runtime.yml"]
     },
     {
@@ -106,13 +106,13 @@
     {
       "name": "Ansible Requirements",
       "description": "Ansible requirements file",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-requirements.json",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-requirements.json",
       "fileMatch": ["requirements.yml"]
     },
     {
       "name": "Ansible Vars File",
       "description": "Ansible variables File",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-vars.json",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-vars.json",
       "fileMatch": [
         "**/vars/*.yml",
         "**/vars/*.yaml",
@@ -127,7 +127,7 @@
     {
       "name": "Ansible Tasks File",
       "description": "Ansible tasks file",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible.json#/$defs/tasks",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible.json#/$defs/tasks",
       "fileMatch": [
         "**/tasks/*.yml",
         "**/tasks/*.yaml",
@@ -138,7 +138,7 @@
     {
       "name": "Ansible Playbook",
       "description": "Ansible playbook files",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible.json#/$defs/playbook",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible.json#/$defs/playbook",
       "fileMatch": [
         "playbook.yml",
         "playbook.yaml",
@@ -151,13 +151,13 @@
     {
       "name": "Ansible Inventory",
       "description": "Ansible inventory files",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-inventory.json",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-inventory.json",
       "fileMatch": ["inventory.yml", "inventory.yaml"]
     },
     {
       "name": "Ansible Collection Galaxy",
       "description": "Ansible Collection Galaxy metadata",
-      "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-galaxy.json",
+      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-galaxy.json",
       "fileMatch": ["galaxy.yml"]
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -98,6 +98,12 @@
       "fileMatch": ["**/meta/runtime.yml"]
     },
     {
+      "name": "Ansible Argument Specs",
+      "description": "Ansible meta/argument_specs.yml file",
+      "url": "https://github.com/ansible/schemas/raw/main/f/ansible-argument-specs.json",
+      "fileMatch": ["**/meta/argument_specs.yml"]
+    },
+    {
       "name": "Ansible Requirements",
       "description": "Ansible requirements file",
       "url": "https://raw.githubusercontent.com/ansible-community/schemas/main/f/ansible-requirements.json",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
I noticed that [Ansible Argument Specs Schema](https://github.com/ansible/schemas/blob/main/f/ansible-argument-specs.json) is not in the catalog.

Also I changed URLs from ansible-community to ansible. Right now https://github.com/ansible-community/schemas redirects to https://github.com/ansible/schemas.