### PR TITLE
Update CICS resource import and resource model locations

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4144,7 +4144,7 @@
       "name": "CICS TS resource import",
       "description": "JSON schema for resource import in IBM CICS Transaction Server for z/OS",
       "fileMatch": ["*.cicsresourceimport.yaml", "*.cicsresourceimport.yml"],
-      "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/resourceimport.json"
+      "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicsts-resourceimport.json"
     },
     {
       "name": "CICS TS resource model",
@@ -4155,7 +4155,7 @@
         "*.cicsappconstraints.yaml",
         "*.cicsappconstraints.yml"
       ],
-      "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/resourcemodel.json"
+      "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicsts-resourcemodel.json"
     },
     {
       "name": "CICS TS resource overrides",


### PR DESCRIPTION
We're making some consistency changes and have moved the canonical URL for CICS resource import and resource model files.