### PR TITLE
Schema for `dbt_project.yml` (Take two)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -696,6 +696,12 @@
       "url": "https://json.schemastore.org/csr.json"
     },
     {
+      "name": "dbt Project",
+      "description": "Schema for dbt project configurations",
+      "fileMatch": ["dbt_project.yml"],
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/dbt_project.json"
+    },
+    {
       "name": "Deadpendency Config Schema",
       "description": "Schema for Deadpendency config, a dependency management GitHub app",
       "fileMatch": [


### PR DESCRIPTION
Corrected the schema file for `dbt` project config file.

Initially, we added this entry on https://github.com/SchemaStore/schemastore/pull/2530, but it was incorrect so we reverted it here: https://github.com/SchemaStore/schemastore/pull/2562