### PR TITLE
fix: Add missing node18 version from Github Actions schema

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -26,7 +26,7 @@
         "using": {
           "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing",
           "description": "The application used to execute the code specified in `main`.",
-          "enum": ["node12", "node16"]
+          "enum": ["node12", "node16", "node18"]
         },
         "main": {
           "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsmain",


### PR DESCRIPTION
Add missing node18 version from Github Actions schema.

Fix for:

![image](https://user-images.githubusercontent.com/862951/202564536-6e5c347a-2594-44e4-b6c1-1bf1f2f6e5a3.png)

As Node 18 has been supported for some time.

- https://github.com/actions/setup-node#supported-version-syntax
- https://github.com/actions/node-versions/blob/main/versions-manifest.json

