### PR TITLE
Add concurrency to host schema

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -1365,6 +1365,22 @@
           }
         }
       ],
+      "concurrency": {
+        "description": "Configuration settings for dynamic concurrency",
+        "type": "object",
+        "properties": {
+          "dynamicConcurrencyEnabled": {
+            "description": "Enables or disables dynamic concurrency for function apps.",
+            "type": "boolean",
+            "default": true
+          },
+          "snapshotPersistenceEnabled" : {
+            "description": "Enables or disables the learned concurrency values persisting in storage.",
+            "type": "boolean", 
+            "default": true
+          }
+        }
+      },
       "additionalProperties": false
     }
   },

--- a/src/test/host/host.v2.json
+++ b/src/test/host/host.v2.json
@@ -3,6 +3,10 @@
     "batchSize": 1000,
     "flushTimeout": "00:00:30"
   },
+  "concurrency": {
+    "dynamicConcurrencyEnabled": true,
+    "snapshotPersistenceEnabled": true
+  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[1.*, 2.0.0)"


### PR DESCRIPTION
This PR adds a concurrency property to the host schema and also adds tests. 
This is needed in order to enable dynamic concurrency. 