### PR TITLE
Add service.nox.json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2232,11 +2232,7 @@
       "name": "NOX Framework (Service)",
       "description": "Schema for NOX service definition",
       "url": "https://noxorg.dev/schemas/NoxConfiguration.json",
-      "fileMatch": [
-        "service.nox.yaml",
-        "service.nox.yml",
-        "service.nox.json"
-      ]
+      "fileMatch": ["service.nox.yaml", "service.nox.yml", "service.nox.json"]
     },
     {
       "name": ".npmpackagejsonlintrc",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2229,6 +2229,16 @@
       "fileMatch": ["nodemon.json"]
     },
     {
+      "name": "NOX Framework (Service)",
+      "description": "Schema for NOX service definition",
+      "url": "https://noxorg.dev/schemas/NoxConfiguration.json",
+      "fileMatch": [
+        "service.nox.yaml",
+        "service.nox.yml",
+        "service.nox.json"
+      ]
+    },
+    {
       "name": ".npmpackagejsonlintrc",
       "description": "Configuration file for npm-package-json-lint",
       "fileMatch": [


### PR DESCRIPTION
Added externally hosted Nox Framework service schema.

```json
    {
      "name": "NOX Framework (Service)",
      "description": "Schema for NOX service definition",
      "url": "https://noxorg.dev/schemas/NoxConfiguration.json",
      "fileMatch": [
        "service.nox.yaml",
        "service.nox.yml",
        "service.nox.json"
      ]
    },
```