### PR TITLE
Fix GitHub cron expression

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1680,7 +1680,7 @@
                   "cron": {
                     "$comment": "https://stackoverflow.com/a/57639657/4044345",
                     "type": "string",
-                    "pattern": "^(((\\d+,)+\\d+|((\\d+|\\*)/\\d+|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?))|(\\d+-\\d+)|\\d+|\\*|((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?)) ?){5}$"
+                    "pattern": "^(((\\d+,)+\\d+|((\\d+|\\*)/\\d+|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?))|(\\d+-\\d+)|\\d+(-\\d+)?/\\d+(-\\d+)?|\\d+|\\*|((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?)) ?){5}$"
                   }
                 },
                 "additionalProperties": false

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1680,7 +1680,7 @@
                   "cron": {
                     "$comment": "https://stackoverflow.com/a/57639657/4044345",
                     "type": "string",
-                    "pattern": "^(((\\d+,)+\\d+|((\\d+|\\*)/\\d+|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?))|(\\d+-\\d+)|\\d+(-\\d+)?/\\d+(-\\d+)?|\\d+|\\*|((MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?)) ?){5}$"
+                    "pattern": "^(((\\d+,)+\\d+|((\\d+|\\*)/\\d+|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(-(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?))|(\\d+-\\d+)|\\d+(-\\d+)?/\\d+(-\\d+)?|\\d+|\\*|(MON|TUE|WED|THU|FRI|SAT|SUN)(-(MON|TUE|WED|THU|FRI|SAT|SUN))?) ?){5}$"
                   }
                 },
                 "additionalProperties": false

--- a/src/test/github-workflow/1162.yaml
+++ b/src/test/github-workflow/1162.yaml
@@ -1,8 +1,8 @@
 name: PR review reminders
 on:
- schedule:
-  # Every weekday every 2 hours during working hours, send notification
-  - cron: '0 14-23/2 * * 1-5'
+  schedule:
+    # Every weekday every 2 hours during working hours, send notification
+    - cron: '0 14-23/2 * * 1-5'
 jobs:
   check_run:
     runs-on: ubuntu-latest

--- a/src/test/github-workflow/1162.yaml
+++ b/src/test/github-workflow/1162.yaml
@@ -1,0 +1,8 @@
+name: PR review reminders
+on:
+ schedule:
+  # Every weekday every 2 hours during working hours, send notification
+  - cron: '0 14-23/2 * * 1-5'
+jobs:
+  check_run:
+    runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1162 (in particular, the last [comment](https://github.com/SchemaStore/schemastore/issues/1162#issuecomment-1349497871))

