### PR TITLE
Refresh base schema: add items for 3 common text editors and missing $id's

### DIFF
--- a/src/schemas/json/base.json
+++ b/src/schemas/json/base.json
@@ -47,11 +47,7 @@
       "type": "string",
       "oneOf": [
         {
-          "enum": [
-            "/usr/bin/nano",
-            "/usr/bin/vim",
-            "/usr/bin/emacs"
-          ]
+          "enum": ["/usr/bin/nano", "/usr/bin/vim", "/usr/bin/emacs"]
         },
         {}
       ]

--- a/src/schemas/json/base.json
+++ b/src/schemas/json/base.json
@@ -27,6 +27,7 @@
       "type": ["string", "null"]
     },
     "path": {
+      "$id": "path",
       "type": "string",
       "minLength": 1
     },
@@ -67,6 +68,7 @@
       ]
     },
     "timezone": {
+      "$id": "timezone",
       "type": "string",
       "enum": [
         "Africa/Abidjan",

--- a/src/schemas/json/base.json
+++ b/src/schemas/json/base.json
@@ -41,6 +41,31 @@
         }
       ]
     },
+    "editor": {
+      "$id": "editor",
+      "type": "string",
+      "oneOf": [
+        {
+          "enum": [
+            "/usr/bin/nano",
+            "/usr/bin/vim",
+            "/usr/bin/emacs"
+          ]
+        },
+        {}
+      ]
+    },
+    "nullable-editor": {
+      "$id": "nullable-editor",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/editor"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "timezone": {
       "type": "string",
       "enum": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
