### PR TITLE
Add grunt task to check for fileMatch that include a directory separator

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,8 +2,6 @@ name: "CodeQL"
 
 on:
   push:
-    paths:
-      - "**.c?js"
   pull_request:
     paths:
       - "**.c?js"

--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -801,6 +801,20 @@ module.exports = function (grunt) {
     grunt.log.ok('No new fileMatch conflict detected.')
   })
 
+  grunt.registerTask('local_catalog-fileMatch-path', 'fileMatch patterns that include a directory separator should consistently start with **/', function () {
+    for (const schema of catalog.schemas) {
+      schema.fileMatch?.forEach(fileMatchItem => {
+        if (fileMatchItem.includes('/')) {
+          // A folder must start with **/
+          if (!fileMatchItem.startsWith('**/')) {
+            throwWithErrorText([`fileMatch with directory must start with "**/" => ${fileMatchItem}`])
+          }
+        }
+      })
+    }
+    grunt.log.ok('fileMatch path OK')
+  })
+
   grunt.registerTask('local_check_filename_extension', 'Dynamically check local schema/test file for filename extension', function () {
     const schemaFileExtension = ['.json']
     const testFileExtension = ['.json', '.yml', '.yaml', '.toml']
@@ -1403,6 +1417,7 @@ module.exports = function (grunt) {
       'local_check_for_test_folders_without_schema_to_be_tested',
       'local_tv4_validator_cannot_have_negative_test',
       'local_catalog',
+      'local_catalog-fileMatch-path',
       'local_catalog-fileMatch-conflict',
       'local_url-present-in-catalog',
       'local_schema-present-in-catalog-list',

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2072,7 +2072,7 @@
     {
       "name": "Netlify config schema",
       "description": "This schema describes the YAML config that Netlify uses",
-      "fileMatch": ["admin/config*.yml"],
+      "fileMatch": ["**/admin/config*.yml"],
       "url": "https://json.schemastore.org/netlify.json"
     },
     {
@@ -2721,7 +2721,7 @@
     {
       "name": "Scoop manifest",
       "description": "Scoop bucket app manifest",
-      "fileMatch": ["bucket/**.json"],
+      "fileMatch": ["**/bucket/**.json"],
       "url": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json"
     },
     {
@@ -2860,7 +2860,7 @@
     {
       "name": "Stale",
       "description": "Configuration file for Stale for closing abandoned issues and pull requests. See https://probot.github.io/apps/stale/.",
-      "fileMatch": [".github/stale.yml"],
+      "fileMatch": ["**/.github/stale.yml"],
       "url": "https://json.schemastore.org/stale.json"
     },
     {
@@ -4078,7 +4078,7 @@
     {
       "name": "Quali Torque Blueprint Spec 2",
       "description": "Schema for Torque bluerpint",
-      "fileMatch": ["blueprints/**.yaml"],
+      "fileMatch": ["**/blueprints/**.yaml"],
       "url": "https://raw.githubusercontent.com/QualiTorque/torque-vs-code-extensions/master/client/schemas/blueprint-spec2-schema.json"
     },
     {
@@ -4126,7 +4126,7 @@
     {
       "name": "KoDE/CI build.yaml",
       "description": "yaml schema for kode/ci build",
-      "fileMatch": [".kode/*.yaml"],
+      "fileMatch": ["**/.kode/*.yaml"],
       "url": "https://json.schemastore.org/kode-ci-build-1.0.0.json"
     },
     {

--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -82,7 +82,7 @@
         <li>RubyMine</li>
 		<li>SublimeText via <a href="https://packagecontrol.io/packages/LSP-json" target="_blank">LSP-json</a></li>
         <li>Visual Studio</li>
-        <li>Visual Studio Code</li>
+        <li>Visual Studio Code via <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml" target="_blank">YAML</a> and <a href="https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore" target="_blank">JSON</a></li>
         <li>Visual Studio for Mac</li>
         <li>WebStorm</li>
     </ul>


### PR DESCRIPTION
fileMatch patterns that include a directory separator should consistently start with **/ 
See #2511