### PR TITLE
Add Unreal Engine plugin descriptor

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4343,6 +4343,12 @@
       "versions": {
         "1.0": "https://json.schemastore.org/qfconfig.json"
       }
+    },
+    {
+      "name": "Unreal Engine Uplugin",
+      "description": "Unreal Engine plugin configuration file",
+      "fileMatch": [".uplugin"],
+      "url": "https://json.schemastore.org/uplugin.json"
     }
   ],
   "version": 1

--- a/src/schemas/json/uplugin.json
+++ b/src/schemas/json/uplugin.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
-  "description": "Descriptor for plugins. Contains all the information contained within a `.uplugin` file.",
   "definitions": {
     "BuildConfiguration": {
       "description": "Available build configurations. Mirorred from `UnrealTargetConfiguration`.",
@@ -213,6 +212,7 @@
       "required": ["Enabled", "Name"]
     }
   },
+  "description": "Descriptor for plugins. Contains all the information contained within a `.uplugin` file.",
   "properties": {
     "CanContainContent": {
       "description": "Can this plugin contain content?",

--- a/src/schemas/json/uplugin.json
+++ b/src/schemas/json/uplugin.json
@@ -1,0 +1,401 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "description": "Descriptor for plugins. Contains all the information contained within a `.uplugin` file.",
+  "definitions": {
+    "BuildConfiguration": {
+      "description": "Available build configurations. Mirorred from `UnrealTargetConfiguration`.",
+      "type": "string",
+      "enum": [
+        "Unknown",
+        "Debug",
+        "DebugGame",
+        "Development",
+        "Shipping",
+        "Test"
+      ]
+    },
+    "BuildTargetType": {
+      "description": "Enumerates build target types.",
+      "type": "string",
+      "enum": ["Unknown", "Game", "Server", "Client", "Editor", "Program"]
+    },
+    "ModuleDescriptor": {
+      "description": "Description of a loadable module.",
+      "type": "object",
+      "properties": {
+        "AdditionalDependencies": {
+          "description": "List of additional dependencies for building this module.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "HasExplicitPlatforms": {
+          "description": "When true, an empty PlatformAllowList is interpeted as 'no platforms' with the expectation that explict platforms will be added in plugin extensions",
+          "type": "boolean",
+          "default": false
+        },
+        "LoadingPhase": {
+          "description": "When should the module be loaded during the startup sequence? This is sort of an advanced setting.",
+          "type": "string",
+          "enum": [
+            "EarliestPossible",
+            "PostConfigInit",
+            "PostSplashScreen",
+            "PreEarlyLoadingScreen",
+            "PreLoadingScreen",
+            "PreDefault",
+            "Default",
+            "PostDefault",
+            "PostEngineInit",
+            "None",
+            "Max"
+          ]
+        },
+        "Name": {
+          "description": "Name of this module",
+          "type": "string"
+        },
+        "PlatformAllowList": {
+          "description": "List of allowed platforms",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PlatformDenyList": {
+          "description": "List of disallowed platforms",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ProgramAllowList": {
+          "description": "List of allowed programs",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ProgramDenyList": {
+          "description": "List of disallowed programs",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TargetAllowList": {
+          "description": "List of allowed targets",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        },
+        "TargetConfigurationAllowList": {
+          "description": "List of allowed target configurations",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "TargetConfigurationDenyList": {
+          "description": "List of disallowed target configurations",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "TargetDenyList": {
+          "description": "List of disallowed targets",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        },
+        "Type": {
+          "description": "Usage type of module",
+          "type": "string",
+          "enum": [
+            "Runtime",
+            "RuntimeNoCommandlet",
+            "RuntimeAndProgram",
+            "CookedOnly",
+            "UncookedOnly",
+            "Developer",
+            "DeveloperTool",
+            "Editor",
+            "EditorNoCommandlet",
+            "EditorAndProgram",
+            "Program",
+            "ServerOnly",
+            "ClientOnly",
+            "ClientOnlyNoCommandlet",
+            "Max"
+          ]
+        }
+      }
+    },
+    "PluginReferenceDescriptor": {
+      "description": "Descriptor for a plugin reference.",
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "description": "Whether it should be enabled by default",
+          "type": "boolean",
+          "default": true
+        },
+        "HasExplicitPlatforms": {
+          "description": "When true, empty `SupportedTargetPlatforms` and `PlatformAllowList` are interpreted as *no platforms* with the expectation that explicit platforms will be added in plugin platform extensions",
+          "type": "boolean",
+          "default": false
+        },
+        "Optional": {
+          "description": "Whether this plugin is optional, and the game should silently ignore it not being present",
+          "type": "boolean",
+          "default": false
+        },
+        "Description": {
+          "description": "Description of the plugin for users that do not have it installed.",
+          "type": "string"
+        },
+        "MarketplaceURL": {
+          "description": "URL for this plugin on the marketplace, if the user doesn't have it installed.",
+          "type": "string"
+        },
+        "Name": {
+          "description": "Name of the plugin",
+          "type": "string"
+        },
+        "PlatformAllowList": {
+          "description": "List of allowed platforms",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PlatformDenyList": {
+          "description": "List of disallowed platforms",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TargetAllowList": {
+          "description": "List of allowed targets",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        },
+        "TargetConfigurationAllowList": {
+          "description": "List of allowed target configurations",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "TargetConfigurationDenyList": {
+          "description": "List of disallowed target configurations",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "TargetDenyList": {
+          "description": "List of disallowed targets",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        }
+      },
+      "required": ["Enabled", "Name"]
+    }
+  },
+  "properties": {
+    "CanContainContent": {
+      "description": "Can this plugin contain content?",
+      "type": "boolean",
+      "default": false
+    },
+    "CanContainVerse": {
+      "description": "Can this plugin contain Verse code?",
+      "type": "boolean",
+      "default": false
+    },
+    "ExplicitlyLoaded": {
+      "description": "When true, this plugin's modules will not be loaded automatically nor will it's content be mounted automatically.",
+      "type": "boolean",
+      "default": false
+    },
+    "HasExplicitPlatforms": {
+      "description": "When true, an empty SupportedTargetPlatforms is interpreted as 'no platforms' with the expectation that explicit platforms will be added in plugin platform extensions",
+      "type": "boolean",
+      "default": false
+    },
+    "Installed": {
+      "description": "Signifies that the plugin was installed on top of the engine",
+      "type": "boolean",
+      "default": false
+    },
+    "IsBetaVersion": {
+      "description": "Marks the plugin as beta in the UI",
+      "type": "boolean",
+      "default": false
+    },
+    "IsExperimentalVersion": {
+      "description": "Marks the plugin as experimental in the UI",
+      "type": "boolean",
+      "default": false
+    },
+    "IsHidden": {
+      "description": "For auto-generated plugins that should not be listed in the plugin browser for users to disable freely.",
+      "type": "boolean",
+      "default": false
+    },
+    "IsPluginExtension": {
+      "description": "If true, this plugin from a platform extension extending another plugin",
+      "type": "boolean",
+      "default": false
+    },
+    "RequiresBuildPlatform": {
+      "description": "For plugins that are under a platform folder (eg. /PS4/), determines whether compiling the plugin requires the build platform and/or SDK to be available",
+      "type": "boolean",
+      "default": false
+    },
+    "Category": {
+      "description": "The name of the category this plugin",
+      "type": "string",
+      "default": "Other"
+    },
+    "CreatedBy": {
+      "description": "The company or individual who created this plugin.",
+      "type": "string"
+    },
+    "CreatedByURL": {
+      "description": "Hyperlink URL string for the company or individual who created this plugin. This is optional.",
+      "type": "string"
+    },
+    "Description": {
+      "description": "Description of the plugin",
+      "type": "string"
+    },
+    "DocsURL": {
+      "description": "Documentation URL string.",
+      "type": "string"
+    },
+    "EditorCustomVirtualPath": {
+      "description": "Optional custom virtual path to display in editor to better organize.",
+      "type": "string"
+    },
+    "EnabledByDefault": {
+      "description": "Whether this plugin should be enabled by default for all projects",
+      "type": "string",
+      "enum": ["Unspecified", "Enabled", "Disabled"]
+    },
+    "EngineVersion": {
+      "description": "Version of the engine that this plugin is compatible with",
+      "type": "string"
+    },
+    "FileVersion": {
+      "description": "Descriptor version number.",
+      "type": "number",
+      "default": 3
+    },
+    "FriendlyName": {
+      "description": "Friendly name of the plugin",
+      "type": "string"
+    },
+    "LocalizationTargets": {
+      "description": "List of all localization targets associated with this plugin",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["LoadingPolicy", "Name"],
+        "properties": {
+          "LoadingPolicy": {
+            "description": "When should the localization data associated with a target should be loaded?",
+            "type": "string",
+            "enum": [
+              "Never",
+              "Always",
+              "Editor",
+              "Game",
+              "PropertyNames",
+              "ToolTips",
+              "Max"
+            ]
+          },
+          "Name": {
+            "description": "Name of this target",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MarketplaceURL": {
+      "description": "Marketplace URL for this plugin.",
+      "type": "string"
+    },
+    "Modules": {
+      "description": "List of all modules associated with this plugin",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ModuleDescriptor"
+      }
+    },
+    "ParentPluginName": {
+      "description": "If specified, this is the real plugin that this one is just extending",
+      "type": "string"
+    },
+    "Plugins": {
+      "description": "Plugins used by this plugin",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PluginReferenceDescriptor"
+      }
+    },
+    "PostBuildSteps": {
+      "description": "Post-build steps for each host platform",
+      "type": "object",
+      "$comment": "Define platform as key, command as value."
+    },
+    "PreBuildSteps": {
+      "description": "Pre-build steps for each host platform",
+      "type": "object",
+      "$comment": "Define platform as key, command as value."
+    },
+    "SupportedPrograms": {
+      "description": "List of programs that are supported by this plugin.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "SupportedTargetPlatforms": {
+      "description": "Controls a subset of platforms that can use this plugin, and which ones will stage the `.uplugin` file and content files.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "SupportURL": {
+      "description": "Support URL/email for this plugin.",
+      "type": "string"
+    },
+    "Version": {
+      "description": "Version number for the plugin.",
+      "type": "number",
+      "default": 1
+    },
+    "VersionName": {
+      "description": "Name of the version for this plugin.",
+      "type": "string",
+      "default": "1.0"
+    }
+  },
+  "required": ["FileVersion"],
+  "title": "JSON schema for Unreal Engine uplugin",
+  "type": "object"
+}

--- a/src/schemas/json/uplugin.json
+++ b/src/schemas/json/uplugin.json
@@ -26,6 +26,7 @@
         "AdditionalDependencies": {
           "description": "List of additional dependencies for building this module.",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -59,6 +60,7 @@
         "PlatformAllowList": {
           "description": "List of allowed platforms",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -66,6 +68,7 @@
         "PlatformDenyList": {
           "description": "List of disallowed platforms",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -73,6 +76,7 @@
         "ProgramAllowList": {
           "description": "List of allowed programs",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -80,6 +84,7 @@
         "ProgramDenyList": {
           "description": "List of disallowed programs",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -87,6 +92,7 @@
         "TargetAllowList": {
           "description": "List of allowed targets",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildTargetType"
           }
@@ -94,6 +100,7 @@
         "TargetConfigurationAllowList": {
           "description": "List of allowed target configurations",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildConfiguration"
           }
@@ -101,6 +108,7 @@
         "TargetConfigurationDenyList": {
           "description": "List of disallowed target configurations",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildConfiguration"
           }
@@ -108,6 +116,7 @@
         "TargetDenyList": {
           "description": "List of disallowed targets",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildTargetType"
           }
@@ -169,6 +178,7 @@
         "PlatformAllowList": {
           "description": "List of allowed platforms",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -176,6 +186,7 @@
         "PlatformDenyList": {
           "description": "List of disallowed platforms",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -183,6 +194,7 @@
         "TargetAllowList": {
           "description": "List of allowed targets",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildTargetType"
           }
@@ -190,6 +202,7 @@
         "TargetConfigurationAllowList": {
           "description": "List of allowed target configurations",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildConfiguration"
           }
@@ -197,6 +210,7 @@
         "TargetConfigurationDenyList": {
           "description": "List of disallowed target configurations",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildConfiguration"
           }
@@ -204,6 +218,7 @@
         "TargetDenyList": {
           "description": "List of disallowed targets",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildTargetType"
           }
@@ -310,6 +325,7 @@
     "LocalizationTargets": {
       "description": "List of all localization targets associated with this plugin",
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "type": "object",
         "required": ["LoadingPolicy", "Name"],
@@ -341,6 +357,7 @@
     "Modules": {
       "description": "List of all modules associated with this plugin",
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/ModuleDescriptor"
       }
@@ -352,6 +369,7 @@
     "Plugins": {
       "description": "Plugins used by this plugin",
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/PluginReferenceDescriptor"
       }
@@ -369,6 +387,7 @@
     "SupportedPrograms": {
       "description": "List of programs that are supported by this plugin.",
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "type": "string"
       }
@@ -376,6 +395,7 @@
     "SupportedTargetPlatforms": {
       "description": "Controls a subset of platforms that can use this plugin, and which ones will stage the `.uplugin` file and content files.",
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "type": "string"
       }

--- a/src/test/uplugin/code-plugin.json
+++ b/src/test/uplugin/code-plugin.json
@@ -1,212 +1,139 @@
 {
-	"FileVersion": 3,
-	"Version": 0,
-	"VersionName": "1970.1.1-0.0-1bcd8008",
-	"FriendlyName": "Code Plugin",
-	"Description": "A description of the code plugin",
-	"Category": "Utilities",
-	"CreatedBy": "John Doe",
-	"CreatedByURL": "https://www.example.com/",
-	"DocsURL": "https://www.example.com/docs",
-	"MarketplaceURL": "https://www.example.com/marketplace",
-	"SupportURL": "https://www.example.com/support",
-	"EngineVersion": "5.0.0",
-	"CanContainContent": true,
-	"Installed": true,
-	"Modules": [
-		{
-			"Name": "Module1",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"IOS",
-				"Android",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Module2",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Module3",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Module4",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Module5",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Android"
-			]
-		},
-		{
-			"Name": "Module6",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"IOS",
-				"Android",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Module7",
-			"Type": "ClientOnly",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"IOS",
-				"Android",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Module8",
-			"Type": "DeveloperTool",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"IOS",
-				"Android",
-				"Linux"
-			],
-			"TargetDenyList": [
-				"Server"
-			]
-		},
-		{
-			"Name": "Module9",
-			"Type": "Editor",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac"
-			]
-		},
-		{
-			"Name": "Module10",
-			"Type": "Editor",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac"
-			]
-		},
-		{
-			"Name": "Module11",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"IOS",
-				"Android",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Module12",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Module13",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"PlatformAllowList": [
-				"Win64",
-				"Mac",
-				"IOS",
-				"Android",
-				"Linux"
-			]
-		}
-	],
-	"PreBuildSteps": 
-	{
-		"Win64": [
-			"\"$(PluginDir)\\Resources\\InstallStagingHooksInEngine.bat\" \"$(ProjectDir)\""
-		]
-	},
-	"Plugins": [
-		{
-			"Name": "Plugin1",
-			"Enabled": true
-		},
-		{
-			"Name": "Plugin2",
-			"Enabled": true
-		},
-		{
-			"Name": "Plugin3",
-			"Enabled": true
-		},
-		{
-			"Name": "Plugin4",
-			"Enabled": true,
-			"Optional": true,
-			"SupportedTargetPlatforms": [
-				"Win64",
-				"Mac",
-				"Linux"
-			]
-		},
-		{
-			"Name": "Plugin5",
-			"Enabled": true,
-			"Optional": true,
-			"SupportedTargetPlatforms": [
-				"Win64",
-				"Android"
-			]
-		},
-		{
-			"Name": "Plugin6",
-			"Enabled": true,
-			"Optional": true,
-			"SupportedTargetPlatforms": [
-				"IOS"
-			]
-		},
-		{
-			"Name": "Plugin7",
-			"Enabled": true,
-			"Optional": true
-		}
-	]
+  "CanContainContent": true,
+  "Category": "Utilities",
+  "CreatedBy": "John Doe",
+  "CreatedByURL": "https://www.example.com/",
+  "Description": "A description of the code plugin",
+  "DocsURL": "https://www.example.com/docs",
+  "EngineVersion": "5.0.0",
+  "FileVersion": 3,
+  "FriendlyName": "Code Plugin",
+  "Installed": true,
+  "MarketplaceURL": "https://www.example.com/marketplace",
+  "Modules": [
+    {
+      "Name": "Module1",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "IOS", "Android", "Linux"]
+    },
+    {
+      "Name": "Module2",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "Linux"]
+    },
+    {
+      "Name": "Module3",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "Linux"]
+    },
+    {
+      "Name": "Module4",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "Linux"]
+    },
+    {
+      "Name": "Module5",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Android"]
+    },
+    {
+      "Name": "Module6",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "IOS", "Android", "Linux"]
+    },
+    {
+      "Name": "Module7",
+      "Type": "ClientOnly",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "IOS", "Android", "Linux"]
+    },
+    {
+      "Name": "Module8",
+      "Type": "DeveloperTool",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "IOS", "Android", "Linux"],
+      "TargetDenyList": ["Server"]
+    },
+    {
+      "Name": "Module9",
+      "Type": "Editor",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac"]
+    },
+    {
+      "Name": "Module10",
+      "Type": "Editor",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac"]
+    },
+    {
+      "Name": "Module11",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "IOS", "Android", "Linux"]
+    },
+    {
+      "Name": "Module12",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "Linux"]
+    },
+    {
+      "Name": "Module13",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "PlatformAllowList": ["Win64", "Mac", "IOS", "Android", "Linux"]
+    }
+  ],
+  "Plugins": [
+    {
+      "Name": "Plugin1",
+      "Enabled": true
+    },
+    {
+      "Name": "Plugin2",
+      "Enabled": true
+    },
+    {
+      "Name": "Plugin3",
+      "Enabled": true
+    },
+    {
+      "Name": "Plugin4",
+      "Enabled": true,
+      "Optional": true,
+      "SupportedTargetPlatforms": ["Win64", "Mac", "Linux"]
+    },
+    {
+      "Name": "Plugin5",
+      "Enabled": true,
+      "Optional": true,
+      "SupportedTargetPlatforms": ["Win64", "Android"]
+    },
+    {
+      "Name": "Plugin6",
+      "Enabled": true,
+      "Optional": true,
+      "SupportedTargetPlatforms": ["IOS"]
+    },
+    {
+      "Name": "Plugin7",
+      "Enabled": true,
+      "Optional": true
+    }
+  ],
+  "PreBuildSteps": {
+    "Win64": [
+      "\"$(PluginDir)\\Resources\\InstallStagingHooksInEngine.bat\" \"$(ProjectDir)\""
+    ]
+  },
+  "SupportURL": "https://www.example.com/support",
+  "Version": 0,
+  "VersionName": "1970.1.1-0.0-1bcd8008"
 }

--- a/src/test/uplugin/code-plugin.json
+++ b/src/test/uplugin/code-plugin.json
@@ -1,0 +1,212 @@
+{
+	"FileVersion": 3,
+	"Version": 0,
+	"VersionName": "1970.1.1-0.0-1bcd8008",
+	"FriendlyName": "Code Plugin",
+	"Description": "A description of the code plugin",
+	"Category": "Utilities",
+	"CreatedBy": "John Doe",
+	"CreatedByURL": "https://www.example.com/",
+	"DocsURL": "https://www.example.com/docs",
+	"MarketplaceURL": "https://www.example.com/marketplace",
+	"SupportURL": "https://www.example.com/support",
+	"EngineVersion": "5.0.0",
+	"CanContainContent": true,
+	"Installed": true,
+	"Modules": [
+		{
+			"Name": "Module1",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"IOS",
+				"Android",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Module2",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Module3",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Module4",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Module5",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Android"
+			]
+		},
+		{
+			"Name": "Module6",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"IOS",
+				"Android",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Module7",
+			"Type": "ClientOnly",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"IOS",
+				"Android",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Module8",
+			"Type": "DeveloperTool",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"IOS",
+				"Android",
+				"Linux"
+			],
+			"TargetDenyList": [
+				"Server"
+			]
+		},
+		{
+			"Name": "Module9",
+			"Type": "Editor",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac"
+			]
+		},
+		{
+			"Name": "Module10",
+			"Type": "Editor",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac"
+			]
+		},
+		{
+			"Name": "Module11",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"IOS",
+				"Android",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Module12",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Module13",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": [
+				"Win64",
+				"Mac",
+				"IOS",
+				"Android",
+				"Linux"
+			]
+		}
+	],
+	"PreBuildSteps": 
+	{
+		"Win64": [
+			"\"$(PluginDir)\\Resources\\InstallStagingHooksInEngine.bat\" \"$(ProjectDir)\""
+		]
+	},
+	"Plugins": [
+		{
+			"Name": "Plugin1",
+			"Enabled": true
+		},
+		{
+			"Name": "Plugin2",
+			"Enabled": true
+		},
+		{
+			"Name": "Plugin3",
+			"Enabled": true
+		},
+		{
+			"Name": "Plugin4",
+			"Enabled": true,
+			"Optional": true,
+			"SupportedTargetPlatforms": [
+				"Win64",
+				"Mac",
+				"Linux"
+			]
+		},
+		{
+			"Name": "Plugin5",
+			"Enabled": true,
+			"Optional": true,
+			"SupportedTargetPlatforms": [
+				"Win64",
+				"Android"
+			]
+		},
+		{
+			"Name": "Plugin6",
+			"Enabled": true,
+			"Optional": true,
+			"SupportedTargetPlatforms": [
+				"IOS"
+			]
+		},
+		{
+			"Name": "Plugin7",
+			"Enabled": true,
+			"Optional": true
+		}
+	]
+}

--- a/src/test/uplugin/plugin-with-content.json
+++ b/src/test/uplugin/plugin-with-content.json
@@ -1,22 +1,22 @@
 {
-	"FileVersion": 3,
-	"Version": 1,
-	"VersionName": "1.0",
-	"FriendlyName": "Test Plugin with content",
-	"Description": "Description for the test plugin with content",
-	"Category": "Other",
-	"CreatedBy": "John Doe",
-	"CreatedByURL": "https://www.example.com/",
-	"DocsURL": "https://www.example.com/docs",
-	"MarketplaceURL": "https://www.example.com/marketplace",
-	"SupportURL": "https://www.example.com/support",
-	"CanContainContent": true,
-	"IsBetaVersion": false,
-	"Installed": false,
-	"Plugins": [
-		{
-			"Name": "BasePlugin",
-			"Enabled": true
-		}
-	]
+  "CanContainContent": true,
+  "Category": "Other",
+  "CreatedBy": "John Doe",
+  "CreatedByURL": "https://www.example.com/",
+  "Description": "Description for the test plugin with content",
+  "DocsURL": "https://www.example.com/docs",
+  "FileVersion": 3,
+  "FriendlyName": "Test Plugin with content",
+  "Installed": false,
+  "IsBetaVersion": false,
+  "MarketplaceURL": "https://www.example.com/marketplace",
+  "Plugins": [
+    {
+      "Name": "BasePlugin",
+      "Enabled": true
+    }
+  ],
+  "SupportURL": "https://www.example.com/support",
+  "Version": 1,
+  "VersionName": "1.0"
 }

--- a/src/test/uplugin/plugin-with-content.json
+++ b/src/test/uplugin/plugin-with-content.json
@@ -1,0 +1,22 @@
+{
+	"FileVersion": 3,
+	"Version": 1,
+	"VersionName": "1.0",
+	"FriendlyName": "Test Plugin with content",
+	"Description": "Description for the test plugin with content",
+	"Category": "Other",
+	"CreatedBy": "John Doe",
+	"CreatedByURL": "https://www.example.com/",
+	"DocsURL": "https://www.example.com/docs",
+	"MarketplaceURL": "https://www.example.com/marketplace",
+	"SupportURL": "https://www.example.com/support",
+	"CanContainContent": true,
+	"IsBetaVersion": false,
+	"Installed": false,
+	"Plugins": [
+		{
+			"Name": "BasePlugin",
+			"Enabled": true
+		}
+	]
+}


### PR DESCRIPTION
Adding configuration support for Unreal Engine `.uplugin` file. This descriptor is based on [FPluginDescriptor](https://docs.unrealengine.com/5.1/en-US/API/Runtime/Projects/FPluginDescriptor/) which will parse the JSON data into relevant fields.