### PR TITLE
Add new run-name Github Workflow parameter

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1713,6 +1713,11 @@
       "minProperties": 1,
       "additionalProperties": false
     },
+    "run-name": {
+      "$comment": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name",
+      "description": "The name for workflow runs generated from the workflow. GitHub displays the workflow run name in the list of workflow runs on your repository's 'Actions' tab.",
+      "type": "string"
+    },
     "permissions": {
       "$ref": "#/definitions/permissions"
     }


### PR DESCRIPTION
Add new `run-name` parameter to the schema for Github (Actions) Workflows.

Reference:

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name
- https://github.blog/changelog/2022-09-26-github-actions-dynamic-names-for-workflow-runs/