### PR TITLE
Update URL for Haystack Pipeline schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1637,7 +1637,7 @@
       "name": "Haystack Pipeline",
       "description": "Haystack Pipeline YAML file describing the nodes of the pipelines. For more info read the docs at: https://haystack.deepset.ai/components/pipelines#yaml-file-definitions",
       "fileMatch": ["*.haystack-pipeline.yml"],
-      "url": "https://raw.githubusercontent.com/deepset-ai/haystack/master/haystack/json-schemas/haystack-pipeline.schema.json"
+      "url": "https://raw.githubusercontent.com/deepset-ai/haystack-json-schema/main/json-schema/haystack-pipeline.schema.json"
     },
     {
       "name": "Hazelcast 5 Configuration",


### PR DESCRIPTION
Update URL for Haystack Pipeline schema. Old URL will keep working alongside the new one until this PR is merged.
