### PR TITLE
fix(circleciconfig.json): Add Docker version 20.10.18 option for setup_remote_docker and set as default

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -620,6 +620,7 @@
             "version": {
               "description": "If your build requires a specific docker image, you can set it as an image attribute",
               "enum": [
+                "20.10.18",
                 "20.10.17",
                 "20.10.14",
                 "20.10.12",
@@ -629,7 +630,7 @@
                 "20.10.2",
                 "19.03.13"
               ],
-              "default": "20.10.17"
+              "default": "20.10.18"
             }
           }
         },


### PR DESCRIPTION
The [CircleCI Documentation](https://circleci.com/docs/building-docker-images/#docker-version) has the latest Docker version for remote docker as 20.10.18, and it is the current default version.

The circleciconfig.json does not yet have this an an option, causing a failing check when specifying version 20.10.18.

This fix adds the latest value to the list and sets it as the default.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
