### PR TITLE
Add Unreal Engine project descriptor

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4349,6 +4349,12 @@
       "description": "Unreal Engine plugin configuration file",
       "fileMatch": [".uplugin"],
       "url": "https://json.schemastore.org/uplugin.json"
+    },
+    {
+      "name": "Unreal Engine Uproject",
+      "description": "Unreal Engine project configuration file",
+      "fileMatch": [".uproject"],
+      "url": "https://json.schemastore.org/uproject.json"
     }
   ],
   "version": 1

--- a/src/schemas/json/uproject.json
+++ b/src/schemas/json/uproject.json
@@ -1,0 +1,304 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "BuildConfiguration": {
+      "description": "Available build configurations. Mirorred from `UnrealTargetConfiguration`.",
+      "type": "string",
+      "enum": [
+        "Unknown",
+        "Debug",
+        "DebugGame",
+        "Development",
+        "Shipping",
+        "Test"
+      ]
+    },
+    "BuildTargetType": {
+      "description": "Enumerates build target types.",
+      "type": "string",
+      "enum": ["Unknown", "Game", "Server", "Client", "Editor", "Program"]
+    },
+    "ModuleDescriptor": {
+      "description": "Description of a loadable module.",
+      "type": "object",
+      "properties": {
+        "AdditionalDependencies": {
+          "description": "List of additional dependencies for building this module.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "HasExplicitPlatforms": {
+          "description": "When true, an empty PlatformAllowList is interpeted as 'no platforms' with the expectation that explict platforms will be added in plugin extensions",
+          "type": "boolean",
+          "default": false
+        },
+        "LoadingPhase": {
+          "description": "When should the module be loaded during the startup sequence? This is sort of an advanced setting.",
+          "type": "string",
+          "enum": [
+            "EarliestPossible",
+            "PostConfigInit",
+            "PostSplashScreen",
+            "PreEarlyLoadingScreen",
+            "PreLoadingScreen",
+            "PreDefault",
+            "Default",
+            "PostDefault",
+            "PostEngineInit",
+            "None",
+            "Max"
+          ]
+        },
+        "Name": {
+          "description": "Name of this module",
+          "type": "string"
+        },
+        "PlatformAllowList": {
+          "description": "List of allowed platforms",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "PlatformDenyList": {
+          "description": "List of disallowed platforms",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "ProgramAllowList": {
+          "description": "List of allowed programs",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "ProgramDenyList": {
+          "description": "List of disallowed programs",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "TargetAllowList": {
+          "description": "List of allowed targets",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        },
+        "TargetConfigurationAllowList": {
+          "description": "List of allowed target configurations",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "TargetConfigurationDenyList": {
+          "description": "List of disallowed target configurations",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "TargetDenyList": {
+          "description": "List of disallowed targets",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        },
+        "Type": {
+          "description": "Usage type of module",
+          "type": "string",
+          "enum": [
+            "Runtime",
+            "RuntimeNoCommandlet",
+            "RuntimeAndProgram",
+            "CookedOnly",
+            "UncookedOnly",
+            "Developer",
+            "DeveloperTool",
+            "Editor",
+            "EditorNoCommandlet",
+            "EditorAndProgram",
+            "Program",
+            "ServerOnly",
+            "ClientOnly",
+            "ClientOnlyNoCommandlet",
+            "Max"
+          ]
+        }
+      }
+    },
+    "PluginReferenceDescriptor": {
+      "description": "Descriptor for a plugin reference.",
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "description": "Whether it should be enabled by default",
+          "type": "boolean",
+          "default": true
+        },
+        "BlacklistPlatforms": {
+          "description": "If enabled, list of platforms for which the plugin should be disabled.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "BlacklistTargetConfigurations": {
+          "description": "If enabled, list of target configurations for which the plugin should be disabled.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "BlacklistTargets": {
+          "description": "If enabled, list of targets for which the plugin should be disabled.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        },
+        "Optional": {
+          "description": "Whether this plugin is optional, and the game should silently ignore it not being present",
+          "type": "boolean",
+          "default": false
+        },
+        "Description": {
+          "description": "Description of the plugin for users that do not have it installed.",
+          "type": "string"
+        },
+        "MarketplaceURL": {
+          "description": "URL for this plugin on the marketplace, if the user doesn't have it installed.",
+          "type": "string"
+        },
+        "Name": {
+          "description": "Name of the plugin",
+          "type": "string"
+        },
+        "SupportedTargetPlatforms": {
+          "description": "The list of supported target platforms for this plugin.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "WhitelistPlatforms": {
+          "description": "If enabled, list of platforms for which the plugin should be enabled (or all platforms if blank).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "WhitelistTargetConfigurations": {
+          "description": "If enabled, list of target configurations for which the plugin should be enabled (or all target configurations if blank).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "WhitelistTargets": {
+          "description": "If enabled, list of targets for which the plugin should be enabled (or all targets if blank).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        }
+      }
+    }
+  },
+  "description": "Descriptor for projects. Contains all the information contained within a `.uproject` file.",
+  "properties": {
+    "DisableEnginePluginsByDefault": {
+      "description": "Indicates that enabled by default engine plugins should not be enabled unless explicitly enabled by the project or target files.",
+      "type": "boolean",
+      "default": false
+    },
+    "IsEnterpriseProject": {
+      "description": "Indicates if this project is an Enterprise project",
+      "type": "boolean",
+      "default": false
+    },
+    "Category": {
+      "description": "Category to show under the project browser",
+      "type": "string"
+    },
+    "Description": {
+      "description": "Description to show in the project browser",
+      "type": "string"
+    },
+    "EngineAssociation": {
+      "description": "The engine to open this project with. Denotes by `<major>.<minor>` convention e.g. `4.20`, `5.0` etc.",
+      "type": "string",
+      "pattern": "([0-9]+)\\.([0-9]+)"
+    },
+    "EpicSampleNameHash": {
+      "description": "A hash that is used to determine if the project was forked from a sample",
+      "type": "number"
+    },
+    "FileVersion": {
+      "description": "Descriptor version number.",
+      "type": "number",
+      "default": 3,
+      "$comment": "More details can be found in `EProjectDescriptorVersion`"
+    },
+    "Modules": {
+      "description": "List of all modules associated with this project",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/ModuleDescriptor"
+      }
+    },
+    "Plugins": {
+      "description": "List of plugins for this project (may be enabled/disabled)",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/PluginReferenceDescriptor"
+      }
+    },
+    "PostBuildSteps": {
+      "description": "Custom steps to execute after building targets in this project",
+      "type": "object",
+      "$comment": "Define platform as key, command as value."
+    },
+    "PreBuildSteps": {
+      "description": "Custom steps to execute before building targets in this project",
+      "type": "object",
+      "$comment": "Define platform as key, command as value."
+    },
+    "TargetPlatforms": {
+      "description": "Array of platforms that this project is targeting",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["EngineAssociation", "FileVersion"],
+  "title": "JSON schema for Unreal Engine uproject",
+  "type": "object"
+}

--- a/src/test/uproject/test-uproject.json
+++ b/src/test/uproject/test-uproject.json
@@ -1,0 +1,96 @@
+{
+	"FileVersion": 3,
+	"EngineAssociation": "4.27",
+	"Category": "",
+	"Description": "",
+	"Modules": [
+		{
+			"Name": "ExampleProject",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"AdditionalDependencies": [
+				"Engine",
+				"Chaos"
+			]
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "Plugin1",
+			"Enabled": true
+		},
+		{
+			"Name": "Plugin2",
+			"Enabled": true
+		},
+		{
+			"Name": "Plugin3",
+			"Enabled": true
+		},
+		{
+			"Name": "Plugin4",
+			"Enabled": true,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+		},
+		{
+			"Name": "Plugin5",
+			"Enabled": true,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+		},
+		{
+			"Name": "Plugin6",
+			"Enabled": true,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+		},
+		{
+			"Name": "Plugin7",
+			"Enabled": true,
+			"SupportedTargetPlatforms": [
+				"IOS",
+				"Win64",
+				"Mac"
+			]
+		},
+		{
+			"Name": "Plugin8",
+			"Enabled": true,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+		},
+		{
+			"Name": "Plugin9",
+			"Enabled": true,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+		},
+		{
+			"Name": "Plugin10",
+			"Enabled": true
+		},
+		{
+			"Name": "Plugin11",
+			"Enabled": true
+		},
+		{
+			"Name": "Plugin12",
+			"Enabled": true,
+			"SupportedTargetPlatforms": [
+				"Android"
+			]
+		},
+		{
+			"Name": "Plugin13",
+			"Enabled": false,
+			"SupportedTargetPlatforms": [
+				"Android"
+			]
+		},
+		{
+			"Name": "Plugin14",
+			"Enabled": true,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/1467023ee74e4a90b630eedbdedc9c20"
+		}
+	],
+	"TargetPlatforms": [
+		"Android",
+		"IOS"
+	]
+}

--- a/src/test/uproject/test-uproject.json
+++ b/src/test/uproject/test-uproject.json
@@ -1,96 +1,82 @@
 {
-	"FileVersion": 3,
-	"EngineAssociation": "4.27",
-	"Category": "",
-	"Description": "",
-	"Modules": [
-		{
-			"Name": "ExampleProject",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"AdditionalDependencies": [
-				"Engine",
-				"Chaos"
-			]
-		}
-	],
-	"Plugins": [
-		{
-			"Name": "Plugin1",
-			"Enabled": true
-		},
-		{
-			"Name": "Plugin2",
-			"Enabled": true
-		},
-		{
-			"Name": "Plugin3",
-			"Enabled": true
-		},
-		{
-			"Name": "Plugin4",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
-		},
-		{
-			"Name": "Plugin5",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
-		},
-		{
-			"Name": "Plugin6",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
-		},
-		{
-			"Name": "Plugin7",
-			"Enabled": true,
-			"SupportedTargetPlatforms": [
-				"IOS",
-				"Win64",
-				"Mac"
-			]
-		},
-		{
-			"Name": "Plugin8",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
-		},
-		{
-			"Name": "Plugin9",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
-		},
-		{
-			"Name": "Plugin10",
-			"Enabled": true
-		},
-		{
-			"Name": "Plugin11",
-			"Enabled": true
-		},
-		{
-			"Name": "Plugin12",
-			"Enabled": true,
-			"SupportedTargetPlatforms": [
-				"Android"
-			]
-		},
-		{
-			"Name": "Plugin13",
-			"Enabled": false,
-			"SupportedTargetPlatforms": [
-				"Android"
-			]
-		},
-		{
-			"Name": "Plugin14",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/1467023ee74e4a90b630eedbdedc9c20"
-		}
-	],
-	"TargetPlatforms": [
-		"Android",
-		"IOS"
-	]
+  "Category": "",
+  "Description": "",
+  "EngineAssociation": "4.27",
+  "FileVersion": 3,
+  "Modules": [
+    {
+      "Name": "ExampleProject",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "AdditionalDependencies": ["Engine", "Chaos"]
+    }
+  ],
+  "Plugins": [
+    {
+      "Name": "Plugin1",
+      "Enabled": true
+    },
+    {
+      "Name": "Plugin2",
+      "Enabled": true
+    },
+    {
+      "Name": "Plugin3",
+      "Enabled": true
+    },
+    {
+      "Name": "Plugin4",
+      "Enabled": true,
+      "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+    },
+    {
+      "Name": "Plugin5",
+      "Enabled": true,
+      "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+    },
+    {
+      "Name": "Plugin6",
+      "Enabled": true,
+      "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+    },
+    {
+      "Name": "Plugin7",
+      "Enabled": true,
+      "SupportedTargetPlatforms": ["IOS", "Win64", "Mac"]
+    },
+    {
+      "Name": "Plugin8",
+      "Enabled": true,
+      "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+    },
+    {
+      "Name": "Plugin9",
+      "Enabled": true,
+      "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1467023ee74e4a90b630eedbdedc9c20"
+    },
+    {
+      "Name": "Plugin10",
+      "Enabled": true
+    },
+    {
+      "Name": "Plugin11",
+      "Enabled": true
+    },
+    {
+      "Name": "Plugin12",
+      "Enabled": true,
+      "SupportedTargetPlatforms": ["Android"]
+    },
+    {
+      "Name": "Plugin13",
+      "Enabled": false,
+      "SupportedTargetPlatforms": ["Android"]
+    },
+    {
+      "Name": "Plugin14",
+      "Enabled": true,
+      "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/1467023ee74e4a90b630eedbdedc9c20"
+    }
+  ],
+  "TargetPlatforms": ["Android", "IOS"]
 }


### PR DESCRIPTION
Adding configuration support for Unreal Engine `.uproject` file. This descriptor is based on [FProjectDescriptor](https://docs.unrealengine.com/4.26/en-US/API/Runtime/Projects/FProjectDescriptor/) which will parse the JSON data into relevant fields.