### PR TITLE
Assert that top-level-$refs are standalone

### DIFF
--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -116,7 +116,7 @@ module.exports = function (grunt) {
    * @prop {Buffer | undefined} rawFile
    * @prop {Record<string, unknown>} jsonObj
    * @prop {string} jsonName
-   * @prop {string} urlorFilePath
+   * @prop {string} urlOrFilePath
    * @prop {boolean} schemaScan
    */
 
@@ -142,7 +142,7 @@ module.exports = function (grunt) {
    * @prop {boolean} fullScanAllFiles
    * @prop {boolean} calledByTV4Validator
    * @prop {boolean} skipReadFile
-   * @prop {boolean} fullScanAllFiles
+   * @prop {boolean} ignoreSkiptest
    * @prop {string} processOnlyThisOneSchemaFile
    */
 
@@ -165,6 +165,7 @@ module.exports = function (grunt) {
       fullScanAllFiles = false,
       calledByTV4Validator = false,
       skipReadFile = true,
+      ignoreSkiptest = false,
       processOnlyThisOneSchemaFile = undefined,
     } = {}
   ) {
@@ -185,7 +186,7 @@ module.exports = function (grunt) {
      * @returns {boolean}
      */
     const canThisTestBeRun = (jsonFilename) => {
-      if (schemaValidation.skiptest.includes(jsonFilename)) {
+      if (!ignoreSkiptest && schemaValidation.skiptest.includes(jsonFilename)) {
         return false // This test can be never process
       }
       if (fullScanAllFiles) {
@@ -928,6 +929,34 @@ module.exports = function (grunt) {
       grunt.log.ok(
         `No duplicated property key found in JSON files. Total files scan: ${countScan}`
       )
+    }
+  )
+
+  grunt.registerTask(
+    'local_assert_top_level_$ref_is_standalone',
+    'top level $ref propertie of schemas must be the only property',
+    function () {
+      let countScan = 0
+      localSchemaFileAndTestFile(
+        {
+          schemaOnlyScan(data) {
+            if (data.jsonObj.$ref?.startsWith('http')) {
+              for (const [member] of Object.entries(data.jsonObj)) {
+                if (member !== '$ref') {
+                  throwWithErrorText([
+                    `Schemas that reference a remote schema must only have $ref as a property. Found property "${member}" for ${data.jsonName}`,
+                  ])
+                }
+              }
+            }
+
+            ++countScan
+          },
+        },
+        { skipReadFile: false, ignoreSkiptest: true }
+      )
+
+      grunt.log.ok(`All urls tested OK. Total: ${countScan}`)
     }
   )
 
@@ -1904,6 +1933,7 @@ module.exports = function (grunt) {
     'local_schema-present-in-catalog-list',
     'local_bom',
     'local_find-duplicated-property-keys',
+    'local_assert_top_level_$ref_is_standalone',
     'local_assert_schema_version_is_valid',
     'local_check_for_schema_version_too_high',
     'local_count_url_in_catalog',

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -251,8 +251,7 @@
     "sarif-external-property-file.json",
     "sarif.json",
     "stylintrc.json",
-    "toolinfo.1.1.0.json",
-    "renovate.json"
+    "toolinfo.1.1.0.json"
   ],
   "options": [
     {
@@ -705,6 +704,7 @@
     "ksp-avc.json",
     "ksp-ckan.json",
     "theme-v1.json",
+    "renovate.json",
     "markdownlint.json",
     "taskfile.json",
     "neoload.json",
@@ -742,7 +742,6 @@
     "lsdlschema.json",
     "mimetypes.json",
     "nodemon.json",
-    "renovate.json",
     "sarif-2.0.0-csd.2.beta.2018-10-10.json",
     "sarif-2.0.0.json",
     "sarif-2.1.0-rtm.0.json",

--- a/src/schemas/json/block.json
+++ b/src/schemas/json/block.json
@@ -1,5 +1,3 @@
 {
-  "$ref": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "JSON schema WordPress blocks"
+  "$ref": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json"
 }

--- a/src/schemas/json/haxelib.json
+++ b/src/schemas/json/haxelib.json
@@ -1,4 +1,3 @@
 {
-  "$ref": "https://raw.githubusercontent.com/HaxeFoundation/haxelib/master/schema.json",
-  "title": "Haxelib project configuration"
+  "$ref": "https://raw.githubusercontent.com/HaxeFoundation/haxelib/master/schema.json"
 }

--- a/src/schemas/json/markdownlint.json
+++ b/src/schemas/json/markdownlint.json
@@ -1,4 +1,3 @@
 {
-  "$ref": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
-  "title": "JSON schema markdownlint"
+  "$ref": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json"
 }

--- a/src/schemas/json/renovate.json
+++ b/src/schemas/json/renovate.json
@@ -1,5 +1,3 @@
 {
-  "$ref": "https://docs.renovatebot.com/renovate-schema.json",
-  "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Deprecated JSON schema for Renovate, please use https://docs.renovatebot.com/renovate-schema.json"
+  "$ref": "https://docs.renovatebot.com/renovate-schema.json"
 }

--- a/src/schemas/json/taskfile.json
+++ b/src/schemas/json/taskfile.json
@@ -1,4 +1,3 @@
 {
-  "$ref": "https://taskfile.dev/schema.json",
-  "title": "Taskfile YAML Schema"
+  "$ref": "https://taskfile.dev/schema.json"
 }

--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -1,5 +1,3 @@
 {
-  "$ref": "https://raw.githubusercontent.com/WordPress/gutenberg/b40b61fabf13a6229c616527689d9a7024f81535/schemas/json/theme.json",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "JSON schema for WordPress block theme global settings and styles"
+  "$ref": "https://raw.githubusercontent.com/WordPress/gutenberg/b40b61fabf13a6229c616527689d9a7024f81535/schemas/json/theme.json"
 }

--- a/src/schemas/json/xunit-2.2.json
+++ b/src/schemas/json/xunit-2.2.json
@@ -1,5 +1,3 @@
 {
-  "$ref": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "xUnit.net Runner Configuration"
+  "$ref": "https://xunit.net/schema/v2.2/xunit.runner.schema.json"
 }

--- a/src/schemas/json/xunit-2.3.json
+++ b/src/schemas/json/xunit-2.3.json
@@ -1,5 +1,3 @@
 {
-  "$ref": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "xUnit.net Runner Configuration"
+  "$ref": "https://xunit.net/schema/v2.3/xunit.runner.schema.json"
 }

--- a/src/schemas/json/xunit.runner.schema.json
+++ b/src/schemas/json/xunit.runner.schema.json
@@ -1,5 +1,3 @@
 {
-  "$ref": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "xUnit.net Runner Configuration"
+  "$ref": "https://xunit.net/schema/current/xunit.runner.schema.json"
 }


### PR DESCRIPTION
This adds a test to the `Gruntfile.cjs` to ensure that schemas that contain a `$ref` at the top level (that point to external URLs) have no other properties. This fixes some inconsistensies; for example:

- With `markdownlint.json`, the `title` was out of date (compared to the remote)
- With `renovate.json`, the `$schema` draft version was different

This improves JSON schemas to be closer to a Single Source of Truth.

This also uncovered an issue where `renovate.json` wasn't properly added to the `"skiptest"` in `schema-validation.json`.

~~This will be undrafted when https://github.com/HaxeFoundation/haxelib/pull/579 is merged (that remote schema did not have a `title` property at the top-level, so my PR adds it before it is removed from here)~~

Some other older issues should be closed to improve the signal to noise ratio of the issue queue:

- Closes #1378 (out of scope)
- Closes #552 (question answered)
- Closes #1587 (question answered, out of scope)
- Closes #1650 (question answered)