### PR TITLE
Remove StackHead schemas from catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2849,24 +2849,6 @@
       "url": "https://json.schemastore.org/swa-cli.config.json"
     },
     {
-      "name": "StackHead CLI config",
-      "description": "Configuration file for StackHead CLI. See https://stackhead.io.",
-      "fileMatch": [".stackhead-cli.yml"],
-      "url": "https://schema.stackhead.io/stackhead-cli/tag/v1/-/cli-config.schema.json"
-    },
-    {
-      "name": "StackHead module configuration",
-      "description": "Configuration file for StackHead modules. See https://stackhead.io.",
-      "fileMatch": ["stackhead-module.yml"],
-      "url": "https://schema.stackhead.io/stackhead/tag/v1/-/module-config.schema.json"
-    },
-    {
-      "name": "StackHead project definition",
-      "description": "Project definition file for deploying projects with StackHead. See https://stackhead.io.",
-      "fileMatch": ["*.stackhead.yml", "*.stackhead.yaml"],
-      "url": "https://schema.stackhead.io/stackhead/tag/v1/-/project-definition.schema.json"
-    },
-    {
       "name": "Stale",
       "description": "Configuration file for Stale for closing abandoned issues and pull requests. See https://probot.github.io/apps/stale/.",
       "fileMatch": ["**/.github/stale.yml"],


### PR DESCRIPTION
`schema.stackhead.io` appears to be offline, and the project repos are primarily inactive or archived. Downloads of these schemas therefore cannot succeed.

---

I've been tinkering with a repackaging of SchemaStore as a python data package (so that it can be installed and then used offline). One of the components in that project downloads all schemas in the catalog, and always fails on these schemas. When I look into StackHead, it seems like the project is probably discontinued.