### PR TITLE
fix(liquibase-3.2): allow empty rollback

### DIFF
--- a/src/schemas/json/liquibase-3.2.json
+++ b/src/schemas/json/liquibase-3.2.json
@@ -2869,6 +2869,12 @@
                   "rollback": {
                     "anyOf": [
                       {
+                        "type": "object",
+                        "description": "If you do not want to undo a change in a rollback mode, you can use an empty rollback tag.",
+                        "additionalProperties": false,
+                        "properties": {}
+                      },
+                      {
                         "$ref": "#/definitions/changes"
                       },
                       {

--- a/src/test/liquibase-3.2/rollbackVariants.json
+++ b/src/test/liquibase-3.2/rollbackVariants.json
@@ -80,6 +80,21 @@
           "changeSetAuthor": "liquibase-docs"
         }
       }
+    },
+    {
+      "changeSet": {
+        "id": "rollbackEmptyObj",
+        "comment": "Set default value in new column before applying not null constraint",
+        "author": "liquibase-docs",
+        "changes": [
+          {
+            "sql": {
+              "sql": "UPDATE person SET version = 0 WHERE version IS NULL;"
+            }
+          }
+        ],
+        "rollback": {}
+      }
     }
   ]
 }


### PR DESCRIPTION
I had previously updated the liquibase schema to the liquibase-3.2 schema to add support for multiple rollback types (#1882); however, I missed the empty rollback option.

According to the [Liquibase Documentation](https://docs.liquibase.com/workflows/liquibase-community/using-rollback.html), "If you do not want to undo a change in a rollback mode, you can use an empty rollback tag."  An empty tag in the XML version of Liquibase changesets translates to an empty object in the JSON version of the changeset.

This PR adds support for specifying an empty rollback, which should have been present my original PR.  This is not a breaking change as the empty rollback has been allowed by Liquibase since at least 3.2 and any document that previously passed validation using the liqubase-3.2.json schema will continue to pass validation.

[edit: grammar]