### PR TITLE
Improve `$schema` property for all schemas

### DIFF
--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -1285,17 +1285,28 @@ module.exports = function (grunt) {
   )
 
   grunt.registerTask(
-    'local_check_for_schema_version_present',
+    'local_assert_schema_version_is_valid',
     'Dynamically load schema file for $schema present check',
     function () {
       let countScan = 0
+
       localSchemaFileAndTestFile(
         {
-          schemaOnlyScan(callbackParameter) {
+          schemaOnlyScan(data) {
             countScan++
-            if (!('$schema' in callbackParameter.jsonObj)) {
+
+            if (
+              ![
+                'http://json-schema.org/draft-03/schema#',
+                'http://json-schema.org/draft-04/schema#',
+                'http://json-schema.org/draft-06/schema#',
+                'http://json-schema.org/draft-07/schema#',
+                'https://json-schema.org/draft/2019-09/schema',
+                'https://json-schema.org/draft/2020-12/schema',
+              ].includes(data.jsonObj.$schema)
+            ) {
               throwWithErrorText([
-                `Schema file is missing '$schema' keyword => ${callbackParameter.jsonName}`,
+                `Schema file has invalid or missing '$schema' keyword => ${data.jsonName}`,
               ])
             }
           },
@@ -1305,6 +1316,7 @@ module.exports = function (grunt) {
           skipReadFile: false,
         }
       )
+
       grunt.log.ok(`Total files scan: ${countScan}`)
     }
   )
@@ -1820,7 +1832,7 @@ module.exports = function (grunt) {
     'local_schema-present-in-catalog-list',
     'local_bom',
     'local_find-duplicated-property-keys',
-    'local_check_for_schema_version_present',
+    'local_assert_schema_version_is_valid',
     'local_check_for_schema_version_too_high',
     'local_count_url_in_catalog',
     'local_count_schema_versions',

--- a/src/schemas/json/BizTalkServerApplicationSchema.json
+++ b/src/schemas/json/BizTalkServerApplicationSchema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "BizTalk Server Application Inventory Schema",
   "id": "http://schema.management.azure.com/schemas/2017-04-01/BizTalkServerApplicationSchema.json#",
   "properties": {

--- a/src/schemas/json/agripparc-1.2.json
+++ b/src/schemas/json/agripparc-1.2.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "properties": {
     "props": {

--- a/src/schemas/json/agripparc-1.3.json
+++ b/src/schemas/json/agripparc-1.3.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "properties": {
     "props": {

--- a/src/schemas/json/agripparc-1.4.json
+++ b/src/schemas/json/agripparc-1.4.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "properties": {
     "props": {

--- a/src/schemas/json/anywork-ac-1.0.json
+++ b/src/schemas/json/anywork-ac-1.0.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/anywork-ac-1.0.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "allOf": [
     {

--- a/src/schemas/json/anywork-ac-1.1.json
+++ b/src/schemas/json/anywork-ac-1.1.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/anywork-ac-1.0.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "allOf": [
     {

--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "webOptimizer": {
       "type": "object",

--- a/src/schemas/json/asconfig-schema.json
+++ b/src/schemas/json/asconfig-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "definitions": {
     "nonEmptyString": {

--- a/src/schemas/json/azure-deviceupdate-import-manifest-4.0.json
+++ b/src/schemas/json/azure-deviceupdate-import-manifest-4.0.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/azure-deviceupdate-import-manifest-4.0.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "instructions": {
       "type": "object",

--- a/src/schemas/json/azure-deviceupdate-import-manifest-5.0.json
+++ b/src/schemas/json/azure-deviceupdate-import-manifest-5.0.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/azure-deviceupdate-import-manifest-5.0.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "instructions": {
       "type": "object",

--- a/src/schemas/json/azure-deviceupdate-manifest-definitions-4.0.json
+++ b/src/schemas/json/azure-deviceupdate-manifest-definitions-4.0.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/azure-deviceupdate-manifest-definitions-4.0.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "updateId": {
       "type": "object",

--- a/src/schemas/json/azure-deviceupdate-manifest-definitions-5.0.json
+++ b/src/schemas/json/azure-deviceupdate-manifest-definitions-5.0.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/azure-deviceupdate-manifest-definitions-5.0.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "updateId": {
       "type": "object",

--- a/src/schemas/json/azure-deviceupdate-update-manifest-4.json
+++ b/src/schemas/json/azure-deviceupdate-update-manifest-4.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/azure-deviceupdate-update-manifest-4.0.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "miniUpdateManifest": {
       "type": "object",

--- a/src/schemas/json/azure-deviceupdate-update-manifest-5.json
+++ b/src/schemas/json/azure-deviceupdate-update-manifest-5.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/azure-deviceupdate-update-manifest-5.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "miniUpdateManifest": {
       "type": "object",

--- a/src/schemas/json/backportrc.json
+++ b/src/schemas/json/backportrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": true,
   "properties": {
     "upsteam": {

--- a/src/schemas/json/bamboo-spec.json
+++ b/src/schemas/json/bamboo-spec.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": {
     "$ref": "#/definitions/job"
   },

--- a/src/schemas/json/base-04.json
+++ b/src/schemas/json/base-04.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "nullable-array": {
       "id": "nullable-array",

--- a/src/schemas/json/base.json
+++ b/src/schemas/json/base.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/base.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "nullable-array": {
       "$id": "nullable-array",

--- a/src/schemas/json/bundleconfig.json
+++ b/src/schemas/json/bundleconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "jsBundle": {
       "properties": {

--- a/src/schemas/json/bxci.schema-1.0.1.json
+++ b/src/schemas/json/bxci.schema-1.0.1.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "branchPattern": {
       "description": "Regular expression for validating branch names",

--- a/src/schemas/json/bxci.schema-1.0.json
+++ b/src/schemas/json/bxci.schema-1.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "branchPattern": {
       "description": "Regular expression for validating branch names",

--- a/src/schemas/json/bxci.schema-2.0.0.json
+++ b/src/schemas/json/bxci.schema-2.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "branchPattern": {
       "description": "Regular expression for validating branch names",

--- a/src/schemas/json/bxci.schema-2.x.json
+++ b/src/schemas/json/bxci.schema-2.x.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "branchPattern": {
       "description": "Regular expression for validating branch names",

--- a/src/schemas/json/catalog-info.json
+++ b/src/schemas/json/catalog-info.json
@@ -1,9 +1,9 @@
 {
   "$id": "https://json.schemastore.org/catalog-info.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "ApiV1alpha1",
       "description": "An API describes an interface that can be exposed by a component. The API can be defined in different formats, like OpenAPI, AsyncAPI, GraphQL, gRPC, or other formats.",
       "examples": [
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "ComponentV1alpha1",
       "description": "A Component describes a software component. It is typically intimately linked to the source code that constitutes the component, and should be what a developer may regard a \"unit of software\", usually with a distinct deployable or linkable artifact.",
       "examples": [
@@ -202,7 +202,7 @@
       ]
     },
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "DomainV1alpha1",
       "description": "A Domain groups a collection of systems that share terminology, domain models, business purpose, or documentation, i.e. form a bounded context.",
       "examples": [
@@ -249,7 +249,7 @@
       ]
     },
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "GroupV1alpha1",
       "description": "A group describes an organizational entity, such as for example a team, a business unit, or a loose collection of people in an interest group. Members of these groups are modeled in the catalog as kind User.",
       "examples": [
@@ -353,7 +353,7 @@
       ]
     },
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "LocationV1alpha1",
       "description": "A location is a marker that references other places to look for catalog data.",
       "examples": [
@@ -421,7 +421,7 @@
       ]
     },
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "ResourceV1alpha1",
       "description": "A resource describes the infrastructure a system needs to operate, like BigTable databases, Pub/Sub topics, S3 buckets or CDNs. Modelling them together with components and systems allows to visualize resource footprint, and create tooling around them.",
       "examples": [
@@ -489,7 +489,7 @@
       ]
     },
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "SystemV1alpha1",
       "description": "A system is a collection of resources and components. The system may expose or consume one or several APIs. It is viewed as abstraction level that provides potential consumers insights into exposed features without needing a too detailed view into the details of all components. This also gives the owning team the possibility to decide about published artifacts and APIs.",
       "examples": [
@@ -543,7 +543,7 @@
       ]
     },
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "TemplateV1beta2",
       "description": "A Template describes a scaffolding task for use with the Scaffolder. It describes the required parameters as well as a series of steps that will be taken to execute the scaffolding task.",
       "examples": [
@@ -727,7 +727,7 @@
       ]
     },
     {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "UserV1alpha1",
       "description": "A user describes a person, such as an employee, a contractor, or similar. Users belong to Group entities in the catalog. These catalog user entries are connected to the way that authentication within the Backstage ecosystem works. See the auth section of the docs for a discussion of these concepts.",
       "examples": [
@@ -809,7 +809,7 @@
   ],
   "definitions": {
     "entity": {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "Entity",
       "description": "The parts of the format that's common to all versions/kinds of entity.",
       "examples": [
@@ -860,7 +860,7 @@
           ]
         },
         "metadata": {
-          "$schema": "http://json-schema.org/draft-07/schema",
+          "$schema": "http://json-schema.org/draft-07/schema#",
           "$id": "EntityMeta",
           "description": "Metadata fields common to all versions/kinds of entity.",
           "examples": [
@@ -999,7 +999,7 @@
       }
     },
     "common": {
-      "$schema": "http://json-schema.org/draft-07/schema",
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "common",
       "type": "object",
       "description": "Common definitions to import from other schemas",

--- a/src/schemas/json/cdk.json
+++ b/src/schemas/json/cdk.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "app": {
       "type": "string",

--- a/src/schemas/json/cheatsheets.json
+++ b/src/schemas/json/cheatsheets.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://github.com/cheat/cheat",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "editor": {

--- a/src/schemas/json/clang-format.json
+++ b/src/schemas/json/clang-format.json
@@ -1,6 +1,6 @@
 {
   "$defs": {},
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": {},
   "description": "The .clang-format file is a YAML file defining formatting styles used by clang-format.\r\r see https://clang.llvm.org/docs/ClangFormatStyleOptions.html",
   "patternProperties": {

--- a/src/schemas/json/clangd.json
+++ b/src/schemas/json/clangd.json
@@ -14,7 +14,7 @@
       ]
     }
   },
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "If": {
       "description": "Conditions in the If block restrict when a fragment applies.",

--- a/src/schemas/json/clasp.json
+++ b/src/schemas/json/clasp.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "scriptId": {
       "description": "An ID of the current Google Apps Script project\nhttps://github.com/google/clasp#scriptid-required",

--- a/src/schemas/json/commands.json
+++ b/src/schemas/json/commands.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "commands": {
       "type": "object",

--- a/src/schemas/json/commitlintrc.json
+++ b/src/schemas/json/commitlintrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "rule": {
       "oneOf": [

--- a/src/schemas/json/compilerconfig.json
+++ b/src/schemas/json/compilerconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "lessOptions": {
       "properties": {

--- a/src/schemas/json/compilerdefaults.json
+++ b/src/schemas/json/compilerdefaults.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "less": {
       "description": "Specify options for the compiler.",

--- a/src/schemas/json/component-detection-manifest.json
+++ b/src/schemas/json/component-detection-manifest.json
@@ -1,6 +1,6 @@
 {
   "$ref": "#/definitions/CGManifest",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "CGManifest": {
       "properties": {

--- a/src/schemas/json/content-security-policy-report-2.json
+++ b/src/schemas/json/content-security-policy-report-2.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "description": "https://www.w3.org/TR/CSP2/#violation-reports",
   "properties": {

--- a/src/schemas/json/cosmos-config.json
+++ b/src/schemas/json/cosmos-config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "properties": {
     "$schema": {

--- a/src/schemas/json/crowdin.json
+++ b/src/schemas/json/crowdin.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://support.crowdin.com/configuration-file/",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Configuration for Crowdin, a crowd-translation platform.",
   "properties": {
     "project_id": {

--- a/src/schemas/json/cryproj.53.schema.json
+++ b/src/schemas/json/cryproj.53.schema.json
@@ -1,6 +1,6 @@
 {
   "$comment": "JSON Schema for CRYENGINE 5.3",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "cvars": {
       "$id": "/definitions/cvars",

--- a/src/schemas/json/cryproj.54.schema.json
+++ b/src/schemas/json/cryproj.54.schema.json
@@ -1,6 +1,6 @@
 {
   "$comment": "JSON Schema for CRYENGINE 5.4",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "cvars": {
       "$id": "/definitions/cvars",

--- a/src/schemas/json/cryproj.55.schema.json
+++ b/src/schemas/json/cryproj.55.schema.json
@@ -1,6 +1,6 @@
 {
   "$comment": "JSON Schema for CRYENGINE 5.5",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "cvars": {
       "$id": "/definitions/cvars",

--- a/src/schemas/json/cryproj.dev.schema.json
+++ b/src/schemas/json/cryproj.dev.schema.json
@@ -1,6 +1,6 @@
 {
   "$comment": "JSON Schema for CRYENGINE dev",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "cvars": {
       "$id": "/definitions/cvars",

--- a/src/schemas/json/cryproj.json
+++ b/src/schemas/json/cryproj.json
@@ -1,6 +1,6 @@
 {
   "$comment": "JSON Schema for CRYENGINE *",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "cvars": {
       "$id": "/definitions/cvars",

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "exclude": {
       "description": "A list of files to ignore in the current project\nhttps://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md#create-custom-config",

--- a/src/schemas/json/dart-build.json
+++ b/src/schemas/json/dart-build.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://json.schemastore.org/dart-build",
   "$ref": "#/definitions/buildConfig",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "_listOfGlobs": {
       "type": "array",

--- a/src/schemas/json/dart-test.json
+++ b/src/schemas/json/dart-test.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://json.schemastore.org/dart-test",
   "$ref": "#/definitions/runnerConfiguration",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "timeout": {
       "$comment": "Based on https://github.com/dart-lang/test/blob/3b8d3b90efd24f55f7316cd414716d1cb031761c/pkgs/test_api/lib/src/frontend/timeout.dart#L55-L68",

--- a/src/schemas/json/docfx.json
+++ b/src/schemas/json/docfx.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "buildConfig": {
       "type": "object",

--- a/src/schemas/json/dockerd.json
+++ b/src/schemas/json/dockerd.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/dockerd.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "https://docs.docker.com/engine/reference/commandline/dockerd/#daemon",
   "properties": {
     "allow-nondistributable-artifacts": {

--- a/src/schemas/json/dotnet-releases-index.json
+++ b/src/schemas/json/dotnet-releases-index.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Schema derived from https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases-index.json and https://github.com/dotnet/deployment-tools/blob/main/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "definitions": {
     "dateYYYYMMDD": {

--- a/src/schemas/json/dotnetcli.host.json
+++ b/src/schemas/json/dotnetcli.host.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "symbolInfo": {
       "properties": {

--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "statics": {
       "type": "object",

--- a/src/schemas/json/foxx-manifest.json
+++ b/src/schemas/json/foxx-manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Schema for ArangoDB Foxx service manifests",
   "properties": {
     "configuration": {

--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
     "expressionSyntax": {

--- a/src/schemas/json/github-funding.json
+++ b/src/schemas/json/github-funding.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
     "github_username": {

--- a/src/schemas/json/github-issue-config.json
+++ b/src/schemas/json/github-issue-config.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "blank_issues_enabled": {
       "description": "Specify whether allow blank issue creation\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser",

--- a/src/schemas/json/github-issue-forms.json
+++ b/src/schemas/json/github-issue-forms.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
     "type": {

--- a/src/schemas/json/github-workflow-template-properties.json
+++ b/src/schemas/json/github-workflow-template-properties.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
     "name": {

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
     "architecture": {

--- a/src/schemas/json/gitversion.json
+++ b/src/schemas/json/gitversion.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "default": {},
   "description": "Output from the GitVersion tool, describing the current version of the repo it was executed from",

--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://gohugo.io/getting-started/configuration/",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "uniqueStringArray": {
       "type": "array",

--- a/src/schemas/json/ide.host.json
+++ b/src/schemas/json/ide.host.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "text": {
       "required": ["text"],

--- a/src/schemas/json/imageoptimizer.json
+++ b/src/schemas/json/imageoptimizer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Schema for imageoptimizer.json files",
   "properties": {
     "optimizations": {

--- a/src/schemas/json/imgbotconfig.json
+++ b/src/schemas/json/imgbotconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "default": {},
   "properties": {
     "schedule": {

--- a/src/schemas/json/jasmine.json
+++ b/src/schemas/json/jasmine.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "allOf": [
     {
       "$ref": "#/definitions/root-items"

--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://jekyllrb.com/docs/configuration/",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "global-permalink": {
       "description": "The global permalink format\nhttps://jekyllrb.com/docs/permalinks/#global",

--- a/src/schemas/json/jovo-language-model.json
+++ b/src/schemas/json/jovo-language-model.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/jovo-language-model",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "dialogflowEntity": {
       "type": "object",

--- a/src/schemas/json/jsdoc-1.0.0.json
+++ b/src/schemas/json/jsdoc-1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "plugins": {
       "type": "array",

--- a/src/schemas/json/kode-ci-build-1.0.0.json
+++ b/src/schemas/json/kode-ci-build-1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "definitions": {
     "branch-matcher": {

--- a/src/schemas/json/label-commenter-config.json
+++ b/src/schemas/json/label-commenter-config.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://github.com/peaceiris/actions-label-commenter",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "labelItem": {
       "type": "object",

--- a/src/schemas/json/lgtm.json
+++ b/src/schemas/json/lgtm.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://lgtm.com/help/lgtm/lgtm.yml-configuration-file",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "queryItem": {
       "title": "Query",

--- a/src/schemas/json/lintstagedrc.schema.json
+++ b/src/schemas/json/lintstagedrc.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
       "$ref": "#/definitions/advancedConfig"

--- a/src/schemas/json/liquibase-3.2.json
+++ b/src/schemas/json/liquibase-3.2.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "default": {},
   "definitions": {

--- a/src/schemas/json/liquibase.json
+++ b/src/schemas/json/liquibase.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "default": {},
   "definitions": {

--- a/src/schemas/json/markdown-lint-check.json
+++ b/src/schemas/json/markdown-lint-check.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "properties": {
     "ignorePatterns": {

--- a/src/schemas/json/mimetypes.json
+++ b/src/schemas/json/mimetypes.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "patternProperties": {
     "^\\..+": {

--- a/src/schemas/json/modernizrrc.json
+++ b/src/schemas/json/modernizrrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "classPrefix": {
       "type": "string",

--- a/src/schemas/json/nodemon.json
+++ b/src/schemas/json/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "pathPattern": {
       "anyOf": [

--- a/src/schemas/json/now.json
+++ b/src/schemas/json/now.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "alias": {
       "type": "string",

--- a/src/schemas/json/nswag.json
+++ b/src/schemas/json/nswag.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "swaggerGenerator": {
       "type": "object",

--- a/src/schemas/json/ocelot.json
+++ b/src/schemas/json/ocelot.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "Routes": {
       "$id": "#/properties/Routes",

--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/pre-commit-config.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "meta_repo": {
       "type": "object",

--- a/src/schemas/json/pterodactyl.json
+++ b/src/schemas/json/pterodactyl.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "properties": {
     "_comment": {

--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/pubspec",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "version": {
       "type": "string",

--- a/src/schemas/json/qfconfig.json
+++ b/src/schemas/json/qfconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "definitions": {
     "generator": {

--- a/src/schemas/json/replit.json
+++ b/src/schemas/json/replit.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "description": "https://docs.replit.com/programming-ide/configuring-repl",
   "properties": {

--- a/src/schemas/json/rust-toolchain.json
+++ b/src/schemas/json/rust-toolchain.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file",
   "properties": {
     "toolchain": {

--- a/src/schemas/json/sarif-2.1.0-rtm.0.json
+++ b/src/schemas/json/sarif-2.1.0-rtm.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
     "address": {

--- a/src/schemas/json/sarif-2.1.0-rtm.2.json
+++ b/src/schemas/json/sarif-2.1.0-rtm.2.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-2.1.0-rtm.2.json",
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
     "address": {

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.2.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.2.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.2.json",
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "properties": {
     "$schema": {

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.3.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.3.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.3.json",
   "properties": {

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.4.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.4.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.4.json",
   "properties": {

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.5.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.5.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.5.json",
   "properties": {

--- a/src/schemas/json/sarif-external-property-file.json
+++ b/src/schemas/json/sarif-external-property-file.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.5.json",
   "properties": {

--- a/src/schemas/json/servicehub.config.schema.json
+++ b/src/schemas/json/servicehub.config.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "controller": {
       "type": "object",

--- a/src/schemas/json/servicehub.service.schema.json
+++ b/src/schemas/json/servicehub.service.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "host": {
       "type": "string",

--- a/src/schemas/json/size-limit.json
+++ b/src/schemas/json/size-limit.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "default": [],
   "items": {
     "title": "Configuration Section",

--- a/src/schemas/json/solution-filter.json
+++ b/src/schemas/json/solution-filter.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
     "solution": {
       "type": "object",

--- a/src/schemas/json/sourcehut-build-0.65.0.json
+++ b/src/schemas/json/sourcehut-build-0.65.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "A recipe for Sourcehut CI service. For details, see https://man.sr.ht/builds.sr.ht/manifest.md.",
   "properties": {
     "image": {

--- a/src/schemas/json/specif-1.1.json
+++ b/src/schemas/json/specif-1.1.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://specif.de/v1.1/schema#",
-  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "definitions": {
     "SpecifId": {
       "description": "A globally unique identifier.",

--- a/src/schemas/json/sponge-mixins.json
+++ b/src/schemas/json/sponge-mixins.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "mixin_class": {
       "type": "string",

--- a/src/schemas/json/sprite.json
+++ b/src/schemas/json/sprite.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Schema for image sprite generation files",
   "properties": {
     "customstyles": {

--- a/src/schemas/json/stale.json
+++ b/src/schemas/json/stale.json
@@ -1,7 +1,7 @@
 {
   "$comment": "https://probot.github.io/apps/stale/",
   "$ref": "#/definitions/configuration",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "configuration": {
       "properties": {

--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "default": {
     "navigationFallback": {

--- a/src/schemas/json/swcrc.json
+++ b/src/schemas/json/swcrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
       "type": "array",

--- a/src/schemas/json/testenvironments.json
+++ b/src/schemas/json/testenvironments.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "config": {
       "required": ["name", "type"],

--- a/src/schemas/json/tmuxinator.json
+++ b/src/schemas/json/tmuxinator.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "properties": {
     "defaults": {

--- a/src/schemas/json/typings.json
+++ b/src/schemas/json/typings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": true,
   "properties": {
     "main": {

--- a/src/schemas/json/typingsrc.json
+++ b/src/schemas/json/typingsrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": true,
   "properties": {
     "ca": {

--- a/src/schemas/json/utam-page-object.json
+++ b/src/schemas/json/utam-page-object.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://json.schemastore.org/utam-page-object.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
     {
       "if": {

--- a/src/schemas/json/vs-2017.3.host.json
+++ b/src/schemas/json/vs-2017.3.host.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "allOf": [
     {
       "$ref": "https://json.schemastore.org/ide.host.json"

--- a/src/schemas/json/winget-pkgs-singleton-0.1.json
+++ b/src/schemas/json/winget-pkgs-singleton-0.1.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "Id": {
       "type": "string",

--- a/src/schemas/json/xunit-2.2.json
+++ b/src/schemas/json/xunit-2.2.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "xUnit.net Runner Configuration"
 }

--- a/src/schemas/json/xunit-2.3.json
+++ b/src/schemas/json/xunit-2.3.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "xUnit.net Runner Configuration"
 }

--- a/src/schemas/json/xunit.runner.schema.json
+++ b/src/schemas/json/xunit.runner.schema.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "xUnit.net Runner Configuration"
 }

--- a/src/schemas/json/zuul.json
+++ b/src/schemas/json/zuul.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "JobEntry": {
       "additionalProperties": false,


### PR DESCRIPTION
The issue of `$schema` versions not being fully valid was brought to my attention by #2265. Many are missing an octothorp at the end, while others were simply generic (`http://json-schema.org/schema#`)

This PR updates the Grunt verification task to handle this case, then fixes all the `$schema` versions.

The array of valid schema versions is derived from the `$id` property of each release of every schema version [meta schema](https://json-schema.org/specification-links.html).