### PR TITLE
fix(schema): cirrus.json credential pattern

### DIFF
--- a/src/schemas/json/cirrus.json
+++ b/src/schemas/json/cirrus.json
@@ -704,7 +704,7 @@
           "type": "string"
         },
         "gcp_credentials": {
-          "pattern": "ENCRYPTED[.*]",
+          "pattern": "^ENCRYPTED\\[!?[0-9a-z]*!?\\]$",
           "type": "string"
         },
         "name": {
@@ -2246,7 +2246,7 @@
           "type": "string"
         },
         "aws_credentials": {
-          "pattern": "ENCRYPTED[.*]",
+          "pattern": "^ENCRYPTED\\[!?[0-9a-z]*!?\\]$",
           "type": "string"
         },
         "azure_container_instance": {
@@ -2278,7 +2278,7 @@
           "type": "object"
         },
         "azure_credentials": {
-          "pattern": "ENCRYPTED[.*]",
+          "pattern": "^ENCRYPTED\\[!?[0-9a-z]*!?\\]$",
           "type": "string"
         },
         "compute_engine_instance": {
@@ -2967,7 +2967,7 @@
           "type": "object"
         },
         "gcp_credentials": {
-          "pattern": "ENCRYPTED[.*]",
+          "pattern": "^ENCRYPTED\\[!?[0-9a-z]*!?\\]$",
           "type": "string"
         },
         "gke_container": {
@@ -3574,7 +3574,7 @@
       "type": "string"
     },
     "aws_credentials": {
-      "pattern": "ENCRYPTED[.*]",
+      "pattern": "^ENCRYPTED\\[!?[0-9a-z]*!?\\]$",
       "type": "string"
     },
     "azure_container_instance": {
@@ -3606,7 +3606,7 @@
       "type": "object"
     },
     "azure_credentials": {
-      "pattern": "ENCRYPTED[.*]",
+      "pattern": "^ENCRYPTED\\[!?[0-9a-z]*!?\\]$",
       "type": "string"
     },
     "compute_engine_instance": {
@@ -4275,7 +4275,7 @@
       "type": "object"
     },
     "gcp_credentials": {
-      "pattern": "ENCRYPTED[.*]",
+      "pattern": "^ENCRYPTED\\[!?[0-9a-z]*!?\\]$",
       "type": "string"
     },
     "gke_container": {

--- a/src/test/cirrus/credentials.yaml
+++ b/src/test/cirrus/credentials.yaml
@@ -1,0 +1,2 @@
+---
+gcp_credentials: ENCRYPTED[!abc123!]


### PR DESCRIPTION
The pattern used to check encrypted credentials was allowing multiple characters after the prefix string.