### PR TITLE
Adding `hex-repository` private registry keys to `dependabot-2.0.json`

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -260,6 +260,7 @@
                 "docker-registry",
                 "git",
                 "hex-organization",
+                "hex-repository",
                 "maven-repository",
                 "npm-registry",
                 "nuget-feed",
@@ -293,6 +294,18 @@
               "type": "boolean"
             },
             "organization": {
+              "description": "",
+              "type": "string"
+            },
+            "repo": {
+              "description": "",
+              "type": "string"
+            },
+            "auth-key": {
+              "description": "",
+              "type": "string"
+            },
+            "public-key-fingerprint": {
               "description": "",
               "type": "string"
             }


### PR DESCRIPTION
Per [GitHub docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#hex-repository):

### `hex-repository`

The `hex-repository` type supports an authentication key.

`repo` is a required field, which must match the name of the repository used in your dependency declaration.

The `public-key-fingerprint` is an optional configuration field, representing the fingerprint of the public key for the Hex repository. `public-key-fingerprint` is used by Hex to establish trust with the private repository. The `public-key-fingerprint` field can be either listed in plaintext or stored as a {% data variables.product.prodname_dependabot %} secret.

```yaml
registries:
   github-hex-repository:
     type: hex-repository
     repo: private-repo
     url: https://private-repo.example.com
     auth-key: ${{secrets.MY_AUTH_KEY}}
     public-key-fingerprint: ${{secrets.MY_PUBLIC_KEY_FINGERPRINT}}
```

---

Adding:
- `hex-repository` to `registry.type` enum
- These additional keys to `registry`:
  - `repo`
  - `auth-key`
  - `public-key-fingerprint`