### PR TITLE
Add Roslyn-related items into `launchSettings` schema

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -1,7 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "JSON schema for the Visual Studio LaunchSettings.json file.",
-  "type": "object",
   "definitions": {
     "profile": {
       "type": "object",
@@ -231,5 +229,7 @@
         }
       ]
     }
-  }
+  },
+  "title": "JSON schema for the Visual Studio LaunchSettings.json file.",
+  "type": "object"
 }

--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -1,5 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON schema for the Visual Studio LaunchSettings.json file.",
+  "type": "object",
   "definitions": {
     "profile": {
       "type": "object",
@@ -72,6 +74,13 @@
         "commandName": {
           "type": "string",
           "description": "Identifies the debug target to run.",
+          "enum": [
+            "Executable",
+            "Project",
+            "IIS",
+            "IISExpress",
+            "DebugRoslynComponent"
+          ],
           "default": "",
           "minLength": 1
         },
@@ -196,6 +205,11 @@
           "type": "string",
           "description": "The url to enable debugging on a Blazor WebAssembly application.",
           "default": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}"
+        },
+        "targetProject": {
+          "type": "string",
+          "description": "A relative ot absolute path to the .NET project file on which Roslyn component should be executed. Relative to the current project's folder.",
+          "default": ""
         }
       }
     }
@@ -217,7 +231,5 @@
         }
       ]
     }
-  },
-  "title": "JSON schema for the Visual Studio LaunchSettings.json file.",
-  "type": "object"
+  }
 }


### PR DESCRIPTION
- ### Strict `commandName` property
  The `commandName` property is a limited set of cases. So it's better to have an enum instead of the plain text value.

- ###  `DebugRoslynComponent` command
  This is a new command that allows easy debug Roslyn analyzers and source generators on some example project. Previously was available only in Visual Studio, but will be also supported in JetBrains Rider soon.
  
  See https://learn.microsoft.com/en-us/visualstudio/releases/2019/release-notes-v16.10#NETProductivity for details.

- ### The `targetProject` property
  A property related to the `DebugRoslynComponent` command. A path to the sample project to test the Roslyn component.
