### PR TITLE
Add JSON schema for Ruff's `ruff.toml`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2687,6 +2687,12 @@
       "url": "https://json.schemastore.org/resjson.json"
     },
     {
+      "name": "Ruff",
+      "description": "JSON schema for Ruff, a fast Python linter",
+      "fileMatch": ["ruff.toml"],
+      "url": "https://raw.githubusercontent.com/charliermarsh/ruff/main/ruff.schema.json"
+    },
+    {
       "name": "Rust Project",
       "description": "JSON schema for non-Cargo based Rust projects",
       "fileMatch": ["rust-project.json"],


### PR DESCRIPTION
This PR adds a schema for [Ruff's](https://github.com/charliermarsh/ruff) `ruff.toml` format.