### PR TITLE
BigQuery Table JSON Schema allows RECORD as alias of STRUCT 

### DIFF
--- a/src/schemas/json/bigquery-table.json
+++ b/src/schemas/json/bigquery-table.json
@@ -54,12 +54,12 @@
       "if": {
         "properties": {
           "type": {
-            "const": "STRUCT"
+            "enum": ["STRUCT", "RECORD"]
           }
         }
       },
       "then": {
-        "required": ["fields", "type", "name", "mode"],
+        "required": ["fields", "type", "name"],
         "properties": {
           "name": {
             "$ref": "#/definitions/field_name"

--- a/src/schemas/json/bigquery-table.json
+++ b/src/schemas/json/bigquery-table.json
@@ -29,11 +29,7 @@
     },
     "field_mode": {
       "type": "string",
-      "enum": [
-        "NULLABLE",
-        "REQUIRED",
-        "REPEATED"
-      ]
+      "enum": ["NULLABLE", "REQUIRED", "REPEATED"]
     },
     "field_description": {
       "type": "string"

--- a/src/schemas/json/bigquery-table.json
+++ b/src/schemas/json/bigquery-table.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/bigquery-table",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "field": {
@@ -57,7 +58,6 @@
     }
   },
   "description": "BigQuery lets you specify a table's schema when you load data into a table or when you create an empty table. A table schema is a JSON file.",
-  "id": "https://json.schemastore.org/bigquery-table",
   "items": {
     "$ref": "#/definitions/field"
   },

--- a/src/schemas/json/bigquery-table.json
+++ b/src/schemas/json/bigquery-table.json
@@ -1,18 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "BigQuery lets you specify a table's schema when you load data into a table or when you create an empty table. A table schema is a JSON file.",
-  "id": "https://json.schemastore.org/bigquery-table",
-  "type": "array",
-  "items": {
-    "$ref": "#/definitions/field"
-  },
   "definitions": {
     "field": {
       "type": "object",
-      "required": [
-        "name",
-        "type"
-      ],
+      "required": ["name", "type"],
       "properties": {
         "name": {
           "type": "string"
@@ -39,11 +30,7 @@
         },
         "mode": {
           "type": "string",
-          "enum": [
-            "NULLABLE",
-            "REQUIRED",
-            "REPEATED"
-          ]
+          "enum": ["NULLABLE", "REQUIRED", "REPEATED"]
         },
         "description": {
           "type": "string"
@@ -57,12 +44,7 @@
         }
       },
       "then": {
-        "required": [
-          "fields",
-          "type",
-          "name",
-          "mode"
-        ],
+        "required": ["fields", "type", "name", "mode"],
         "properties": {
           "fields": {
             "type": "array",
@@ -73,5 +55,11 @@
         }
       }
     }
-  }
+  },
+  "description": "BigQuery lets you specify a table's schema when you load data into a table or when you create an empty table. A table schema is a JSON file.",
+  "id": "https://json.schemastore.org/bigquery-table",
+  "items": {
+    "$ref": "#/definitions/field"
+  },
+  "type": "array"
 }

--- a/src/schemas/json/bigquery-table.json
+++ b/src/schemas/json/bigquery-table.json
@@ -2,41 +2,57 @@
   "$id": "https://json.schemastore.org/bigquery-table",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "field_name": {
+      "type": "string"
+    },
+    "field_type": {
+      "type": "string",
+      "enum": [
+        "INT64",
+        "INTEGER",
+        "FLOAT64",
+        "FLOAT",
+        "NUMERIC",
+        "BIGNUMERIC",
+        "BOOL",
+        "BOOLEAN",
+        "STRING",
+        "BYTES",
+        "DATE",
+        "DATETIME",
+        "TIME",
+        "TIMESTAMP",
+        "STRUCT",
+        "RECORD",
+        "GEOGRAPHY"
+      ]
+    },
+    "field_mode": {
+      "type": "string",
+      "enum": [
+        "NULLABLE",
+        "REQUIRED",
+        "REPEATED"
+      ]
+    },
+    "field_description": {
+      "type": "string"
+    },
     "field": {
       "type": "object",
       "required": ["name", "type"],
       "properties": {
         "name": {
-          "type": "string"
+          "$ref": "#/definitions/field_name"
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "INT64",
-            "INTEGER",
-            "FLOAT64",
-            "FLOAT",
-            "NUMERIC",
-            "BIGNUMERIC",
-            "BOOL",
-            "BOOLEAN",
-            "STRING",
-            "BYTES",
-            "DATE",
-            "DATETIME",
-            "TIME",
-            "TIMESTAMP",
-            "STRUCT",
-            "RECORD",
-            "GEOGRAPHY"
-          ]
+          "$ref": "#/definitions/field_type"
         },
         "mode": {
-          "type": "string",
-          "enum": ["NULLABLE", "REQUIRED", "REPEATED"]
+          "$ref": "#/definitions/field_mode"
         },
         "description": {
-          "type": "string"
+          "$ref": "#/definitions/field_description"
         }
       },
       "if": {
@@ -49,6 +65,18 @@
       "then": {
         "required": ["fields", "type", "name", "mode"],
         "properties": {
+          "name": {
+            "$ref": "#/definitions/field_name"
+          },
+          "type": {
+            "$ref": "#/definitions/field_type"
+          },
+          "mode": {
+            "$ref": "#/definitions/field_mode"
+          },
+          "description": {
+            "$ref": "#/definitions/field_description"
+          },
           "fields": {
             "type": "array",
             "items": {

--- a/src/schemas/json/bigquery-table.json
+++ b/src/schemas/json/bigquery-table.json
@@ -13,7 +13,9 @@
           "type": "string",
           "enum": [
             "INT64",
+            "INTEGER",
             "FLOAT64",
+            "FLOAT",
             "NUMERIC",
             "BIGNUMERIC",
             "BOOL",

--- a/src/schemas/json/bigquery-table.json
+++ b/src/schemas/json/bigquery-table.json
@@ -1,43 +1,77 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "BigQuery lets you specify a table's schema when you load data into a table or when you create an empty table. A table schema is a JSON file.",
   "id": "https://json.schemastore.org/bigquery-table",
+  "type": "array",
   "items": {
-    "type": "object",
-    "description": "A column in a BigQuery table",
-    "additionalProperties": false,
-    "properties": {
-      "description": {
-        "type": "string"
-      },
-      "name": {
-        "type": "string"
-      },
-      "type": {
-        "type": "string",
-        "enum": [
-          "INT64",
-          "FLOAT64",
-          "NUMERIC",
-          "BIGNUMERIC",
-          "BOOL",
-          "STRING",
-          "BYTES",
-          "DATE",
-          "DATETIME",
-          "TIME",
-          "TIMESTAMP",
-          "STRUCT",
-          "GEOGRAPHY"
-        ]
-      },
-      "mode": {
-        "type": "string",
-        "enum": ["NULLABLE", "REQUIRED", "REPEATED"]
-      }
-    },
-    "required": ["name", "type"]
+    "$ref": "#/definitions/field"
   },
-  "title": "BigQuery table schema",
-  "type": "array"
+  "definitions": {
+    "field": {
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "INT64",
+            "FLOAT64",
+            "NUMERIC",
+            "BIGNUMERIC",
+            "BOOL",
+            "BOOLEAN",
+            "STRING",
+            "BYTES",
+            "DATE",
+            "DATETIME",
+            "TIME",
+            "TIMESTAMP",
+            "STRUCT",
+            "RECORD",
+            "GEOGRAPHY"
+          ]
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "NULLABLE",
+            "REQUIRED",
+            "REPEATED"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "STRUCT"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "fields",
+          "type",
+          "name",
+          "mode"
+        ],
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/field"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/test/bigquery-table/sample.bigquery.json
+++ b/src/test/bigquery-table/sample.bigquery.json
@@ -1,51 +1,51 @@
 [
-    {
-        "name": "primary_id",
+  {
+    "name": "primary_id",
+    "type": "INT64",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "children",
+    "type": "STRUCT",
+    "mode": "REPEATED",
+    "fields": [
+      {
+        "name": "children_id",
         "type": "INT64",
         "mode": "REQUIRED"
-    },
-    {
-        "name": "children",
+      },
+      {
+        "name": "name",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "children_weight",
         "type": "STRUCT",
-        "mode": "REPEATED",
+        "mode": "NULLABLE",
         "fields": [
-            {
-                "name": "children_id",
-                "type": "INT64",
-                "mode": "REQUIRED"
-            },
-            {
-                "name": "name",
-                "type": "STRING",
-                "mode": "REQUIRED"
-            },
-            {
-                "name": "children_weight",
-                "type": "STRUCT",
-                "mode": "NULLABLE",
-                "fields": [
-                    {
-                        "name": "value",
-                        "type": "INT64",
-                        "mode": "NULLABLE"
-                    },
-                    {
-                        "name": "unit",
-                        "type": "STRING",
-                        "mode": "NULLABLE"
-                    }
-                ]
-            },
-            {
-                "name": "age",
-                "type": "INT64",
-                "mode": "NULLABLE"
-            },
-            {
-                "name": "timestamp",
-                "type": "BIGNUMERIC",
-                "mode": "NULLABLE"
-            }
+          {
+            "name": "value",
+            "type": "INT64",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "unit",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
         ]
-    }
+      },
+      {
+        "name": "age",
+        "type": "INT64",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "timestamp",
+        "type": "BIGNUMERIC",
+        "mode": "NULLABLE"
+      }
+    ]
+  }
 ]

--- a/src/test/bigquery-table/sample.bigquery.json
+++ b/src/test/bigquery-table/sample.bigquery.json
@@ -1,18 +1,51 @@
 [
-  {
-    "description": "Person name",
-    "mode": "REQUIRED",
-    "name": "full_name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "team",
-    "type": "STRING"
-  },
-  {
-    "description": "High-score",
-    "name": "score",
-    "type": "BIGNUMERIC"
-  }
+    {
+        "name": "primary_id",
+        "type": "INT64",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "children",
+        "type": "STRUCT",
+        "mode": "REPEATED",
+        "fields": [
+            {
+                "name": "children_id",
+                "type": "INT64",
+                "mode": "REQUIRED"
+            },
+            {
+                "name": "name",
+                "type": "STRING",
+                "mode": "REQUIRED"
+            },
+            {
+                "name": "children_weight",
+                "type": "STRUCT",
+                "mode": "NULLABLE",
+                "fields": [
+                    {
+                        "name": "value",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "name": "unit",
+                        "type": "STRING",
+                        "mode": "NULLABLE"
+                    }
+                ]
+            },
+            {
+                "name": "age",
+                "type": "INT64",
+                "mode": "NULLABLE"
+            },
+            {
+                "name": "timestamp",
+                "type": "BIGNUMERIC",
+                "mode": "NULLABLE"
+            }
+        ]
+    }
 ]


### PR DESCRIPTION
RECORD and STRUCT types **MUST** always have a `fields` property.