### PR TITLE
Update location of ansible schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -88,37 +88,37 @@
     {
       "name": "Ansible Execution Environment",
       "description": "Ansible execution-environment.yml file",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-ee.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/execution-environment.json",
       "fileMatch": ["**/execution-environment.yml"]
     },
     {
       "name": "Ansible Meta",
       "description": "Ansible meta/main.yml file",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-meta.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json",
       "fileMatch": ["**/meta/main.yml"]
     },
     {
       "name": "Ansible Meta Runtime",
       "description": "Ansible meta/runtime.yml file",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-meta-runtime.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta-runtime.json",
       "fileMatch": ["**/meta/runtime.yml"]
     },
     {
       "name": "Ansible Argument Specs",
       "description": "Ansible meta/argument_specs.yml file",
-      "url": "https://github.com/ansible/schemas/raw/main/f/ansible-argument-specs.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/arg_specs.json",
       "fileMatch": ["**/meta/argument_specs.yml"]
     },
     {
       "name": "Ansible Requirements",
       "description": "Ansible requirements file",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-requirements.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json",
       "fileMatch": ["requirements.yml"]
     },
     {
       "name": "Ansible Vars File",
       "description": "Ansible variables File",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-vars.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/vars.json",
       "fileMatch": [
         "**/vars/*.yml",
         "**/vars/*.yaml",
@@ -133,7 +133,7 @@
     {
       "name": "Ansible Tasks File",
       "description": "Ansible tasks file",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible.json#/$defs/tasks",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/tasks",
       "fileMatch": [
         "**/tasks/*.yml",
         "**/tasks/*.yaml",
@@ -144,7 +144,7 @@
     {
       "name": "Ansible Playbook",
       "description": "Ansible playbook files",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible.json#/$defs/playbook",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible.json#/$defs/playbook",
       "fileMatch": [
         "playbook.yml",
         "playbook.yaml",
@@ -157,13 +157,13 @@
     {
       "name": "Ansible Inventory",
       "description": "Ansible inventory files",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-inventory.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json",
       "fileMatch": ["inventory.yml", "inventory.yaml"]
     },
     {
       "name": "Ansible Collection Galaxy",
       "description": "Ansible Collection Galaxy metadata",
-      "url": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-galaxy.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/galaxy.json",
       "fileMatch": ["galaxy.yml"]
     },
     {


### PR DESCRIPTION
Ansible own schemas repository was assimilated into ansible-lint one
and marked as archived, so we need to update the URLs.

See: https://github.com/ansible/schemas

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
