### PR TITLE
Multiple inheritance in jsconfig.json

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -89,8 +89,20 @@
     "extendsDefinition": {
       "properties": {
         "extends": {
-          "description": "Path to base configuration file to inherit from. Requires TypeScript version 2.1 or later.",
-          "type": "string"
+          "description": "Path to base configuration file to inherit from (requires TypeScript version 2.1 or later), or array of base files, with the rightmost files having the greater priority (requires TypeScript version 5.0 or later).",
+          "oneOf": [
+            {
+              "default": "",
+              "type": "string"
+            },
+            {
+              "default": [],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
         }
       }
     },

--- a/src/test/jsconfig/jsconfig-extends-multiple.json
+++ b/src/test/jsconfig/jsconfig-extends-multiple.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./jsconfig.json", "./jsconfig-emit-tds.json"]
+}

--- a/src/test/jsconfig/jsconfig-extends-single.json
+++ b/src/test/jsconfig/jsconfig-extends-single.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}


### PR DESCRIPTION
A follow-up to https://github.com/SchemaStore/schemastore/pull/2682 . Because `jsconfig.json` [is a descendant](https://code.visualstudio.com/docs/languages/jsconfig#:~:text=jsconfig.json%20is%20a%20descendant%20of%20tsconfig.json) of `tsconfig.json`, it needs to catchup these changes too. Thanks
