### PR TITLE
Add translate property for pack.mcmeta description (to fit with Minecraft 1.19.3).

### DIFF
--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -13,7 +13,20 @@
         },
         "description": {
           "title": "Description",
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "translate": {
+                  "title": "Translate",
+                  "type": "string"
+                }
+              }
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
This PR modify pack.mcmeta schema (for minecraft) to add the possibility that the description is an object and has a "translate" property.