### PR TITLE
Add schema for `rust-project.json`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2667,6 +2667,12 @@
       "url": "https://json.schemastore.org/resjson.json"
     },
     {
+      "name": "Rust Project",
+      "description": "JSON schema for non-Cargo based Rust projects",
+      "fileMatch": ["rust-project.json"],
+      "url": "https://json.schemastore.org/rust-project.json"
+    },
+    {
       "name": "JSON Resume",
       "description": "A JSON schema to describe a résumé.",
       "fileMatch": [

--- a/src/schemas/json/rust-project.json
+++ b/src/schemas/json/rust-project.json
@@ -7,44 +7,44 @@
             "type": "object",
             "properties": {
                 "display_name": {
+                    "description": "Crate name used for display purposes, without affecting semantics.",
                     "title": "Display name",
-                    "type": "string",
-                    "description": "Crate name used for display purposes, without affecting semantics."
+                    "type": "string"
                 },
                 "root_module": {
+                    "description": "Path to the root module of the crate.",
                     "title": "Root module",
-                    "type": "string",
-                    "description": "Path to the root module of the crate."
+                    "type": "string"
                 },
                 "edition": {
+                    "description": "Edition of the crate.",
                     "title": "Edition",
                     "type": "string",
-                    "description": "Edition of the crate.",
                     "enum": [ "2015", "2018", "2021" ]
                 },
                 "deps": {
+                    "description": "Crate dependencies.",
                     "title": "Dependencies",
                     "type": "array",
-                    "description": "Crate dependencies.",
                     "items": {
                         "$ref": "#/definitions/dep"
                     }
                 },
                 "version": {
+                    "description": "The crate's version",
                     "title": "Version",
                     "type": "string",
-                    "description": "The crate's version",
                     "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$"
                 },
                 "is_workspace_member": {
+                    "description": "Whether this crate should be treated as a member of the current \"workspace\".",
                     "title": "Is workspace member?",
-                    "type": "boolean",
-                    "description": "Whether this crate should be treated as a member of the current \"workspace\"."
+                    "type": "boolean"
                 },
                 "source": {
+                    "description": "(Super)set of `.rs` files comprising this crate.",
                     "title": "Source",
                     "type": "object",
-                    "description": "(Super)set of `.rs` files comprising this crate.",
                     "properties": {
                         "include_dirs": {
                             "title": "Included directories",
@@ -67,22 +67,22 @@
                     ]
                 },
                 "cfg": {
+                    "description": "The set of cfgs activated for a given crate.",
                     "title": "Configurations",
                     "type": "array",
-                    "description": "The set of cfgs activated for a given crate.",
                     "items": {
                         "type": "string"
                     }
                 },
                 "target": {
+                    "description": "Target triple for this crate.",
                     "title": "Target",
-                    "type": "string",
-                    "description": "Target triple for this crate."
+                    "type": "string"
                 },
                 "env": {
+                    "description": "Environment variables, used for the `env!` macro",
                     "title": "Environment variables",
                     "type": "object",
-                    "description": "Environment variables, used for the `env!` macro",
                     "patternProperties": {
                         "^.*$": {
                             "type": "string"
@@ -91,19 +91,19 @@
                     "additionalProperties": false
                 },
                 "is_proc_macro": {
+                    "description": "Whether the crate is a proc-macro crate.",
                     "title": "Is proc-macro?",
-                    "type": "boolean",
-                    "description": "Whether the crate is a proc-macro crate."
+                    "type": "boolean"
                 },
                 "proc_macro_dylib_path": {
+                    "description": "For proc-macro crates, path to compiled proc-macro (.so file).",
                     "title": "Path to compiled proc-macro",
-                    "type": "string",
-                    "description": "For proc-macro crates, path to compiled proc-macro (.so file)."
+                    "type": "string"
                 },
                 "repository": {
+                    "description": "URL to the source repository of the crate.",
                     "title": "Repository",
-                    "type": "string",
-                    "description": "URL to the source repository of the crate."
+                    "type": "string"
                 }
             },
             "required": [
@@ -117,14 +117,14 @@
             "type": "object",
             "properties": {
                 "crate": {
+                    "description": "Index of a crate in the `crates` array.",
                     "title": "Crate index",
-                    "type": "integer",
-                    "description": "Index of a crate in the `crates` array."
+                    "type": "integer"
                 },
                 "name": {
+                    "description": "Name as should appear in the (implicit) `extern crate name` declaration.",
                     "title": "Name",
-                    "type": "string",
-                    "description": "Name as should appear in the (implicit) `extern crate name` declaration."
+                    "type": "string"
                 }
             },
             "required": [
@@ -135,22 +135,22 @@
     },
     "properties": {
         "sysroot": {
+            "description": "Path to sysroot.",
             "title": "Sysroot",
-            "type": "string",
-            "description": "Path to sysroot."
+            "type": "string"
         },
         "sysroot_src": {
+            "description": "Path to the directory with source code of sysroot crates.",
             "title": "Sysroot source",
-            "type": "string",
-            "description": "Path to the directory with source code of sysroot crates."
+            "type": "string"
         },
         "crates": {
+            "description": "The set of crates comprising the current project.",
             "title": "Crates",
             "type": "array",
             "items": {
                 "$ref": "#/definitions/crate"
-            },
-            "description": "The set of crates comprising the current project."
+            }
         }
     },
     "required": [

--- a/src/schemas/json/rust-project.json
+++ b/src/schemas/json/rust-project.json
@@ -26,6 +26,7 @@
                     "description": "Crate dependencies.",
                     "title": "Dependencies",
                     "type": "array",
+                    "uniqueItems": true,
                     "items": {
                         "$ref": "#/definitions/dep"
                     }
@@ -49,6 +50,7 @@
                         "include_dirs": {
                             "title": "Included directories",
                             "type": "array",
+                            "uniqueItems": true,
                             "items": {
                                 "type": "string"
                             }
@@ -56,6 +58,7 @@
                         "exclude_dirs": {
                             "title": "Excluded directories",
                             "type": "array",
+                            "uniqueItems": true,
                             "items": {
                                 "type": "string"
                             }
@@ -70,6 +73,7 @@
                     "description": "The set of cfgs activated for a given crate.",
                     "title": "Configurations",
                     "type": "array",
+                    "uniqueItems": true,
                     "items": {
                         "type": "string"
                     }
@@ -148,6 +152,7 @@
             "description": "The set of crates comprising the current project.",
             "title": "Crates",
             "type": "array",
+            "uniqueItems": true,
             "items": {
                 "$ref": "#/definitions/crate"
             }

--- a/src/schemas/json/rust-project.json
+++ b/src/schemas/json/rust-project.json
@@ -1,0 +1,138 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON schema for non-Cargo based Rust projects",
+    "type": "object",
+    "definitions": {
+        "crate": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string",
+                    "description": "Crate name used for display purposes, without affecting semantics."
+                },
+                "root_module": {
+                    "type": "string",
+                    "description": "Path to the root module of the crate."
+                },
+                "edition": {
+                    "type": "string",
+                    "description": "Edition of the crate.",
+                    "enum": [ "2015", "2018", "2021" ]
+                },
+                "deps": {
+                    "type": "array",
+                    "description": "Crate dependencies.",
+                    "items": {
+                        "$ref": "#/definitions/dep"
+                    }
+                },
+                "version": {
+                    "type": "string",
+                    "description": "The crate's version",
+                    "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$"
+                },
+                "is_workspace_member": {
+                    "type": "boolean",
+                    "description": "Whether this crate should be treated as a member of the current \"workspace\"."
+                },
+                "source": {
+                    "type": "object",
+                    "description": "(Super)set of `.rs` files comprising this crate.",
+                    "properties": {
+                        "include_dirs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "exclude_dirs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "include_dirs",
+                        "exclude_dirs"
+                    ]
+                },
+                "cfg": {
+                    "type": "array",
+                    "description": "The set of cfgs activated for a given crate.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "target": {
+                    "type": "string",
+                    "description": "Target triple for this crate."
+                },
+                "env": {
+                    "type": "object",
+                    "description": "Environment variables, used for the `env!` macro",
+                    "patternProperties": {
+                        "^.*$": {
+                            "type": "string"
+                        }
+                      },
+                    "additionalProperties": false
+                },
+                "is_proc_macro": {
+                    "type": "boolean",
+                    "description": "Whether the crate is a proc-macro crate."
+                },
+                "proc_macro_dylib_path": {
+                    "type": "string",
+                    "description": "For proc-macro crates, path to compiled proc-macro (.so file)."
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "URL to the source repository of the crate."
+                }
+            },
+            "required": [
+                "root_module",
+                "edition",
+                "deps"
+            ]
+        },
+        "dep": {
+            "type": "object",
+            "properties": {
+                "crate": {
+                    "type": "integer",
+                    "description": "Index of a crate in the `crates` array."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name as should appear in the (implicit) `extern crate name` declaration."
+                }
+            },
+            "required": [
+                "crate",
+                "name"
+            ]
+        }
+    },
+    "properties": {
+        "sysroot": {
+            "type": "string",
+            "description": "Path to sysroot."
+        },
+        "sysroot_src": {
+            "type": "string",
+            "description": "Path to the directory with source code of sysroot crates."
+        },
+        "crates": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/crate"
+            },
+            "description": "The set of crates comprising the current project."
+        }
+    },
+    "required": [
+        "crates"
+    ]
+}

--- a/src/schemas/json/rust-project.json
+++ b/src/schemas/json/rust-project.json
@@ -1,164 +1,152 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "JSON schema for non-Cargo based Rust projects",
-    "type": "object",
-    "definitions": {
-        "crate": {
-            "type": "object",
-            "properties": {
-                "display_name": {
-                    "description": "Crate name used for display purposes, without affecting semantics.",
-                    "title": "Display name",
-                    "type": "string"
-                },
-                "root_module": {
-                    "description": "Path to the root module of the crate.",
-                    "title": "Root module",
-                    "type": "string"
-                },
-                "edition": {
-                    "description": "Edition of the crate.",
-                    "title": "Edition",
-                    "type": "string",
-                    "enum": [ "2015", "2018", "2021" ]
-                },
-                "deps": {
-                    "description": "Crate dependencies.",
-                    "title": "Dependencies",
-                    "type": "array",
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/dep"
-                    }
-                },
-                "version": {
-                    "description": "The crate's version",
-                    "title": "Version",
-                    "type": "string",
-                    "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$"
-                },
-                "is_workspace_member": {
-                    "description": "Whether this crate should be treated as a member of the current \"workspace\".",
-                    "title": "Is workspace member?",
-                    "type": "boolean"
-                },
-                "source": {
-                    "description": "(Super)set of `.rs` files comprising this crate.",
-                    "title": "Source",
-                    "type": "object",
-                    "properties": {
-                        "include_dirs": {
-                            "title": "Included directories",
-                            "type": "array",
-                            "uniqueItems": true,
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "exclude_dirs": {
-                            "title": "Excluded directories",
-                            "type": "array",
-                            "uniqueItems": true,
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "required": [
-                        "include_dirs",
-                        "exclude_dirs"
-                    ]
-                },
-                "cfg": {
-                    "description": "The set of cfgs activated for a given crate.",
-                    "title": "Configurations",
-                    "type": "array",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "target": {
-                    "description": "Target triple for this crate.",
-                    "title": "Target",
-                    "type": "string"
-                },
-                "env": {
-                    "description": "Environment variables, used for the `env!` macro",
-                    "title": "Environment variables",
-                    "type": "object",
-                    "patternProperties": {
-                        "^.*$": {
-                            "type": "string"
-                        }
-                      },
-                    "additionalProperties": false
-                },
-                "is_proc_macro": {
-                    "description": "Whether the crate is a proc-macro crate.",
-                    "title": "Is proc-macro?",
-                    "type": "boolean"
-                },
-                "proc_macro_dylib_path": {
-                    "description": "For proc-macro crates, path to compiled proc-macro (.so file).",
-                    "title": "Path to compiled proc-macro",
-                    "type": "string"
-                },
-                "repository": {
-                    "description": "URL to the source repository of the crate.",
-                    "title": "Repository",
-                    "type": "string"
-                }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "crate": {
+      "type": "object",
+      "properties": {
+        "display_name": {
+          "description": "Crate name used for display purposes, without affecting semantics.",
+          "title": "Display name",
+          "type": "string"
+        },
+        "root_module": {
+          "description": "Path to the root module of the crate.",
+          "title": "Root module",
+          "type": "string"
+        },
+        "edition": {
+          "description": "Edition of the crate.",
+          "title": "Edition",
+          "type": "string",
+          "enum": ["2015", "2018", "2021"]
+        },
+        "deps": {
+          "description": "Crate dependencies.",
+          "title": "Dependencies",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/dep"
+          }
+        },
+        "version": {
+          "description": "The crate's version",
+          "title": "Version",
+          "type": "string",
+          "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$"
+        },
+        "is_workspace_member": {
+          "description": "Whether this crate should be treated as a member of the current \"workspace\".",
+          "title": "Is workspace member?",
+          "type": "boolean"
+        },
+        "source": {
+          "description": "(Super)set of `.rs` files comprising this crate.",
+          "title": "Source",
+          "type": "object",
+          "properties": {
+            "include_dirs": {
+              "title": "Included directories",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
             },
-            "required": [
-                "root_module",
-                "edition",
-                "deps"
-            ]
-        },
-        "dep": {
-            "title": "Dependencies",
-            "type": "object",
-            "properties": {
-                "crate": {
-                    "description": "Index of a crate in the `crates` array.",
-                    "title": "Crate index",
-                    "type": "integer"
-                },
-                "name": {
-                    "description": "Name as should appear in the (implicit) `extern crate name` declaration.",
-                    "title": "Name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "crate",
-                "name"
-            ]
-        }
-    },
-    "properties": {
-        "sysroot": {
-            "description": "Path to sysroot.",
-            "title": "Sysroot",
-            "type": "string"
-        },
-        "sysroot_src": {
-            "description": "Path to the directory with source code of sysroot crates.",
-            "title": "Sysroot source",
-            "type": "string"
-        },
-        "crates": {
-            "description": "The set of crates comprising the current project.",
-            "title": "Crates",
-            "type": "array",
-            "uniqueItems": true,
-            "items": {
-                "$ref": "#/definitions/crate"
+            "exclude_dirs": {
+              "title": "Excluded directories",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
             }
+          },
+          "required": ["include_dirs", "exclude_dirs"]
+        },
+        "cfg": {
+          "description": "The set of cfgs activated for a given crate.",
+          "title": "Configurations",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "target": {
+          "description": "Target triple for this crate.",
+          "title": "Target",
+          "type": "string"
+        },
+        "env": {
+          "description": "Environment variables, used for the `env!` macro",
+          "title": "Environment variables",
+          "type": "object",
+          "patternProperties": {
+            "^.*$": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "is_proc_macro": {
+          "description": "Whether the crate is a proc-macro crate.",
+          "title": "Is proc-macro?",
+          "type": "boolean"
+        },
+        "proc_macro_dylib_path": {
+          "description": "For proc-macro crates, path to compiled proc-macro (.so file).",
+          "title": "Path to compiled proc-macro",
+          "type": "string"
+        },
+        "repository": {
+          "description": "URL to the source repository of the crate.",
+          "title": "Repository",
+          "type": "string"
         }
+      },
+      "required": ["root_module", "edition", "deps"]
     },
-    "required": [
-        "crates"
-    ]
+    "dep": {
+      "title": "Dependencies",
+      "type": "object",
+      "properties": {
+        "crate": {
+          "description": "Index of a crate in the `crates` array.",
+          "title": "Crate index",
+          "type": "integer"
+        },
+        "name": {
+          "description": "Name as should appear in the (implicit) `extern crate name` declaration.",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": ["crate", "name"]
+    }
+  },
+  "properties": {
+    "sysroot": {
+      "description": "Path to sysroot.",
+      "title": "Sysroot",
+      "type": "string"
+    },
+    "sysroot_src": {
+      "description": "Path to the directory with source code of sysroot crates.",
+      "title": "Sysroot source",
+      "type": "string"
+    },
+    "crates": {
+      "description": "The set of crates comprising the current project.",
+      "title": "Crates",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/crate"
+      }
+    }
+  },
+  "required": ["crates"],
+  "title": "JSON schema for non-Cargo based Rust projects",
+  "type": "object"
 }

--- a/src/schemas/json/rust-project.json
+++ b/src/schemas/json/rust-project.json
@@ -7,19 +7,23 @@
             "type": "object",
             "properties": {
                 "display_name": {
+                    "title": "Display name",
                     "type": "string",
                     "description": "Crate name used for display purposes, without affecting semantics."
                 },
                 "root_module": {
+                    "title": "Root module",
                     "type": "string",
                     "description": "Path to the root module of the crate."
                 },
                 "edition": {
+                    "title": "Edition",
                     "type": "string",
                     "description": "Edition of the crate.",
                     "enum": [ "2015", "2018", "2021" ]
                 },
                 "deps": {
+                    "title": "Dependencies",
                     "type": "array",
                     "description": "Crate dependencies.",
                     "items": {
@@ -27,25 +31,30 @@
                     }
                 },
                 "version": {
+                    "title": "Version",
                     "type": "string",
                     "description": "The crate's version",
                     "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$"
                 },
                 "is_workspace_member": {
+                    "title": "Is workspace member?",
                     "type": "boolean",
                     "description": "Whether this crate should be treated as a member of the current \"workspace\"."
                 },
                 "source": {
+                    "title": "Source",
                     "type": "object",
                     "description": "(Super)set of `.rs` files comprising this crate.",
                     "properties": {
                         "include_dirs": {
+                            "title": "Included directories",
                             "type": "array",
                             "items": {
                                 "type": "string"
                             }
                         },
                         "exclude_dirs": {
+                            "title": "Excluded directories",
                             "type": "array",
                             "items": {
                                 "type": "string"
@@ -58,6 +67,7 @@
                     ]
                 },
                 "cfg": {
+                    "title": "Configurations",
                     "type": "array",
                     "description": "The set of cfgs activated for a given crate.",
                     "items": {
@@ -65,10 +75,12 @@
                     }
                 },
                 "target": {
+                    "title": "Target",
                     "type": "string",
                     "description": "Target triple for this crate."
                 },
                 "env": {
+                    "title": "Environment variables",
                     "type": "object",
                     "description": "Environment variables, used for the `env!` macro",
                     "patternProperties": {
@@ -79,14 +91,17 @@
                     "additionalProperties": false
                 },
                 "is_proc_macro": {
+                    "title": "Is proc-macro?",
                     "type": "boolean",
                     "description": "Whether the crate is a proc-macro crate."
                 },
                 "proc_macro_dylib_path": {
+                    "title": "Path to compiled proc-macro",
                     "type": "string",
                     "description": "For proc-macro crates, path to compiled proc-macro (.so file)."
                 },
                 "repository": {
+                    "title": "Repository",
                     "type": "string",
                     "description": "URL to the source repository of the crate."
                 }
@@ -98,13 +113,16 @@
             ]
         },
         "dep": {
+            "title": "Dependencies",
             "type": "object",
             "properties": {
                 "crate": {
+                    "title": "Crate index",
                     "type": "integer",
                     "description": "Index of a crate in the `crates` array."
                 },
                 "name": {
+                    "title": "Name",
                     "type": "string",
                     "description": "Name as should appear in the (implicit) `extern crate name` declaration."
                 }
@@ -117,14 +135,17 @@
     },
     "properties": {
         "sysroot": {
+            "title": "Sysroot",
             "type": "string",
             "description": "Path to sysroot."
         },
         "sysroot_src": {
+            "title": "Sysroot source",
             "type": "string",
             "description": "Path to the directory with source code of sysroot crates."
         },
         "crates": {
+            "title": "Crates",
             "type": "array",
             "items": {
                 "$ref": "#/definitions/crate"

--- a/src/test/rust-project/rust-project.json
+++ b/src/test/rust-project/rust-project.json
@@ -1,29 +1,23 @@
 {
-    "sysroot_src": "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library",
-    "crates": [
-        {
-            "root_module": "examples/example1.rs",
-            "edition": "2021",
-            "deps": [],
-            "cfg": [
-                "test"
-            ]
-        },
-        {
-            "root_module": "examples/example2.rs",
-            "edition": "2021",
-            "deps": [],
-            "cfg": [
-                "test"
-            ]
-        },
-        {
-            "root_module": "examples/example3.rs",
-            "edition": "2021",
-            "deps": [],
-            "cfg": [
-                "test"
-            ]
-        }
-    ]
+  "crates": [
+    {
+      "root_module": "examples/example1.rs",
+      "edition": "2021",
+      "deps": [],
+      "cfg": ["test"]
+    },
+    {
+      "root_module": "examples/example2.rs",
+      "edition": "2021",
+      "deps": [],
+      "cfg": ["test"]
+    },
+    {
+      "root_module": "examples/example3.rs",
+      "edition": "2021",
+      "deps": [],
+      "cfg": ["test"]
+    }
+  ],
+  "sysroot_src": "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library"
 }

--- a/src/test/rust-project/rust-project.json
+++ b/src/test/rust-project/rust-project.json
@@ -1,0 +1,29 @@
+{
+    "sysroot_src": "/Users/user/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library",
+    "crates": [
+        {
+            "root_module": "examples/example1.rs",
+            "edition": "2021",
+            "deps": [],
+            "cfg": [
+                "test"
+            ]
+        },
+        {
+            "root_module": "examples/example2.rs",
+            "edition": "2021",
+            "deps": [],
+            "cfg": [
+                "test"
+            ]
+        },
+        {
+            "root_module": "examples/example3.rs",
+            "edition": "2021",
+            "deps": [],
+            "cfg": [
+                "test"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
Adding the schema for `rust-project.json`, which is documented [here](https://rust-analyzer.github.io/manual.html#non-cargo-based-projects).

Note that I also added some extra fields that are not mentioned in the public link above but that are part of the [implementation](https://github.com/rust-lang/rust-analyzer/blob/398a71affb05aeeea1991044ec9ca1229e68f0f3/crates/project-model/src/project_json.rs).
