### PR TITLE
Add `experiment_apis` to `webextension.json`

### DIFF
--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -348,6 +348,79 @@
       "type": "string",
       "description": "A DevTools extension adds functionality to the Chrome DevTools. It can add new UI panels and sidebars, interact with the inspected page, get information about network requests, and more."
     },
+    "experiment_apis": {
+      "type": "object",
+      "items": {
+        "type": "object",
+        "required": ["schema"],
+
+        "properties": {
+          "child": {
+            "type": "object",
+            "required": ["paths", "script", "scopes"],
+            "properties": {
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+
+              "scopes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+
+              "script": {
+                "type": "string"
+              }
+            }
+          },
+          "parent": {
+            "type": "object",
+            "required": ["paths", "scopes", "scripts"],
+
+            "properties": {
+              "events": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+
+              "scopes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+
+              "script": {
+                "type": "string"
+              }
+            }
+          },
+          "schema": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "homepage_url": {
       "type": "string",
       "description": "The URL of the homepage for this add-on. The add-on management page will contain a link to this URL.",

--- a/src/test/webextension/webcompat-reporter.json
+++ b/src/test/webextension/webcompat-reporter.json
@@ -1,0 +1,71 @@
+{
+  "manifest_version": 2,
+  "name": "WebCompat Reporter",
+  "description": "Report site compatibility issues on webcompat.com",
+  "author": "Thomas Wisniewski <twisniewski@mozilla.com>",
+  "version": "1.5.0",
+  "homepage_url": "https://github.com/mozilla/webcompat-reporter",
+  "applications": {
+    "gecko": {
+      "id": "webcompat-reporter@mozilla.org"
+    }
+  },
+  "experiment_apis": {
+    "aboutConfigPrefs": {
+      "schema": "experimentalAPIs/aboutConfigPrefs.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experimentalAPIs/aboutConfigPrefs.js",
+        "paths": [["aboutConfigPrefs"]]
+      }
+    },
+    "browserInfo": {
+      "schema": "experimentalAPIs/browserInfo.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experimentalAPIs/browserInfo.js",
+        "paths": [["browserInfo"]]
+      }
+    },
+    "helpMenu": {
+      "schema": "experimentalAPIs/helpMenu.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experimentalAPIs/helpMenu.js",
+        "paths": [["helpMenu"]]
+      }
+    },
+    "l10n": {
+      "schema": "experimentalAPIs/l10n.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experimentalAPIs/l10n.js",
+        "paths": [["l10n"]]
+      }
+    },
+    "tabExtras": {
+      "schema": "experimentalAPIs/tabExtras.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experimentalAPIs/tabExtras.js",
+        "paths": [["tabExtras"]]
+      }
+    }
+  },
+  "icons": {
+    "16": "icons/lightbulb.svg",
+    "32": "icons/lightbulb.svg",
+    "48": "icons/lightbulb.svg",
+    "96": "icons/lightbulb.svg",
+    "128": "icons/lightbulb.svg"
+  },
+  "permissions": [
+    "tabs",
+    "<all_urls>"
+  ],
+  "background": {
+    "scripts": [
+      "background.js"
+    ]
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

The schema for this pull request is based of [this example](https://searchfox.org/mozilla-central/source/browser/extensions/report-site-issue/manifest.json) (which is included as a test) and [Mozilla's internal schema files](https://searchfox.org/mozilla-central/source/toolkit/components/extensions/schemas/experiments.json). Fixes #2499.