### PR TITLE
FoundryVTT Manifest  Update Entity To Type for Latest Compatibility

### DIFF
--- a/src/schemas/json/foundryvtt-manifest.json
+++ b/src/schemas/json/foundryvtt-manifest.json
@@ -218,7 +218,7 @@
       "format": "url"
     }
   },
-  "required": ["name", "title", "description", "version", "minimumCoreVersion"],
+  "required": ["name", "title", "description", "version", "compatibility"],
   "title": "JSON schema for Foundry VTT system.json and module.json files.",
   "type": "object"
 }

--- a/src/schemas/json/foundryvtt-manifest.json
+++ b/src/schemas/json/foundryvtt-manifest.json
@@ -42,11 +42,7 @@
       "type": "array",
       "description": "Array of authors who have contributed to this package. Cannot be used together with `author`."
     },
-    "minimumCoreVersion": {
-      "type": "string",
-      "description": "Specifies the minimum Foundry version required to be able to install and use this package."
-    },
-    "compatibleCoreVersion": {
+    "compatibility": {
       "type": "string",
       "description": "Specifies the latest Foundry version this package is compatible with."
     },

--- a/src/schemas/json/foundryvtt-manifest.json
+++ b/src/schemas/json/foundryvtt-manifest.json
@@ -92,7 +92,7 @@
             "type": "string",
             "description": "The relative path to the Compendium .db file. Best practice is to put these in the /packs subdirectory."
           },
-          "entity": {
+          "type": {
             "type": "string",
             "description": "Each Compendium pack must designate which type of Entity it contains.",
             "enum": [
@@ -109,7 +109,7 @@
             ]
           }
         },
-        "required": ["name", "label", "system", "path", "entity"]
+        "required": ["name", "label", "system", "path", "type"]
       }
     },
     "dependencies": {


### PR DESCRIPTION
FoundryVTT Manifest  Update Entity To Type for Latest Compatibility

The latest FoundryVTT Manifest Uses Type instead of Entity.
