### PR TITLE
fix: add missing type to pre-commit-hooks.json

### DIFF
--- a/src/schemas/json/pre-commit-hooks.json
+++ b/src/schemas/json/pre-commit-hooks.json
@@ -80,6 +80,7 @@
         "directory",
         "dockerfile",
         "dockerignore",
+        "dotenv",
         "dtd",
         "editorconfig",
         "edn",


### PR DESCRIPTION
`dotenv` is a valid type in `identify-cli`:

https://github.com/pre-commit/identify/blob/56aa6afbe66c9da96dcdb66d9a61632f45c6b44b/identify/extensions.py#L49

and:

```text
app@ubuntu-full(local):/app$ identify-cli etc/local/config.env
["dotenv", "executable", "file", "text"]
```

... but it's missing from `#definitions/file_type`.
