### PR TITLE
Add Ruff schema to pyproject.toml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2690,7 +2690,7 @@
       "name": "Ruff",
       "description": "JSON schema for Ruff, a fast Python linter",
       "fileMatch": ["ruff.toml"],
-      "url": "https://raw.githubusercontent.com/charliermarsh/ruff/main/ruff.schema.json"
+      "url": "https://json.schemastore.org/ruff.json"
     },
     {
       "name": "Rust Project",

--- a/src/negative_test/pyproject/ruff-bad-line-length.toml
+++ b/src/negative_test/pyproject/ruff-bad-line-length.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+line-length = "79"

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -661,6 +661,9 @@
     },
     {
       "pyproject.json": {
+        "externalSchema": [
+          "ruff.json"
+        ],
         "unknownKeywords": ["x-taplo", "x-taplo-info"]
       }
     },

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -661,9 +661,7 @@
     },
     {
       "pyproject.json": {
-        "externalSchema": [
-          "ruff.json"
-        ],
+        "externalSchema": ["ruff.json"],
         "unknownKeywords": ["x-taplo", "x-taplo-info"]
       }
     },

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -499,6 +499,9 @@
         }
       },
       "properties": {
+        "ruff": {
+          "$ref": "https://json.schemastore.org/ruff.json"
+        },
         "poetry": {
           "type": "object",
           "additionalProperties": true,

--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -1,0 +1,1282 @@
+{
+  "$id": "https://json.schemastore.org/ruff.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Options",
+  "type": "object",
+  "properties": {
+    "allowed-confusables": {
+      "description": "A list of allowed \"confusable\" Unicode characters to ignore when enforcing `RUF001`, `RUF002`, and `RUF003`.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string",
+        "maxLength": 1,
+        "minLength": 1
+      }
+    },
+    "cache-dir": {
+      "description": "A path to the cache directory.\n\nBy default, Ruff stores cache results in a `.ruff_cache` directory in the current project root.\n\nHowever, Ruff will also respect the `RUFF_CACHE_DIR` environment variable, which takes precedence over that default.\n\nThis setting will override even the `RUFF_CACHE_DIR` environment variable, if set.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "dummy-variable-rgx": {
+      "description": "A regular expression used to identify \"dummy\" variables, or those which should be ignored when evaluating (e.g.) unused-variable checks. The default expression matches `_`, `__`, and `_var`, but not `_var_`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "exclude": {
+      "description": "A list of file patterns to exclude from linting.\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nNote that you'll typically want to use [`extend-exclude`](#extend-exclude) to modify the excluded paths.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "extend": {
+      "description": "A path to a local `pyproject.toml` file to merge into this configuration. User home directory and environment variables will be expanded.\n\nTo resolve the current `pyproject.toml` file, Ruff will first resolve this base configuration file, then merge in any properties defined in the current configuration file.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "extend-exclude": {
+      "description": "A list of file patterns to omit from linting, in addition to those specified by `exclude`.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "extend-ignore": {
+      "description": "A list of check code prefixes to ignore, in addition to those specified by `ignore`.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "extend-select": {
+      "description": "A list of check code prefixes to enable, in addition to those specified by `select`.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "external": {
+      "description": "A list of check codes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented in Ruff.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "fix": {
+      "description": "Enable autofix behavior by-default when running `ruff` (overridden by the `--fix` and `--no-fix` command-line flags).",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "fix-only": {
+      "description": "Like `fix`, but disables reporting on leftover violation. Implies `fix`.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "fixable": {
+      "description": "A list of check code prefixes to consider autofix-able.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "flake8-annotations": {
+      "description": "Options for the `flake8-annotations` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8AnnotationsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-bugbear": {
+      "description": "Options for the `flake8-bugbear` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8BugbearOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-errmsg": {
+      "description": "Options for the `flake8-errmsg` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8ErrMsgOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-import-conventions": {
+      "description": "Options for the `flake8-import-conventions` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8ImportConventionsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-quotes": {
+      "description": "Options for the `flake8-quotes` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8QuotesOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-tidy-imports": {
+      "description": "Options for the `flake8-tidy-imports` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8TidyImportsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-unused-arguments": {
+      "description": "Options for the `flake8-unused-arguments` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8UnusedArgumentsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "force-exclude": {
+      "description": "Whether to enforce `exclude` and `extend-exclude` patterns, even for paths that are passed to Ruff explicitly. Typically, Ruff will lint any paths passed in directly, even if they would typically be excluded. Setting `force-exclude = true` will cause Ruff to respect these exclusions unequivocally.\n\nThis is useful for [`pre-commit`](https://pre-commit.com/), which explicitly passes all changed files to the [`ruff-pre-commit`](https://github.com/charliermarsh/ruff-pre-commit) plugin, regardless of whether they're marked as excluded by Ruff's own settings.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "format": {
+      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations) or `\"gitlab\"` (GitLab CI code quality report).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SerializationFormat"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ignore": {
+      "description": "A list of check code prefixes to ignore. Prefixes can specify exact checks (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled checks (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "ignore-init-module-imports": {
+      "description": "Avoid automatically removing unused imports in `__init__.py` files. Such imports will still be +flagged, but with a dedicated message suggesting that the import is either added to the module' +`__all__` symbol, or re-exported with a redundant alias (e.g., `import os as os`).",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "isort": {
+      "description": "Options for the `isort` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/IsortOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "line-length": {
+      "description": "The line length to use when enforcing long-lines violations (like `E501`).",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0.0
+    },
+    "mccabe": {
+      "description": "Options for the `mccabe` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/McCabeOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "pep8-naming": {
+      "description": "Options for the `pep8-naming` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Pep8NamingOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "per-file-ignores": {
+      "description": "A list of mappings from file pattern to check code prefixes to exclude, when considering any matching files.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/CheckCodePrefix"
+        }
+      }
+    },
+    "pydocstyle": {
+      "description": "Options for the `pydocstyle` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Pydocstyle"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "pyupgrade": {
+      "description": "Options for the `pyupgrade` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PyUpgradeOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "required-version": {
+      "description": "Require a specific version of Ruff to be running (useful for unifying results across many environments, e.g., with a `pyproject.toml` file).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Version"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "respect-gitignore": {
+      "description": "Whether to automatically exclude files that are ignored by `.ignore`, `.gitignore`, `.git/info/exclude`, and global `gitignore` files. Enabled by default.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "select": {
+      "description": "A list of check code prefixes to enable. Prefixes can specify exact checks (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled checks (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "show-source": {
+      "description": "Whether to show source code snippets when reporting lint error violations (overridden by the `--show-source` command-line flag).",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "src": {
+      "description": "The source code paths to consider, e.g., when resolving first- vs. third-party imports.\n\nAs an example: given a Python package structure like:\n\n```text my_package/ pyproject.toml src/ my_package/ __init__.py foo.py bar.py ```\n\nThe `src` directory should be included in `source` (e.g., `source = [\"src\"]`), such that when resolving imports, `my_package.foo` is considered a first-party import.\n\nThis field supports globs. For example, if you have a series of Python packages in a `python_modules` directory, `src = [\"python_modules/*\"]` would expand to incorporate all of the packages in that directory. User home directory and environment variables will also be expanded.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "target-version": {
+      "description": "The Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Note that the target version will _not_ be inferred from the _current_ Python version, and instead must be specified explicitly (as seen below).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PythonVersion"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "unfixable": {
+      "description": "A list of check code prefixes to consider un-autofix-able.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "CheckCodePrefix": {
+      "type": "string",
+      "enum": [
+        "A",
+        "A0",
+        "A00",
+        "A001",
+        "A002",
+        "A003",
+        "ALL",
+        "ANN",
+        "ANN0",
+        "ANN00",
+        "ANN001",
+        "ANN002",
+        "ANN003",
+        "ANN1",
+        "ANN10",
+        "ANN101",
+        "ANN102",
+        "ANN2",
+        "ANN20",
+        "ANN201",
+        "ANN202",
+        "ANN204",
+        "ANN205",
+        "ANN206",
+        "ANN4",
+        "ANN40",
+        "ANN401",
+        "ARG",
+        "ARG0",
+        "ARG00",
+        "ARG001",
+        "ARG002",
+        "ARG003",
+        "ARG004",
+        "ARG005",
+        "B",
+        "B0",
+        "B00",
+        "B002",
+        "B003",
+        "B004",
+        "B005",
+        "B006",
+        "B007",
+        "B008",
+        "B009",
+        "B01",
+        "B010",
+        "B011",
+        "B012",
+        "B013",
+        "B014",
+        "B015",
+        "B016",
+        "B017",
+        "B018",
+        "B019",
+        "B02",
+        "B020",
+        "B021",
+        "B022",
+        "B023",
+        "B024",
+        "B025",
+        "B026",
+        "B027",
+        "B9",
+        "B90",
+        "B904",
+        "B905",
+        "BLE",
+        "BLE0",
+        "BLE00",
+        "BLE001",
+        "C",
+        "C4",
+        "C40",
+        "C400",
+        "C401",
+        "C402",
+        "C403",
+        "C404",
+        "C405",
+        "C406",
+        "C408",
+        "C409",
+        "C41",
+        "C410",
+        "C411",
+        "C413",
+        "C414",
+        "C415",
+        "C416",
+        "C417",
+        "C9",
+        "C90",
+        "C901",
+        "D",
+        "D1",
+        "D10",
+        "D100",
+        "D101",
+        "D102",
+        "D103",
+        "D104",
+        "D105",
+        "D106",
+        "D107",
+        "D2",
+        "D20",
+        "D200",
+        "D201",
+        "D202",
+        "D203",
+        "D204",
+        "D205",
+        "D206",
+        "D207",
+        "D208",
+        "D209",
+        "D21",
+        "D210",
+        "D211",
+        "D212",
+        "D213",
+        "D214",
+        "D215",
+        "D3",
+        "D30",
+        "D300",
+        "D301",
+        "D4",
+        "D40",
+        "D400",
+        "D402",
+        "D403",
+        "D404",
+        "D405",
+        "D406",
+        "D407",
+        "D408",
+        "D409",
+        "D41",
+        "D410",
+        "D411",
+        "D412",
+        "D413",
+        "D414",
+        "D415",
+        "D416",
+        "D417",
+        "D418",
+        "D419",
+        "DTZ",
+        "DTZ0",
+        "DTZ00",
+        "DTZ001",
+        "DTZ002",
+        "DTZ003",
+        "DTZ004",
+        "DTZ005",
+        "DTZ006",
+        "DTZ007",
+        "DTZ01",
+        "DTZ011",
+        "DTZ012",
+        "E",
+        "E4",
+        "E40",
+        "E401",
+        "E402",
+        "E5",
+        "E50",
+        "E501",
+        "E7",
+        "E71",
+        "E711",
+        "E712",
+        "E713",
+        "E714",
+        "E72",
+        "E721",
+        "E722",
+        "E73",
+        "E731",
+        "E74",
+        "E741",
+        "E742",
+        "E743",
+        "E9",
+        "E90",
+        "E902",
+        "E99",
+        "E999",
+        "EM",
+        "EM1",
+        "EM10",
+        "EM101",
+        "EM102",
+        "EM103",
+        "ERA",
+        "ERA0",
+        "ERA00",
+        "ERA001",
+        "F",
+        "F4",
+        "F40",
+        "F401",
+        "F402",
+        "F403",
+        "F404",
+        "F405",
+        "F406",
+        "F407",
+        "F5",
+        "F50",
+        "F501",
+        "F502",
+        "F503",
+        "F504",
+        "F505",
+        "F506",
+        "F507",
+        "F508",
+        "F509",
+        "F52",
+        "F521",
+        "F522",
+        "F523",
+        "F524",
+        "F525",
+        "F54",
+        "F541",
+        "F6",
+        "F60",
+        "F601",
+        "F602",
+        "F62",
+        "F621",
+        "F622",
+        "F63",
+        "F631",
+        "F632",
+        "F633",
+        "F634",
+        "F7",
+        "F70",
+        "F701",
+        "F702",
+        "F704",
+        "F706",
+        "F707",
+        "F72",
+        "F722",
+        "F8",
+        "F81",
+        "F811",
+        "F82",
+        "F821",
+        "F822",
+        "F823",
+        "F83",
+        "F831",
+        "F84",
+        "F841",
+        "F842",
+        "F9",
+        "F90",
+        "F901",
+        "FBT",
+        "FBT0",
+        "FBT00",
+        "FBT001",
+        "FBT002",
+        "FBT003",
+        "I",
+        "I0",
+        "I00",
+        "I001",
+        "I2",
+        "I25",
+        "I252",
+        "IC",
+        "IC0",
+        "IC001",
+        "IC002",
+        "IC003",
+        "IC004",
+        "ICN",
+        "ICN0",
+        "ICN00",
+        "ICN001",
+        "M",
+        "M0",
+        "M001",
+        "N",
+        "N8",
+        "N80",
+        "N801",
+        "N802",
+        "N803",
+        "N804",
+        "N805",
+        "N806",
+        "N807",
+        "N81",
+        "N811",
+        "N812",
+        "N813",
+        "N814",
+        "N815",
+        "N816",
+        "N817",
+        "N818",
+        "PD",
+        "PD0",
+        "PD00",
+        "PD002",
+        "PD003",
+        "PD004",
+        "PD007",
+        "PD008",
+        "PD009",
+        "PD01",
+        "PD010",
+        "PD011",
+        "PD012",
+        "PD013",
+        "PD015",
+        "PD9",
+        "PD90",
+        "PD901",
+        "PDV",
+        "PDV0",
+        "PDV002",
+        "PDV003",
+        "PDV004",
+        "PDV007",
+        "PDV008",
+        "PDV009",
+        "PDV01",
+        "PDV010",
+        "PDV011",
+        "PDV012",
+        "PDV013",
+        "PDV015",
+        "PDV9",
+        "PDV90",
+        "PDV901",
+        "PGH",
+        "PGH0",
+        "PGH00",
+        "PGH001",
+        "PGH002",
+        "PGH003",
+        "PLC",
+        "PLC0",
+        "PLC04",
+        "PLC041",
+        "PLC0414",
+        "PLC2",
+        "PLC22",
+        "PLC220",
+        "PLC2201",
+        "PLC3",
+        "PLC30",
+        "PLC300",
+        "PLC3002",
+        "PLE",
+        "PLE0",
+        "PLE01",
+        "PLE011",
+        "PLE0117",
+        "PLE0118",
+        "PLE1",
+        "PLE11",
+        "PLE114",
+        "PLE1142",
+        "PLR",
+        "PLR0",
+        "PLR02",
+        "PLR020",
+        "PLR0206",
+        "PLR04",
+        "PLR040",
+        "PLR0402",
+        "PLR1",
+        "PLR17",
+        "PLR170",
+        "PLR1701",
+        "PLR172",
+        "PLR1722",
+        "PLW",
+        "PLW0",
+        "PLW01",
+        "PLW012",
+        "PLW0120",
+        "PLW06",
+        "PLW060",
+        "PLW0602",
+        "Q",
+        "Q0",
+        "Q00",
+        "Q000",
+        "Q001",
+        "Q002",
+        "Q003",
+        "R",
+        "R5",
+        "R50",
+        "R501",
+        "R502",
+        "R503",
+        "R504",
+        "R505",
+        "R506",
+        "R507",
+        "R508",
+        "RET",
+        "RET5",
+        "RET50",
+        "RET501",
+        "RET502",
+        "RET503",
+        "RET504",
+        "RET505",
+        "RET506",
+        "RET507",
+        "RET508",
+        "RUF",
+        "RUF0",
+        "RUF00",
+        "RUF001",
+        "RUF002",
+        "RUF003",
+        "RUF004",
+        "RUF1",
+        "RUF10",
+        "RUF100",
+        "S",
+        "S1",
+        "S10",
+        "S101",
+        "S102",
+        "S104",
+        "S105",
+        "S106",
+        "S107",
+        "SIM",
+        "SIM1",
+        "SIM11",
+        "SIM118",
+        "T",
+        "T1",
+        "T10",
+        "T100",
+        "T2",
+        "T20",
+        "T201",
+        "T203",
+        "TID",
+        "TID2",
+        "TID25",
+        "TID252",
+        "U",
+        "U0",
+        "U00",
+        "U001",
+        "U003",
+        "U004",
+        "U005",
+        "U006",
+        "U007",
+        "U008",
+        "U009",
+        "U01",
+        "U010",
+        "U011",
+        "U012",
+        "U013",
+        "U014",
+        "U015",
+        "U016",
+        "U017",
+        "U019",
+        "UP",
+        "UP0",
+        "UP00",
+        "UP001",
+        "UP003",
+        "UP004",
+        "UP005",
+        "UP006",
+        "UP007",
+        "UP008",
+        "UP009",
+        "UP01",
+        "UP010",
+        "UP011",
+        "UP012",
+        "UP013",
+        "UP014",
+        "UP015",
+        "UP016",
+        "UP017",
+        "UP018",
+        "UP019",
+        "UP02",
+        "UP020",
+        "UP021",
+        "UP022",
+        "UP023",
+        "W",
+        "W2",
+        "W29",
+        "W292",
+        "W6",
+        "W60",
+        "W605",
+        "YTT",
+        "YTT1",
+        "YTT10",
+        "YTT101",
+        "YTT102",
+        "YTT103",
+        "YTT2",
+        "YTT20",
+        "YTT201",
+        "YTT202",
+        "YTT203",
+        "YTT204",
+        "YTT3",
+        "YTT30",
+        "YTT301",
+        "YTT302",
+        "YTT303"
+      ]
+    },
+    "Convention": {
+      "type": "string",
+      "enum": [
+        "google",
+        "numpy"
+      ]
+    },
+    "Flake8AnnotationsOptions": {
+      "type": "object",
+      "properties": {
+        "allow-star-arg-any": {
+          "description": "Whether to suppress `ANN401` for dynamically typed `*args` and `**kwargs` arguments.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "mypy-init-return": {
+          "description": "Whether to allow the omission of a return type hint for `__init__` if at least one argument is annotated.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suppress-dummy-args": {
+          "description": "Whether to suppress `ANN000`-level errors for arguments matching the \"dummy\" variable regex (like `_`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suppress-none-returning": {
+          "description": "Whether to suppress `ANN200`-level errors for functions that meet either of the following criteria:\n\n- Contain no `return` statement. - Explicit `return` statement(s) all return `None` (explicitly or implicitly).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Flake8BugbearOptions": {
+      "type": "object",
+      "properties": {
+        "extend-immutable-calls": {
+          "description": "Additional callable functions to consider \"immutable\" when evaluating, e.g., `no-mutable-default-argument` checks (`B006`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Flake8ErrMsgOptions": {
+      "type": "object",
+      "properties": {
+        "max-string-length": {
+          "description": "Maximum string length for string literals in exception messages.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Flake8ImportConventionsOptions": {
+      "type": "object",
+      "properties": {
+        "aliases": {
+          "description": "The conventional aliases for imports. These aliases can be extended by the `extend_aliases` option.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "extend-aliases": {
+          "description": "A mapping of modules to their conventional import aliases. These aliases will be added to the `aliases` mapping.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Flake8QuotesOptions": {
+      "type": "object",
+      "properties": {
+        "avoid-escape": {
+          "description": "Whether to avoid using single quotes if a string contains single quotes, or vice-versa with double quotes, as per [PEP8](https://peps.python.org/pep-0008/#string-quotes). This minimizes the need to escape quotation marks within strings.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "docstring-quotes": {
+          "description": "Quote style to prefer for docstrings (either \"single\" (`'`) or \"double\" (`\"`)).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Quote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "inline-quotes": {
+          "description": "Quote style to prefer for inline strings (either \"single\" (`'`) or \"double\" (`\"`)).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Quote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "multiline-quotes": {
+          "description": "Quote style to prefer for multiline strings (either \"single\" (`'`) or \"double\" (`\"`)).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Quote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Flake8TidyImportsOptions": {
+      "type": "object",
+      "properties": {
+        "ban-relative-imports": {
+          "description": "Whether to ban all relative imports (`\"all\"`), or only those imports that extend into the parent module and beyond (`\"parents\"`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Strictness"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Flake8UnusedArgumentsOptions": {
+      "type": "object",
+      "properties": {
+        "ignore-variadic-names": {
+          "description": "Whether to allow unused variadic arguments, like `*args` and `**kwargs`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "IsortOptions": {
+      "type": "object",
+      "properties": {
+        "combine-as-imports": {
+          "description": "Combines as imports on the same line. See isort's [`combine-as-imports`](https://pycqa.github.io/isort/docs/configuration/options.html#combine-as-imports) option.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "extra-standard-library": {
+          "description": "A list of modules to consider standard-library, in addition to those known to Ruff in advance.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "force-single-line": {
+          "description": "Forces all from imports to appear on their own line.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "force-wrap-aliases": {
+          "description": "Force `import from` statements with multiple members and at least one alias (e.g., `import A as B`) to wrap such that every line contains exactly one member. For example, this formatting would be retained, rather than condensing to a single line:\n\n```py from .utils import ( test_directory as test_directory, test_id as test_id ) ```\n\nNote that this setting is only effective when combined with `combine-as-imports = true`. When `combine-as-imports` isn't enabled, every aliased `import from` will be given its own line, in which case, wrapping is not necessary.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "known-first-party": {
+          "description": "A list of modules to consider first-party, regardless of whether they can be identified as such via introspection of the local filesystem.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "known-third-party": {
+          "description": "A list of modules to consider third-party, regardless of whether they can be identified as such via introspection of the local filesystem.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "single-line-exclusions": {
+          "description": "One or more modules to exclude from the single line rule.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "split-on-trailing-comma": {
+          "description": "If a comma is placed after the last member in a multi-line import, then the imports will never be folded into one line.\n\nSee isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "McCabeOptions": {
+      "type": "object",
+      "properties": {
+        "max-complexity": {
+          "description": "The maximum McCabe complexity to allow before triggering `C901` errors.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Pep8NamingOptions": {
+      "type": "object",
+      "properties": {
+        "classmethod-decorators": {
+          "description": "A list of decorators that, when applied to a method, indicate that the method should be treated as a class method. For example, Ruff will expect that any method decorated by a decorator in this list takes a `cls` argument as its first argument.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignore-names": {
+          "description": "A list of names to ignore when considering `pep8-naming` violations.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "staticmethod-decorators": {
+          "description": "A list of decorators that, when applied to a method, indicate that the method should be treated as a static method. For example, Ruff will expect that any method decorated by a decorator in this list has no `self` or `cls` argument.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "PyUpgradeOptions": {
+      "type": "object",
+      "properties": {
+        "keep-runtime-typing": {
+          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Optional[str]` -> `str | None`) rewrites even if a file imports `from __future__ import annotations`. Note that this setting is only applicable when the target Python version is below 3.9 and 3.10 respectively.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Pydocstyle": {
+      "type": "object",
+      "properties": {
+        "convention": {
+          "description": "Whether to use Google-style or Numpy-style conventions when detecting docstring sections. By default, conventions will be inferred from the available sections.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Convention"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "PythonVersion": {
+      "type": "string",
+      "enum": [
+        "py33",
+        "py34",
+        "py35",
+        "py36",
+        "py37",
+        "py38",
+        "py39",
+        "py310",
+        "py311"
+      ]
+    },
+    "Quote": {
+      "type": "string",
+      "enum": [
+        "single",
+        "double"
+      ]
+    },
+    "SerializationFormat": {
+      "type": "string",
+      "enum": [
+        "text",
+        "json",
+        "junit",
+        "grouped",
+        "github",
+        "gitlab"
+      ]
+    },
+    "Strictness": {
+      "type": "string",
+      "enum": [
+        "parents",
+        "all"
+      ]
+    },
+    "Version": {
+      "type": "string"
+    }
+  }
+}

--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -1,371 +1,6 @@
 {
   "$id": "https://json.schemastore.org/ruff.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Options",
-  "type": "object",
-  "properties": {
-    "allowed-confusables": {
-      "description": "A list of allowed \"confusable\" Unicode characters to ignore when enforcing `RUF001`, `RUF002`, and `RUF003`.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string",
-        "maxLength": 1,
-        "minLength": 1
-      }
-    },
-    "cache-dir": {
-      "description": "A path to the cache directory.\n\nBy default, Ruff stores cache results in a `.ruff_cache` directory in the current project root.\n\nHowever, Ruff will also respect the `RUFF_CACHE_DIR` environment variable, which takes precedence over that default.\n\nThis setting will override even the `RUFF_CACHE_DIR` environment variable, if set.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "dummy-variable-rgx": {
-      "description": "A regular expression used to identify \"dummy\" variables, or those which should be ignored when evaluating (e.g.) unused-variable checks. The default expression matches `_`, `__`, and `_var`, but not `_var_`.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "exclude": {
-      "description": "A list of file patterns to exclude from linting.\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nNote that you'll typically want to use [`extend-exclude`](#extend-exclude) to modify the excluded paths.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
-    "extend": {
-      "description": "A path to a local `pyproject.toml` file to merge into this configuration. User home directory and environment variables will be expanded.\n\nTo resolve the current `pyproject.toml` file, Ruff will first resolve this base configuration file, then merge in any properties defined in the current configuration file.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "extend-exclude": {
-      "description": "A list of file patterns to omit from linting, in addition to those specified by `exclude`.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
-    "extend-ignore": {
-      "description": "A list of check code prefixes to ignore, in addition to those specified by `ignore`.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/CheckCodePrefix"
-      }
-    },
-    "extend-select": {
-      "description": "A list of check code prefixes to enable, in addition to those specified by `select`.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/CheckCodePrefix"
-      }
-    },
-    "external": {
-      "description": "A list of check codes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented in Ruff.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
-    "fix": {
-      "description": "Enable autofix behavior by-default when running `ruff` (overridden by the `--fix` and `--no-fix` command-line flags).",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "fix-only": {
-      "description": "Like `fix`, but disables reporting on leftover violation. Implies `fix`.",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "fixable": {
-      "description": "A list of check code prefixes to consider autofix-able.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/CheckCodePrefix"
-      }
-    },
-    "flake8-annotations": {
-      "description": "Options for the `flake8-annotations` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Flake8AnnotationsOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "flake8-bugbear": {
-      "description": "Options for the `flake8-bugbear` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Flake8BugbearOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "flake8-errmsg": {
-      "description": "Options for the `flake8-errmsg` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Flake8ErrMsgOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "flake8-import-conventions": {
-      "description": "Options for the `flake8-import-conventions` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Flake8ImportConventionsOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "flake8-quotes": {
-      "description": "Options for the `flake8-quotes` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Flake8QuotesOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "flake8-tidy-imports": {
-      "description": "Options for the `flake8-tidy-imports` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Flake8TidyImportsOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "flake8-unused-arguments": {
-      "description": "Options for the `flake8-unused-arguments` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Flake8UnusedArgumentsOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "force-exclude": {
-      "description": "Whether to enforce `exclude` and `extend-exclude` patterns, even for paths that are passed to Ruff explicitly. Typically, Ruff will lint any paths passed in directly, even if they would typically be excluded. Setting `force-exclude = true` will cause Ruff to respect these exclusions unequivocally.\n\nThis is useful for [`pre-commit`](https://pre-commit.com/), which explicitly passes all changed files to the [`ruff-pre-commit`](https://github.com/charliermarsh/ruff-pre-commit) plugin, regardless of whether they're marked as excluded by Ruff's own settings.",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "format": {
-      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations) or `\"gitlab\"` (GitLab CI code quality report).",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SerializationFormat"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "ignore": {
-      "description": "A list of check code prefixes to ignore. Prefixes can specify exact checks (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled checks (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/CheckCodePrefix"
-      }
-    },
-    "ignore-init-module-imports": {
-      "description": "Avoid automatically removing unused imports in `__init__.py` files. Such imports will still be +flagged, but with a dedicated message suggesting that the import is either added to the module' +`__all__` symbol, or re-exported with a redundant alias (e.g., `import os as os`).",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "isort": {
-      "description": "Options for the `isort` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/IsortOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "line-length": {
-      "description": "The line length to use when enforcing long-lines violations (like `E501`).",
-      "type": [
-        "integer",
-        "null"
-      ],
-      "minimum": 0.0
-    },
-    "mccabe": {
-      "description": "Options for the `mccabe` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/McCabeOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "pep8-naming": {
-      "description": "Options for the `pep8-naming` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Pep8NamingOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "per-file-ignores": {
-      "description": "A list of mappings from file pattern to check code prefixes to exclude, when considering any matching files.",
-      "type": [
-        "object",
-        "null"
-      ],
-      "additionalProperties": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/CheckCodePrefix"
-        }
-      }
-    },
-    "pydocstyle": {
-      "description": "Options for the `pydocstyle` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Pydocstyle"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "pyupgrade": {
-      "description": "Options for the `pyupgrade` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PyUpgradeOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "required-version": {
-      "description": "Require a specific version of Ruff to be running (useful for unifying results across many environments, e.g., with a `pyproject.toml` file).",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Version"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "respect-gitignore": {
-      "description": "Whether to automatically exclude files that are ignored by `.ignore`, `.gitignore`, `.git/info/exclude`, and global `gitignore` files. Enabled by default.",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "select": {
-      "description": "A list of check code prefixes to enable. Prefixes can specify exact checks (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled checks (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/CheckCodePrefix"
-      }
-    },
-    "show-source": {
-      "description": "Whether to show source code snippets when reporting lint error violations (overridden by the `--show-source` command-line flag).",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "src": {
-      "description": "The source code paths to consider, e.g., when resolving first- vs. third-party imports.\n\nAs an example: given a Python package structure like:\n\n```text my_package/ pyproject.toml src/ my_package/ __init__.py foo.py bar.py ```\n\nThe `src` directory should be included in `source` (e.g., `source = [\"src\"]`), such that when resolving imports, `my_package.foo` is considered a first-party import.\n\nThis field supports globs. For example, if you have a series of Python packages in a `python_modules` directory, `src = [\"python_modules/*\"]` would expand to incorporate all of the packages in that directory. User home directory and environment variables will also be expanded.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
-    "target-version": {
-      "description": "The Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Note that the target version will _not_ be inferred from the _current_ Python version, and instead must be specified explicitly (as seen below).",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PythonVersion"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "unfixable": {
-      "description": "A list of check code prefixes to consider un-autofix-able.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/CheckCodePrefix"
-      }
-    }
-  },
   "additionalProperties": false,
   "definitions": {
     "CheckCodePrefix": {
@@ -911,41 +546,26 @@
     },
     "Convention": {
       "type": "string",
-      "enum": [
-        "google",
-        "numpy"
-      ]
+      "enum": ["google", "numpy"]
     },
     "Flake8AnnotationsOptions": {
       "type": "object",
       "properties": {
         "allow-star-arg-any": {
           "description": "Whether to suppress `ANN401` for dynamically typed `*args` and `**kwargs` arguments.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "mypy-init-return": {
           "description": "Whether to allow the omission of a return type hint for `__init__` if at least one argument is annotated.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "suppress-dummy-args": {
           "description": "Whether to suppress `ANN000`-level errors for arguments matching the \"dummy\" variable regex (like `_`).",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "suppress-none-returning": {
           "description": "Whether to suppress `ANN200`-level errors for functions that meet either of the following criteria:\n\n- Contain no `return` statement. - Explicit `return` statement(s) all return `None` (explicitly or implicitly).",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         }
       },
       "additionalProperties": false
@@ -955,10 +575,7 @@
       "properties": {
         "extend-immutable-calls": {
           "description": "Additional callable functions to consider \"immutable\" when evaluating, e.g., `no-mutable-default-argument` checks (`B006`).",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -971,10 +588,7 @@
       "properties": {
         "max-string-length": {
           "description": "Maximum string length for string literals in exception messages.",
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": ["integer", "null"],
           "minimum": 0.0
         }
       },
@@ -985,20 +599,14 @@
       "properties": {
         "aliases": {
           "description": "The conventional aliases for imports. These aliases can be extended by the `extend_aliases` option.",
-          "type": [
-            "object",
-            "null"
-          ],
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": "string"
           }
         },
         "extend-aliases": {
           "description": "A mapping of modules to their conventional import aliases. These aliases will be added to the `aliases` mapping.",
-          "type": [
-            "object",
-            "null"
-          ],
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": "string"
           }
@@ -1011,10 +619,7 @@
       "properties": {
         "avoid-escape": {
           "description": "Whether to avoid using single quotes if a string contains single quotes, or vice-versa with double quotes, as per [PEP8](https://peps.python.org/pep-0008/#string-quotes). This minimizes the need to escape quotation marks within strings.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "docstring-quotes": {
           "description": "Quote style to prefer for docstrings (either \"single\" (`'`) or \"double\" (`\"`)).",
@@ -1074,10 +679,7 @@
       "properties": {
         "ignore-variadic-names": {
           "description": "Whether to allow unused variadic arguments, like `*args` and `**kwargs`.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         }
       },
       "additionalProperties": false
@@ -1087,71 +689,47 @@
       "properties": {
         "combine-as-imports": {
           "description": "Combines as imports on the same line. See isort's [`combine-as-imports`](https://pycqa.github.io/isort/docs/configuration/options.html#combine-as-imports) option.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "extra-standard-library": {
           "description": "A list of modules to consider standard-library, in addition to those known to Ruff in advance.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "force-single-line": {
           "description": "Forces all from imports to appear on their own line.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "force-wrap-aliases": {
           "description": "Force `import from` statements with multiple members and at least one alias (e.g., `import A as B`) to wrap such that every line contains exactly one member. For example, this formatting would be retained, rather than condensing to a single line:\n\n```py from .utils import ( test_directory as test_directory, test_id as test_id ) ```\n\nNote that this setting is only effective when combined with `combine-as-imports = true`. When `combine-as-imports` isn't enabled, every aliased `import from` will be given its own line, in which case, wrapping is not necessary.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "known-first-party": {
           "description": "A list of modules to consider first-party, regardless of whether they can be identified as such via introspection of the local filesystem.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "known-third-party": {
           "description": "A list of modules to consider third-party, regardless of whether they can be identified as such via introspection of the local filesystem.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "single-line-exclusions": {
           "description": "One or more modules to exclude from the single line rule.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "split-on-trailing-comma": {
           "description": "If a comma is placed after the last member in a multi-line import, then the imports will never be folded into one line.\n\nSee isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         }
       },
       "additionalProperties": false
@@ -1161,10 +739,7 @@
       "properties": {
         "max-complexity": {
           "description": "The maximum McCabe complexity to allow before triggering `C901` errors.",
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": ["integer", "null"],
           "minimum": 0.0
         }
       },
@@ -1175,30 +750,21 @@
       "properties": {
         "classmethod-decorators": {
           "description": "A list of decorators that, when applied to a method, indicate that the method should be treated as a class method. For example, Ruff will expect that any method decorated by a decorator in this list takes a `cls` argument as its first argument.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "ignore-names": {
           "description": "A list of names to ignore when considering `pep8-naming` violations.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "staticmethod-decorators": {
           "description": "A list of decorators that, when applied to a method, indicate that the method should be treated as a static method. For example, Ruff will expect that any method decorated by a decorator in this list has no `self` or `cls` argument.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -1211,10 +777,7 @@
       "properties": {
         "keep-runtime-typing": {
           "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Optional[str]` -> `str | None`) rewrites even if a file imports `from __future__ import annotations`. Note that this setting is only applicable when the target Python version is below 3.9 and 3.10 respectively.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         }
       },
       "additionalProperties": false
@@ -1252,31 +815,317 @@
     },
     "Quote": {
       "type": "string",
-      "enum": [
-        "single",
-        "double"
-      ]
+      "enum": ["single", "double"]
     },
     "SerializationFormat": {
       "type": "string",
-      "enum": [
-        "text",
-        "json",
-        "junit",
-        "grouped",
-        "github",
-        "gitlab"
-      ]
+      "enum": ["text", "json", "junit", "grouped", "github", "gitlab"]
     },
     "Strictness": {
       "type": "string",
-      "enum": [
-        "parents",
-        "all"
-      ]
+      "enum": ["parents", "all"]
     },
     "Version": {
       "type": "string"
     }
-  }
+  },
+  "properties": {
+    "allowed-confusables": {
+      "description": "A list of allowed \"confusable\" Unicode characters to ignore when enforcing `RUF001`, `RUF002`, and `RUF003`.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string",
+        "maxLength": 1,
+        "minLength": 1
+      }
+    },
+    "cache-dir": {
+      "description": "A path to the cache directory.\n\nBy default, Ruff stores cache results in a `.ruff_cache` directory in the current project root.\n\nHowever, Ruff will also respect the `RUFF_CACHE_DIR` environment variable, which takes precedence over that default.\n\nThis setting will override even the `RUFF_CACHE_DIR` environment variable, if set.",
+      "type": ["string", "null"]
+    },
+    "dummy-variable-rgx": {
+      "description": "A regular expression used to identify \"dummy\" variables, or those which should be ignored when evaluating (e.g.) unused-variable checks. The default expression matches `_`, `__`, and `_var`, but not `_var_`.",
+      "type": ["string", "null"]
+    },
+    "exclude": {
+      "description": "A list of file patterns to exclude from linting.\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nNote that you'll typically want to use [`extend-exclude`](#extend-exclude) to modify the excluded paths.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "extend": {
+      "description": "A path to a local `pyproject.toml` file to merge into this configuration. User home directory and environment variables will be expanded.\n\nTo resolve the current `pyproject.toml` file, Ruff will first resolve this base configuration file, then merge in any properties defined in the current configuration file.",
+      "type": ["string", "null"]
+    },
+    "extend-exclude": {
+      "description": "A list of file patterns to omit from linting, in addition to those specified by `exclude`.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "extend-ignore": {
+      "description": "A list of check code prefixes to ignore, in addition to those specified by `ignore`.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "extend-select": {
+      "description": "A list of check code prefixes to enable, in addition to those specified by `select`.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "external": {
+      "description": "A list of check codes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented in Ruff.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "fix": {
+      "description": "Enable autofix behavior by-default when running `ruff` (overridden by the `--fix` and `--no-fix` command-line flags).",
+      "type": ["boolean", "null"]
+    },
+    "fix-only": {
+      "description": "Like `fix`, but disables reporting on leftover violation. Implies `fix`.",
+      "type": ["boolean", "null"]
+    },
+    "fixable": {
+      "description": "A list of check code prefixes to consider autofix-able.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "flake8-annotations": {
+      "description": "Options for the `flake8-annotations` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8AnnotationsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-bugbear": {
+      "description": "Options for the `flake8-bugbear` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8BugbearOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-errmsg": {
+      "description": "Options for the `flake8-errmsg` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8ErrMsgOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-import-conventions": {
+      "description": "Options for the `flake8-import-conventions` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8ImportConventionsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-quotes": {
+      "description": "Options for the `flake8-quotes` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8QuotesOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-tidy-imports": {
+      "description": "Options for the `flake8-tidy-imports` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8TidyImportsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "flake8-unused-arguments": {
+      "description": "Options for the `flake8-unused-arguments` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8UnusedArgumentsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "force-exclude": {
+      "description": "Whether to enforce `exclude` and `extend-exclude` patterns, even for paths that are passed to Ruff explicitly. Typically, Ruff will lint any paths passed in directly, even if they would typically be excluded. Setting `force-exclude = true` will cause Ruff to respect these exclusions unequivocally.\n\nThis is useful for [`pre-commit`](https://pre-commit.com/), which explicitly passes all changed files to the [`ruff-pre-commit`](https://github.com/charliermarsh/ruff-pre-commit) plugin, regardless of whether they're marked as excluded by Ruff's own settings.",
+      "type": ["boolean", "null"]
+    },
+    "format": {
+      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations) or `\"gitlab\"` (GitLab CI code quality report).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SerializationFormat"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ignore": {
+      "description": "A list of check code prefixes to ignore. Prefixes can specify exact checks (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled checks (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "ignore-init-module-imports": {
+      "description": "Avoid automatically removing unused imports in `__init__.py` files. Such imports will still be +flagged, but with a dedicated message suggesting that the import is either added to the module' +`__all__` symbol, or re-exported with a redundant alias (e.g., `import os as os`).",
+      "type": ["boolean", "null"]
+    },
+    "isort": {
+      "description": "Options for the `isort` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/IsortOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "line-length": {
+      "description": "The line length to use when enforcing long-lines violations (like `E501`).",
+      "type": ["integer", "null"],
+      "minimum": 0.0
+    },
+    "mccabe": {
+      "description": "Options for the `mccabe` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/McCabeOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "pep8-naming": {
+      "description": "Options for the `pep8-naming` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Pep8NamingOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "per-file-ignores": {
+      "description": "A list of mappings from file pattern to check code prefixes to exclude, when considering any matching files.",
+      "type": ["object", "null"],
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/CheckCodePrefix"
+        }
+      }
+    },
+    "pydocstyle": {
+      "description": "Options for the `pydocstyle` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Pydocstyle"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "pyupgrade": {
+      "description": "Options for the `pyupgrade` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PyUpgradeOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "required-version": {
+      "description": "Require a specific version of Ruff to be running (useful for unifying results across many environments, e.g., with a `pyproject.toml` file).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Version"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "respect-gitignore": {
+      "description": "Whether to automatically exclude files that are ignored by `.ignore`, `.gitignore`, `.git/info/exclude`, and global `gitignore` files. Enabled by default.",
+      "type": ["boolean", "null"]
+    },
+    "select": {
+      "description": "A list of check code prefixes to enable. Prefixes can specify exact checks (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled checks (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    },
+    "show-source": {
+      "description": "Whether to show source code snippets when reporting lint error violations (overridden by the `--show-source` command-line flag).",
+      "type": ["boolean", "null"]
+    },
+    "src": {
+      "description": "The source code paths to consider, e.g., when resolving first- vs. third-party imports.\n\nAs an example: given a Python package structure like:\n\n```text my_package/ pyproject.toml src/ my_package/ __init__.py foo.py bar.py ```\n\nThe `src` directory should be included in `source` (e.g., `source = [\"src\"]`), such that when resolving imports, `my_package.foo` is considered a first-party import.\n\nThis field supports globs. For example, if you have a series of Python packages in a `python_modules` directory, `src = [\"python_modules/*\"]` would expand to incorporate all of the packages in that directory. User home directory and environment variables will also be expanded.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "target-version": {
+      "description": "The Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Note that the target version will _not_ be inferred from the _current_ Python version, and instead must be specified explicitly (as seen below).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PythonVersion"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "unfixable": {
+      "description": "A list of check code prefixes to consider un-autofix-able.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/CheckCodePrefix"
+      }
+    }
+  },
+  "title": "Options",
+  "type": "object"
 }

--- a/src/test/pyproject/ruff-sample-project.toml
+++ b/src/test/pyproject/ruff-sample-project.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+
+[tool.ruff.isort]
+force-wrap-aliases = true
+combine-as-imports = true
+force-single-line = true
+single-line-exclusions = ["os", "logging.handlers"]
+
+[tool.ruff.pydocstyle]
+convention = "google"


### PR DESCRIPTION
This PR makes Ruff accessible via `[tool.ruff]` in `pyproject.toml` (known here as `pyproject.json`). I mostly followed [this PR](https://github.com/SchemaStore/schemastore/pull/2292) adding Stylelint to `package.json` as a template.
