### PR TITLE
ava: refresh schema: add missing `title` properties

### DIFF
--- a/src/schemas/json/ava.json
+++ b/src/schemas/json/ava.json
@@ -59,6 +59,7 @@
       "description": "If `false`, does not fail a test if it doesn't run assertions"
     },
     "environmentVariables": {
+      "title": "environment variables",
       "type": "object",
       "description": "Specifies environment variables to be made available to the tests. The environment variables defined here override the ones from `process.env`",
       "additionalProperties": {
@@ -85,6 +86,7 @@
           "$ref": "#/definitions/array-of-strings"
         },
         {
+          "title": "extensions",
           "type": "object",
           "patternProperties": {
             "^(c|m)?js$": {
@@ -127,6 +129,7 @@
       "description": "If `false`, disable parallel builds (default: `true`)"
     },
     "typescript": {
+      "title": "configuration",
       "type": "object",
       "description": "Configures @ava/typescript for projects that precompile TypeScript. Alternatively, you can use `ts-node` to do live testing without transpiling, in which case you shouldn't use the `typescript` property",
       "properties": {
@@ -136,6 +139,7 @@
           "description": "You can configure AVA to recognize additional file extensions as TypeScript (e.g., `[\"ts\", \"tsx\"]` to add partial JSX support). Note that the preserve mode for JSX is not (yet) supported. See also AVA's `extensions` object"
         },
         "rewritePaths": {
+          "title": "paths",
           "type": "object",
           "description": "AVA searches your entire project for `*.js`, `*.cjs`, `*.mjs` and `*.ts` files (or other extensions you've configured). It will ignore such files found in the `rewritePaths` targets (e.g. `build/`). If you use more specific paths, for instance `build/main/`, you may need to change AVA's `files` configuration to ignore other directories. Paths are relative to your project directory",
           "patternProperties": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
