### PR TITLE
Add stripe-app-local.json schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2914,6 +2914,12 @@
       "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app.schema.json"
     },
     {
+      "name": "stripe-app-local.json",
+      "description": "Stripe Apps local manifest file",
+      "fileMatch": ["stripe-app.*.json"],
+      "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app-local.schema.json"
+    },
+    {
       "name": "Stryker Mutator",
       "description": "Configuration file for Stryker Mutator, the mutation testing framework for JavaScript and friends. See https://stryker-mutator.io.",
       "fileMatch": ["stryker.conf.json", "stryker-*.conf.json"],


### PR DESCRIPTION
Adding a new `stripe-app-local.json` schema to support local development manifests, e.g. `stripe-app.dev.json`. Thanks!
