### PR TITLE
Fix Unreal Engine uproject plugin reference descriptor missing fields

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -688,6 +688,11 @@
       "clasp.json": {
         "externalSchema": ["base-04.json"]
       }
+    },
+    {
+      "uproject.json": {
+        "unknownKeywords": ["markdownDescription"]
+      }
     }
   ],
   "skiptest": [

--- a/src/schemas/json/uproject.json
+++ b/src/schemas/json/uproject.json
@@ -3,7 +3,8 @@
   "additionalProperties": false,
   "definitions": {
     "BuildConfiguration": {
-      "description": "Available build configurations. Mirorred from `UnrealTargetConfiguration`.",
+      "description": "Available build configurations. Mirorred from UnrealTargetConfiguration.",
+      "markdownDescription": "Available build configurations. Mirorred from `UnrealTargetConfiguration`.",
       "type": "string",
       "enum": [
         "Unknown",
@@ -31,7 +32,8 @@
           }
         },
         "HasExplicitPlatforms": {
-          "description": "When true, an empty PlatformAllowList is interpeted as 'no platforms' with the expectation that explict platforms will be added in plugin extensions",
+          "description": "When true, an empty PlatformAllowList is interpeted as 'no platforms' with the expectation that explict platforms will be added in plugin extensions.",
+          "markdownDescription": "When true, an empty `PlatformAllowList` is interpeted as **no platforms** with the expectation that explict platforms will be added in plugin extensions.",
           "type": "boolean",
           "default": false
         },
@@ -53,11 +55,11 @@
           ]
         },
         "Name": {
-          "description": "Name of this module",
+          "description": "Name of this module.",
           "type": "string"
         },
         "PlatformAllowList": {
-          "description": "List of allowed platforms",
+          "description": "List of allowed platforms.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -65,7 +67,7 @@
           }
         },
         "PlatformDenyList": {
-          "description": "List of disallowed platforms",
+          "description": "List of disallowed platforms.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -73,7 +75,7 @@
           }
         },
         "ProgramAllowList": {
-          "description": "List of allowed programs",
+          "description": "List of allowed programs.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -81,7 +83,7 @@
           }
         },
         "ProgramDenyList": {
-          "description": "List of disallowed programs",
+          "description": "List of disallowed programs.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -89,7 +91,7 @@
           }
         },
         "TargetAllowList": {
-          "description": "List of allowed targets",
+          "description": "List of allowed targets.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -97,7 +99,7 @@
           }
         },
         "TargetConfigurationAllowList": {
-          "description": "List of allowed target configurations",
+          "description": "List of allowed target configurations.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -105,7 +107,7 @@
           }
         },
         "TargetConfigurationDenyList": {
-          "description": "List of disallowed target configurations",
+          "description": "List of disallowed target configurations.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -113,7 +115,7 @@
           }
         },
         "TargetDenyList": {
-          "description": "List of disallowed targets",
+          "description": "List of disallowed targets.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -121,7 +123,7 @@
           }
         },
         "Type": {
-          "description": "Usage type of module",
+          "description": "Usage type of module.",
           "type": "string",
           "enum": [
             "Runtime",
@@ -148,36 +150,18 @@
       "type": "object",
       "properties": {
         "Enabled": {
-          "description": "Whether it should be enabled by default",
+          "description": "Whether it should be enabled by default.",
           "type": "boolean",
           "default": true
         },
-        "BlacklistPlatforms": {
-          "description": "If enabled, list of platforms for which the plugin should be disabled.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "type": "string"
-          }
-        },
-        "BlacklistTargetConfigurations": {
-          "description": "If enabled, list of target configurations for which the plugin should be disabled.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/BuildConfiguration"
-          }
-        },
-        "BlacklistTargets": {
-          "description": "If enabled, list of targets for which the plugin should be disabled.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/BuildTargetType"
-          }
+        "HasExplicitPlatforms": {
+          "description": "When true, empty SupportedTargetPlatforms and PlatformAllowList are interpreted as 'no platforms' with the expectation that explicit platforms will be added in plugin platform extensions.",
+          "markdownDescription": "When true, empty `SupportedTargetPlatforms` and `PlatformAllowList` are interpreted as **no platforms** with the expectation that explicit platforms will be added in plugin platform extensions.",
+          "type": "boolean",
+          "default": false
         },
         "Optional": {
-          "description": "Whether this plugin is optional, and the game should silently ignore it not being present",
+          "description": "Whether this plugin is optional, and the game should silently ignore it not being present.",
           "type": "boolean",
           "default": false
         },
@@ -190,45 +174,63 @@
           "type": "string"
         },
         "Name": {
-          "description": "Name of the plugin",
+          "description": "Name of the plugin.",
           "type": "string"
         },
-        "SupportedTargetPlatforms": {
-          "description": "The list of supported target platforms for this plugin.",
+        "PlatformAllowList": {
+          "description": "List of allowed platforms.",
           "type": "array",
           "uniqueItems": true,
           "items": {
             "type": "string"
           }
         },
-        "WhitelistPlatforms": {
-          "description": "If enabled, list of platforms for which the plugin should be enabled (or all platforms if blank).",
+        "PlatformDenyList": {
+          "description": "List of disallowed platforms.",
           "type": "array",
           "uniqueItems": true,
           "items": {
             "type": "string"
           }
         },
-        "WhitelistTargetConfigurations": {
-          "description": "If enabled, list of target configurations for which the plugin should be enabled (or all target configurations if blank).",
+        "TargetAllowList": {
+          "description": "List of allowed targets.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildTargetType"
+          }
+        },
+        "TargetConfigurationAllowList": {
+          "description": "List of allowed target configurations.",
           "type": "array",
           "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildConfiguration"
           }
         },
-        "WhitelistTargets": {
-          "description": "If enabled, list of targets for which the plugin should be enabled (or all targets if blank).",
+        "TargetConfigurationDenyList": {
+          "description": "List of disallowed target configurations.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/BuildConfiguration"
+          }
+        },
+        "TargetDenyList": {
+          "description": "List of disallowed targets.",
           "type": "array",
           "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/BuildTargetType"
           }
         }
-      }
+      },
+      "required": ["Enabled", "Name"]
     }
   },
-  "description": "Descriptor for projects. Contains all the information contained within a `.uproject` file.",
+  "description": "Descriptor for projects. Contains all the information contained within a .uproject file.",
+  "markdownDescription": "Descriptor for projects. Contains all the information contained within a `.uproject` file.",
   "properties": {
     "DisableEnginePluginsByDefault": {
       "description": "Indicates that enabled by default engine plugins should not be enabled unless explicitly enabled by the project or target files.",
@@ -236,35 +238,37 @@
       "default": false
     },
     "IsEnterpriseProject": {
-      "description": "Indicates if this project is an Enterprise project",
+      "description": "Indicates if this project is an Enterprise project.",
       "type": "boolean",
       "default": false
     },
     "Category": {
-      "description": "Category to show under the project browser",
+      "description": "Category to show under the project browser.",
       "type": "string"
     },
     "Description": {
-      "description": "Description to show in the project browser",
+      "description": "Description to show in the project browser.",
       "type": "string"
     },
     "EngineAssociation": {
-      "description": "The engine to open this project with. Denotes by `<major>.<minor>` convention e.g. `4.20`, `5.0` etc.",
+      "description": "The engine to open this project with. Denotes by <major>.<minor> convention e.g. 4.20, 5.0 or source engine hash.",
+      "markdownDescription": "The engine to open this project with. Denotes by `<major>.<minor>` convention e.g. `4.20`, `5.0` or source engine GUID.",
       "type": "string",
-      "pattern": "([0-9]+)\\.([0-9]+)"
+      "pattern": "(^([0-9]+)\\.([0-9]+)$)|(^\\{[A-F0-9]{8}(-[A-F0-9]{4}){3}-[A-F0-9]{12}\\}$)"
     },
     "EpicSampleNameHash": {
-      "description": "A hash that is used to determine if the project was forked from a sample",
+      "description": "A hash that is used to determine if the project was forked from a sample.",
       "type": "number"
     },
     "FileVersion": {
       "description": "Descriptor version number.",
+      "markdownDescription": "Descriptor version number. More details can be found in the [EProjectDescriptorVersion](https://docs.unrealengine.com/4.26/en-US/API/Runtime/Projects/EProjectDescriptorVersion__Type/).",
       "type": "number",
       "default": 3,
-      "$comment": "More details can be found in `EProjectDescriptorVersion`"
+      "$comment": "More details can be found in https://docs.unrealengine.com/4.26/en-US/API/Runtime/Projects/EProjectDescriptorVersion__Type/"
     },
     "Modules": {
-      "description": "List of all modules associated with this project",
+      "description": "List of all modules associated with this project.",
       "type": "array",
       "uniqueItems": true,
       "items": {
@@ -272,7 +276,7 @@
       }
     },
     "Plugins": {
-      "description": "List of plugins for this project (may be enabled/disabled)",
+      "description": "List of plugins for this project (may be enabled/disabled).",
       "type": "array",
       "uniqueItems": true,
       "items": {
@@ -280,17 +284,17 @@
       }
     },
     "PostBuildSteps": {
-      "description": "Custom steps to execute after building targets in this project",
+      "description": "Custom steps to execute after building targets in this project.",
       "type": "object",
       "$comment": "Define platform as key, command as value."
     },
     "PreBuildSteps": {
-      "description": "Custom steps to execute before building targets in this project",
+      "description": "Custom steps to execute before building targets in this project.",
       "type": "object",
       "$comment": "Define platform as key, command as value."
     },
     "TargetPlatforms": {
-      "description": "Array of platforms that this project is targeting",
+      "description": "Array of platforms that this project is targeting.",
       "type": "array",
       "uniqueItems": true,
       "items": {


### PR DESCRIPTION
Some fields were missing in the `PluginReferenceDescriptor` definitions, Added them based on the latest Unreal Engine documentation of [FPluginReferenceDescriptor](https://docs.unrealengine.com/5.1/en-US/API/Runtime/Projects/FPluginReferenceDescriptor/). Other changes:

* add markdown description field
* fix engine version pattern not including source hash
* standardize properties' description

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
