### PR TITLE
docs: Fix formatting of file extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ After adding a schema file in `src/schemas`, register them in alphabetical order
 To make sure that files are validated against your schema correctly (we strongly suggest adding at least one before creating a pull request):
 
 1. Create a subfolder in [`src/test`](src/test) named as your schema file
-2. Create one or more `.json, .yml, .yaml or toml` files in that folder
+2. Create one or more `.json`, `.yml`, `.yaml` or `toml` files in that folder
 
 #### Adding negative tests
 


### PR DESCRIPTION
Closes #197 because instructions on how to do schemas with multiple versions is already in the `CONTRIBUTING.md`

Also, to keep the signal/noise ratio high in the issue queue, closes #425 should be closed.