### PR TITLE
skaffold v2 comes with new v3 schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3735,7 +3735,7 @@
       "name": "skaffold.yaml",
       "description": "Schema for the skaffold.yaml configuration file for Skaffold (https://skaffold.dev/)",
       "fileMatch": ["skaffold.yaml", "skaffold.yml"],
-      "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta28.json",
+      "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/docs-v2/content/en/schemas/v3.json",
       "versions": {
         "v1alpha1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha1.json",
         "v1alpha2": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v1alpha2.json",
@@ -3791,7 +3791,9 @@
         "v2beta25": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta25.json",
         "v2beta26": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta26.json",
         "v2beta27": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta27.json",
-        "v2beta28": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta28.json"
+        "v2beta28": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta28.json",
+        "v2beta29": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/docs/content/en/schemas/v2beta29.json",
+        "v3": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/docs-v2/content/en/schemas/v3.json"
       }
     },
     {


### PR DESCRIPTION
Skaffold released [version 2.0.0](https://github.com/GoogleContainerTools/skaffold/releases/tag/v2.0.0) a few days ago and it comes with a [new v3 schema](https://skaffold.dev/docs/references/yaml/?version=v3).