### PR TITLE
[github-workflow] Fix "inputs.required" requirements

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1607,7 +1607,7 @@
                           }
                         }
                       ],
-                      "required": ["description", "required"],
+                      "required": ["description"],
                       "additionalProperties": false
                     }
                   },


### PR DESCRIPTION
This commit fixes "inputs.required" requirements
- "inputs.required" is not required according to documentation
- However, it is set as required in github-workflow.json
- This commit fixes this mismatch

Signed-off-by: periannath <yu65789@gmail.com>

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

---

> `inputs.<input_id>.required`
> 
> **Optional** A boolean to indicate whether the action requires the input parameter. Set to true when the parameter is required.

From Document https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_idrequired