### PR TITLE
fix: add types to workflows schema

### DIFF
--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -20,7 +20,7 @@
   ],
   "definitions": {
     "subworkflow": {
-      "type":"object",
+      "type": "object",
       "description": "A subworkflow.",
       "additionalProperties": false,
       "properties": {

--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -2,12 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
-      "type": "array",
       "description": "A list of steps.",
       "$ref": "#/definitions/stepArray"
     },
     {
-      "type": "object",
       "description": "A map of subworkflows.",
       "minProperties": 1,
       "additionalProperties": false,

--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -2,12 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
+      "type": "array",
       "description": "A list of steps.",
       "$ref": "#/definitions/stepArray"
     },
     {
+      "type": "object",
       "description": "A map of subworkflows.",
-      "minItems": 1,
+      "minProperties": 1,
       "additionalProperties": false,
       "patternProperties": {
         "^.*$": {
@@ -19,6 +21,7 @@
   ],
   "definitions": {
     "subworkflow": {
+      "type":"object",
       "description": "A subworkflow.",
       "additionalProperties": false,
       "properties": {
@@ -40,9 +43,10 @@
       "description": "An array of objects with a single step.",
       "minItems": 1,
       "items": {
+        "type": "object",
         "description": "An object with a single step.",
-        "minItems": 1,
-        "maxItems": 1,
+        "minProperties": 1,
+        "maxProperties": 1,
         "additionalProperties": false,
         "patternProperties": {
           "^.*$": {
@@ -53,6 +57,7 @@
       }
     },
     "step": {
+      "type": "object",
       "description": "A single workflow step.",
       "additionalProperties": false,
       "properties": {
@@ -71,6 +76,7 @@
           ]
         },
         "args": {
+          "type": "object",
           "description": "Arguments to a workflow step.",
           "additionalProperties": false,
           "properties": {
@@ -115,6 +121,7 @@
               "description": "Request query parameters."
             },
             "auth": {
+              "type": "object",
               "description": "Required if the API being called requires authentication.",
               "additionalProperties": false,
               "properties": {
@@ -138,9 +145,10 @@
           "type": "array",
           "description": "Define a dictionary.",
           "items": {
+            "type": "object",
             "description": "A single variable assignment.",
-            "minItems": 1,
-            "maxItems": 1
+            "minProperties": 1,
+            "maxProperties": 1
           }
         },
         "result": {
@@ -151,6 +159,7 @@
           "type": "array",
           "description": "A switch block.",
           "items": {
+            "type": "object",
             "additionalProperties": false,
             "properties": {
               "condition": {
@@ -190,6 +199,7 @@
           "$ref": "#/definitions/step"
         },
         "retry": {
+          "type": "object",
           "description": "Optional. If omitted, all other fields are required. Options include ${http.default_retry} and ${http.default_retry_non_idempotent}. Allows you to specify a default retry policy to use. If you specify a retry policy, omit all other fields in the retry block.",
           "additionalProperties": false,
           "properties": {
@@ -202,6 +212,7 @@
               "description": "Maximum number of times a step will be retried."
             },
             "backoff": {
+              "type": "object",
               "description": "Block that controls how retries occur.",
               "additionalProperties": false,
               "properties": {
@@ -228,6 +239,7 @@
               "$ref": "#/definitions/step"
             },
             {
+              "type": "object",
               "additionalProperties": false,
               "properties": {
                 "as": {

--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -6,6 +6,7 @@
       "$ref": "#/definitions/stepArray"
     },
     {
+      "type": "object",
       "description": "A map of subworkflows.",
       "minProperties": 1,
       "additionalProperties": false,


### PR DESCRIPTION
This PR will:
- Add `type` parameter in various places in `workflows.yaml`
- Replace `minItems` and `maxItems` properties for object types with `minProperties` and `maxProperties`