### PR TITLE
docs: Instruct to install Prettier editor plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,10 @@ If you wish to retain full control over your schema definition, simply register 
 - In [schema-validation.json](src/schema-validation.json), in `"options": []` list add
  `"schema_x.json": {"externalSchema": ["schema_y.json"]}`
 
-### JSON formatter
+### Recommended Editor Extensions
 
-This project contains an [`.editorconfig`](https://github.com/SchemaStore/schemastore/blob/master/.editorconfig) file.
-If your IDE or code editor doesn't natively support it, please install the [EditorConfig](https://editorconfig.org) plugin.
+This project uses [EditorConfig](https://editorconfig.org) to configure editor settings and [Prettier](https://prettier.io) to configure file formatting.
+Please install the EditorConfig and Prettier extensions for your IDE or code editor if they are not natively supported.
 
 ### Validation mode
 


### PR DESCRIPTION
As recommended [here](https://github.com/SchemaStore/schemastore/pull/2670#issuecomment-1364653098), this PR adds a note to use the Prettier plugin for users' respective editors.