### PR TITLE
drone.json - Add Kubernetes volumes types

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -124,6 +124,12 @@
           },
           {
             "required": ["name", "temp"]
+          },
+          {
+            "required": ["name", "claim"]
+          },
+          {
+            "required": ["name", "config_map"]
           }
         ],
         "properties": {
@@ -145,6 +151,31 @@
               "medium": {
                 "type": "string",
                 "enum": ["memory"]
+              }
+            }
+          },
+          "claim": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/nonEmptyString"
+              },
+              "read_only": {
+                "type": "boolean"
+              }
+            }
+          },
+          "config_map": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/nonEmptyString"
+              },
+              "default_mode": {
+                "type": "integer"
+              },
+              "optional": {
+                "type": "boolean"
               }
             }
           }

--- a/src/test/drone/kubernetes_volumes.yaml
+++ b/src/test/drone/kubernetes_volumes.yaml
@@ -3,25 +3,25 @@ name: deploy/test/docker
 kind: kubernetes
 
 steps:
-- name: build
-  image: node
-  pull: if-not-exists
-  commands: 
-  - npm install
-  - npm test
-  volumes:
-  - name: shared
-    path: /shared
-  - name: build-config
-    path: /my-config-dir
+  - name: build
+    image: node
+    pull: if-not-exists
+    commands:
+      - npm install
+      - npm test
+    volumes:
+      - name: shared
+        path: /shared
+      - name: build-config
+        path: /my-config-dir
 
 volumes:
-- name: shared
-  claim:
-    name: received-data-claim
-    read_only: false # <true|false>
-- name: build-config
-  config_map:
-    name: my-build-config
-    default_mode: 420     # same as 644 in octal, or u+w,a+r
-    optional: false
+  - name: shared
+    claim:
+      name: received-data-claim
+      read_only: false # <true|false>
+  - name: build-config
+    config_map:
+      name: my-build-config
+      default_mode: 420 # same as 644 in octal, or u+w,a+r
+      optional: false

--- a/src/test/drone/kubernetes_volumes.yaml
+++ b/src/test/drone/kubernetes_volumes.yaml
@@ -1,0 +1,27 @@
+type: docker
+name: deploy/test/docker
+kind: kubernetes
+
+steps:
+- name: build
+  image: node
+  pull: if-not-exists
+  commands: 
+  - npm install
+  - npm test
+  volumes:
+  - name: shared
+    path: /shared
+  - name: build-config
+    path: /my-config-dir
+
+volumes:
+- name: shared
+  claim:
+    name: received-data-claim
+    read_only: false # <true|false>
+- name: build-config
+  config_map:
+    name: my-build-config
+    default_mode: 420     # same as 644 in octal, or u+w,a+r
+    optional: false

--- a/src/test/drone/kubernetes_volumes.yaml
+++ b/src/test/drone/kubernetes_volumes.yaml
@@ -3,25 +3,25 @@ type: kubernetes
 name: default
 
 steps:
-- name: build
-  image: node
-  pull: if-not-exists
-  commands: 
-  - npm install
-  - npm test
-  volumes:
-  - name: shared
-    path: /shared
-  - name: build-config
-    path: /my-config-dir
+  - name: build
+    image: node
+    pull: if-not-exists
+    commands:
+      - npm install
+      - npm test
+    volumes:
+      - name: shared
+        path: /shared
+      - name: build-config
+        path: /my-config-dir
 
 volumes:
-- name: shared
-  claim:
-    name: received-data-claim
-    read_only: false # <true|false>
-- name: build-config
-  config_map:
-    name: my-build-config
-    default_mode: 420     # same as 644 in octal, or u+w,a+r
-    optional: false
+  - name: shared
+    claim:
+      name: received-data-claim
+      read_only: false # <true|false>
+  - name: build-config
+    config_map:
+      name: my-build-config
+      default_mode: 420 # same as 644 in octal, or u+w,a+r
+      optional: false

--- a/src/test/drone/kubernetes_volumes.yaml
+++ b/src/test/drone/kubernetes_volumes.yaml
@@ -1,27 +1,27 @@
-type: docker
-name: deploy/test/docker
-kind: kubernetes
+kind: pipeline
+type: kubernetes
+name: default
 
 steps:
-  - name: build
-    image: node
-    pull: if-not-exists
-    commands:
-      - npm install
-      - npm test
-    volumes:
-      - name: shared
-        path: /shared
-      - name: build-config
-        path: /my-config-dir
+- name: build
+  image: node
+  pull: if-not-exists
+  commands: 
+  - npm install
+  - npm test
+  volumes:
+  - name: shared
+    path: /shared
+  - name: build-config
+    path: /my-config-dir
 
 volumes:
-  - name: shared
-    claim:
-      name: received-data-claim
-      read_only: false # <true|false>
-  - name: build-config
-    config_map:
-      name: my-build-config
-      default_mode: 420 # same as 644 in octal, or u+w,a+r
-      optional: false
+- name: shared
+  claim:
+    name: received-data-claim
+    read_only: false # <true|false>
+- name: build-config
+  config_map:
+    name: my-build-config
+    default_mode: 420     # same as 644 in octal, or u+w,a+r
+    optional: false


### PR DESCRIPTION
add kubernetes volumes types

original docs: 
- [PersistentVolumeClaim | Drone](https://docs.drone.io/pipeline/kubernetes/syntax/volumes/persistentvolumeclaim/)
- [ConfigMap Volumes | Drone](https://docs.drone.io/pipeline/kubernetes/syntax/volumes/configmap/)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
