### PR TITLE
pyproject: license can be a string

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -823,9 +823,9 @@
         },
         "license": {
           "title": "Project license",
-          "type": "object",
           "oneOf": [
             {
+              "type": "object",
               "additionalProperties": false,
               "required": ["file"],
               "properties": {
@@ -836,6 +836,7 @@
               }
             },
             {
+              "type": "object",
               "additionalProperties": false,
               "required": ["text"],
               "properties": {
@@ -844,6 +845,10 @@
                   "type": "string"
                 }
               }
+            },
+            {
+              "type": "string",
+              "description": "A SPDX license identifier"
             }
           ],
           "examples": [
@@ -852,7 +857,9 @@
             },
             {
               "file": "LICENSE"
-            }
+            },
+            "MIT",
+            "LicenseRef-Proprietary"
           ]
         },
         "authors": {


### PR DESCRIPTION
See https://peps.python.org/pep-0639/ and https://hatch.pypa.io/latest/config/metadata/#license