### PR TITLE
test: Improve error message for invalid `$schema`s

### DIFF
--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -1363,18 +1363,18 @@ module.exports = function (grunt) {
           schemaOnlyScan(data) {
             countScan++
 
-            if (
-              ![
-                'http://json-schema.org/draft-03/schema#',
-                'http://json-schema.org/draft-04/schema#',
-                'http://json-schema.org/draft-06/schema#',
-                'http://json-schema.org/draft-07/schema#',
-                'https://json-schema.org/draft/2019-09/schema',
-                'https://json-schema.org/draft/2020-12/schema',
-              ].includes(data.jsonObj.$schema)
-            ) {
+            const validSchemas = [
+              'http://json-schema.org/draft-03/schema#',
+              'http://json-schema.org/draft-04/schema#',
+              'http://json-schema.org/draft-06/schema#',
+              'http://json-schema.org/draft-07/schema#',
+              'https://json-schema.org/draft/2019-09/schema',
+              'https://json-schema.org/draft/2020-12/schema',
+            ]
+            if (!validSchemas.includes(data.jsonObj.$schema)) {
               throwWithErrorText([
                 `Schema file has invalid or missing '$schema' keyword => ${data.jsonName}`,
+                `Valid schemas: ${JSON.stringify(validSchemas)}`,
               ])
             }
           },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Improve the error message so people don't need to look in Gruntfile to see valid schema values. Addresses [#2659 (comment)](https://github.com/SchemaStore/schemastore/pull/2659#issuecomment-1368149274)