### PR TITLE
Add `task.internal` property in Taskfile schema

### DIFF
--- a/src/schemas/json/taskfile.json
+++ b/src/schemas/json/taskfile.json
@@ -110,6 +110,10 @@
             "enum": ["none", "checksum", "timestamp"],
             "default": "none"
           },
+          "internal": {
+            "description": "Indicates that the task cannot be called directly by the user",
+            "type": "boolean"
+          },
           "silent": {
             "description": "Silent mode disables echoing of commands before Task runs it",
             "type": "boolean"


### PR DESCRIPTION
Add the boolean property `internal` under `task` in Taskfile schema.

Related: [Changelog](https://taskfile.dev/changelog/#v3160---2022-09-29) of Task.
