### PR TITLE
Added codecov github_checks section

### DIFF
--- a/src/negative_test/codecov/wrong-patch.json
+++ b/src/negative_test/codecov/wrong-patch.json
@@ -1,0 +1,8 @@
+{
+  "coverage": {
+    "status": {
+      "patch": "on"
+    }
+  },
+  "github_checks": false
+}

--- a/src/schemas/json/codecov.json
+++ b/src/schemas/json/codecov.json
@@ -508,6 +508,9 @@
                 {
                   "type": "string",
                   "enum": ["off"]
+                },
+                {
+                  "type": "boolean"
                 }
               ]
             },
@@ -594,6 +597,21 @@
         {
           "const": false
         }
+      ]
+    },
+    "github_checks": {
+      "description": "GitHub Checks. See https://docs.codecov.com/docs/github-checks for details.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "annotations": {
+              "type": "boolean"
+            }
+          }
+        },
+        { "type": "boolean" },
+        { "type": "string", "enum": ["off"] }
       ]
     }
   },

--- a/src/test/codecov/codecov-example-5.json
+++ b/src/test/codecov/codecov-example-5.json
@@ -1,0 +1,8 @@
+{
+  "coverage": {
+    "status": {
+      "patch": false
+    }
+  },
+  "github_checks": false
+}


### PR DESCRIPTION
According to the current documentation, github checks is now live and we can use boolean value to disable checks.
Disabling with boolean type also documented in github checks document.

- Add codecov [github_checks](https://docs.codecov.com/docs/github-checks)
- Add boolean type to patch property

## Tests
- I tested within live environment of codecov and cli tool provide by codecov
```
cat codecov.yml | curl --data-binary @- https://codecov.io/validate
Valid!

{
  "coverage": {
    "status": {
      "project": {
        "default": {
          "target": 80.0
        }
      },
      "patch": true
    }
  },
  "github_checks": false
}
```