### PR TITLE
Modify Minecraft Recipe JSON Schema to fit with 1.19.3

### DIFF
--- a/src/schemas/json/minecraft-recipe.json
+++ b/src/schemas/json/minecraft-recipe.json
@@ -353,8 +353,6 @@
       "type": "object",
       "properties": {
         "category": {
-          "title": "Category",
-          "description": "A string identifier. Used to add recipe to a specific existing category in the recipe book.",
           "type": "string",
           "enum": ["building", "redstone", "equipment", "misc"]
         }
@@ -364,8 +362,6 @@
       "type": "object",
       "properties": {
         "category": {
-          "title": "Category",
-          "description": "A string identifier. Used to add recipe to a specific existing category in the recipe book.",
           "type": "string",
           "enum": ["food", "blocks", "misc "]
         }

--- a/src/schemas/json/minecraft-recipe.json
+++ b/src/schemas/json/minecraft-recipe.json
@@ -356,7 +356,7 @@
           "title": "Category",
           "description": "A string identifier. Used to add recipe to a specific existing category in the recipe book.",
           "type": "string",
-          "enum": [ "building", "redstone", "equipment", "misc" ]
+          "enum": ["building", "redstone", "equipment", "misc"]
         }
       }
     },
@@ -367,7 +367,7 @@
           "title": "Category",
           "description": "A string identifier. Used to add recipe to a specific existing category in the recipe book.",
           "type": "string",
-          "enum": [ "food", "blocks", "misc " ]
+          "enum": ["food", "blocks", "misc "]
         }
       }
     },

--- a/src/schemas/json/minecraft-recipe.json
+++ b/src/schemas/json/minecraft-recipe.json
@@ -356,7 +356,7 @@
       "properties": {
         "category": {
           "type": "string",
-          "enum": [ "building", "redstone", "equipment", "misc" ]
+          "enum": ["building", "redstone", "equipment", "misc"]
         }
       }
     },
@@ -367,7 +367,7 @@
       "properties": {
         "category": {
           "type": "string",
-          "enum": [ "food", "blocks", "misc " ]
+          "enum": ["food", "blocks", "misc "]
         }
       }
     },

--- a/src/schemas/json/minecraft-recipe.json
+++ b/src/schemas/json/minecraft-recipe.json
@@ -350,20 +350,24 @@
       }
     },
     "commonRecipeCategory": {
+      "title": "Category",
+      "description": "Category of common recipes (in recipe book).",
       "type": "object",
       "properties": {
         "category": {
           "type": "string",
-          "enum": ["building", "redstone", "equipment", "misc"]
+          "enum": [ "building", "redstone", "equipment", "misc" ]
         }
       }
     },
     "cookingRecipeCategory": {
+      "title": "Category",
+      "description": "Category of cooking recipes (in recipe book).",
       "type": "object",
       "properties": {
         "category": {
           "type": "string",
-          "enum": ["food", "blocks", "misc "]
+          "enum": [ "food", "blocks", "misc " ]
         }
       }
     },

--- a/src/schemas/json/minecraft-recipe.json
+++ b/src/schemas/json/minecraft-recipe.json
@@ -18,6 +18,9 @@
           },
           {
             "$ref": "#/definitions/tagsCommonToAllCookingRecipes"
+          },
+          {
+            "$ref": "#/definitions/cookingRecipeCategory"
           }
         ]
       }
@@ -38,6 +41,9 @@
           },
           {
             "$ref": "#/definitions/tagsCommonToAllCookingRecipes"
+          },
+          {
+            "$ref": "#/definitions/cookingRecipeCategory"
           }
         ]
       }
@@ -52,6 +58,14 @@
       },
       "then": {
         "description": "Represents a shaped crafting recipe in a crafting table.",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/tagsCommonToAllRecipes"
+          },
+          {
+            "$ref": "#/definitions/commonRecipeCategory"
+          }
+        ],
         "properties": {
           "pattern": {
             "title": "Pattern",
@@ -113,7 +127,14 @@
       },
       "then": {
         "description": "Represents a shapeless crafting recipe in a crafting table.",
-        "$ref": "#/definitions/tagsCommonToAllRecipes",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/tagsCommonToAllRecipes"
+          },
+          {
+            "$ref": "#/definitions/commonRecipeCategory"
+          }
+        ],
         "properties": {
           "ingredients": {
             "title": "Ingredients",
@@ -162,6 +183,9 @@
           },
           {
             "$ref": "#/definitions/tagsCommonToAllCookingRecipes"
+          },
+          {
+            "$ref": "#/definitions/cookingRecipeCategory"
           }
         ]
       }
@@ -210,6 +234,9 @@
           },
           {
             "$ref": "#/definitions/tagsCommonToAllCookingRecipes"
+          },
+          {
+            "$ref": "#/definitions/cookingRecipeCategory"
           }
         ]
       }
@@ -319,6 +346,28 @@
           "title": "Cooking Time",
           "description": "The cook time of the recipe in ticks.",
           "type": "integer"
+        }
+      }
+    },
+    "commonRecipeCategory": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "title": "Category",
+          "description": "A string identifier. Used to add recipe to a specific existing category in the recipe book.",
+          "type": "string",
+          "enum": [ "building", "redstone", "equipment", "misc" ]
+        }
+      }
+    },
+    "cookingRecipeCategory": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "title": "Category",
+          "description": "A string identifier. Used to add recipe to a specific existing category in the recipe book.",
+          "type": "string",
+          "enum": [ "food", "blocks", "misc " ]
         }
       }
     },


### PR DESCRIPTION
This PR modify JSON schema for Minecraft Recipe to fit with 1.19.3 additions (category field).

![image](https://user-images.githubusercontent.com/40738104/210172573-56e2916d-a47b-4135-895e-7661acffe4c1.png)
https://www.minecraft.net/en-us/article/minecraft-snapshot-22w42a