### PR TITLE
Extend "Woodpecker pipeline config" fileMatch to allow `.yaml`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4007,7 +4007,12 @@
     {
       "name": "Woodpecker pipeline config",
       "description": "YAML schema for configuring Woodpecker CI",
-      "fileMatch": ["**/.woodpecker/**.yml", "**/.woodpecker.yml"],
+      "fileMatch": [
+        "**/.woodpecker/**.yml",
+        "**/.woodpecker.yml",
+        "**/.woodpecker/**.yaml",
+        "**/.woodpecker.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/woodpecker-ci/woodpecker/master/pipeline/schema/schema.json"
     },
     {


### PR DESCRIPTION
Extend "Woodpecker pipeline config" fileMatch to allow `.yaml`

Fixes [woodpecker-ci/woodpecker/isues1529](https://github.com/woodpecker-ci/woodpecker/issues/1529)

Update the "Woodpecker pipeline config" `fileMatch` (introduced in #1845) to also match `.yaml`.

The `.yaml` extension (as an alternative to `.yml`) was introduced to woodpecker in https://github.com/woodpecker-ci/woodpecker/pull/1388 and utilizes the same schema.json (it's just an alternative file ending for those more used to `.yaml`)
