### PR TITLE
Fix Jekyll _config.yml defaults scope type

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -831,16 +831,7 @@
               },
               "type": {
                 "description": "The page type for this scope\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
-                "oneOf": [
-                  {
-                    "type": "string",
-                    "enum": ["pages", "posts", "drafts"]
-                  },
-                  {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                ]
+                "type": "string"
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
The Jekyll [docs](https://jekyllrb.com/docs/configuration/front-matter-defaults/) state that the defaults scope type can be:

* "pages"
* "posts"
* "drafts"
* any collection in your site
* optional

This PR allows the scope type to be any string or nothing at all.

Note that the existing setup doesn't work with the examples given in the Jekyll docs, e.g., if you create a `_config.yml` with:

```yaml
defaults:
  -
    scope:
      path: "" # an empty string here means all files in the project
      type: "posts" # previously `post` in Jekyll 2.2.
    values:
      layout: "default"
```

and try to validate this using `v8r _config.yml` you get the following error:

```
_config.yml#/defaults/0/scope/type must match exactly one schema in oneOf
```