### PR TITLE
add changelog object to github-workflow.json

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -929,6 +929,71 @@
       "description": "The name of your workflow. GitHub displays the names of your workflows on your repository's actions page. If you omit this field, GitHub sets the name to the workflow's filename.",
       "type": "string"
     },
+    "changelog": {
+      "type": "object",
+      "$comment": "https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes",
+      "description": "An object used to configure the changelog generation for GitHub Releases",
+      "properties": {
+        "exclude": {
+          "type": "object",
+          "description": "An array of labels to exclude from the changelog.",
+          "properties": {
+            "labels": {
+              "type": "array",
+              "description": "A list of labels that exclude a pull request from appearing in release notes.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "authors": {
+              "type": "array",
+              "description": "A list of user or bot login handles whose pull requests are to be excluded from release notes.",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "categories": {
+          "type": "array",
+          "description": "An object that maps labels to categories in the changelog.",
+          "items": {
+            "type": "object",
+            "required": ["labels", "title"],
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "The title to use for the category."
+              },
+              "labels": {
+                "type": "array",
+                "description": "Required. Labels that qualify a pull request for this category. Use * as a catch-all for pull requests that didn't match any of the previous categories.",
+                "items": true
+              },
+              "exclude": {
+                "type": "object",
+                "properties": {
+                  "labels": {
+                    "type": "array",
+                    "description": "A list of labels that exclude a pull request from appearing in release notes.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "authors": {
+                    "type": "array",
+                    "description": "A list of user or bot login handles whose pull requests are to be excluded from release notes.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "on": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#on",
       "description": "The name of the GitHub event that triggers the workflow. You can provide a single event string, array of events, array of event types, or an event configuration map that schedules a workflow or restricts the execution of a workflow to specific files, tags, or branch changes. For a list of available events, see https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows.",

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -929,71 +929,6 @@
       "description": "The name of your workflow. GitHub displays the names of your workflows on your repository's actions page. If you omit this field, GitHub sets the name to the workflow's filename.",
       "type": "string"
     },
-    "changelog": {
-      "type": "object",
-      "$comment": "https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes",
-      "description": "An object used to configure the changelog generation for GitHub Releases",
-      "properties": {
-        "exclude": {
-          "type": "object",
-          "description": "An array of labels to exclude from the changelog.",
-          "properties": {
-            "labels": {
-              "type": "array",
-              "description": "A list of labels that exclude a pull request from appearing in release notes.",
-              "items": {
-                "type": "string"
-              }
-            },
-            "authors": {
-              "type": "array",
-              "description": "A list of user or bot login handles whose pull requests are to be excluded from release notes.",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "categories": {
-          "type": "array",
-          "description": "An object that maps labels to categories in the changelog.",
-          "items": {
-            "type": "object",
-            "required": ["labels", "title"],
-            "properties": {
-              "title": {
-                "type": "string",
-                "description": "The title to use for the category."
-              },
-              "labels": {
-                "type": "array",
-                "description": "Required. Labels that qualify a pull request for this category. Use * as a catch-all for pull requests that didn't match any of the previous categories.",
-                "items": true
-              },
-              "exclude": {
-                "type": "object",
-                "properties": {
-                  "labels": {
-                    "type": "array",
-                    "description": "A list of labels that exclude a pull request from appearing in release notes.",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "authors": {
-                    "type": "array",
-                    "description": "A list of user or bot login handles whose pull requests are to be excluded from release notes.",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "on": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#on",
       "description": "The name of the GitHub event that triggers the workflow. You can provide a single event string, array of events, array of event types, or an event configuration map that schedules a workflow or restricts the execution of a workflow to specific files, tags, or branch changes. For a list of available events, see https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows.",
@@ -1805,8 +1740,72 @@
     },
     "permissions": {
       "$ref": "#/definitions/permissions"
+    },
+    "changelog": {
+      "type": "object",
+      "$comment": "https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes",
+      "description": "An object used to configure the changelog generation for GitHub Releases",
+      "properties": {
+        "exclude": {
+          "type": "object",
+          "description": "An array of labels to exclude from the changelog.",
+          "properties": {
+            "labels": {
+              "type": "array",
+              "description": "A list of labels that exclude a pull request from appearing in release notes.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "authors": {
+              "type": "array",
+              "description": "A list of user or bot login handles whose pull requests are to be excluded from release notes.",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "categories": {
+          "type": "array",
+          "description": "An object that maps labels to categories in the changelog.",
+          "items": {
+            "type": "object",
+            "required": ["labels", "title"],
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "The title to use for the category."
+              },
+              "labels": {
+                "type": "array",
+                "description": "Required. Labels that qualify a pull request for this category. Use * as a catch-all for pull requests that didn't match any of the previous categories.",
+                "items": true
+              },
+              "exclude": {
+                "type": "object",
+                "properties": {
+                  "labels": {
+                    "type": "array",
+                    "description": "A list of labels that exclude a pull request from appearing in release notes.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "authors": {
+                    "type": "array",
+                    "description": "A list of user or bot login handles whose pull requests are to be excluded from release notes.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
-  "required": ["on", "jobs"],
   "type": "object"
 }

--- a/src/test/github-workflow/changelog.yaml
+++ b/src/test/github-workflow/changelog.yaml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Hey Folks, I found a semi-recent GitHub feature that enables the auto-generation of changelogs and the red squiggles sent me this way!

I have tried to add a test but I'm a bit stuck on how to resolve a failing negative test for an empty file, I think it was really testing a side effect about `"on"` and `"jobs"` being required. Please let me know if I can help move this forward, thanks!