### PR TITLE
feat(workflows): Add support for parallel keyword

### DIFF
--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -266,23 +266,23 @@
           "additionalProperties": false,
           "properties": {
             "exception_policy": {
-              "description": "determines action of other branches when an exception occurs",
+              "description": "The action for other branches when an exception occurs",
               "type": "string",
               "enum": ["continueAll"]
             },
             "shared": {
-              "description": "list of shared variables",
+              "description": "A list of shared variables",
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
             "concurrency_limit": {
-              "type": "integer",
-              "description": "upper limit for branches/iterations to perform concurrently"
+              "description": "An upper limit for branches/iterations to perform concurrently",
+              "type": "integer"
             },
             "branches": {
-              "description": "a list of branches that will run concurrently",
+              "description": "A list of branches that will run concurrently",
               "type": "array",
               "minItems": 2,
               "maxItems": 10,
@@ -290,14 +290,14 @@
                 "type": "object",
                 "properties": {
                   "steps": {
-                    "description": "A list of steps.",
+                    "description": "A list of steps",
                     "$ref": "#/definitions/stepArray"
                   }
                 }
               }
             },
             "for": {
-              "description": "a standard for loop to be evaluated in parallel",
+              "description": "A standard for loop to be evaluated in parallel",
               "$ref": "#/definitions/for"
             }
           }

--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -273,6 +273,7 @@
             "shared": {
               "description": "A list of shared variables",
               "type": "array",
+              "uniqueItems": true,
               "items": {
                 "type": "string"
               }

--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -259,6 +259,48 @@
         },
         "for": {
           "$ref": "#/definitions/for"
+        },
+        "parallel": {
+          "type": "object",
+          "description": "Run branches or iterations in parallel",
+          "additionalProperties": false,
+          "properties": {
+            "exception_policy": {
+              "description": "determines action of other branches when an exception occurs",
+              "type": "string",
+              "enum": ["continueAll"]
+            },
+            "shared": {
+              "description": "list of shared variables",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "concurrency_limit": {
+              "type": "integer",
+              "description": "upper limit for branches/iterations to perform concurrently"
+            },
+            "branches": {
+              "description": "a list of branches that will run concurrently",
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 10,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "steps": {
+                    "description": "A list of steps.",
+                    "$ref": "#/definitions/stepArray"
+                  }
+                }
+              }
+            },
+            "for": {
+              "description": "a standard for loop to be evaluated in parallel",
+              "$ref": "#/definitions/for"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
Adds Google Cloud Workflows `parallel` keyword, as described at https://cloud.google.com/workflows/docs/reference/syntax/parallel-steps

Fixes https://github.com/GoogleCloudPlatform/workflows-samples/issues/163

Tested with https://github.com/GoogleCloudPlatform/workflows-samples/blob/main/src/parallel_branch.workflows.yaml

