### PR TITLE
Visual Studio Code with URL text is too long

### DIFF
--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -82,7 +82,7 @@
         <li>RubyMine</li>
 		<li>SublimeText via <a href="https://packagecontrol.io/packages/LSP-json" target="_blank">LSP-json</a></li>
         <li>Visual Studio</li>
-        <li>Visual Studio Code via <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml" target="_blank">YAML</a> and <a href="https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore" target="_blank">JSON</a></li>
+        <li>Visual Studio Code(<a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml" target="_blank">YAML</a>,<a href="https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore" target="_blank">JSON</a>)</li>
         <li>Visual Studio for Mac</li>
         <li>WebStorm</li>
     </ul>


### PR DESCRIPTION
It doesn't fit in the "Supporting editors" list view
https://www.schemastore.org

