### PR TITLE
Fix typo in property name

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -192,7 +192,7 @@
           "description": "Set to true to display a message when the project is building.",
           "default": true
         },
-        "instpectUri": {
+        "inspectUri": {
           "type": "string",
           "description": "The url to enable debugging on a Blazor WebAssembly application.",
           "default": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}"


### PR DESCRIPTION
Change `intspect` to `inspect` (assuming it’s not a historical typo that is intentional).

/cc @sebastienros 

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
