### PR TITLE
chore: Apply EditorConfig to more files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
-root=true
+root = true
 
-[*.{json,md,toml,yml,yaml}]
+[*]
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
@@ -11,8 +11,15 @@ indent_style = space
 indent_size = 2
 
 [*.md]
+indent_style = space
+indent_size = 2
 trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
 indent_style = space
+indent_size = 2
 trim_trailing_whitespace = false
+
+[*.cshtml]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This improves the EditorConfig to apply to more files

- Namely, when creating files like `.git-blame-ignore-revs`, the editor didn't automatically add a newline, this fixes that
- This also adds support for the various `.cshtml` files, which appear to all have an indent size of 4
