### PR TITLE
Add alacritty config yaml schema definition

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3996,6 +3996,12 @@
       "url": "https://raw.githubusercontent.com/lalcebo/json-schema/master/serverless/reference.json"
     },
     {
+      "name": "Alacritty Configuration Schema",
+      "description": "Schema for Alacritty configuration yaml file",
+      "fileMatch": [".alacritty.yml", "alacritty.yml"],
+      "url": "https://raw.githubusercontent.com/distinction-dev/alacritty-schema/main/alacritty/reference.json"
+    },
+    {
       "name": "Serverless Workflow Schema",
       "description": "Schema for serverless workflows",
       "fileMatch": ["*.sw.json", "*.sw.yml"],


### PR DESCRIPTION
[Alacritty](https://github.com/alacritty/alacritty) is a fast, cross-platform, OpenGL terminal emulator that uses yaml for it's configuration.

I've already created the schema and tested it locally and it seems to work. Noticed that the schema for this file didn't exist so I decided to create it.