### PR TITLE
Enable support for wider tsconfig files & refresh babel

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -363,7 +363,7 @@
     {
       "name": "babelrc.json",
       "description": "Babel configuration file",
-      "fileMatch": [".babelrc", "babel.config.json"],
+      "fileMatch": [".babelrc", ".babelrc.json", "babel.config.json"],
       "url": "https://json.schemastore.org/babelrc.json"
     },
     {
@@ -3001,7 +3001,7 @@
     {
       "name": "tsconfig.json",
       "description": "TypeScript compiler configuration file",
-      "fileMatch": ["tsconfig.json"],
+      "fileMatch": ["tsconfig*.json"],
       "url": "https://json.schemastore.org/tsconfig.json"
     },
     {


### PR DESCRIPTION
1. It's very commnon to have multiple `tsconfig.json` files in a single project, for example `tsconfig.test.json`, `tsconfig.build.json` etc... so I modified the fileMatch to support this.
2. Added `.babelrc.json` file for babel


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->