### PR TITLE
GolangCI Lint accepts multiple output formats

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -445,7 +445,7 @@
       "properties": {
         "format": {
           "description": "Output format to use.",
-          "pattern": "^(,?(colored-line-number|line-number|json|tab|checkstyle|code-climate)(:[^,]+)?)+$",
+          "pattern": "^(,?(colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions)(:[^,]+)?)+$",
           "default": "colored-line-number",
           "examples": ["colored-line-number", "checkstyle:report.json,colored-line-number", "line-number:golangci-lint.out,colored-line-number:stdout"]
         },

--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -445,15 +445,9 @@
       "properties": {
         "format": {
           "description": "Output format to use.",
-          "enum": [
-            "colored-line-number",
-            "line-number",
-            "json",
-            "tab",
-            "checkstyle",
-            "code-climate"
-          ],
-          "default": "colored-line-number"
+          "pattern": "^(,?(colored-line-number|line-number|json|tab|checkstyle|code-climate)(:[^,]+)?)+$",
+          "default": "colored-line-number",
+          "examples": ["colored-line-number", "checkstyle:report.json,colored-line-number", "line-number:golangci-lint.out,colored-line-number:stdout"]
         },
         "print-issued-lines": {
           "description": "Print lines of code with issue.",

--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -447,7 +447,11 @@
           "description": "Output format to use.",
           "pattern": "^(,?(colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions)(:[^,]+)?)+$",
           "default": "colored-line-number",
-          "examples": ["colored-line-number", "checkstyle:report.json,colored-line-number", "line-number:golangci-lint.out,colored-line-number:stdout"]
+          "examples": [
+            "colored-line-number",
+            "checkstyle:report.json,colored-line-number",
+            "line-number:golangci-lint.out,colored-line-number:stdout"
+          ]
         },
         "print-issued-lines": {
           "description": "Print lines of code with issue.",

--- a/src/test/golangci-lint/example-values.json
+++ b/src/test/golangci-lint/example-values.json
@@ -1461,7 +1461,7 @@
     }
   },
   "output": {
-    "format": "json",
+    "format": "checkstyle:report.json,colored-line-number",
     "print-issued-lines": false,
     "print-linter-name": false,
     "uniq-by-line": false,


### PR DESCRIPTION
Hello! Submitting my first PR here, as I noticed that the schema was flagging my format even though it was following the example given in the documentation:
```
  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
  #
  # Multiple can be specified by separating them by comma, output can be provided
  # for each of them by separating format name and path by colon symbol.
  # Output path can be either `stdout`, `stderr` or path to the file to write to.
  # Example: "checkstyle:report.json,colored-line-number"
  #
  # Default: colored-line-number
```
https://golangci-lint.run/usage/configuration/#output-configuration

This also updates the format strings to the current config options (adding junit-xml and github-actions).