### PR TITLE
csscomb: refresh schema

### DIFF
--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema",
   "properties": {
     "exclude": {
       "description": "A list of files to ignore in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "exclude": {
-      "description": "An array of files/globbing patterns to ignore",
+      "description": "An array of files/globbing patterns to ignore\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "array",
       "items": {
         "type": "string"
@@ -15,91 +15,91 @@
       "type": "boolean"
     },
     "block-indent": {
-      "description": "Whether to add a semicolon after the last value/mixin.",
+      "description": "Whether to add a semicolon after the last value/mixin\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "color-case": {
-      "description": "Unify case of hexadecimal colors.",
+      "description": "Unify case of hexadecimal colors\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "enum": ["lower", "upper"]
     },
     "color-shorthand": {
-      "description": "Whether to expand hexadecimal colors or use shorthands.",
+      "description": "Whether to expand hexadecimal colors or use shorthands\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "element-case": {
-      "description": "Unify case of element selectors.",
+      "description": "Unify case of element selectors\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "enum": ["lower", "upper"]
     },
     "eof-newline": {
-      "description": "Add/remove line break at EOF.",
+      "description": "Add/remove line break at EOF\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "leading-zero": {
-      "description": "Add/remove leading zero in dimensions.",
+      "description": "Add/remove leading zero in dimensions\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "quotes": {
-      "description": "Unify quotes style.",
+      "description": "Unify quotes style\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "enum": ["single", "double"]
     },
     "remove-empty-rulesets": {
-      "description": "Remove all rulesets that contain nothing but spaces.",
+      "description": "Remove all rulesets that contain nothing but spaces\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "space-after-colon": {
-      "description": "Set space after `:` in declarations.",
+      "description": "Set space after `:` in declarations\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-after-combinator": {
-      "description": "Set space after combinator (for example, in selectors like `p > a`).",
+      "description": "Set space after combinator (for example, in selectors like `p > a`)\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-after-opening-brace": {
-      "description": "Set space after `{`.",
+      "description": "Set space after `{`\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-after-selector-delimiter": {
-      "description": "Set space after selector delimiter.",
+      "description": "Set space after selector delimiter\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-after-closing-brace": {
-      "description": "Set space before `}`.",
+      "description": "Set space before `}`\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-before-colon": {
-      "description": "Set space before `:` in declarations.",
+      "description": "Set space before `:` in declarations\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-before-combinator": {
-      "description": "Set space before combinator (for example, in selectors like `p > a`).",
+      "description": "Set space before combinator (for example, in selectors like `p > a`)\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-before-opening-brace": {
-      "description": "Set space before `{`.",
+      "description": "Set space before `{`\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-before-selector-delimiter": {
-      "description": "Set space before selector delimiter.",
+      "description": "Set space before selector delimiter\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-between-declarations": {
-      "description": "Set space between declarations (i.e. `color: tomato`).",
+      "description": "Set space between declarations (i.e. `color: tomato`)\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "strip-spaces": {
-      "description": "Whether to trim trailing spaces.",
+      "description": "Whether to trim trailing spaces\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "unitless-zero": {
-      "description": "Whether to remove units in zero-valued dimensions.",
+      "description": "Whether to remove units in zero-valued dimensions\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "vendor-prefix-align": {
-      "description": "Whether to align prefixes in properties and values.",
+      "description": "Whether to align prefixes in properties and values\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "sort-order": {
-      "description": "Sort properties in particular order.",
+      "description": "Sort properties in particular order\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "array",
       "items": {
         "type": "array",
@@ -112,7 +112,7 @@
       "type": "boolean"
     },
     "sort-order-fallback": {
-      "description": "Sort unknown properties alphabetically",
+      "description": "Sort unknown properties alphabetically\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "enum": ["abc"]
     }
   },

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "exclude": {
-      "description": "An array of files/globbing patterns to ignore\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A list of files to ignore in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "array",
       "items": {
         "type": "string"
@@ -15,91 +15,91 @@
       "type": "boolean"
     },
     "block-indent": {
-      "description": "Whether to add a semicolon after the last value/mixin\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A block indent style in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "color-case": {
-      "description": "Unify case of hexadecimal colors\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A hexadecimal color style in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "enum": ["lower", "upper"]
     },
     "color-shorthand": {
-      "description": "Whether to expand hexadecimal colors or use shorthands\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "Whether to expand hexadecimal color or use shorthand in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "element-case": {
-      "description": "Unify case of element selectors\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "Whether to unify case of element selector in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "enum": ["lower", "upper"]
     },
     "eof-newline": {
-      "description": "Add/remove line break at EOF\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "Whether to add a trailing line break in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "leading-zero": {
-      "description": "Add/remove leading zero in dimensions\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "Whether to add leading zero in a dimension in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "quotes": {
-      "description": "Unify quotes style\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A quote style in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "enum": ["single", "double"]
     },
     "remove-empty-rulesets": {
-      "description": "Remove all rulesets that contain nothing but spaces\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "Whether to remove empty rulesets\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "space-after-colon": {
-      "description": "Set space after `:` in declarations\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style after a colon in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-after-combinator": {
-      "description": "Set space after combinator (for example, in selectors like `p > a`)\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style after a combinator in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-after-opening-brace": {
-      "description": "Set space after `{`\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style after an opening brace in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-after-selector-delimiter": {
-      "description": "Set space after selector delimiter\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style after a selector delimiter in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-after-closing-brace": {
-      "description": "Set space before `}`\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style after a closing brace in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-before-colon": {
-      "description": "Set space before `:` in declarations\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style before a colon in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-before-combinator": {
-      "description": "Set space before combinator (for example, in selectors like `p > a`)\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style before a combinator in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-before-opening-brace": {
-      "description": "Set space before `{`\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style before an opening brace in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-before-selector-delimiter": {
-      "description": "Set space before selector delimiter\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style before a selector delimiter in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "space-between-declarations": {
-      "description": "Set space between declarations (i.e. `color: tomato`)\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A space style between declarations in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "string"
     },
     "strip-spaces": {
-      "description": "Whether to trim trailing spaces\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "Whether to trim trailing space in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "unitless-zero": {
-      "description": "Whether to remove units in zero-valued dimensions\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "Whether to remove unit in zero-valued dimension in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "vendor-prefix-align": {
-      "description": "Whether to align prefixes in properties and values\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "Whether to align prefix in property and value in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "sort-order": {
-      "description": "Sort properties in particular order\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A sort order in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "array",
       "items": {
         "type": "array",
@@ -112,7 +112,7 @@
       "type": "boolean"
     },
     "sort-order-fallback": {
-      "description": "Sort unknown properties alphabetically\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "description": "A sort style of unknown properties in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "enum": ["abc"]
     }
   },

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -116,6 +116,6 @@
       "enum": ["abc"]
     }
   },
-  "title": "JSON schema for CSS Comb configuration files",
+  "title": "A CSS Comb config schema",
   "type": "object"
 }

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -117,7 +117,7 @@
     },
     "sort-order-fallback": {
       "description": "A sort style of unknown properties in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
-      "enum": ["abc"]
+      "type": "string"
     }
   },
   "title": "A CSS Comb config schema",

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -4,8 +4,9 @@
     "exclude": {
       "description": "A list of files to ignore in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "array",
+      "uniqueItems": true,
       "items": {
-        "type": "string"
+        "$ref": "https://json.schemastore.org/base-04.json#/definitions/path"
       }
     },
     "verbose": {

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -6,7 +6,8 @@
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$ref": "https://json.schemastore.org/base-04.json#/definitions/path"
+        "type": "string",
+        "minLength": 1
       }
     },
     "verbose": {

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -13,6 +13,7 @@
       "type": "boolean"
     },
     "always-semicolon": {
+      "description": "Whether to add missing semicolon in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
       "type": "boolean"
     },
     "block-indent": {

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -21,6 +21,7 @@
     },
     "color-case": {
       "description": "A hexadecimal color style in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "type": "string",
       "enum": ["lower", "upper"]
     },
     "color-shorthand": {
@@ -29,6 +30,7 @@
     },
     "element-case": {
       "description": "Whether to unify case of element selector in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "type": "string",
       "enum": ["lower", "upper"]
     },
     "eof-newline": {
@@ -41,6 +43,7 @@
     },
     "quotes": {
       "description": "A quote style in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",
+      "type": "string",
       "enum": ["single", "double"]
     },
     "remove-empty-rulesets": {


### PR DESCRIPTION
- standardize descriptions
- add links to docs
- fix broken props

[Related issue in CSS Comb repo](https://github.com/csscomb/csscomb.js/issues/657): these problems will be addressed in a separate PR here

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
