### PR TITLE
Fix nodemon.json `delay` description

### DIFF
--- a/src/schemas/json/nodemon.json
+++ b/src/schemas/json/nodemon.json
@@ -75,7 +75,7 @@
     },
     "delay": {
       "default": 0,
-      "description": "debounce restart for a number of seconds",
+      "description": "debounce restart for a number of milliseconds",
       "type": "number"
     },
     "dump": {


### PR DESCRIPTION
While debugging some strange nodemon behavior, I noticed that it was logging a message indicating that it was delaying a restart for 0.1ms when I was expecting it to be either 100ms or 0.1s based on the tooltip hint given in VS Code when using https://json.schemastore.org/nodemon.

It turns out that nodemon [treats](https://github.com/remy/nodemon/blob/1de684b00acada6f7dc11489dd698152e4b1a8d9/README.md#delaying-restarting) the `delay` option differently depending on whether it is given as a command line option or specified in `nodemon.json` (emphasis mine):

> The delay figure is number of seconds (or milliseconds, if specified) to delay before restarting. So nodemon will only restart your app the given number of seconds after the last file change.
>
> If you are setting this value in nodemon.json, **the value will always be interpreted in milliseconds**.

To match the behavior with `nodemon.json`, the value given on the command line will be [converted to milliseconds](https://github.com/remy/nodemon/blob/1de684b00acada6f7dc11489dd698152e4b1a8d9/lib/cli/parse.js#L216-L229) internally when the options are parsed.