### PR TITLE
Add missing services for appveyor.json schema

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -377,19 +377,25 @@
               "iis",
               "mongodb",
               "msmq",
+              "mssql",
               "mssql2008r2sp2",
               "mssql2008r2sp2rs",
               "mssql2012sp1",
               "mssql2012sp1rs",
               "mssql2014",
               "mssql2014rs",
+              "mssql2016",
+              "mssql2017",
               "mysql",
               "postgresql",
               "postgresql93",
               "postgresql94",
               "postgresql95",
               "postgresql96",
-              "postgresql10"
+              "postgresql10",
+              "postgresql11",
+              "postgresql12",
+              "postgresql13"
             ]
           }
         },


### PR DESCRIPTION
According to the current documentation, there are a few values missing from the json schema definition for "services".

Ref:
https://www.appveyor.com/docs/getting-started-with-appveyor-for-linux/#sql-server-2017-for-linux
https://www.appveyor.com/docs/services-databases/#sql-server-2017
https://www.appveyor.com/docs/services-databases/#sql-server-2019
https://www.appveyor.com/docs/services-databases/#postgresql

