### PR TITLE
Fix spelling mistake in minecraft-advancement

### DIFF
--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -259,8 +259,8 @@
       "description": "The rewards provided when this advancement is obtained.",
       "type": "object",
       "properties": {
-        "recipies": {
-          "title": "Recipies",
+        "recipes": {
+          "title": "Recipes",
           "description": "A list of recipes to unlock.",
           "type": "array",
           "items": {

--- a/src/test/minecraft-advancement/recipes-test.json
+++ b/src/test/minecraft-advancement/recipes-test.json
@@ -1,10 +1,4 @@
 {
-  "parent": "minecraft:recipes/root",
-  "rewards": {
-    "recipes": [
-      "minecraft:chest"
-    ]
-  },
   "criteria": {
     "has_lots_of_items": {
       "trigger": "minecraft:inventory_changed",
@@ -23,11 +17,9 @@
       }
     }
   },
-  "requirements": [
-    [
-      "has_lots_of_items",
-      "has_the_recipe"
-    ]
-  ]
+  "parent": "minecraft:recipes/root",
+  "requirements": [["has_lots_of_items", "has_the_recipe"]],
+  "rewards": {
+    "recipes": ["minecraft:chest"]
+  }
 }
-

--- a/src/test/minecraft-advancement/recipes-test.json
+++ b/src/test/minecraft-advancement/recipes-test.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:chest"
+    ]
+  },
+  "criteria": {
+    "has_lots_of_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "slots": {
+          "occupied": {
+            "min": 10
+          }
+        }
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:chest"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_lots_of_items",
+      "has_the_recipe"
+    ]
+  ]
+}
+


### PR DESCRIPTION
`recipes` is spelled with only one `i`.

Also added a test case for recipe advancements where this thing actually pops up.
The test case wouldn't fail though with the typo, as `additionalProperties` are not disabled.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
