### PR TITLE
Fix schema for rust-toolchain.toml

### DIFF
--- a/src/schemas/json/rust-toolchain.json
+++ b/src/schemas/json/rust-toolchain.json
@@ -10,7 +10,7 @@
         "channel": {
           "description": "`channel` is a named release channel, a major and minor version number such as `1.42`, or a fully specified version number, such as `1.42.0`. Channel names can be optionally appended with an archive date, as in `nightly-2014-12-18`, in which case the toolchain is downloaded from the archive for that date. Get more from [`Toolchain specification`](https://rust-lang.github.io/rustup/concepts/toolchains.html).\n\nOther valid channel like `stable`,`1.63`,`1.63.0`,`nightly-2022-09-20`,`stable-x86_64-pc-windows-msvc`,`1.63.0-riscv64gc-unknown-linux-gnu`,`nightly-2022-09-20-x86_64-unknown-nux-gnu`",
           "type": "string",
-          "pattern": "^(?:stable|beat|nightly|\\d+\\.(?:\\d+\\.)?\\d+)(?:-\\d{4}-\\d{2}-\\d{2})?(?:(?:-\\w+)(?:-\\w+)(?:-\\w+)?(?:-\\w+)?)?$",
+          "pattern": "^(?:stable|beta|nightly|\\d+\\.(?:\\d+\\.)?\\d+)(?:-\\d{4}-\\d{2}-\\d{2})?(?:(?:-\\w+)(?:-\\w+)(?:-\\w+)?(?:-\\w+)?)?$",
           "examples": [
             "stable",
             "1.63",


### PR DESCRIPTION
"beta" was spelled "beat".