### PR TITLE
Update codemagic schema location

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -840,7 +840,7 @@
       "name": "codemagic",
       "description": "JSON schema for Codemagic CI/CD file configuration",
       "fileMatch": ["codemagic.yaml", "codemagic.yml"],
-      "url": "https://static.codemagic.io/codemagic-schema.json"
+      "url": "https://codemagic.io/media/codemagic-schema.json"
     },
     {
       "name": "Codux",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -840,7 +840,7 @@
       "name": "codemagic",
       "description": "JSON schema for Codemagic CI/CD file configuration",
       "fileMatch": ["codemagic.yaml", "codemagic.yml"],
-      "url": "https://codemagic.io/media/codemagic-schema.json"
+      "url": "https://codemagic.io/codemagic-schema.json"
     },
     {
       "name": "Codux",


### PR DESCRIPTION
The `codemagic-schema.json` is moving to a new location. Currently exists in the old and new URL.