### PR TITLE
Fix github-workflow "env" requirements

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -225,13 +225,7 @@
           }
         },
         {
-          "type": "string",
-          "pattern": "^\\$\\{\\{\\s*(secrets|inputs)\\s*\\}\\}$"
-        },
-        {
-          "type": "string",
-          "$comment": "https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson",
-          "pattern": "^\\$\\{\\{\\s*fromJSON\\(.*\\)\\s*\\}\\}$"
+          "$ref": "#/definitions/stringContainingExpressionSyntax"
         }
       ]
     },

--- a/src/test/github-workflow/env-with-simple-expression.yaml
+++ b/src/test/github-workflow/env-with-simple-expression.yaml
@@ -1,0 +1,14 @@
+name: env from expression
+on:
+  - push
+jobs:
+  echo-env-var-from-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env:
+          - MYVAR=1
+          - MYVAR=2
+    steps:
+      - run: "echo $MYVAR"
+        env: ${{ matrix.env }}


### PR DESCRIPTION
An expression should be allowed for the value of "env". This is used in real-world workflows to insert matrix parameters into environment variables.

This makes the value of `env` significantly more permissive, removing the previously present expressions.

---

This was reported downstream in check-jsonschema: https://github.com/python-jsonschema/check-jsonschema/issues/157

The regression appears to have been introduced across #2461, #2463, #2465 . #2465 fixes a malformed schema, which python's `jsonschema` and other libraries handled in _some way_ which happened to work on such workflows in the past.

I've included a test which fails against the current schema in `master` but which works with this fix.