### PR TITLE
lint.yml remove editorconfig-checker

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,9 @@ jobs:
 
       # Enablement of https://pre-commit.ci is desirable as it also
       # enable auto-fixes for formatting violations. Still we still want to run
-      # our own github action, just in case the external service becomes
+      # our own GitHub action, just in case the external service becomes
       # unavailable.
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install pre-commit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-      - name: Check for editorconfig violations
-        uses: editorconfig-checker/action-editorconfig-checker@v1
 
       # Enablement of https://pre-commit.ci is desirable as it also
       # enable auto-fixes for formatting violations. Still we still want to run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       # unavailable.
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install pre-commit
         run: |
           python3 -m pip install --upgrade pip


### PR DESCRIPTION
Pre-commit use "Prettier" with auto fix.
"Prettier" also reads the .editorconfig file.
This site is "Prettier" oriented, no extra lint is needed.