### PR TITLE
chore(knative-func): update to v1.8

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1413,7 +1413,8 @@
       "fileMatch": ["func.yaml"],
       "url": "https://raw.githubusercontent.com/knative/func/latest-release/schema/func_yaml-schema.json",
       "versions": {
-        "1.7": "https://raw.githubusercontent.com/knative/func/release-1.7/schema/func_yaml-schema.json"
+        "1.7": "https://raw.githubusercontent.com/knative/func/release-1.7/schema/func_yaml-schema.json",
+        "1.8": "https://raw.githubusercontent.com/knative/func/release-1.8/schema/func_yaml-schema.json"
       }
     },
     {


### PR DESCRIPTION
Updates Knative Function schema to `func` version 1.8.

/kind chore

Signed-off-by: Lance Ball <lball@redhat.com>
