### PR TITLE
update cloudbuild machineType values/descriptions

### DIFF
--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -73,20 +73,46 @@
       "properties": {
         "machineType": {
           "enum": [
-            "UNSPECIFIED",
+            "E2_HIGHCPU_2",
+            "E2_HIGHCPU_4",
+            "E2_HIGHCPU_8",
+            "E2_HIGHCPU_16",
+            "E2_HIGHCPU_32",
+            "E2_HIGHMEM_2",
+            "E2_HIGHMEM_4",
+            "E2_HIGHMEM_8",
+            "E2_HIGHMEM_16",
+            "E2_MEDIUM",
+            "E2_STANDARD_2",
+            "E2_STANDARD_4",
+            "E2_STANDARD_8",
+            "E2_STANDARD_16",
+            "E2_STANDARD_32",
             "N1_HIGHCPU_8",
             "N1_HIGHCPU_32",
-            "E2_HIGHCPU_8",
-            "E2_HIGHCPU_32"
+            "UNSPECIFIED"
           ],
           "description": "Compute Engine machine type on which to run the build.",
           "type": "string",
           "enumDescriptions": [
-            "Standard machine type.",
-            "Highcpu machine with 8 CPUs.",
-            "Highcpu machine with 32 CPUs.",
-            "Highcpu e2 machine with 8 CPUs.",
-            "Highcpu e2 machine with 32 CPUs."
+            "e2 HighCPU: 2 vCPUs, 2GB RAM",
+            "e2 HighCPU: 4 vCPUs, 4GB RAM",
+            "e2 HighCPU: 8 vCPUs, 8GB RAM",
+            "e2 HighCPU: 16 vCPUs, 16GB RAM",
+            "e2 HighCPU: 32 vCPUs, 32GB RAM",
+            "e2 HighMem: 2 vCPUs, 16GB RAM",
+            "e2 HighMem: 4 vCPUs, 32GB RAM",
+            "e2 HighMem: 8 vCPUs, 64GB RAM",
+            "e2 HighMem: 16 vCPUs, 128GB RAM",
+            "e2 Medium: 1 vCPU, 4GB RAM",
+            "e2 Standard: 2 vCPU, 8GB RAM",
+            "e2 Standard: 4 vCPU, 16GB RAM",
+            "e2 Standard: 8 vCPU, 32GB RAM",
+            "e2 Standard: 16 vCPU, 64GB RAM",
+            "e2 Standard: 32 vCPU, 128GB RAM",
+            "n1 HighCPU: 8 vCPUs, 7.2GB RAM",
+            "n1 HighCPU: 32 vCPUs, 28.8GB RAM",
+            "e2 Medium: 1 vCPU, 4GB RAM"
           ]
         },
         "volumes": {


### PR DESCRIPTION
* latest per https://cloud.google.com/build/pricing (as of 2022-10-24)
* revised description: more info, more succinct
* sorted values in alpha order
