### PR TITLE
drone: Fix arch and Add retries/cron/paths

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -94,7 +94,13 @@
         "branch": {
           "$ref": "#/definitions/conditions"
         },
+        "cron": {
+          "$ref": "#/definitions/conditions"
+        },
         "event": {
+          "$ref": "#/definitions/conditions"
+        },
+        "paths": {
           "$ref": "#/definitions/conditions"
         },
         "ref": {

--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -351,6 +351,9 @@
             },
             "disable": {
               "const": true
+            },
+            "retries": {
+              "type": "integer"
             }
           }
         },

--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -22,7 +22,7 @@
             "solaris"
           ]
         },
-        "arсh": {
+        "arch": {
           "type": "string",
           "enum": ["arm", "arm64", "amd64", "386"]
         },


### PR DESCRIPTION
The Drone schema had a cyrillic c in the keyword `arch` which had some odd effect while
using it in jsonnet. This should fix that.

Along with this I'm shipping a few other attributes that were missing.



<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->