### PR TITLE
*.json: refresh schemas: lower case all `title` properties in all schemas

### DIFF
--- a/src/schemas/json/BizTalkServerApplicationSchema.json
+++ b/src/schemas/json/BizTalkServerApplicationSchema.json
@@ -130,6 +130,6 @@
     }
   },
   "required": ["BizTalkAssemblies", "BindingsFiles", "DeploymentSequence"],
-  "title": "BizTalkServerApplicationInventorySchema",
+  "title": "biztalkserverapplicationinventoryschema",
   "type": "object"
 }

--- a/src/schemas/json/agripparc-1.2.json
+++ b/src/schemas/json/agripparc-1.2.json
@@ -72,6 +72,6 @@
       "enum": ["https://json.schemastore.org/agripparc-1.2.json"]
     }
   },
-  "title": "JSON schema for the Agrippa config file",
+  "title": "json schema for the agrippa config file",
   "type": "object"
 }

--- a/src/schemas/json/agripparc-1.3.json
+++ b/src/schemas/json/agripparc-1.3.json
@@ -83,6 +83,6 @@
       "enum": ["https://json.schemastore.org/agripparc-1.3.json"]
     }
   },
-  "title": "JSON schema for the Agrippa config file",
+  "title": "json schema for the agrippa config file",
   "type": "object"
 }

--- a/src/schemas/json/agripparc-1.4.json
+++ b/src/schemas/json/agripparc-1.4.json
@@ -96,6 +96,6 @@
       "enum": ["https://json.schemastore.org/agripparc-1.4.json"]
     }
   },
-  "title": "JSON schema for the Agrippa config file",
+  "title": "json schema for the agrippa config file",
   "type": "object"
 }

--- a/src/schemas/json/anywork-ac-1.0.json
+++ b/src/schemas/json/anywork-ac-1.0.json
@@ -134,6 +134,6 @@
     }
   },
   "required": ["ctype", "cversion"],
-  "title": "AnyWork Automation Configuration schema",
+  "title": "anywork automation configuration schema",
   "type": "object"
 }

--- a/src/schemas/json/anywork-ac-1.1.json
+++ b/src/schemas/json/anywork-ac-1.1.json
@@ -270,6 +270,6 @@
     }
   },
   "required": ["ctype", "cversion"],
-  "title": "AnyWork Automation Configuration schema",
+  "title": "anywork automation configuration schema",
   "type": "object"
 }

--- a/src/schemas/json/apibuilder.json
+++ b/src/schemas/json/apibuilder.json
@@ -720,5 +720,5 @@
     }
   },
   "required": ["name"],
-  "title": "API Builder Schema"
+  "title": "api builder schema"
 }

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -32,6 +32,6 @@
     }
   },
   "required": ["applinks"],
-  "title": "Apple Universal Link, App Site Association",
+  "title": "apple universal link, app site association",
   "type": "object"
 }

--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -1526,6 +1526,6 @@
       "$ref": "#/definitions/connectionStrings"
     }
   },
-  "title": "JSON schema ASP.NET Core's appsettings.json file",
+  "title": "json schema asp.net core's appsettings.json file",
   "type": "object"
 }

--- a/src/schemas/json/appsscript.json
+++ b/src/schemas/json/appsscript.json
@@ -435,6 +435,6 @@
       }
     }
   },
-  "title": "JSON schema for Google Apps Script manifest files",
+  "title": "json schema for google apps script manifest files",
   "type": "object"
 }

--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -744,5 +744,5 @@
       }
     }
   },
-  "title": "JSON schema for AppVeyor CI configuration files"
+  "title": "json schema for appveyor ci configuration files"
 }

--- a/src/schemas/json/artifacthub-repo.json
+++ b/src/schemas/json/artifacthub-repo.json
@@ -44,6 +44,6 @@
       }
     }
   },
-  "title": "Artifact Hub repository metadata file",
+  "title": "artifact hub repository metadata file",
   "type": "object"
 }

--- a/src/schemas/json/asconfig-schema.json
+++ b/src/schemas/json/asconfig-schema.json
@@ -289,6 +289,6 @@
       }
     }
   },
-  "title": "JSON schema for asconfig.json",
+  "title": "json schema for asconfig.json",
   "type": "object"
 }

--- a/src/schemas/json/asmdef.json
+++ b/src/schemas/json/asmdef.json
@@ -153,6 +153,6 @@
     }
   },
   "required": ["name"],
-  "title": "Unity Assembly Definition",
+  "title": "unity assembly definition",
   "type": "object"
 }

--- a/src/schemas/json/ava.json
+++ b/src/schemas/json/ava.json
@@ -157,6 +157,6 @@
       }
     }
   },
-  "title": "AVA Config Schema",
+  "title": "ava config schema",
   "type": "object"
 }

--- a/src/schemas/json/avro-avsc.json
+++ b/src/schemas/json/avro-avsc.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "avroSchema": {
-      "title": "Avro Schema",
+      "title": "avro schema",
       "description": "Root Schema",
       "oneOf": [
         {
@@ -11,7 +11,7 @@
       ]
     },
     "types": {
-      "title": "Avro Types",
+      "title": "avro types",
       "description": "Allowed Avro types",
       "oneOf": [
         {
@@ -44,7 +44,7 @@
       ]
     },
     "primitiveType": {
-      "title": "Primitive Type",
+      "title": "primitive type",
       "description": "Basic type primitives.",
       "type": "string",
       "enum": [
@@ -59,7 +59,7 @@
       ]
     },
     "primitiveTypeWithMetadata": {
-      "title": "Primitive Type With Metadata",
+      "title": "primitive type with metadata",
       "description": "A primitive type with metadata attached.",
       "type": "object",
       "properties": {
@@ -70,7 +70,7 @@
       "required": ["type"]
     },
     "customTypeReference": {
-      "title": "Custom Type",
+      "title": "custom type",
       "description": "Reference to a ComplexType",
       "not": {
         "$ref": "#/definitions/primitiveType"
@@ -79,7 +79,7 @@
       "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
     },
     "avroUnion": {
-      "title": "Union",
+      "title": "union",
       "description": "A Union of types",
       "type": "array",
       "items": {
@@ -88,7 +88,7 @@
       "minItems": 1
     },
     "avroField": {
-      "title": "Field",
+      "title": "field",
       "description": "A field within a Record",
       "type": "object",
       "properties": {
@@ -115,7 +115,7 @@
       "required": ["name", "type"]
     },
     "avroRecord": {
-      "title": "Record",
+      "title": "record",
       "description": "A Record",
       "type": "object",
       "properties": {
@@ -148,7 +148,7 @@
       "required": ["type", "name", "fields"]
     },
     "avroEnum": {
-      "title": "Enum",
+      "title": "enum",
       "description": "An enumeration",
       "type": "object",
       "properties": {
@@ -181,7 +181,7 @@
       "required": ["type", "name", "symbols"]
     },
     "avroArray": {
-      "title": "Array",
+      "title": "array",
       "description": "An array",
       "type": "object",
       "properties": {
@@ -211,7 +211,7 @@
       "required": ["type", "items"]
     },
     "avroMap": {
-      "title": "Map",
+      "title": "map",
       "description": "A map of values",
       "type": "object",
       "properties": {
@@ -241,7 +241,7 @@
       "required": ["type", "values"]
     },
     "avroFixed": {
-      "title": "Fixed",
+      "title": "fixed",
       "description": "A fixed sized array of bytes",
       "type": "object",
       "properties": {
@@ -285,5 +285,5 @@
       "$ref": "#/definitions/avroSchema"
     }
   ],
-  "title": "Avro Schema Definition"
+  "title": "avro schema definition"
 }

--- a/src/schemas/json/azure-deviceupdate-import-manifest-4.0.json
+++ b/src/schemas/json/azure-deviceupdate-import-manifest-4.0.json
@@ -4,12 +4,12 @@
   "definitions": {
     "instructions": {
       "type": "object",
-      "title": "Installation instructions",
+      "title": "installation instructions",
       "description": "Update installation instructions.",
       "properties": {
         "steps": {
           "type": "array",
-          "title": "Installation steps",
+          "title": "installation steps",
           "items": {
             "anyOf": [
               {
@@ -29,14 +29,14 @@
     },
     "stepDescription": {
       "type": "string",
-      "title": "Step description",
+      "title": "step description",
       "description": "Optional instruction step description.",
       "minLength": 1,
       "maxLength": 64
     },
     "inlineStep": {
       "type": "object",
-      "title": "Inline installation step",
+      "title": "inline installation step",
       "description": "Installation instruction step that performs code execution.",
       "properties": {
         "type": {
@@ -50,7 +50,7 @@
         },
         "files": {
           "type": "array",
-          "title": "Step update files",
+          "title": "step update files",
           "description": "Names of update files that agent will pass to handler.",
           "items": {
             "$ref": "azure-deviceupdate-manifest-definitions-4.0.json#/definitions/filename"
@@ -67,7 +67,7 @@
     },
     "referenceStep": {
       "type": "object",
-      "title": "Reference installation step",
+      "title": "reference installation step",
       "description": "Installation instruction step that installs another update.",
       "properties": {
         "type": {
@@ -142,7 +142,7 @@
     },
     "description": {
       "type": "string",
-      "title": "Update description",
+      "title": "update description",
       "description": "Optional update description.",
       "minLength": 1,
       "maxLength": 512
@@ -155,7 +155,7 @@
     },
     "files": {
       "type": "array",
-      "title": "Update files",
+      "title": "update files",
       "description": "List of update payload files. Sum of all file sizes may not exceed 2 GB. May be empty or null if all instruction steps are reference steps.",
       "items": {
         "$ref": "azure-deviceupdate-manifest-definitions-4.0.json#/definitions/file"
@@ -165,13 +165,13 @@
     },
     "manifestVersion": {
       "type": "string",
-      "title": "Import manifest schema version",
+      "title": "import manifest schema version",
       "description": "Import manifest schema version. Must be 4.0.",
       "const": "4.0"
     },
     "createdDateTime": {
       "type": "string",
-      "title": "Created date & time",
+      "title": "created date & time",
       "description": "Date & time import manifest was created in ISO 8601 format.",
       "examples": ["2020-10-02T22:18:04.9446744Z"]
     }
@@ -183,6 +183,6 @@
     "manifestVersion",
     "createdDateTime"
   ],
-  "title": "JSON Schema for Azure Device Update for IoT Hub 'Import Manifest' version 4.0",
+  "title": "json schema for azure device update for iot hub 'import manifest' version 4.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-deviceupdate-import-manifest-5.0.json
+++ b/src/schemas/json/azure-deviceupdate-import-manifest-5.0.json
@@ -4,12 +4,12 @@
   "definitions": {
     "instructions": {
       "type": "object",
-      "title": "Installation instructions",
+      "title": "installation instructions",
       "description": "Update installation instructions.",
       "properties": {
         "steps": {
           "type": "array",
-          "title": "Installation steps",
+          "title": "installation steps",
           "items": {
             "anyOf": [
               {
@@ -29,14 +29,14 @@
     },
     "stepDescription": {
       "type": "string",
-      "title": "Step description",
+      "title": "step description",
       "description": "Optional instruction step description.",
       "minLength": 1,
       "maxLength": 64
     },
     "inlineStep": {
       "type": "object",
-      "title": "Inline installation step",
+      "title": "inline installation step",
       "description": "Installation instruction step that performs code execution.",
       "properties": {
         "type": {
@@ -50,7 +50,7 @@
         },
         "files": {
           "type": "array",
-          "title": "Step update files",
+          "title": "step update files",
           "description": "Names of update files that agent will pass to handler.",
           "items": {
             "$ref": "azure-deviceupdate-manifest-definitions-5.0.json#/definitions/filename"
@@ -67,7 +67,7 @@
     },
     "referenceStep": {
       "type": "object",
-      "title": "Reference installation step",
+      "title": "reference installation step",
       "description": "Installation instruction step that installs another update.",
       "properties": {
         "type": {
@@ -158,7 +158,7 @@
     },
     "description": {
       "type": "string",
-      "title": "Update description",
+      "title": "update description",
       "description": "Optional update description.",
       "minLength": 1,
       "maxLength": 512
@@ -171,7 +171,7 @@
     },
     "files": {
       "type": "array",
-      "title": "Update files",
+      "title": "update files",
       "description": "List of update payload files. Sum of all file sizes may not exceed 2 GB. May be empty or null if all instruction steps are reference steps.",
       "items": {
         "$ref": "azure-deviceupdate-manifest-definitions-5.0.json#/definitions/file"
@@ -181,13 +181,13 @@
     },
     "manifestVersion": {
       "type": "string",
-      "title": "Import manifest schema version",
+      "title": "import manifest schema version",
       "description": "Import manifest schema version. Must be 5.0.",
       "const": "5.0"
     },
     "createdDateTime": {
       "type": "string",
-      "title": "Created date & time",
+      "title": "created date & time",
       "description": "Date & time import manifest was created in ISO 8601 format.",
       "examples": ["2020-10-02T22:18:04.9446744Z"]
     }
@@ -199,6 +199,6 @@
     "manifestVersion",
     "createdDateTime"
   ],
-  "title": "JSON Schema for Azure Device Update for IoT Hub 'Import Manifest' version 5.0",
+  "title": "json schema for azure device update for iot hub 'import manifest' version 5.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-deviceupdate-manifest-definitions-4.0.json
+++ b/src/schemas/json/azure-deviceupdate-manifest-definitions-4.0.json
@@ -4,12 +4,12 @@
   "definitions": {
     "updateId": {
       "type": "object",
-      "title": "Update identity",
+      "title": "update identity",
       "description": "Unique update identifier.",
       "properties": {
         "provider": {
           "type": "string",
-          "title": "Update provider",
+          "title": "update provider",
           "description": "Entity who is creating or directly responsible for the update. It can be a company name.",
           "minLength": 1,
           "maxLength": 64,
@@ -17,7 +17,7 @@
         },
         "name": {
           "type": "string",
-          "title": "Update name",
+          "title": "update name",
           "description": "Identifier for a class of update. It can be a device class or model name.",
           "minLength": 1,
           "maxLength": 64,
@@ -25,7 +25,7 @@
         },
         "version": {
           "type": "string",
-          "title": "Update version",
+          "title": "update version",
           "description": "Two to four part dot separated numerical version numbers. Each part must be a number between 0 and 2147483647 and leading zeroes will be dropped.",
           "pattern": "^\\d+(?:\\.\\d+)+$",
           "examples": ["1.0", "2021.11.8"]
@@ -36,7 +36,7 @@
     },
     "compatibility": {
       "type": "array",
-      "title": "Update compatibility",
+      "title": "update compatibility",
       "description": "List of device property sets this update is compatible with.",
       "items": {
         "$ref": "azure-deviceupdate-manifest-definitions-4.0.json#/definitions/compatibilityInfo"
@@ -46,7 +46,7 @@
     },
     "compatibilityInfo": {
       "type": "object",
-      "title": "Update compatibility info",
+      "title": "update compatibility info",
       "description": "Properties of a device this update is compatible with.",
       "additionalProperties": {
         "type": "string",
@@ -62,7 +62,7 @@
     },
     "file": {
       "type": "object",
-      "title": "Update file",
+      "title": "update file",
       "description": "Update payload file, e.g. binary, firmware, script, etc. Must be unique within update.",
       "properties": {
         "filename": {
@@ -70,7 +70,7 @@
         },
         "sizeInBytes": {
           "type": "number",
-          "title": "File size",
+          "title": "file size",
           "description": "File size in number of bytes.",
           "minimum": 1,
           "maximum": 2147483648
@@ -84,19 +84,19 @@
     },
     "filename": {
       "type": "string",
-      "title": "Update file name",
+      "title": "update file name",
       "description": "Update payload file name.",
       "minLength": 1,
       "maxLength": 255
     },
     "fileHashes": {
       "type": "object",
-      "title": "File hashes",
+      "title": "file hashes",
       "description": "Base64-encoded file hashes with algorithm name as key. At least SHA-256 algorithm must be specified, and additional algorithm may be specified if supported by agent.",
       "properties": {
         "sha256": {
           "type": "string",
-          "title": "SHA-256 hash value",
+          "title": "sha-256 hash value",
           "description": "Base64-encoded file hash value using SHA-256 algorithm."
         }
       },
@@ -111,19 +111,19 @@
     },
     "referenceStepType": {
       "type": "string",
-      "title": "'Reference' step type",
+      "title": "'reference' step type",
       "description": "Instruction step type that installs another update.",
       "const": "reference"
     },
     "inlineStepType": {
       "type": "string",
-      "title": "'Inline' step type",
+      "title": "'inline' step type",
       "description": "Instruction step type that performs code execution.",
       "const": "inline"
     },
     "inlineStepHandler": {
       "type": "string",
-      "title": "Step handler",
+      "title": "step handler",
       "description": "Identity of handler on device that can execute this step.",
       "pattern": "^\\S+/\\S+:\\d{1,5}$",
       "minLength": 5,
@@ -136,12 +136,12 @@
     },
     "inlineStepHandlerProperties": {
       "type": "object",
-      "title": "Handler properties",
+      "title": "handler properties",
       "description": "JSON object that agent will pass to handler as arguments.",
       "additionalProperties": true
     }
   },
   "description": "Shared schema definitions for 'Import Manifest' and 'Update Manifest'.",
-  "title": "JSON Schema Definitions for Azure Device Update for IoT Hub Manifests version 4.0",
+  "title": "json schema definitions for azure device update for iot hub manifests version 4.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-deviceupdate-manifest-definitions-5.0.json
+++ b/src/schemas/json/azure-deviceupdate-manifest-definitions-5.0.json
@@ -4,12 +4,12 @@
   "definitions": {
     "updateId": {
       "type": "object",
-      "title": "Update identity",
+      "title": "update identity",
       "description": "Unique update identifier.",
       "properties": {
         "provider": {
           "type": "string",
-          "title": "Update provider",
+          "title": "update provider",
           "description": "Entity who is creating or directly responsible for the update. It can be a company name.",
           "minLength": 1,
           "maxLength": 64,
@@ -17,7 +17,7 @@
         },
         "name": {
           "type": "string",
-          "title": "Update name",
+          "title": "update name",
           "description": "Identifier for a class of update. It can be a device class or model name.",
           "minLength": 1,
           "maxLength": 64,
@@ -25,7 +25,7 @@
         },
         "version": {
           "type": "string",
-          "title": "Update version",
+          "title": "update version",
           "description": "Two to four part dot separated numerical version numbers. Each part must be a number between 0 and 2147483647 and leading zeroes will be dropped.",
           "pattern": "^\\d+(?:\\.\\d+)+$",
           "examples": ["1.0", "2021.11.8"]
@@ -36,7 +36,7 @@
     },
     "compatibility": {
       "type": "array",
-      "title": "Update compatibility",
+      "title": "update compatibility",
       "description": "List of device property sets this update is compatible with.",
       "items": {
         "$ref": "azure-deviceupdate-manifest-definitions-5.0.json#/definitions/compatibilityInfo"
@@ -46,7 +46,7 @@
     },
     "compatibilityInfo": {
       "type": "object",
-      "title": "Update compatibility info",
+      "title": "update compatibility info",
       "description": "Properties of a device this update is compatible with.",
       "additionalProperties": {
         "type": "string",
@@ -62,7 +62,7 @@
     },
     "baseFile": {
       "type": "object",
-      "title": "Basic update file information",
+      "title": "basic update file information",
       "description": "Update payload file, e.g. binary, firmware, script, etc. Must be unique within update.",
       "properties": {
         "filename": {
@@ -70,7 +70,7 @@
         },
         "sizeInBytes": {
           "type": "number",
-          "title": "File size",
+          "title": "file size",
           "description": "File size in number of bytes.",
           "minimum": 1,
           "maximum": 2147483648
@@ -88,7 +88,7 @@
     },
     "file": {
       "type": "object",
-      "title": "Update file",
+      "title": "update file",
       "description": "Update payload file, e.g. binary, firmware, script, etc. Must be unique within update.",
       "allOf": [
         {
@@ -113,19 +113,19 @@
     },
     "filename": {
       "type": "string",
-      "title": "Update file name",
+      "title": "update file name",
       "description": "Update payload file name.",
       "minLength": 1,
       "maxLength": 255
     },
     "fileHashes": {
       "type": "object",
-      "title": "File hashes",
+      "title": "file hashes",
       "description": "Base64-encoded file hashes with algorithm name as key. At least SHA-256 algorithm must be specified, and additional algorithm may be specified if supported by agent.",
       "properties": {
         "sha256": {
           "type": "string",
-          "title": "SHA-256 hash value",
+          "title": "sha-256 hash value",
           "description": "Base64-encoded file hash value using SHA-256 algorithm."
         }
       },
@@ -155,19 +155,19 @@
     },
     "referenceStepType": {
       "type": "string",
-      "title": "'Reference' step type",
+      "title": "'reference' step type",
       "description": "Instruction step type that installs another update.",
       "const": "reference"
     },
     "inlineStepType": {
       "type": "string",
-      "title": "'Inline' step type",
+      "title": "'inline' step type",
       "description": "Instruction step type that performs code execution.",
       "const": "inline"
     },
     "inlineStepHandler": {
       "type": "string",
-      "title": "Step handler",
+      "title": "step handler",
       "description": "Identity of handler on device that can execute this step.",
       "pattern": "^\\S+/\\S+:\\d{1,5}$",
       "minLength": 5,
@@ -180,12 +180,12 @@
     },
     "inlineStepHandlerProperties": {
       "type": "object",
-      "title": "Handler properties",
+      "title": "handler properties",
       "description": "JSON object that agent will pass to handler as arguments.",
       "additionalProperties": true
     }
   },
   "description": "Shared schema definitions for 'Import Manifest' and 'Update Manifest'.",
-  "title": "JSON Schema Definitions for Azure Device Update for IoT Hub Manifests version 5.0",
+  "title": "json schema definitions for azure device update for iot hub manifests version 5.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-deviceupdate-update-manifest-4.json
+++ b/src/schemas/json/azure-deviceupdate-update-manifest-4.json
@@ -4,7 +4,7 @@
   "definitions": {
     "miniUpdateManifest": {
       "type": "object",
-      "title": "Mini update manifest",
+      "title": "mini update manifest",
       "description": "Manifest containing metadata of the detached, downloadable, complete update manifest.",
       "properties": {
         "detachedManifestFileId": {
@@ -12,7 +12,7 @@
         },
         "files": {
           "type": "object",
-          "title": "Update manifest file",
+          "title": "update manifest file",
           "description": "Map of '#/definitions/fileId' to file metadata.",
           "additionalProperties": {
             "$ref": "azure-deviceupdate-manifest-definitions-4.0.json#/definitions/file"
@@ -25,7 +25,7 @@
     },
     "fullUpdateManifest": {
       "type": "object",
-      "title": "Complete update manifest.",
+      "title": "complete update manifest.",
       "description": "Full update manifest containing metadata of the update being deployed.",
       "properties": {
         "compatibility": {
@@ -33,11 +33,11 @@
         },
         "instructions": {
           "type": "object",
-          "title": "Installation instructions",
+          "title": "installation instructions",
           "properties": {
             "steps": {
               "type": "array",
-              "title": "Installation steps",
+              "title": "installation steps",
               "items": {
                 "anyOf": [
                   {
@@ -56,7 +56,7 @@
         },
         "files": {
           "type": "object",
-          "title": "Update files",
+          "title": "update files",
           "description": "Map of '#/definitions/fileId' to file metadata.",
           "additionalProperties": {
             "$ref": "azure-deviceupdate-manifest-definitions-4.0.json#/definitions/file"
@@ -66,7 +66,7 @@
         },
         "createdDateTime": {
           "type": "string",
-          "title": "Created date & time",
+          "title": "created date & time",
           "description": "Date & time update was created in ISO 8601 format.",
           "examples": ["2020-10-02T22:18:04.9446744Z"]
         }
@@ -75,13 +75,13 @@
     },
     "fileId": {
       "type": "string",
-      "title": "Update file id",
+      "title": "update file id",
       "description": "Server generated file identifier to be used for retrieving file metadata and download URL.",
       "minLength": 1
     },
     "inlineStep": {
       "type": "object",
-      "title": "Inline installation step",
+      "title": "inline installation step",
       "description": "Installation instruction step that performs code execution.",
       "properties": {
         "type": {
@@ -92,7 +92,7 @@
         },
         "files": {
           "type": "array",
-          "title": "Step update files",
+          "title": "step update files",
           "description": "'fileId' of update files that agent will pass to handler.",
           "items": {
             "$ref": "#/definitions/fileId"
@@ -109,7 +109,7 @@
     },
     "referenceStep": {
       "type": "object",
-      "title": "Reference installation step",
+      "title": "reference installation step",
       "description": "Installation instruction step that installs another update.",
       "properties": {
         "type": {
@@ -190,11 +190,11 @@
     },
     "manifestVersion": {
       "type": "string",
-      "title": "Update manifest schema version",
+      "title": "update manifest schema version",
       "const": "4"
     }
   },
   "required": ["updateId", "manifestVersion"],
-  "title": "JSON Schema for Azure Device Update for IoT Hub 'Update Manifest' version 4.0",
+  "title": "json schema for azure device update for iot hub 'update manifest' version 4.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-deviceupdate-update-manifest-5.json
+++ b/src/schemas/json/azure-deviceupdate-update-manifest-5.json
@@ -4,7 +4,7 @@
   "definitions": {
     "miniUpdateManifest": {
       "type": "object",
-      "title": "Mini update manifest",
+      "title": "mini update manifest",
       "description": "Manifest containing metadata of the detached, downloadable, complete update manifest.",
       "properties": {
         "detachedManifestFileId": {
@@ -12,7 +12,7 @@
         },
         "files": {
           "type": "object",
-          "title": "Update manifest file",
+          "title": "update manifest file",
           "description": "Map of '#/definitions/fileId' to file metadata.",
           "additionalProperties": {
             "$ref": "azure-deviceupdate-manifest-definitions-5.0.json#/definitions/file"
@@ -25,7 +25,7 @@
     },
     "fullUpdateManifest": {
       "type": "object",
-      "title": "Complete update manifest.",
+      "title": "complete update manifest.",
       "description": "Full update manifest containing metadata of the update being deployed.",
       "properties": {
         "compatibility": {
@@ -33,11 +33,11 @@
         },
         "instructions": {
           "type": "object",
-          "title": "Installation instructions",
+          "title": "installation instructions",
           "properties": {
             "steps": {
               "type": "array",
-              "title": "Installation steps",
+              "title": "installation steps",
               "items": {
                 "anyOf": [
                   {
@@ -56,7 +56,7 @@
         },
         "files": {
           "type": "object",
-          "title": "Update files",
+          "title": "update files",
           "description": "Map of '#/definitions/fileId' to file metadata.",
           "additionalProperties": {
             "$ref": "azure-deviceupdate-manifest-definitions-5.0.json#/definitions/file"
@@ -66,7 +66,7 @@
         },
         "createdDateTime": {
           "type": "string",
-          "title": "Created date & time",
+          "title": "created date & time",
           "description": "Date & time update was created in ISO 8601 format.",
           "examples": ["2020-10-02T22:18:04.9446744Z"]
         }
@@ -75,13 +75,13 @@
     },
     "fileId": {
       "type": "string",
-      "title": "Update file id",
+      "title": "update file id",
       "description": "Server generated file identifier to be used for retrieving file metadata and download URL.",
       "minLength": 1
     },
     "inlineStep": {
       "type": "object",
-      "title": "Inline installation step",
+      "title": "inline installation step",
       "description": "Installation instruction step that performs code execution.",
       "properties": {
         "type": {
@@ -92,7 +92,7 @@
         },
         "files": {
           "type": "array",
-          "title": "Step update files",
+          "title": "step update files",
           "description": "'fileId' of update files that agent will pass to handler.",
           "items": {
             "$ref": "#/definitions/fileId"
@@ -109,7 +109,7 @@
     },
     "referenceStep": {
       "type": "object",
-      "title": "Reference installation step",
+      "title": "reference installation step",
       "description": "Installation instruction step that installs another update.",
       "properties": {
         "type": {
@@ -206,11 +206,11 @@
     },
     "manifestVersion": {
       "type": "string",
-      "title": "Update manifest schema version",
+      "title": "update manifest schema version",
       "const": "4"
     }
   },
   "required": ["updateId", "manifestVersion"],
-  "title": "JSON Schema for Azure Device Update for IoT Hub 'Update Manifest' version 4.0",
+  "title": "json schema for azure device update for iot hub 'update manifest' version 4.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edge-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-1.0.json
@@ -47,12 +47,12 @@
   "properties": {
     "modulesContent": {
       "type": "object",
-      "title": "The configuration for all the modules.",
+      "title": "the configuration for all the modules.",
       "required": ["$edgeAgent", "$edgeHub"],
       "properties": {
         "$edgeAgent": {
           "type": "object",
-          "title": "Configuration for the edgeAgent module",
+          "title": "configuration for the edgeagent module",
           "required": ["properties.desired"],
           "properties": {
             "properties.desired": {
@@ -132,7 +132,7 @@
                     },
                     "edgeHub": {
                       "type": "object",
-                      "title": "The Edgehub Schema",
+                      "title": "the edgehub schema",
                       "required": [
                         "type",
                         "settings",
@@ -202,7 +202,7 @@
         },
         "$edgeHub": {
           "type": "object",
-          "title": "Configuration for the edgeHub module",
+          "title": "configuration for the edgehub module",
           "required": ["properties.desired"],
           "properties": {
             "properties.desired": {
@@ -253,6 +253,6 @@
     }
   },
   "required": ["modulesContent"],
-  "title": "JSON schema for Azure IoT Edge Deployment version 1.0",
+  "title": "json schema for azure iot edge deployment version 1.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edge-deployment-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-2.0.json
@@ -60,12 +60,12 @@
   "properties": {
     "modulesContent": {
       "type": "object",
-      "title": "The configuration for all the modules.",
+      "title": "the configuration for all the modules.",
       "required": ["$edgeAgent", "$edgeHub"],
       "properties": {
         "$edgeAgent": {
           "type": "object",
-          "title": "Configuration for the edgeAgent module",
+          "title": "configuration for the edgeagent module",
           "required": ["properties.desired"],
           "properties": {
             "properties.desired": {
@@ -152,7 +152,7 @@
                     },
                     "edgeHub": {
                       "type": "object",
-                      "title": "The Edgehub Schema",
+                      "title": "the edgehub schema",
                       "required": [
                         "type",
                         "settings",
@@ -238,7 +238,7 @@
         },
         "$edgeHub": {
           "type": "object",
-          "title": "Configuration for the edgeHub module",
+          "title": "configuration for the edgehub module",
           "required": ["properties.desired"],
           "properties": {
             "properties.desired": {
@@ -320,6 +320,6 @@
     }
   },
   "required": ["modulesContent"],
-  "title": "JSON schema for Azure IoT Edge Deployment version 2.0",
+  "title": "json schema for azure iot edge deployment version 2.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edge-deployment-template-1.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-1.0.json
@@ -34,12 +34,12 @@
   "properties": {
     "modulesContent": {
       "type": "object",
-      "title": "The configuration for all the modules.",
+      "title": "the configuration for all the modules.",
       "required": ["$edgeAgent", "$edgeHub"],
       "properties": {
         "$edgeAgent": {
           "type": "object",
-          "title": "Configuration for the edgeAgent module",
+          "title": "configuration for the edgeagent module",
           "required": ["properties.desired"],
           "properties": {
             "properties.desired": {
@@ -79,7 +79,7 @@
                     },
                     "edgeHub": {
                       "type": "object",
-                      "title": "The Edgehub Schema",
+                      "title": "the edgehub schema",
                       "required": [
                         "type",
                         "settings",
@@ -166,6 +166,6 @@
     }
   },
   "required": ["modulesContent"],
-  "title": "JSON schema for Azure IoT Edge Deployment Template version 1.0",
+  "title": "json schema for azure iot edge deployment template version 1.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -44,12 +44,12 @@
   "properties": {
     "modulesContent": {
       "type": "object",
-      "title": "The configuration for all the modules.",
+      "title": "the configuration for all the modules.",
       "required": ["$edgeAgent", "$edgeHub"],
       "properties": {
         "$edgeAgent": {
           "type": "object",
-          "title": "Configuration for the edgeAgent module",
+          "title": "configuration for the edgeagent module",
           "required": ["properties.desired"],
           "properties": {
             "properties.desired": {
@@ -136,7 +136,7 @@
                     },
                     "edgeHub": {
                       "type": "object",
-                      "title": "The Edgehub Schema",
+                      "title": "the edgehub schema",
                       "required": [
                         "type",
                         "settings",
@@ -246,6 +246,6 @@
     }
   },
   "required": ["modulesContent"],
-  "title": "JSON schema for Azure IoT Edge Deployment Template version 2.0",
+  "title": "json schema for azure iot edge deployment template version 2.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edge-deployment-template-3.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-3.0.json
@@ -24,12 +24,12 @@
   "properties": {
     "modulesContent": {
       "type": "object",
-      "title": "The configuration for all the modules.",
+      "title": "the configuration for all the modules.",
       "required": ["$edgeAgent"],
       "properties": {
         "$edgeAgent": {
           "type": "object",
-          "title": "Configuration for the edgeAgent module",
+          "title": "configuration for the edgeagent module",
           "required": ["properties.desired"],
           "properties": {
             "properties.desired": {
@@ -71,7 +71,7 @@
                     },
                     "edgeHub": {
                       "type": "object",
-                      "title": "The Edgehub Schema",
+                      "title": "the edgehub schema",
                       "required": [
                         "type",
                         "settings",
@@ -156,6 +156,6 @@
     }
   },
   "required": ["modulesContent"],
-  "title": "JSON schema for Azure IoT Edge Deployment Template version 3.0 (Edge Agent schema v1.1 + Edge Hub schema v1.1 )",
+  "title": "json schema for azure iot edge deployment template version 3.0 (edge agent schema v1.1 + edge hub schema v1.1 )",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edge-deployment-template-4.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-4.0.json
@@ -24,12 +24,12 @@
   "properties": {
     "modulesContent": {
       "type": "object",
-      "title": "The configuration for all the modules.",
+      "title": "the configuration for all the modules.",
       "required": ["$edgeAgent"],
       "properties": {
         "$edgeAgent": {
           "type": "object",
-          "title": "Configuration for the edgeAgent module",
+          "title": "configuration for the edgeagent module",
           "required": ["properties.desired"],
           "properties": {
             "properties.desired": {
@@ -71,7 +71,7 @@
                     },
                     "edgeHub": {
                       "type": "object",
-                      "title": "The Edgehub Schema",
+                      "title": "the edgehub schema",
                       "required": [
                         "type",
                         "settings",
@@ -156,6 +156,6 @@
     }
   },
   "required": ["modulesContent"],
-  "title": "JSON schema for Azure IoT Edge Deployment Template version 4.0 (Edge Agent schema v1.1 + Edge Hub schema v1.2 )",
+  "title": "json schema for azure iot edge deployment template version 4.0 (edge agent schema v1.1 + edge hub schema v1.2 )",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.0.json
@@ -47,7 +47,7 @@
   "properties": {
     "$edgeAgent": {
       "type": "object",
-      "title": "Configuration for the edgeAgent module",
+      "title": "configuration for the edgeagent module",
       "required": ["properties.desired"],
       "properties": {
         "properties.desired": {
@@ -122,7 +122,7 @@
                 },
                 "edgeHub": {
                   "type": "object",
-                  "title": "The Edgehub Schema",
+                  "title": "the edgehub schema",
                   "required": ["type", "settings", "status", "restartPolicy"],
                   "properties": {
                     "type": {
@@ -182,6 +182,6 @@
     }
   },
   "required": ["$edgeAgent"],
-  "title": "JSON schema for Azure IoT EdgeAgent Deployment version 1.0",
+  "title": "json schema for azure iot edgeagent deployment version 1.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.1.json
@@ -60,7 +60,7 @@
   "properties": {
     "$edgeAgent": {
       "type": "object",
-      "title": "Configuration for the edgeAgent module",
+      "title": "configuration for the edgeagent module",
       "required": ["properties.desired"],
       "properties": {
         "properties.desired": {
@@ -142,7 +142,7 @@
                 },
                 "edgeHub": {
                   "type": "object",
-                  "title": "The Edgehub Schema",
+                  "title": "the edgehub schema",
                   "required": ["type", "settings", "status", "restartPolicy"],
                   "properties": {
                     "type": {
@@ -218,6 +218,6 @@
     }
   },
   "required": ["$edgeAgent"],
-  "title": "JSON schema for Azure IoT EdgeAgent Deployment version 1.1",
+  "title": "json schema for azure iot edgeagent deployment version 1.1",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.0.json
@@ -4,7 +4,7 @@
   "properties": {
     "$edgeHub": {
       "type": "object",
-      "title": "Configuration for the edgeHub module",
+      "title": "configuration for the edgehub module",
       "required": ["properties.desired"],
       "properties": {
         "properties.desired": {
@@ -41,6 +41,6 @@
     }
   },
   "required": ["$edgeHub"],
-  "title": "JSON schema for Azure IoT EdgeHub Deployment version 1.0",
+  "title": "json schema for azure iot edgehub deployment version 1.0",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.1.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.1.json
@@ -5,7 +5,7 @@
   "properties": {
     "$edgeHub": {
       "type": "object",
-      "title": "Configuration for the edgeHub module",
+      "title": "configuration for the edgehub module",
       "required": ["properties.desired"],
       "properties": {
         "properties.desired": {
@@ -72,6 +72,6 @@
     }
   },
   "required": ["$edgeHub"],
-  "title": "JSON schema for Azure IoT EdgeHub Deployment version 1.1",
+  "title": "json schema for azure iot edgehub deployment version 1.1",
   "type": "object"
 }

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.2.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.2.json
@@ -31,7 +31,7 @@
   "properties": {
     "$edgeHub": {
       "type": "object",
-      "title": "Configuration for the edgeHub module",
+      "title": "configuration for the edgehub module",
       "required": ["properties.desired"],
       "properties": {
         "properties.desired": {
@@ -169,6 +169,6 @@
     }
   },
   "required": ["$edgeHub"],
-  "title": "JSON schema for Azure IoT EdgeHub Deployment version 1.2",
+  "title": "json schema for azure iot edgehub deployment version 1.2",
   "type": "object"
 }

--- a/src/schemas/json/babelrc.json
+++ b/src/schemas/json/babelrc.json
@@ -164,6 +164,6 @@
       }
     }
   },
-  "title": "JSON schema for Babel 6+ configuration files",
+  "title": "json schema for babel 6+ configuration files",
   "type": "object"
 }

--- a/src/schemas/json/backportrc.json
+++ b/src/schemas/json/backportrc.json
@@ -42,6 +42,6 @@
     }
   },
   "required": ["upstream", "branches"],
-  "title": "JSON schema for Backport config file",
+  "title": "json schema for backport config file",
   "type": "object"
 }

--- a/src/schemas/json/bamboo-spec.json
+++ b/src/schemas/json/bamboo-spec.json
@@ -6,7 +6,7 @@
   "definitions": {
     "deployment": {
       "type": "object",
-      "title": "Deployment projects",
+      "title": "deployment projects",
       "description": "A deployment project in Bamboo is a container for holding the software project you are deploying: releases that have been built and tested, and the environments to which releases are deployed",
       "properties": {
         "name": {
@@ -18,7 +18,7 @@
       }
     },
     "docker": {
-      "title": "Docker",
+      "title": "docker",
       "description": "Builds and deployments are normally run on the Bamboo agent's native operating system",
       "anyOf": [
         {
@@ -68,12 +68,12 @@
       ]
     },
     "job": {
-      "title": "Job",
+      "title": "job",
       "description": "A job is a single build unit within a plan and is made up of one or more tasks.",
       "definitions": {
         "artifact": {
           "type": "object",
-          "title": "Artifact",
+          "title": "artifact",
           "description": "Artifacts are files created by a job build (e.g. JAR files)",
           "properties": {
             "location": {
@@ -410,7 +410,7 @@
       ]
     },
     "stage": {
-      "title": "Stage",
+      "title": "stage",
       "description": "Stages group jobs to individual steps within a plan's build process.",
       "type": "object",
       "additionalProperties": false,
@@ -596,7 +596,7 @@
   "description": "Full spec reference: https://docs.atlassian.com/bamboo-specs-docs/7.2.4/specs.html",
   "properties": {
     "default-environment-permissions": {
-      "title": "Default Environment Permissions",
+      "title": "default environment permissions",
       "description": "These permissions apply to all environments defined in this deployment project",
       "type": "array",
       "items": {
@@ -604,7 +604,7 @@
       }
     },
     "deployment": {
-      "title": "Deployment",
+      "title": "deployment",
       "anyOf": [
         {
           "type": "string"
@@ -615,7 +615,7 @@
       ]
     },
     "deployment-permissions": {
-      "title": "Deployment Permissions",
+      "title": "deployment permissions",
       "description": "These permissions apply to the deployment project",
       "type": "array",
       "items": {
@@ -626,7 +626,7 @@
       "$ref": "#/definitions/docker"
     },
     "environment-permissions": {
-      "title": "Environment Permissions",
+      "title": "environment permissions",
       "description": "Permissions specific to an environment",
       "type": "array",
       "items": {
@@ -706,7 +706,7 @@
       "$ref": "#/definitions/plan"
     },
     "plan-permissions": {
-      "title": "Plan Permissions",
+      "title": "plan permissions",
       "type": "array",
       "items": {
         "$ref": "#/definitions/permission"
@@ -845,6 +845,6 @@
       "type": "object"
     }
   },
-  "title": "Bamboo CI Specification",
+  "title": "bamboo ci specification",
   "type": "object"
 }

--- a/src/schemas/json/band-manifest.json
+++ b/src/schemas/json/band-manifest.json
@@ -254,6 +254,6 @@
     }
   },
   "required": ["manifestVersion", "name", "tileIcon", "resources", "pages"],
-  "title": "JSON schema for Microsoft Band manifests",
+  "title": "json schema for microsoft band manifests",
   "type": "object"
 }

--- a/src/schemas/json/base-04.json
+++ b/src/schemas/json/base-04.json
@@ -652,5 +652,5 @@
     }
   },
   "id": "https://json.schemastore.org/base-04.json",
-  "title": "Common types for all schemas"
+  "title": "common types for all schemas"
 }

--- a/src/schemas/json/base.json
+++ b/src/schemas/json/base.json
@@ -652,5 +652,5 @@
       ]
     }
   },
-  "title": "Common types for all schemas"
+  "title": "common types for all schemas"
 }

--- a/src/schemas/json/behat.json
+++ b/src/schemas/json/behat.json
@@ -1,12 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": {
-    "title": "Profile name",
+    "title": "profile name",
     "$ref": "#/definitions/profile"
   },
   "definitions": {
     "profile": {
-      "title": "Profile",
+      "title": "profile",
       "type": "object",
       "properties": {
         "autoload": {
@@ -16,34 +16,34 @@
           }
         },
         "formatters": {
-          "title": "How to format tests output",
+          "title": "how to format tests output",
           "default": "pretty",
           "type": "object",
           "properties": {
             "pretty": {
-              "title": "Prints the feature as is",
+              "title": "prints the feature as is",
               "type": "boolean"
             },
             "progress": {
-              "title": "Prints one character per step",
+              "title": "prints one character per step",
               "type": "boolean"
             },
             "junit": {
-              "title": "Outputs the failures in JUnit compatible files.",
+              "title": "outputs the failures in junit compatible files.",
               "type": "boolean"
             }
           },
           "additionalProperties": false
         },
         "suites": {
-          "title": "Test suites",
+          "title": "test suites",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/suite"
           }
         },
         "extensions": {
-          "title": "Behat extensions",
+          "title": "behat extensions",
           "type": "object",
           "additionalProperties": {
             "type": "object"
@@ -52,11 +52,11 @@
       }
     },
     "suite": {
-      "title": "Test suite",
+      "title": "test suite",
       "type": "object",
       "properties": {
         "paths": {
-          "title": "Paths to execute",
+          "title": "paths to execute",
           "type": "array",
           "items": {
             "type": "string"
@@ -64,7 +64,7 @@
           "uniqueItems": true
         },
         "contexts": {
-          "title": "Suite contexts",
+          "title": "suite contexts",
           "type": "array",
           "items": {
             "type": ["string", "object"]
@@ -72,7 +72,7 @@
           "uniqueItems": true
         },
         "filters": {
-          "title": "Suite filters",
+          "title": "suite filters",
           "type": "object",
           "properties": {
             "tags": {
@@ -88,7 +88,7 @@
   },
   "properties": {
     "default": {
-      "title": "Default profile",
+      "title": "default profile",
       "$ref": "#/definitions/profile"
     },
     "imports": {
@@ -99,6 +99,6 @@
       "uniqueItems": true
     }
   },
-  "title": "JSON schema for Behat configuration files",
+  "title": "json schema for behat configuration files",
   "type": "object"
 }

--- a/src/schemas/json/bettercodehub.json
+++ b/src/schemas/json/bettercodehub.json
@@ -26,10 +26,10 @@
       ]
     },
     "excludeFileFilter": {
-      "title": "Exclude",
+      "title": "exclude",
       "type": "array",
       "items": {
-        "title": "Pattern",
+        "title": "pattern",
         "description": "A regular expression for the path(s) to exclude.",
         "type": "string"
       }
@@ -39,10 +39,10 @@
       "additionalProperties": false,
       "properties": {
         "include": {
-          "title": "Include",
+          "title": "include",
           "type": "array",
           "items": {
-            "title": "Pattern",
+            "title": "pattern",
             "description": "A regular expression for the path(s) to include.",
             "type": "string"
           }
@@ -56,12 +56,12 @@
   "description": "Configuration file for Better Code Hub to override the default configuration.",
   "properties": {
     "component_depth": {
-      "title": "Component Depth",
+      "title": "component depth",
       "type": "integer",
       "default": 1
     },
     "languages": {
-      "title": "Languages",
+      "title": "languages",
       "type": "array",
       "items": {
         "anyOf": [
@@ -73,15 +73,15 @@
             "additionalProperties": false,
             "properties": {
               "name": {
-                "title": "Name",
+                "title": "name",
                 "$ref": "#/definitions/supportedProgrammingLanguage"
               },
               "production": {
-                "title": "Production",
+                "title": "production",
                 "$ref": "#/definitions/fileFilter"
               },
               "test": {
-                "title": "Test",
+                "title": "test",
                 "$ref": "#/definitions/fileFilter"
               }
             }
@@ -93,6 +93,6 @@
       "$ref": "#/definitions/excludeFileFilter"
     }
   },
-  "title": "Better Code Hub",
+  "title": "better code hub",
   "type": "object"
 }

--- a/src/schemas/json/block.json
+++ b/src/schemas/json/block.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "JSON schema WordPress blocks"
+  "title": "json schema wordpress blocks"
 }

--- a/src/schemas/json/bootstraprc.json
+++ b/src/schemas/json/bootstraprc.json
@@ -115,6 +115,6 @@
       }
     }
   },
-  "title": "JSON schema for Webpack's bootstrap-loader configuration file",
+  "title": "json schema for webpack's bootstrap-loader configuration file",
   "type": "object"
 }

--- a/src/schemas/json/bower.json
+++ b/src/schemas/json/bower.json
@@ -110,6 +110,6 @@
     }
   },
   "required": ["name"],
-  "title": "JSON schema for Bower configuration files",
+  "title": "json schema for bower configuration files",
   "type": "object"
 }

--- a/src/schemas/json/bowerrc.json
+++ b/src/schemas/json/bowerrc.json
@@ -137,6 +137,6 @@
       }
     }
   },
-  "title": "JSON schema for .bowerrc files",
+  "title": "json schema for .bowerrc files",
   "type": "object"
 }

--- a/src/schemas/json/bukkit-plugin.json
+++ b/src/schemas/json/bukkit-plugin.json
@@ -97,7 +97,7 @@
       }
     },
     "website": {
-      "title": "Website",
+      "title": "website",
       "description": "The URL to the plugin's site",
       "type": "string",
       "format": "uri"
@@ -186,6 +186,6 @@
     }
   },
   "required": ["name", "main", "version"],
-  "title": "JSON schema for Bukkit Plugin YAML",
+  "title": "json schema for bukkit plugin yaml",
   "type": "object"
 }

--- a/src/schemas/json/bungee-plugin.json
+++ b/src/schemas/json/bungee-plugin.json
@@ -46,6 +46,6 @@
     }
   },
   "required": ["name", "main"],
-  "title": "JSON schema for BungeeCord Plugin YAML",
+  "title": "json schema for bungeecord plugin yaml",
   "type": "object"
 }

--- a/src/schemas/json/bxci.schema-2.x.json
+++ b/src/schemas/json/bxci.schema-2.x.json
@@ -32,7 +32,7 @@
     },
     "checkmarx": {
       "type": "object",
-      "title": "CheckMarx",
+      "title": "checkmarx",
       "properties": {
         "enabled": {
           "type": "boolean",
@@ -177,7 +177,7 @@
         "vulnerability_scan": {
           "type": "object",
           "description": "Configuration for running vulnerability scans on published Docker images",
-          "title": "Vulnerability scan",
+          "title": "vulnerability scan",
           "properties": {
             "enabled": {
               "type": "boolean",

--- a/src/schemas/json/cargo-make.json
+++ b/src/schemas/json/cargo-make.json
@@ -4,12 +4,12 @@
   "additionalProperties": false,
   "definitions": {
     "semver": {
-      "title": "Semantic Version",
+      "title": "semantic version",
       "type": "string",
       "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     },
     "extend": {
-      "title": "External Makefile",
+      "title": "external makefile",
       "description": "A potentially optional external makefile to extend",
       "type": "object",
       "x-taplo": {
@@ -19,7 +19,7 @@
       "additionalProperties": false,
       "properties": {
         "path": {
-          "title": "File Path",
+          "title": "file path",
           "description": "The path of the external makefile, relative to this file",
           "type": "string",
           "default": "path/to/Makefile.toml"
@@ -32,21 +32,21 @@
       }
     },
     "script": {
-      "title": "Script",
+      "title": "script",
       "oneOf": [
         {
-          "title": "Script Line",
+          "title": "script line",
           "type": "string"
         },
         {
-          "title": "Script Lines",
+          "title": "script lines",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         {
-          "title": "Script File",
+          "title": "script file",
           "type": "object",
           "examples": [
             {
@@ -61,7 +61,7 @@
           "additionalProperties": false,
           "properties": {
             "file": {
-              "title": "File Path",
+              "title": "file path",
               "description": "Scipt file name",
               "type": "string",
               "default": "path/to/script"
@@ -74,7 +74,7 @@
           }
         },
         {
-          "title": "Split Script",
+          "title": "split script",
           "description": "Script content split to parts to enable a more fine tuned extension capability",
           "type": "object",
           "x-taplo": {
@@ -83,17 +83,17 @@
           "additionalProperties": false,
           "properties": {
             "pre": {
-              "title": "Pre-Main Script",
+              "title": "pre-main script",
               "description": "Pre-main script section",
               "type": "string"
             },
             "main": {
-              "title": "Main Script",
+              "title": "main script",
               "description": "Main script section",
               "type": "string"
             },
             "post": {
-              "title": "Post-Main Script",
+              "title": "post-main script",
               "description": "Post-main script section",
               "type": "string"
             }
@@ -102,7 +102,7 @@
       ]
     },
     "env_files": {
-      "title": "List of Env Files",
+      "title": "list of env files",
       "description": "Load environment files",
       "type": "array",
       "default": [],
@@ -117,7 +117,7 @@
       "uniqueItems": true
     },
     "envfile": {
-      "title": "Env File",
+      "title": "env file",
       "description": "File containing environment variables and their values",
       "examples": [
         "path/to/env.env",
@@ -128,7 +128,7 @@
       ],
       "oneOf": [
         {
-          "title": "File Path",
+          "title": "file path",
           "description": "The path to the env file",
           "type": "string",
           "default": "path/to/env.env"
@@ -143,19 +143,19 @@
           "additionalProperties": false,
           "properties": {
             "path": {
-              "title": "File Path",
+              "title": "file path",
               "description": "The path to the env file",
               "type": "string",
               "default": "path/to/env.env"
             },
             "base_path": {
-              "title": "Directory Path",
+              "title": "directory path",
               "description": "The path base directory (relative paths are from this base path)",
               "type": "string",
               "default": "path/to/dir"
             },
             "profile": {
-              "title": "Profile",
+              "title": "profile",
               "description": "The profile name this file is relevant to",
               "type": "string",
               "default": "development",
@@ -166,7 +166,7 @@
       ]
     },
     "env": {
-      "title": "Env Vars",
+      "title": "env vars",
       "description": "Setup environment variables",
       "type": "object",
       "x-taplo": {
@@ -179,7 +179,7 @@
       }
     },
     "env_value": {
-      "title": "Env Value",
+      "title": "env value",
       "description": "An environment variable value",
       "x-taplo": {
         "links": {
@@ -188,19 +188,19 @@
       },
       "anyOf": [
         {
-          "title": "Boolean",
+          "title": "boolean",
           "type": "boolean"
         },
         {
-          "title": "Integer",
+          "title": "integer",
           "type": "integer"
         },
         {
-          "title": "String",
+          "title": "string",
           "type": "string"
         },
         {
-          "title": "Separator List",
+          "title": "separator list",
           "description": "An array which will be joined with the `;` separator ",
           "type": "array",
           "items": {
@@ -223,14 +223,14 @@
           "$ref": "#/definitions/env_value_path_glob"
         },
         {
-          "title": "Profile Env Vars",
+          "title": "profile env vars",
           "description": "Profile dependent environment variables",
           "$ref": "#/definitions/env"
         }
       ]
     },
     "env_value_unset": {
-      "title": "Unset",
+      "title": "unset",
       "description": "Unsets environment variable",
       "type": "object",
       "required": ["unset"],
@@ -244,14 +244,14 @@
       }
     },
     "env_value_script": {
-      "title": "Env Value Script",
+      "title": "env value script",
       "description": "Provide environment variable via script",
       "type": "object",
       "required": ["script"],
       "additionalProperties": false,
       "properties": {
         "script": {
-          "title": "Script Lines",
+          "title": "script lines",
           "type": "array",
           "items": {
             "type": "string"
@@ -266,7 +266,7 @@
       }
     },
     "env_value_decode": {
-      "title": "Env Value Mapping",
+      "title": "env value mapping",
       "description": "Environment variable value provided by decoding other values",
       "type": "object",
       "x-taplo": {
@@ -276,29 +276,29 @@
       "additionalProperties": false,
       "properties": {
         "source": {
-          "title": "Env Var",
+          "title": "env var",
           "description": "The source environment variable (can be an env expression)",
           "type": "string"
         },
         "default_value": {
-          "title": "Env Value",
+          "title": "env value",
           "description": "The default value in case no decode mapping was found, if not provided it will default to the source value",
           "type": "string"
         },
         "mapping": {
-          "title": "Value Mapping",
+          "title": "value mapping",
           "description": "The decoding mapping from one value to another value",
           "type": "object",
           "default": {},
           "additionalProperties": {
-            "title": "Env Value",
+            "title": "env value",
             "type": "string"
           }
         }
       }
     },
     "env_value_conditioned": {
-      "title": "Conditional Env Value",
+      "title": "conditional env value",
       "description": "Environment variable value set if condition is met",
       "type": "object",
       "x-taplo": {
@@ -308,7 +308,7 @@
       "additionalProperties": false,
       "properties": {
         "value": {
-          "title": "Env Value",
+          "title": "env value",
           "description": "The value to set (can be an env expression)",
           "type": "string"
         },
@@ -319,14 +319,14 @@
       }
     },
     "env_value_path_glob": {
-      "title": "Env Value Glob",
+      "title": "env value glob",
       "description": "Environment value holding a list of paths based on given glob definitions",
       "type": "object",
       "required": ["glob"],
       "additionalProperties": false,
       "properties": {
         "glob": {
-          "title": "Glob Pattern",
+          "title": "glob pattern",
           "description": "The glob used to fetch all paths",
           "type": "string"
         },
@@ -341,7 +341,7 @@
           "type": "boolean"
         },
         "ignore_type": {
-          "title": "Ignore Source",
+          "title": "ignore source",
           "description": "An ignore source that enables respecting ignore files from that source",
           "enum": ["git"],
           "type": "string",
@@ -350,7 +350,7 @@
       }
     },
     "task_condition": {
-      "title": "Condition",
+      "title": "condition",
       "description": "Conditions allow you to evaluate at runtime if to run a specific task or not",
       "type": "object",
       "x-taplo": {
@@ -361,39 +361,39 @@
       "additionalProperties": false,
       "properties": {
         "fail_message": {
-          "title": "Message",
+          "title": "message",
           "description": "Message to display when the condition fails",
           "type": "string"
         },
         "profiles": {
-          "title": "List of Profiles",
+          "title": "list of profiles",
           "description": "Profile names to match for the condition",
           "type": "array",
           "default": [],
           "items": {
-            "title": "Profile",
+            "title": "profile",
             "description": "Profile name",
             "type": "string",
             "default": "development"
           }
         },
         "platforms": {
-          "title": "List of Platforms",
+          "title": "list of platforms",
           "description": "Platform names to match for the condition",
           "type": "array",
           "items": {
-            "title": "Platform",
+            "title": "platform",
             "description": "Platform name",
             "enum": ["linux", "windows", "mac"],
             "type": "string"
           }
         },
         "channels": {
-          "title": "List of Channels",
+          "title": "list of channels",
           "description": "Rust channels to match for the condition",
           "type": "array",
           "items": {
-            "title": "Channel",
+            "title": "channel",
             "description": "Rust channel",
             "enum": ["stable", "beta", "nightly"],
             "type": "string",
@@ -401,67 +401,67 @@
           }
         },
         "env_set": {
-          "title": "List of Env Vars",
+          "title": "list of env vars",
           "description": "List of environment variables which must be defined",
           "type": "array",
           "items": {
-            "title": "Env Var",
+            "title": "env var",
             "description": "Environment variable",
             "type": "string"
           }
         },
         "env_not_set": {
-          "title": "List of Env Vars",
+          "title": "list of env vars",
           "description": "List of environment variables which must not be defined",
           "type": "array",
           "items": {
-            "title": "Env Var",
+            "title": "env var",
             "description": "Environment variable",
             "type": "string"
           }
         },
         "env_true": {
-          "title": "List of Env Vars",
+          "title": "list of env vars",
           "description": "List of environment variables which must be defined and must not be set to any of the following (case insensitive): `false`, `no`, `0`, or empty",
           "type": "array",
           "items": {
-            "title": "Env Var",
+            "title": "env var",
             "description": "Environment variable",
             "type": "string"
           }
         },
         "env_false": {
-          "title": "List of Env Vars",
+          "title": "list of env vars",
           "description": "List of environment variables which must be defined and must be set to any of the following (case insensitive): `false`, `no`, `0`, or empty",
           "type": "array",
           "items": {
-            "title": "Env Var",
+            "title": "env var",
             "description": "Environment variable",
             "type": "string"
           }
         },
         "env": {
-          "title": "Env Vars",
+          "title": "env vars",
           "description": "Map of environment variables that must be defined and equal to the provided values",
           "type": "object",
           "additionalProperties": {
-            "title": "Env Value",
+            "title": "env value",
             "description": "Environment value",
             "type": "string"
           }
         },
         "env_contains": {
-          "title": "Env Vars",
+          "title": "env vars",
           "description": "Map of environment variables that must be defined and contain (case insensitive) the provided values",
           "type": "object",
           "additionalProperties": {
-            "title": "Env Value",
+            "title": "env value",
             "description": "Environment value",
             "type": "string"
           }
         },
         "rust_version": {
-          "title": "Rust Version Criteria",
+          "title": "rust version criteria",
           "description": "A definition of min, max and/or specific rust version",
           "type": "object",
           "x-taplo": {
@@ -484,21 +484,21 @@
           }
         },
         "files_exist": {
-          "title": "List of Files",
+          "title": "list of files",
           "description": "List of absolute path files to check they exist. Environment substitution is supported so you can define relative paths",
           "type": "array",
           "items": {
-            "title": "File Path",
+            "title": "file path",
             "description": "File path",
             "type": "string"
           }
         },
         "files_not_exist": {
-          "title": "List of Files",
+          "title": "list of files",
           "description": "List of absolute path files to check they do not exist. Environment substitution is supported so you can define relative paths",
           "type": "array",
           "items": {
-            "title": "File Path",
+            "title": "file path",
             "description": "File path",
             "type": "string"
           }
@@ -506,7 +506,7 @@
       }
     },
     "task": {
-      "title": "Task",
+      "title": "task",
       "description": "A task is a command, script, rust code or other sub tasks to execute. Tasks can have dependencies which are also tasks that will be executed before the task itself.",
       "type": "object",
       "additionalProperties": false,
@@ -522,12 +522,12 @@
           }
         },
         "description": {
-          "title": "Description",
+          "title": "description",
           "description": "A description used to document the task",
           "type": "string"
         },
         "category": {
-          "title": "Category",
+          "title": "category",
           "description": "Category name used to document the task",
           "type": "string"
         },
@@ -564,13 +564,13 @@
               "type": "boolean"
             },
             {
-              "title": "Deprecation Message",
+              "title": "deprecation message",
               "type": "string"
             }
           ]
         },
         "extend": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "Extends the specified task as a base task",
           "type": "string",
           "x-taplo": {
@@ -602,7 +602,7 @@
               "type": "boolean"
             },
             {
-              "title": "Watch Options",
+              "title": "watch options",
               "type": "object",
               "x-taplo": {
                 "initKeys": ["watch"]
@@ -619,7 +619,7 @@
                   "type": "boolean"
                 },
                 "ignore_pattern": {
-                  "title": "Glob Pattern",
+                  "title": "glob pattern",
                   "description": "Ignore a glob/gitignore-style pattern while watching",
                   "type": "string"
                 },
@@ -629,11 +629,11 @@
                   "type": "boolean"
                 },
                 "watch": {
-                  "title": "List of Paths",
+                  "title": "list of paths",
                   "description": "List of files and folders to watch",
                   "type": "array",
                   "items": {
-                    "title": "Path",
+                    "title": "path",
                     "description": "File or folder to watch",
                     "type": "string"
                   }
@@ -647,7 +647,7 @@
           "$ref": "#/definitions/task_condition"
         },
         "condition_script": {
-          "title": "Script",
+          "title": "script",
           "description": "If script exit code is not 0, the command/script of this task will not be invoked, dependencies however will be",
           "type": "array",
           "items": {
@@ -687,13 +687,13 @@
           "$ref": "#/definitions/env"
         },
         "cwd": {
-          "title": "Directory Path",
+          "title": "directory path",
           "description": "The working directory for the task to execute its command/script",
           "type": "string",
           "default": "path/to/dir"
         },
         "alias": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "If defined, task points to another task and all other properties are ignored",
           "type": "string",
           "x-taplo": {
@@ -703,7 +703,7 @@
           }
         },
         "linux_alias": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "If defined and this platform is Linux, task points to another task and all other properties are ignored (takes precedence over `alias` on Linux)",
           "type": "string",
           "x-taplo": {
@@ -713,7 +713,7 @@
           }
         },
         "windows_alias": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "If defined and this platform is Windows, task points to another task and all other properties are ignored (takes precedence over `alias` on Windows)",
           "type": "string",
           "x-taplo": {
@@ -723,7 +723,7 @@
           }
         },
         "mac_alias": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "If defined and this platform is Mac, task points to another task and all other properties are ignored (takes precedence over `alias` on Mac)",
           "type": "string",
           "x-taplo": {
@@ -746,34 +746,34 @@
               "type": "boolean"
             },
             {
-              "title": "Crate Name",
+              "title": "crate name",
               "description": "Name of the crate to install",
               "type": "string"
             },
             {
-              "title": "Crate Install Options",
+              "title": "crate install options",
               "description": "Instructions on how to install a crate",
               "type": "object",
               "required": ["crate_name", "binary", "test_arg"],
               "additionalProperties": false,
               "properties": {
                 "crate_name": {
-                  "title": "Crate Name",
+                  "title": "crate name",
                   "description": "Name of the crate to install",
                   "type": "string"
                 },
                 "rustup_component_name": {
-                  "title": "Component Name",
+                  "title": "component name",
                   "description": "The component to install via rustup",
                   "type": "string"
                 },
                 "binary": {
-                  "title": "File Name",
+                  "title": "file name",
                   "description": "The binary file name to be used to test if the crate is already installed",
                   "type": "string"
                 },
                 "test_arg": {
-                  "title": "Args",
+                  "title": "args",
                   "description": "Arguments used to check whether a crate or rustup component is installed.",
                   "oneOf": [
                     {
@@ -798,24 +798,24 @@
               }
             },
             {
-              "title": "Component Install Options",
+              "title": "component install options",
               "description": "Instructions on how to install a rustup component",
               "type": "object",
               "required": ["rustup_component_name"],
               "additionalProperties": false,
               "properties": {
                 "rustup_component_name": {
-                  "title": "Component Name",
+                  "title": "component name",
                   "description": "The component to install via rustup",
                   "type": "string"
                 },
                 "binary": {
-                  "title": "File Name",
+                  "title": "file name",
                   "description": "The binary file name to be used to test if the crate is already installed",
                   "type": "string"
                 },
                 "test_arg": {
-                  "title": "Args",
+                  "title": "args",
                   "description": "Arguments used to check whether a crate or rustup component is installed.",
                   "oneOf": [
                     {
@@ -832,14 +832,14 @@
               }
             },
             {
-              "title": "Plugin Install Options",
+              "title": "plugin install options",
               "description": "Instructions on how to install a cargo plugin",
               "type": "object",
               "required": ["crate_name", "min_version"],
               "additionalProperties": false,
               "properties": {
                 "crate_name": {
-                  "title": "Crate Name",
+                  "title": "crate name",
                   "description": "Name of the crate to install",
                   "type": "string"
                 },
@@ -852,7 +852,7 @@
           ]
         },
         "install_crate_args": {
-          "title": "Args",
+          "title": "args",
           "description": "Additional cargo install args",
           "type": "array",
           "items": {
@@ -864,7 +864,7 @@
           "$ref": "#/definitions/script"
         },
         "command": {
-          "title": "File Name",
+          "title": "file name",
           "description": "The command to execute for this task",
           "type": "string",
           "x-taplo": {
@@ -874,7 +874,7 @@
           }
         },
         "args": {
-          "title": "Args",
+          "title": "args",
           "description": "The args for the executed command",
           "type": "array",
           "items": {
@@ -896,7 +896,7 @@
           }
         },
         "script_runner": {
-          "title": "Script Runner",
+          "title": "script runner",
           "description": "The script attribute may hold non OS scripts, for example rust code to be compiled and executed. In order to use non OS script runners, you must define the special script_runner with the @ prefix.",
           "type": "string",
           "examples": [
@@ -916,7 +916,7 @@
           }
         },
         "script_runner_args": {
-          "title": "Args",
+          "title": "args",
           "description": "The script runner arguments before the script file path",
           "type": "string",
           "examples": ["-f"],
@@ -927,7 +927,7 @@
           }
         },
         "script_extension": {
-          "title": "File Extension",
+          "title": "file extension",
           "description": "The file extension to use for the script",
           "type": "string",
           "examples": ["py", "pl", "js", "php", "ps1"]
@@ -946,7 +946,7 @@
           },
           "oneOf": [
             {
-              "title": "Task Name",
+              "title": "task name",
               "description": "Name of the sub-task to execute",
               "type": "string"
             },
@@ -956,17 +956,17 @@
               "additionalProperties": false,
               "properties": {
                 "name": {
-                  "title": "Task Name",
+                  "title": "task name",
                   "description": "Name(s) of the sub-task to execute",
                   "oneOf": [
                     {
                       "type": "string"
                     },
                     {
-                      "title": "List of Task Names",
+                      "title": "list of task names",
                       "type": "array",
                       "items": {
-                        "title": "Task Name",
+                        "title": "task name",
                         "type": "string"
                       }
                     }
@@ -993,7 +993,7 @@
                   }
                 },
                 "cleanup_task": {
-                  "title": "Task Name",
+                  "title": "task name",
                   "description": "A task to run after all specified sub-tasks have completed",
                   "type": "string",
                   "x-taplo": {
@@ -1005,7 +1005,7 @@
               }
             },
             {
-              "title": "Conditional Tasks",
+              "title": "conditional tasks",
               "description": "Conditional sub-task selector",
               "type": "array",
               "items": {
@@ -1015,17 +1015,17 @@
                 "additionalProperties": false,
                 "properties": {
                   "name": {
-                    "title": "Task Name",
+                    "title": "task name",
                     "description": "Name(s) of the sub-task to execute",
                     "oneOf": [
                       {
                         "type": "string"
                       },
                       {
-                        "title": "List of Task Names",
+                        "title": "list of task names",
                         "type": "array",
                         "items": {
-                          "title": "Task Name",
+                          "title": "task name",
                           "type": "string"
                         }
                       }
@@ -1052,7 +1052,7 @@
                     }
                   },
                   "cleanup_task": {
-                    "title": "Task Name",
+                    "title": "task name",
                     "description": "A task to run after all specified sub-tasks have completed",
                     "type": "string",
                     "x-taplo": {
@@ -1066,7 +1066,7 @@
                     "$ref": "#/definitions/task_condition"
                   },
                   "condition_script": {
-                    "title": "Script",
+                    "title": "script",
                     "description": "If script exit code is not 0, the sub tasks will not be invoked",
                     "type": "array",
                     "items": {
@@ -1079,7 +1079,7 @@
           ]
         },
         "dependencies": {
-          "title": "List of Tasks",
+          "title": "list of tasks",
           "description": "A list of tasks to execute before this task",
           "type": "array",
           "x-taplo": {
@@ -1090,12 +1090,12 @@
           "items": {
             "oneOf": [
               {
-                "title": "Task Name",
+                "title": "task name",
                 "description": "The name of a task in this file",
                 "type": "string"
               },
               {
-                "title": "External Task",
+                "title": "external task",
                 "description": "A task dependency potentially in another file",
                 "type": "object",
                 "x-taplo": {
@@ -1105,12 +1105,12 @@
                 "additionalProperties": false,
                 "properties": {
                   "name": {
-                    "title": "Task Name",
+                    "title": "task name",
                     "description": "The task name to execute",
                     "type": "string"
                   },
                   "path": {
-                    "title": "File Path",
+                    "title": "file path",
                     "description": "The path to the makefile the task resides in",
                     "type": "string",
                     "default": "path/to/makefile"
@@ -1121,7 +1121,7 @@
           }
         },
         "toolchain": {
-          "title": "Toolchain",
+          "title": "toolchain",
           "description": "The rust toolchain used to invoke the command or install the needed crates/components",
           "type": "string",
           "x-taplo": {
@@ -1148,7 +1148,7 @@
   "description": "A schema for cargo-make makefiles",
   "properties": {
     "extend": {
-      "title": "Extend External Makefile",
+      "title": "extend external makefile",
       "description": "Extend an external makefile by importing its tasks and properties to this file. Paths are relative to this makefile",
       "x-taplo": {
         "links": {
@@ -1171,7 +1171,7 @@
       ],
       "oneOf": [
         {
-          "title": "File Path",
+          "title": "file path",
           "description": "File path to external makefile relative to this file",
           "type": "string",
           "examples": ["path/to/Makefile.toml"]
@@ -1180,7 +1180,7 @@
           "$ref": "#/definitions/extend"
         },
         {
-          "title": "External Makefile List",
+          "title": "external makefile list",
           "description": "List of external makefiles to extend",
           "type": "array",
           "items": {
@@ -1191,7 +1191,7 @@
       ]
     },
     "config": {
-      "title": "Config",
+      "title": "config",
       "description": "Configuration options for this makefile",
       "type": "object",
       "x-taplo": {
@@ -1270,7 +1270,7 @@
               "type": "boolean"
             },
             "namespace": {
-              "title": "Namespace",
+              "title": "namespace",
               "description": "If set to some value, all core tasks are modified to: `namespace::name`",
               "type": "string",
               "default": "default"
@@ -1278,7 +1278,7 @@
           }
         },
         "init_task": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "Init task name which will be invoked at the start of every run",
           "type": "string",
           "x-taplo": {
@@ -1289,7 +1289,7 @@
           "default": "init"
         },
         "end_task": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "End task name which will be invoked at the end of every run",
           "default": "end",
           "type": "string",
@@ -1300,7 +1300,7 @@
           }
         },
         "on_error_task": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "The name of the task to run in case of any error during the invocation of the flow",
           "type": "string",
           "x-taplo": {
@@ -1311,7 +1311,7 @@
           "default": "catch"
         },
         "legacy_migration_task": {
-          "title": "Task Name",
+          "title": "task name",
           "description": "The name of the task which runs legacy migration flows",
           "default": "legacy-migration",
           "type": "string",
@@ -1320,7 +1320,7 @@
           }
         },
         "additional_profiles": {
-          "title": "List of Profiles",
+          "title": "list of profiles",
           "description": "Additional profile names to load",
           "default": [],
           "type": "array",
@@ -1331,7 +1331,7 @@
           },
           "examples": [["additional_profile"]],
           "items": {
-            "title": "Profile",
+            "title": "profile",
             "description": "Additional profile name to load",
             "type": "string",
             "default": "additional_profile"
@@ -1380,7 +1380,7 @@
           }
         },
         "main_project_member": {
-          "title": "Crate",
+          "title": "crate",
           "description": "The project information member (used by workspaces)",
           "type": "string",
           "default": "main-crate"
@@ -1428,7 +1428,7 @@
       "$ref": "#/definitions/env_files"
     },
     "env_scripts": {
-      "title": "List of Env Scripts",
+      "title": "list of env scripts",
       "description": "The environment scripts to execute after environment files and the env block. These scripts can be used to run anything needed before starting up the flow.",
       "type": "array",
       "x-taplo": {
@@ -1455,7 +1455,7 @@
       }
     }
   },
-  "title": "Makefile.toml",
+  "title": "makefile.toml",
   "type": "object",
   "x-taplo-info": {
     "authors": ["Kathryn Long (https://github.com/starkat99)"],

--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Build": {
-      "title": "Build",
+      "title": "build",
       "description": "The `build` field specifies a file in the package root which is a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html) for building native code. More information can be found in the [build script guide](https://doc.rust-lang.org/cargo/reference/build-scripts.html).\n\n\n```toml\n[package]\n# ...\nbuild = \"build.rs\"\n```\n\nThe default is `\"build.rs\"`, which loads the script from a file named\n`build.rs` in the root of the package. Use `build = \"custom_build_name.rs\"` to\nspecify a path to a different file or `build = false` to disable automatic\ndetection of the build script.\n",
       "anyOf": [
         {
@@ -29,7 +29,7 @@
       }
     },
     "DebugLevel": {
-      "title": "Debug Level",
+      "title": "debug level",
       "description": "The `debug` setting controls the [`-C debuginfo` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#debuginfo) which controls the\namount of debug information included in the compiled binary.",
       "enum": [0, 1, 2, true, false],
       "x-taplo": {
@@ -48,7 +48,7 @@
       }
     },
     "Dependency": {
-      "title": "Dependency",
+      "title": "dependency",
       "anyOf": [
         {
           "$ref": "#/definitions/SemVerRequirement"
@@ -59,7 +59,7 @@
       ]
     },
     "DetailedDependency": {
-      "title": "Detailed Dependency",
+      "title": "detailed dependency",
       "type": "object",
       "properties": {
         "branch": {
@@ -192,7 +192,7 @@
       }
     },
     "Edition": {
-      "title": "Edition",
+      "title": "edition",
       "description": "The `edition` key affects which edition your package is compiled with. Cargo\nwill always generate packages via [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html) with the `edition` key set to the\nlatest edition. Setting the `edition` key in `[package]` will affect all\ntargets/crates in the package, including test suites, benchmarks, binaries,\nexamples, etc.",
       "type": "string",
       "enum": ["2015", "2018", "2021"],
@@ -203,7 +203,7 @@
       }
     },
     "Lto": {
-      "title": "Lto",
+      "title": "lto",
       "description": "The `lto` setting controls the [`-C lto` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#lto) which controls LLVM's [link time optimizations](https://llvm.org/docs/LinkTimeOptimization.html). LTO can produce better optimized code, using\nwhole-program analysis, at the cost of longer linking time.\n                    \nSee also the [`-C linker-plugin-lto`](https://doc.rust-lang.org/rustc/codegen-options/index.html#linker-plugin-lto) `rustc` flag for cross-language LTO.",
       "enum": ["fat", "thin", "off", true, false],
       "x-taplo": {
@@ -222,14 +222,14 @@
       }
     },
     "MetaBuild": {
-      "title": "Meta Build",
+      "title": "meta build",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "Resolver": {
-      "title": "Resolver",
+      "title": "resolver",
       "description": "A different feature resolver algorithm can be used by specifying the resolver version in Cargo.toml like this:\n\n[package]\nname = \"my-package\"\nversion = \"1.0.0\"\nresolver = \"2\"\n\nThe version \"1\" resolver is the original resolver that shipped with Cargo up to version 1.50. The default is \"2\" if the root package specifies edition = \"2021\" or a newer edition. Otherwise the default is \"1\".\n\nThe version \"2\" resolver introduces changes in feature unification. See the features chapter for more details.\n\nThe resolver is a global option that affects the entire workspace. The resolver version in dependencies is ignored, only the value in the top-level package will be used. If using a virtual workspace, the version should be specified in the [workspace] table, for example:\n\n[workspace]\nmembers = [\"member1\", \"member2\"]\nresolver = \"2\"",
       "type": "string",
       "enum": ["1", "2"],
@@ -240,7 +240,7 @@
       }
     },
     "OptLevel": {
-      "title": "Optimization Level",
+      "title": "optimization level",
       "description": "The `opt-level` setting controls the [`-C opt-level` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#opt-level) which controls the level\nof optimization. Higher optimization levels may produce faster runtime code at\nthe expense of longer compiler times. Higher levels may also change and\nrearrange the compiled code which may make it harder to use with a debugger.\n\nIt is recommended to experiment with different levels to find the right\nbalance for your project. There may be surprising results, such as level `3`\nbeing slower than `2`, or the `\"s\"` and `\"z\"` levels not being necessarily\nsmaller. You may also want to reevaluate your settings over time as newer\nversions of `rustc` changes optimization behavior.\n\nSee also [Profile Guided Optimization](https://doc.rust-lang.org/rustc/profile-guided-optimization.html) for more advanced optimization\ntechniques.",
       "enum": [0, 1, 2, 3, "s", "z"],
       "x-taplo": {
@@ -260,7 +260,7 @@
       }
     },
     "Package": {
-      "title": "Package",
+      "title": "package",
       "description": "The only fields required by Cargo are [`name`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field) and\n[`version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field). If publishing to a registry, the registry may\nrequire additional fields. See the notes below and [the publishing chapter](https://doc.rust-lang.org/cargo/reference/publishing.html) for requirements for publishing to [crates.io](https://crates.io/).",
       "type": "object",
       "required": ["name", "version"],
@@ -546,7 +546,7 @@
       }
     },
     "Panic": {
-      "title": "Panic",
+      "title": "panic",
       "description": "The `panic` setting controls the [`-C panic` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#panic) which controls which panic\nstrategy to use.\n\nWhen set to `\"unwind\"`, the actual value depends on the default of the target\nplatform. For example, the NVPTX platform does not support unwinding, so it\nalways uses `\"abort\"`.\n\nTests, benchmarks, build scripts, and proc macros ignore the `panic` setting.\nThe `rustc` test harness currently requires `unwind` behavior. See the\n[`panic-abort-tests`](https://doc.rust-lang.org/cargo/reference/unstable.html#panic-abort-tests) unstable flag which enables `abort` behavior.\n\nAdditionally, when using the `abort` strategy and building a test, all of the\ndependencies will also be forced to built with the `unwind` strategy.",
       "type": "string",
       "enum": ["unwind", "abort"],
@@ -563,7 +563,7 @@
       }
     },
     "Platform": {
-      "title": "Platform",
+      "title": "platform",
       "type": "object",
       "properties": {
         "build-dependencies": {
@@ -631,7 +631,7 @@
       }
     },
     "BuildOverride": {
-      "title": "Build Override",
+      "title": "build override",
       "type": "object",
       "description": "Profile settings can be overridden for specific packages and build-time\ncrates. To override the settings for a specific package, use the `package`\ntable to change the settings for the named package:\n\n```toml\n# The `foo` package will use the -Copt-level=3 flag.\n[profile.dev.package.foo]\nopt-level = 3\n```\n\nThe package name is actually a [Package ID Spec](https://doc.rust-lang.org/cargo/reference/pkgid-spec.html), so you can\ntarget individual versions of a package with syntax such as\n`[profile.dev.package.\"foo:2.1.0\"]`.\n\nTo override the settings for all dependencies (but not any workspace member),\nuse the `\"*\"` package name:\n\n```toml\n# Set the default for dependencies.\n[profile.dev.package.\"*\"]\nopt-level = 2\n```\n\nTo override the settings for build scripts, proc macros, and their\ndependencies, use the `build-override` table:\n\n```toml\n# Set the settings for build scripts and proc-macros.\n[profile.dev.build-override]\nopt-level = 3\n```\n\n> Note: When a dependency is both a normal dependency and a build dependency,\n> Cargo will try to only build it once when `--target` is not specified. When\n> using `build-override`, the dependency may need to be built twice, once as a\n> normal dependency and once with the overridden build settings. This may\n> increase initial build times.\n",
       "allOf": [
@@ -664,7 +664,7 @@
       ]
     },
     "Profile": {
-      "title": "Profile",
+      "title": "profile",
       "type": "object",
       "properties": {
         "codegen-units": {
@@ -753,7 +753,7 @@
       }
     },
     "Profiles": {
-      "title": "Profiles",
+      "title": "profiles",
       "description": "Profiles provide a way to alter the compiler settings, influencing things like optimizations and debugging symbols.\n\nCargo has 4 built-in profiles: dev, release, test, and bench. It automatically chooses the profile based on which command is being run, the package and target that is being built, and command-line flags like --release.",
       "type": "object",
       "properties": {
@@ -780,7 +780,7 @@
       }
     },
     "Publish": {
-      "title": "Publish",
+      "title": "publish",
       "description": "The `publish` field can be used to prevent a package from being published to a package registry (like *crates.io*) by mistake, for instance to keep a package\nprivate in a company.\n\n```toml\n[package]\n# ...\npublish = false\n```\n\nThe value may also be an array of strings which are registry names that are\nallowed to be published to.\n\n```toml\n[package]\n# ...\npublish = [\"some-registry-name\"]\n```",
       "anyOf": [
         {
@@ -812,7 +812,7 @@
       }
     },
     "Readme": {
-      "title": "Readme",
+      "title": "readme",
       "description": "The `readme` field should be the path to a file in the package root (relative\nto this `Cargo.toml`) that contains general information about the package.\nThis file will be transferred to the registry when you publish. [crates.io](https://crates.io)\nwill interpret it as Markdown and render it on the crate's page.\n\n```toml\n[package]\n# ...\nreadme = \"README.md\"\n```\n\nIf no value is specified for this field, and a file named `README.md`,\n`README.txt` or `README` exists in the package root, then the name of that\nfile will be used. You can suppress this behavior by setting this field to\n`false`. If the field is set to `true`, a default value of `README.md` will\nbe assumed.\n",
       "anyOf": [
         {
@@ -839,7 +839,7 @@
       }
     },
     "SemVer": {
-      "title": "Semantic Version",
+      "title": "semantic version",
       "description": "Cargo bakes in the concept of [Semantic Versioning](https://semver.org/), so make sure you follow some basic rules:\n\n* Before you reach 1.0.0, anything goes, but if you make breaking changes,\n    increment the minor version. In Rust, breaking changes include adding fields to\n    structs or variants to enums.\n* After 1.0.0, only make breaking changes when you increment the major version.\n    Don't break the build.\n* After 1.0.0, don't add any new public API (no new `pub` anything) in patch-level\n    versions. Always increment the minor version if you add any new `pub` structs,\n    traits, fields, types, functions, methods or anything else.\n* Use version numbers with three numeric parts such as 1.0.0 rather than 1.0.",
       "default": "0.1.0",
       "type": "string",
@@ -851,7 +851,7 @@
       }
     },
     "SemVerRequirement": {
-      "title": "Semantic Version Requirement",
+      "title": "semantic version requirement",
       "description": "The [version requirement](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) of the target dependency.",
       "default": "*",
       "type": "string",
@@ -867,7 +867,7 @@
       }
     },
     "Target": {
-      "title": "Target",
+      "title": "target",
       "type": "object",
       "properties": {
         "bench": {
@@ -1030,7 +1030,7 @@
       }
     },
     "Workspace": {
-      "title": "Workspace",
+      "title": "workspace",
       "description": "The `[workspace]` table in `Cargo.toml` defines which packages are members of\nthe workspace:\n\n```toml\n[workspace]\nmembers = [\"member1\", \"path/to/member2\", \"crates/*\"]\nexclude = [\"crates/foo\", \"path/to/other\"]\n```\n\nAn empty `[workspace]` table can be used with a `[package]` to conveniently\ncreate a workspace with the package and all of its path dependencies.\n\nAll [`path` dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies) residing in the workspace directory automatically\nbecome members. Additional members can be listed with the `members` key, which\nshould be an array of strings containing directories with `Cargo.toml` files.\n\nThe `members` list also supports [globs](https://docs.rs/glob/0.3.0/glob/struct.Pattern.html) to match multiple paths, using\ntypical filename glob patterns like `*` and `?`.\n\nThe `exclude` key can be used to prevent paths from being included in a\nworkspace. This can be useful if some path dependencies aren't desired to be\nin the workspace at all, or using a glob pattern and you want to remove a\ndirectory.\n\nAn empty `[workspace]` table can be used with a `[package]` to conveniently\ncreate a workspace with the package and all of its path dependencies.",
       "type": "object",
       "properties": {
@@ -1168,7 +1168,7 @@
       }
     },
     "Authors": {
-      "title": "Authors",
+      "title": "authors",
       "description": "The `authors` field lists people or organizations that are considered the\n\"authors\" of the package. The exact meaning is open to interpretation — it may\nlist the original or primary authors, current maintainers, or owners of the\npackage. These names will be listed on the crate's page on\n[crates.io](https://crates.io). An optional email address may be included within angled\nbrackets at the end of each author.\n\n> **Note**: [crates.io](https://crates.io) requires at least one author to be listed.",
       "type": "array",
       "items": {
@@ -1187,7 +1187,7 @@
       }
     },
     "Categories": {
-      "title": "Categories",
+      "title": "categories",
       "description": "The `categories` field is an array of strings of the categories this package\nbelongs to.\n\n```toml\ncategories = [\"command-line-utilities\", \"development-tools::cargo-plugins\"]\n```\n\n> **Note**: [crates.io](https://crates.io) has a maximum of 5 categories. Each category should\n> match one of the strings available at https://crates.io/category_slugs, and\n> must match exactly.",
       "type": "array",
       "items": {
@@ -1206,7 +1206,7 @@
       }
     },
     "Description": {
-      "title": "Description",
+      "title": "description",
       "description": "The description is a short blurb about the package. [crates.io](https://crates.io) will display\nthis with your package. This should be plain text (not Markdown).\n\n```toml\n[package]\n# ...\ndescription = \"A short description of my package\"\n```\n\n> **Note**: [crates.io](https://crates.io) requires the `description` to be set.",
       "type": "string",
       "x-taplo": {
@@ -1216,7 +1216,7 @@
       }
     },
     "Documentation": {
-      "title": "Documentation",
+      "title": "documentation",
       "description": "\nThe `documentation` field specifies a URL to a website hosting the crate's\ndocumentation. If no URL is specified in the manifest file, [crates.io](https://crates.io) will\nautomatically link your crate to the corresponding [docs.rs](https://docs.rs) page.\n\n```toml\n[package]\n# ...\ndocumentation = \"https://docs.rs/bitflags\"\n```\n",
       "type": "string",
       "x-taplo": {
@@ -1226,7 +1226,7 @@
       }
     },
     "Exclude": {
-      "title": "Exclude",
+      "title": "exclude",
       "description": "You can explicitly specify that a set of file patterns should be ignored or\nincluded for the purposes of packaging. The patterns specified in the\n`exclude` field identify a set of files that are not included, and the\npatterns in `include` specify files that are explicitly included.\n\nThe patterns should be [gitignore](https://git-scm.com/docs/gitignore)-style patterns. Briefly:\n\n- `foo` matches any file or directory with the name `foo` anywhere in the\n  package. This is equivalent to the pattern `**/foo`.\n- `/foo` matches any file or directory with the name `foo` only in the root of\n  the package.\n- `foo/` matches any *directory* with the name `foo` anywhere in the package.\n- Common glob patterns like `*`, `?`, and `[]` are supported:\n  - `*` matches zero or more characters except `/`.  For example, `*.html`\n    matches any file or directory with the `.html` extension anywhere in the\n    package.\n  - `?` matches any character except `/`. For example, `foo?` matches `food`,\n    but not `foo`.\n  - `[]` allows for matching a range of characters. For example, `[ab]`\n    matches either `a` or `b`. `[a-z]` matches letters a through z.\n- `**/` prefix matches in any directory. For example, `**/foo/bar` matches the\n  file or directory `bar` anywhere that is directly under directory `foo`.\n- `/**` suffix matches everything inside. For example, `foo/**` matches all\n  files inside directory `foo`, including all files in subdirectories below\n  `foo`.\n- `/**/` matches zero or more directories. For example, `a/**/b` matches\n  `a/b`, `a/x/b`, `a/x/y/b`, and so on.\n- `!` prefix negates a pattern. For example, a pattern of `src/**.rs` and\n  `!foo.rs` would match all files with the `.rs` extension inside the `src`\n  directory, except for any file named `foo.rs`.\n\nIf git is being used for a package, the `exclude` field will be seeded with\nthe `gitignore` settings from the repository.\n\n```toml\n[package]\n# ...\nexclude = [\"build/**/*.o\", \"doc/**/*.html\"]\n```\n\n```toml\n[package]\n# ...\ninclude = [\"src/**/*\", \"Cargo.toml\"]\n```\n\nThe options are mutually exclusive: setting `include` will override an\n`exclude`. Note that `include` must be an exhaustive list of files as otherwise\nnecessary source files may not be included. The package's `Cargo.toml` is\nautomatically included.\n\nThe include/exclude list is also used for change tracking in some situations.\nFor targets built with `rustdoc`, it is used to determine the list of files to\ntrack to determine if the target should be rebuilt. If the package has a\n[build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html) that does not emit any `rerun-if-*` directives, then the\ninclude/exclude list is used for tracking if the build script should be re-run\nif any of those files change.",
       "type": "array",
       "items": {
@@ -1245,7 +1245,7 @@
       }
     },
     "Homepage": {
-      "title": "Homepage",
+      "title": "homepage",
       "description": "The `homepage` field should be a URL to a site that is the home page for your\npackage.\n\n```toml\n[package]\n# ...\nhomepage = \"https://serde.rs/\"\n```",
       "type": "string",
       "x-taplo": {
@@ -1273,7 +1273,7 @@
       }
     },
     "Keywords": {
-      "title": "Keywords",
+      "title": "keywords",
       "description": "The `keywords` field is an array of strings that describe this package. This\ncan help when searching for the package on a registry, and you may choose any\nwords that would help someone find this crate.\n\n```toml\n[package]\n# ...\nkeywords = [\"gamedev\", \"graphics\"]\n```\n\n> **Note**: [crates.io](https://crates.io) has a maximum of 5 keywords. Each keyword must be\n> ASCII text, start with a letter, and only contain letters, numbers, `_` or\n> `-`, and have at most 20 characters.",
       "type": "array",
       "items": {
@@ -1292,7 +1292,7 @@
       }
     },
     "License": {
-      "title": "License",
+      "title": "license",
       "description": "The `license` field contains the name of the software license that the package\nis released under.\n\n[crates.io](https://crates.io/) interprets the `license` field as an [SPDX 2.1 license\nexpression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60). The name must be a known license\nfrom the [SPDX license list 3.6](https://github.com/spdx/license-list-data/tree/v3.6). Parentheses are not\ncurrently supported. See the [SPDX site](https://spdx.org/license-list) for more information.\n\nSPDX license expressions support AND and OR operators to combine multiple\nlicenses.\n\n```toml\n[package]\n# ...\nlicense = \"MIT OR Apache-2.0\"\n```\n\nUsing `OR` indicates the user may choose either license. Using `AND` indicates\nthe user must comply with both licenses simultaneously. The `WITH` operator\nindicates a license with a special exception. Some examples:\n\n* `MIT OR Apache-2.0`\n* `LGPL-2.1 AND MIT AND BSD-2-Clause`\n* `GPL-2.0+ WITH Bison-exception-2.2`\n\nIf a package is using a nonstandard license, then the `license-file` field may\nbe specified in lieu of the `license` field.",
       "type": "string",
       "x-taplo": {
@@ -1302,7 +1302,7 @@
       }
     },
     "LicenseFile": {
-      "title": "LicenseFile",
+      "title": "licensefile",
       "description": "The `license-file` field contains the path to a file\ncontaining the text of the license (relative to this `Cargo.toml`).\n\n```toml\n[package]\n# ...\nlicense-file = \"LICENSE.txt\"\n```\n\n> **Note**: [crates.io](https://crates.io) requires either `license` or `license-file` to be set.",
       "type": "string",
       "x-taplo": {
@@ -1312,7 +1312,7 @@
       }
     },
     "Repository": {
-      "title": "Repository",
+      "title": "repository",
       "description": "The `repository` field should be a URL to the source repository for your\npackage.\n\n```toml\n[package]\n# ...\nrepository = \"https://github.com/rust-lang/cargo/\"\n```",
       "type": "string",
       "x-taplo": {
@@ -1322,7 +1322,7 @@
       }
     },
     "RustVersion": {
-      "title": "RustVersion",
+      "title": "rustversion",
       "description": "The `rust-version` field is an optional key that tells cargo what version of the\nRust language and compiler your package can be compiled with. If the currently\nselected version of the Rust compiler is older than the stated version, cargo\nwill exit with an error, telling the user what version is required.\n\nThe first version of Cargo that supports this field was released with Rust 1.56.0.\nIn older releases, the field will be ignored, and Cargo will display a warning.\n\n```toml\n[package]\n# ...\nrust-version = \"1.56\"\n```\n\nThe Rust version must be a bare version number with two or three components; it\ncannot include semver operators or pre-release identifiers. Compiler pre-release\nidentifiers such as -nightly will be ignored while checking the Rust version.\nThe `rust-version` must be equal to or newer than the version that first\nintroduced the configured `edition`.\n\nThe `rust-version` may be ignored using the `--ignore-rust-version` option.\n\nSetting the `rust-version` key in `[package]` will affect all targets/crates in\nthe package, including test suites, benchmarks, binaries, examples, etc.",
       "type": "string",
       "x-taplo": {
@@ -1332,7 +1332,7 @@
       }
     },
     "WorkspaceInheritance": {
-      "title": "Workspace",
+      "title": "workspace",
       "description": "The `workspace` field allow keys to be inherited by defining them in the member package with `{key}.workspace = true`",
       "type": "object",
       "properties": {
@@ -1572,7 +1572,7 @@
       "$ref": "#/definitions/Workspace"
     }
   },
-  "title": "Cargo.toml",
+  "title": "cargo.toml",
   "type": "object",
   "x-taplo-info": {
     "authors": ["tamasfe (https://github.com/tamasfe)"],

--- a/src/schemas/json/catalog-info.json
+++ b/src/schemas/json/catalog-info.json
@@ -552,7 +552,7 @@
           "kind": "Template",
           "metadata": {
             "name": "react-ssr-template",
-            "title": "React SSR Template",
+            "title": "react ssr template",
             "description": "Next.js application skeleton for creating isomorphic web applications.",
             "tags": ["recommended", "react"]
           },
@@ -563,12 +563,12 @@
               "required": ["name", "description"],
               "properties": {
                 "name": {
-                  "title": "Name",
+                  "title": "name",
                   "type": "string",
                   "description": "Unique name of the component"
                 },
                 "description": {
-                  "title": "Description",
+                  "title": "description",
                   "type": "string",
                   "description": "Description of the component"
                 }

--- a/src/schemas/json/cdk.json
+++ b/src/schemas/json/cdk.json
@@ -32,6 +32,6 @@
       "type": "object"
     }
   },
-  "title": "Schema for AWS CDK context files (cdk.json)",
+  "title": "schema for aws cdk context files (cdk.json)",
   "type": "object"
 }

--- a/src/schemas/json/chart-lock.json
+++ b/src/schemas/json/chart-lock.json
@@ -37,6 +37,6 @@
     }
   },
   "required": ["generated", "digest", "dependencies"],
-  "title": "Helm Chart.lock",
+  "title": "helm chart.lock",
   "type": "object"
 }

--- a/src/schemas/json/chart.json
+++ b/src/schemas/json/chart.json
@@ -226,6 +226,6 @@
     }
   },
   "required": ["apiVersion", "name", "version"],
-  "title": "Helm Chart.yaml",
+  "title": "helm chart.yaml",
   "type": "object"
 }

--- a/src/schemas/json/cheatsheets.json
+++ b/src/schemas/json/cheatsheets.json
@@ -126,6 +126,6 @@
       }
     }
   },
-  "title": "A cheatsheet config schema",
+  "title": "a cheatsheet config schema",
   "type": "object"
 }

--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -887,6 +887,6 @@
       }
     }
   },
-  "title": "JSON schema for Google Chrome extension manifest files",
+  "title": "json schema for google chrome extension manifest files",
   "type": "object"
 }

--- a/src/schemas/json/chutzpah.json
+++ b/src/schemas/json/chutzpah.json
@@ -354,6 +354,6 @@
       "type": "object"
     }
   },
-  "title": "JSON schema for Chutzpah test runner settings files",
+  "title": "json schema for chutzpah test runner settings files",
   "type": "object"
 }

--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -1209,6 +1209,6 @@
     }
   },
   "required": ["version"],
-  "title": "JSON schema for CircleCI configuration files",
+  "title": "json schema for circleci configuration files",
   "type": "object"
 }

--- a/src/schemas/json/cirrus.json
+++ b/src/schemas/json/cirrus.json
@@ -4586,6 +4586,6 @@
       "type": "object"
     }
   },
-  "title": "JSON schema for Cirrus CI configuration files",
+  "title": "json schema for cirrus ci configuration files",
   "type": "object"
 }

--- a/src/schemas/json/clasp.json
+++ b/src/schemas/json/clasp.json
@@ -35,6 +35,6 @@
     }
   },
   "required": ["scriptId"],
-  "title": "Google Apps Script config schema",
+  "title": "google apps script config schema",
   "type": "object"
 }

--- a/src/schemas/json/cloud-sdk-pipeline-config-schema.json
+++ b/src/schemas/json/cloud-sdk-pipeline-config-schema.json
@@ -1030,6 +1030,6 @@
       }
     }
   },
-  "title": "SAP Cloud SDK pipeline_config JSON schema",
+  "title": "sap cloud sdk pipeline_config json schema",
   "type": "object"
 }

--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -400,6 +400,6 @@
     }
   },
   "required": ["steps"],
-  "title": "Google Cloud Build build config file",
+  "title": "google cloud build build config file",
   "type": "object"
 }

--- a/src/schemas/json/cloudify.json
+++ b/src/schemas/json/cloudify.json
@@ -13077,6 +13077,6 @@
       "$ref": "#/definitions/nodeTemplates"
     }
   },
-  "title": "Blueprint",
+  "title": "blueprint",
   "type": "object"
 }

--- a/src/schemas/json/codeclimate.json
+++ b/src/schemas/json/codeclimate.json
@@ -6,53 +6,53 @@
       "type": "object",
       "properties": {
         "enabled": {
-          "title": "Enabled",
+          "title": "enabled",
           "type": "boolean",
           "default": true
         }
       }
     },
     "config": {
-      "title": "Config",
+      "title": "config",
       "type": "object"
     },
     "threshold": {
-      "title": "Threshold",
+      "title": "threshold",
       "type": ["integer", "null"]
     }
   },
   "description": "Configuration file as an alternative for configuring your repository in the settings page.",
   "properties": {
     "version": {
-      "title": "Version",
+      "title": "version",
       "description": "Required to adjust maintainability checks.",
       "type": "string",
       "default": "2"
     },
     "prepare": {
-      "title": "Prepare",
+      "title": "prepare",
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
           "url": {
-            "title": "URL",
+            "title": "url",
             "type": "string",
             "format": "uri"
           },
           "path": {
-            "title": "Path",
+            "title": "path",
             "type": "string"
           }
         }
       }
     },
     "checks": {
-      "title": "Checks",
+      "title": "checks",
       "type": "object",
       "properties": {
         "argument-count": {
-          "title": "Argument Count",
+          "title": "argument count",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -67,7 +67,7 @@
           }
         },
         "complex-logic": {
-          "title": "Complex Logic",
+          "title": "complex logic",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -82,7 +82,7 @@
           }
         },
         "file-lines": {
-          "title": "File Lines",
+          "title": "file lines",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -97,7 +97,7 @@
           }
         },
         "method-complexity": {
-          "title": "Method Complexity",
+          "title": "method complexity",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -112,7 +112,7 @@
           }
         },
         "method-count": {
-          "title": "Method Count",
+          "title": "method count",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -127,7 +127,7 @@
           }
         },
         "method-lines": {
-          "title": "Method Lines",
+          "title": "method lines",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -142,7 +142,7 @@
           }
         },
         "nested-control-flow": {
-          "title": "Nested Control Flow",
+          "title": "nested control flow",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -157,7 +157,7 @@
           }
         },
         "return-statements": {
-          "title": "Return Statements",
+          "title": "return statements",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -172,7 +172,7 @@
           }
         },
         "similar-code": {
-          "title": "Similar Code",
+          "title": "similar code",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -186,7 +186,7 @@
           }
         },
         "identical-code": {
-          "title": "Identical Code",
+          "title": "identical code",
           "$ref": "#/definitions/enabled",
           "properties": {
             "config": {
@@ -202,7 +202,7 @@
       }
     },
     "plugins": {
-      "title": "Plugins",
+      "title": "plugins",
       "description": "To add a plugin to your analysis. You can find the complete list of available plugins here: https://docs.codeclimate.com/docs/list-of-engines",
       "type": "object",
       "additionalProperties": {
@@ -210,14 +210,14 @@
       }
     },
     "exclude_patterns": {
-      "title": "Exclude Patterns",
+      "title": "exclude patterns",
       "type": "array",
       "items": {
-        "title": "Exclude Pattern",
+        "title": "exclude pattern",
         "type": "string"
       }
     }
   },
-  "title": "Code Climate Configuration",
+  "title": "code climate configuration",
   "type": "object"
 }

--- a/src/schemas/json/codecov.json
+++ b/src/schemas/json/codecov.json
@@ -615,6 +615,6 @@
       ]
     }
   },
-  "title": "JSON schema for Codecov configuration files",
+  "title": "json schema for codecov configuration files",
   "type": "object"
 }

--- a/src/schemas/json/codeship-services.json
+++ b/src/schemas/json/codeship-services.json
@@ -5,7 +5,7 @@
   },
   "definitions": {
     "ExternalService": {
-      "title": "CodeShip Pro Service",
+      "title": "codeship pro service",
       "description": "The definition of a service in a CodeShip Pro build, which can have steps run on it or have other services depend on it",
       "properties": {
         "add_docker": {
@@ -235,7 +235,7 @@
       ]
     },
     "externalBuild": {
-      "title": "Image Build",
+      "title": "image build",
       "description": "Configuration of how to build the image for this service",
       "properties": {
         "path": {
@@ -322,6 +322,6 @@
     }
   },
   "description": "codeship-services.yml is where you configure each service you need to run your CI/CD builds with CodeShip.",
-  "title": "CodeShip Pro services configuration",
+  "title": "codeship pro services configuration",
   "type": "object"
 }

--- a/src/schemas/json/codeship-steps.json
+++ b/src/schemas/json/codeship-steps.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "ExternalStep": {
-      "title": "CodeShip Pro Step",
+      "title": "codeship pro step",
       "description": "The definition of a step",
       "properties": {
         "name": {
@@ -168,6 +168,6 @@
   "items": {
     "$ref": "#/definitions/ExternalStep"
   },
-  "title": "CodeShip Pro steps configuration",
+  "title": "codeship pro steps configuration",
   "type": "array"
 }

--- a/src/schemas/json/coffeelint.json
+++ b/src/schemas/json/coffeelint.json
@@ -389,6 +389,6 @@
       ]
     }
   },
-  "title": "JSON schema for coffeelint.json files",
+  "title": "json schema for coffeelint.json files",
   "type": "object"
 }

--- a/src/schemas/json/comet.json
+++ b/src/schemas/json/comet.json
@@ -1088,6 +1088,6 @@
       }
     }
   },
-  "title": "Starlake Data Pipeline",
+  "title": "starlake data pipeline",
   "type": "object"
 }

--- a/src/schemas/json/compile-commands.json
+++ b/src/schemas/json/compile-commands.json
@@ -41,6 +41,6 @@
   "items": {
     "$ref": "#/definitions/commandObject"
   },
-  "title": "LLVM compilation database",
+  "title": "llvm compilation database",
   "type": "array"
 }

--- a/src/schemas/json/component-detection-manifest.json
+++ b/src/schemas/json/component-detection-manifest.json
@@ -15,11 +15,11 @@
         }
       },
       "required": ["registrations", "version"],
-      "title": "CGManifest",
+      "title": "cgmanifest",
       "type": "object"
     },
     "Registration": {
-      "title": "Registration",
+      "title": "registration",
       "type": "object",
       "properties": {
         "component": {
@@ -38,7 +38,7 @@
       "required": ["component"]
     },
     "Component": {
-      "title": "Component",
+      "title": "component",
       "type": "object",
       "oneOf": [
         {
@@ -80,7 +80,7 @@
       ]
     },
     "Cargo": {
-      "title": "Cargo",
+      "title": "cargo",
       "type": "object",
       "properties": {
         "type": {
@@ -103,7 +103,7 @@
       "required": ["type", "cargo"]
     },
     "Git": {
-      "title": "Git",
+      "title": "git",
       "type": "object",
       "properties": {
         "type": {
@@ -127,7 +127,7 @@
       "required": ["type", "git"]
     },
     "Go": {
-      "title": "Go",
+      "title": "go",
       "type": "object",
       "properties": {
         "type": {
@@ -150,7 +150,7 @@
       "required": ["type", "go"]
     },
     "Linux": {
-      "title": "Linux",
+      "title": "linux",
       "type": "object",
       "properties": {
         "type": {
@@ -187,7 +187,7 @@
       "required": ["type", "linux"]
     },
     "Maven": {
-      "title": "Maven",
+      "title": "maven",
       "type": "object",
       "properties": {
         "type": {
@@ -213,7 +213,7 @@
       "required": ["type", "maven"]
     },
     "Npm": {
-      "title": "Npm",
+      "title": "npm",
       "type": "object",
       "properties": {
         "type": {
@@ -236,7 +236,7 @@
       "required": ["type", "npm"]
     },
     "NuGet": {
-      "title": "NuGet",
+      "title": "nuget",
       "type": "object",
       "properties": {
         "type": {
@@ -259,7 +259,7 @@
       "required": ["type", "nuget"]
     },
     "Other": {
-      "title": "Other",
+      "title": "other",
       "type": "object",
       "properties": {
         "type": {
@@ -267,7 +267,7 @@
           "enum": ["other"]
         },
         "other": {
-          "title": "Other",
+          "title": "other",
           "type": "object",
           "properties": {
             "name": {
@@ -290,7 +290,7 @@
       "required": ["type", "other"]
     },
     "Pip": {
-      "title": "Pip",
+      "title": "pip",
       "type": "object",
       "properties": {
         "type": {
@@ -313,7 +313,7 @@
       "required": ["type", "pip"]
     },
     "Pod": {
-      "title": "Pod",
+      "title": "pod",
       "type": "object",
       "properties": {
         "type": {
@@ -336,7 +336,7 @@
       "required": ["type", "pod"]
     },
     "RubyGems": {
-      "title": "RubyGems",
+      "title": "rubygems",
       "type": "object",
       "properties": {
         "type": {
@@ -359,7 +359,7 @@
       "required": ["type", "rubygems"]
     },
     "VCPKG": {
-      "title": "VCPKG",
+      "title": "vcpkg",
       "type": "object",
       "properties": {
         "type": {
@@ -397,5 +397,5 @@
       "required": ["type", "vcpkg"]
     }
   },
-  "title": "Component Detection manifest"
+  "title": "component detection manifest"
 }

--- a/src/schemas/json/component.json
+++ b/src/schemas/json/component.json
@@ -134,6 +134,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for component.json files",
+  "title": "json schema for component.json files",
   "type": "object"
 }

--- a/src/schemas/json/config.json
+++ b/src/schemas/json/config.json
@@ -5,6 +5,6 @@
       "type": "object"
     }
   },
-  "title": "JSON schema for DNX configuration files",
+  "title": "json schema for dnx configuration files",
   "type": "object"
 }

--- a/src/schemas/json/container-structure-test.json
+++ b/src/schemas/json/container-structure-test.json
@@ -315,6 +315,6 @@
     }
   },
   "required": ["schemaVersion"],
-  "title": "Container Structure Tests",
+  "title": "container structure tests",
   "type": "object"
 }

--- a/src/schemas/json/content-security-policy-report-2.json
+++ b/src/schemas/json/content-security-policy-report-2.json
@@ -50,6 +50,6 @@
     }
   },
   "required": ["csp-report"],
-  "title": "JSON Schema for Content Security Policy (Level 2) violation reports",
+  "title": "json schema for content security policy (level 2) violation reports",
   "type": "object"
 }

--- a/src/schemas/json/cosmos-config.json
+++ b/src/schemas/json/cosmos-config.json
@@ -239,6 +239,6 @@
       }
     }
   },
-  "title": "JSON schema for React Cosmos configs",
+  "title": "json schema for react cosmos configs",
   "type": "object"
 }

--- a/src/schemas/json/creatomic.json
+++ b/src/schemas/json/creatomic.json
@@ -76,6 +76,6 @@
       "scope": "resource"
     }
   },
-  "title": "JSON schema for Creatomic configuration file",
+  "title": "json schema for creatomic configuration file",
   "type": "object"
 }

--- a/src/schemas/json/crowdin.json
+++ b/src/schemas/json/crowdin.json
@@ -4,114 +4,114 @@
   "description": "Configuration for Crowdin, a crowd-translation platform.",
   "properties": {
     "project_id": {
-      "title": "Project ID",
+      "title": "project id",
       "type": "string"
     },
     "project_id_env": {
-      "title": "Project ID Environment Variable",
+      "title": "project id environment variable",
       "type": "string"
     },
     "api_token": {
-      "title": "API Token",
+      "title": "api token",
       "type": "string"
     },
     "api_token_env": {
-      "title": "API Token Environment Variable",
+      "title": "api token environment variable",
       "type": "string"
     },
     "base_path": {
-      "title": "Base Path",
+      "title": "base path",
       "type": "string"
     },
     "base_path_env": {
-      "title": "Base Path Environment Variable",
+      "title": "base path environment variable",
       "type": "string"
     },
     "base_url": {
-      "title": "Base URL",
+      "title": "base url",
       "type": "string",
       "format": "uri"
     },
     "base_url_env": {
-      "title": "Base URL Environment Variable",
+      "title": "base url environment variable",
       "type": "string"
     },
     "preserve_hierarchy": {
-      "title": "Preserve Hierarchy",
+      "title": "preserve hierarchy",
       "type": "boolean"
     },
     "commit_message": {
-      "title": "Commit Message",
+      "title": "commit message",
       "type": "string"
     },
     "append_commit_message": {
-      "title": "Append Commit Message",
+      "title": "append commit message",
       "description": "Replace the default commit message with the one specified in commit_message.",
       "type": "boolean"
     },
     "export_languages": {
-      "title": "Export Languages",
+      "title": "export languages",
       "description": "Specify a list of specific languages to export.",
       "type": "array",
       "items": {
-        "title": "Language",
+        "title": "language",
         "type": "string"
       }
     },
     "files": {
-      "title": "Files",
+      "title": "files",
       "type": "array",
       "items": {
-        "title": "File",
+        "title": "file",
         "type": "object",
         "properties": {
           "source": {
-            "title": "Source",
+            "title": "source",
             "type": "string"
           },
           "translation": {
-            "title": "Translation",
+            "title": "translation",
             "type": "string"
           },
           "ignore": {
-            "title": "Ignore",
+            "title": "ignore",
             "type": "array",
             "items": {
               "type": "string"
             }
           },
           "translation_replace": {
-            "title": "Translation Replace",
+            "title": "translation replace",
             "additionalProperties": {
               "type": "string"
             }
           },
           "excluded_target_languages": {
-            "title": "Excluded Target Languages",
+            "title": "excluded target languages",
             "type": "array",
             "items": {
-              "title": "Excluded Target Language",
+              "title": "excluded target language",
               "type": "string"
             }
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "type": "string"
           },
           "dest": {
-            "title": "Destination",
+            "title": "destination",
             "type": "string"
           },
           "type": {
-            "title": "Type",
+            "title": "type",
             "type": "string"
           },
           "update_option": {
-            "title": "Update Option",
+            "title": "update option",
             "enum": ["update_as_unapproved", "update_without_changes"]
           },
           "translate_content": {
-            "title": "Translate Content",
+            "title": "translate content",
             "description": "Defines whether to translate texts placed inside the tags.",
             "type": "number",
             "minimum": 0,
@@ -119,7 +119,7 @@
             "default": 1
           },
           "translate_attributes": {
-            "title": "Translate Attributes",
+            "title": "translate attributes",
             "description": "Defines whether to translate tags' attributes.",
             "type": "number",
             "minimum": 0,
@@ -127,7 +127,7 @@
             "default": 1
           },
           "content_segmentation": {
-            "title": "Content Segmentation",
+            "title": "content segmentation",
             "description": "Defines whether to split long texts into smaller text segments.",
             "type": "number",
             "minimum": 0,
@@ -135,28 +135,28 @@
             "default": 1
           },
           "translatable_elements": {
-            "title": "Translatable Elements",
+            "title": "translatable elements",
             "description": "An array of strings, where each item is the XPaths to DOM element that should be imported. ",
             "type": "array",
             "items": {
-              "title": "Translatable Element",
+              "title": "translatable element",
               "type": "string"
             }
           },
           "skip_untranslated_strings": {
-            "title": "Skip Untranslated Strings",
+            "title": "skip untranslated strings",
             "type": "boolean"
           },
           "skip_untranslated_files": {
-            "title": "Skip Untranslated Files",
+            "title": "skip untranslated files",
             "type": "boolean"
           },
           "export_only_approved": {
-            "title": "Export Only Approved",
+            "title": "export only approved",
             "type": "boolean"
           },
           "escape_quotes": {
-            "title": "Escape Quotes",
+            "title": "escape quotes",
             "description": "Defines whether a single quote should be escaped by another single quote or backslash in exported translations.",
             "type": "number",
             "minimum": 0,
@@ -164,7 +164,7 @@
             "default": 3
           },
           "escape_special_characters": {
-            "title": "Escape Sepcial Characters",
+            "title": "escape sepcial characters",
             "description": "Defines whether any special characters (=, :, ! and #) should be escaped by backslash in exported translations.",
             "type": "number",
             "minimum": 0,
@@ -172,11 +172,11 @@
             "default": 1
           },
           "first_line_contains_header": {
-            "title": "First Line Contains Header",
+            "title": "first line contains header",
             "type": "boolean"
           },
           "languages_mapping": {
-            "title": "Language Mapping",
+            "title": "language mapping",
             "properties": {
               "two_letters_code": {
                 "additionalProperties": {
@@ -191,10 +191,10 @@
             }
           },
           "labels": {
-            "title": "Labels",
+            "title": "labels",
             "type": "array",
             "items": {
-              "title": "Label",
+              "title": "label",
               "type": "string"
             }
           }

--- a/src/schemas/json/cryproj.52.schema.json
+++ b/src/schemas/json/cryproj.52.schema.json
@@ -5,7 +5,7 @@
     "cvars": {
       "$id": "/definitions/cvars",
       "type": "string",
-      "title": "Variable name",
+      "title": "variable name",
       "description": "CVar name",
       "default": "sys_target_platforms",
       "enum": [
@@ -2456,7 +2456,7 @@
     "commands": {
       "$id": "/definitions/commands",
       "type": "string",
-      "title": "Command name",
+      "title": "command name",
       "description": "Console command name",
       "default": "",
       "enum": [
@@ -2661,7 +2661,7 @@
           "value": {
             "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
-            "title": "Value of the CVar",
+            "title": "value of the cvar",
             "description": "The default value of the CVar",
             "default": "pc,ps4,xboxone,linux"
           }
@@ -2679,7 +2679,7 @@
           "items": {
             "$id": "/properties/content/properties/assets/items",
             "type": "string",
-            "title": "Assets folder",
+            "title": "assets folder",
             "description": "This indicates where the assets are stored",
             "default": "Assets",
             "examples": ["Assets"]
@@ -2691,7 +2691,7 @@
           "items": {
             "$id": "/properties/content/properties/code/items",
             "type": "string",
-            "title": "Code folder",
+            "title": "code folder",
             "description": "This indicates where the code is stored",
             "default": "Code",
             "examples": ["Code"]
@@ -2707,7 +2707,7 @@
               "name": {
                 "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
-                "title": "Lib's name",
+                "title": "lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
@@ -2718,21 +2718,21 @@
                   "any": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
-                    "title": "Lib's name to import for all the supported platforms",
+                    "title": "lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x64 platform",
+                    "title": "lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x86 platform",
+                    "title": "lib's name to import for the win_x86 platform",
                     "default": "",
                     "examples": ["bin/win_x86/Game.dll"]
                   }
@@ -2751,7 +2751,7 @@
         "name": {
           "$id": "/properties/info/properties/name",
           "type": "string",
-          "title": "Project name",
+          "title": "project name",
           "description": "This indicates the project name",
           "default": "",
           "examples": ["MyFancyProject"]
@@ -2759,7 +2759,7 @@
         "guid": {
           "$id": "/properties/info/properties/guid",
           "type": "string",
-          "title": "Project GUID",
+          "title": "project guid",
           "default": "",
           "pattern": "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
         }
@@ -2773,7 +2773,7 @@
         "engine": {
           "$id": "/properties/require/properties/engine",
           "type": "string",
-          "title": "Engine version",
+          "title": "engine version",
           "description": "This indicates which engine version will be used",
           "default": "",
           "examples": ["engine-5.4"],
@@ -2789,7 +2789,7 @@
               "path": {
                 "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
-                "title": "Plugin name",
+                "title": "plugin name",
                 "description": "Required plugin's name",
                 "examples": [
                   "CryDefaultEntities",
@@ -2805,7 +2805,7 @@
               "type": {
                 "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
-                "title": "Plugin type",
+                "title": "plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
                 "default": "",
                 "examples": ["EPluginType::Native", "EPluginType::Managed"],
@@ -2817,7 +2817,7 @@
                 "items": {
                   "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
-                  "title": "This plugin will be used only by these platforms",
+                  "title": "this plugin will be used only by these platforms",
                   "default": "",
                   "examples": ["PS4"],
                   "enum": ["pc", "ps4", "xboxone", "linux"]
@@ -2840,7 +2840,7 @@
     "version": {
       "$id": "/properties/version",
       "type": "integer",
-      "title": "Project version",
+      "title": "project version",
       "default": 1,
       "examples": [1]
     },
@@ -2859,7 +2859,7 @@
           "value": {
             "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
-            "title": "Value of the command",
+            "title": "value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",
             "default": ""
           }
@@ -2869,6 +2869,6 @@
     }
   },
   "required": ["content", "info", "require", "version"],
-  "title": "CryProj schema",
+  "title": "cryproj schema",
   "type": "object"
 }

--- a/src/schemas/json/cryproj.53.schema.json
+++ b/src/schemas/json/cryproj.53.schema.json
@@ -5,7 +5,7 @@
     "cvars": {
       "$id": "/definitions/cvars",
       "type": "string",
-      "title": "Variable name",
+      "title": "variable name",
       "description": "CVar name",
       "default": "sys_target_platforms",
       "enum": [
@@ -2464,7 +2464,7 @@
     "commands": {
       "$id": "/definitions/commands",
       "type": "string",
-      "title": "Command name",
+      "title": "command name",
       "description": "Console command name",
       "default": "",
       "enum": [
@@ -2676,7 +2676,7 @@
           "value": {
             "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
-            "title": "Value of the CVar",
+            "title": "value of the cvar",
             "description": "The default value of the CVar",
             "default": "pc,ps4,xboxone,linux"
           }
@@ -2694,7 +2694,7 @@
           "items": {
             "$id": "/properties/content/properties/assets/items",
             "type": "string",
-            "title": "Assets folder",
+            "title": "assets folder",
             "description": "This indicates where the assets are stored",
             "default": "Assets",
             "examples": ["Assets"]
@@ -2706,7 +2706,7 @@
           "items": {
             "$id": "/properties/content/properties/code/items",
             "type": "string",
-            "title": "Code folder",
+            "title": "code folder",
             "description": "This indicates where the code is stored",
             "default": "Code",
             "examples": ["Code"]
@@ -2722,7 +2722,7 @@
               "name": {
                 "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
-                "title": "Lib's name",
+                "title": "lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
@@ -2733,21 +2733,21 @@
                   "any": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
-                    "title": "Lib's name to import for all the supported platforms",
+                    "title": "lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x64 platform",
+                    "title": "lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x86 platform",
+                    "title": "lib's name to import for the win_x86 platform",
                     "default": "",
                     "examples": ["bin/win_x86/Game.dll"]
                   }
@@ -2766,7 +2766,7 @@
         "name": {
           "$id": "/properties/info/properties/name",
           "type": "string",
-          "title": "Project name",
+          "title": "project name",
           "description": "This indicates the project name",
           "default": "",
           "examples": ["MyFancyProject"]
@@ -2774,7 +2774,7 @@
         "guid": {
           "$id": "/properties/info/properties/guid",
           "type": "string",
-          "title": "Project GUID",
+          "title": "project guid",
           "default": "",
           "pattern": "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
         }
@@ -2788,7 +2788,7 @@
         "engine": {
           "$id": "/properties/require/properties/engine",
           "type": "string",
-          "title": "Engine version",
+          "title": "engine version",
           "description": "This indicates which engine version will be used",
           "default": "",
           "examples": ["engine-5.4"],
@@ -2804,7 +2804,7 @@
               "path": {
                 "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
-                "title": "Plugin name",
+                "title": "plugin name",
                 "description": "Required plugin's name",
                 "examples": [
                   "CryDefaultEntities",
@@ -2820,7 +2820,7 @@
               "type": {
                 "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
-                "title": "Plugin type",
+                "title": "plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
                 "default": "",
                 "examples": ["EPluginType::Native", "EPluginType::Managed"],
@@ -2832,7 +2832,7 @@
                 "items": {
                   "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
-                  "title": "This plugin will be used only by these platforms",
+                  "title": "this plugin will be used only by these platforms",
                   "default": "",
                   "examples": ["PS4"],
                   "enum": ["pc", "ps4", "xboxone", "linux"]
@@ -2855,7 +2855,7 @@
     "version": {
       "$id": "/properties/version",
       "type": "integer",
-      "title": "Project version",
+      "title": "project version",
       "default": 1,
       "examples": [1]
     },
@@ -2874,7 +2874,7 @@
           "value": {
             "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
-            "title": "Value of the command",
+            "title": "value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",
             "default": ""
           }
@@ -2884,6 +2884,6 @@
     }
   },
   "required": ["content", "info", "require", "version"],
-  "title": "CryProj schema",
+  "title": "cryproj schema",
   "type": "object"
 }

--- a/src/schemas/json/cryproj.54.schema.json
+++ b/src/schemas/json/cryproj.54.schema.json
@@ -5,7 +5,7 @@
     "cvars": {
       "$id": "/definitions/cvars",
       "type": "string",
-      "title": "Variable name",
+      "title": "variable name",
       "description": "CVar name",
       "default": "sys_target_platforms",
       "enum": [
@@ -2471,7 +2471,7 @@
     "commands": {
       "$id": "/definitions/commands",
       "type": "string",
-      "title": "Command name",
+      "title": "command name",
       "description": "Console command name",
       "default": "",
       "enum": [
@@ -2682,7 +2682,7 @@
           "value": {
             "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
-            "title": "Value of the CVar",
+            "title": "value of the cvar",
             "description": "The default value of the CVar",
             "default": "pc,ps4,xboxone,linux"
           }
@@ -2700,7 +2700,7 @@
           "items": {
             "$id": "/properties/content/properties/assets/items",
             "type": "string",
-            "title": "Assets folder",
+            "title": "assets folder",
             "description": "This indicates where the assets are stored",
             "default": "Assets",
             "examples": ["Assets"]
@@ -2712,7 +2712,7 @@
           "items": {
             "$id": "/properties/content/properties/code/items",
             "type": "string",
-            "title": "Code folder",
+            "title": "code folder",
             "description": "This indicates where the code is stored",
             "default": "Code",
             "examples": ["Code"]
@@ -2728,7 +2728,7 @@
               "name": {
                 "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
-                "title": "Lib's name",
+                "title": "lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
@@ -2739,21 +2739,21 @@
                   "any": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
-                    "title": "Lib's name to import for all the supported platforms",
+                    "title": "lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x64 platform",
+                    "title": "lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x86 platform",
+                    "title": "lib's name to import for the win_x86 platform",
                     "default": "",
                     "examples": ["bin/win_x86/Game.dll"]
                   }
@@ -2772,7 +2772,7 @@
         "name": {
           "$id": "/properties/info/properties/name",
           "type": "string",
-          "title": "Project name",
+          "title": "project name",
           "description": "This indicates the project name",
           "default": "",
           "examples": ["MyFancyProject"]
@@ -2780,7 +2780,7 @@
         "guid": {
           "$id": "/properties/info/properties/guid",
           "type": "string",
-          "title": "Project GUID",
+          "title": "project guid",
           "default": "",
           "pattern": "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
         }
@@ -2794,7 +2794,7 @@
         "engine": {
           "$id": "/properties/require/properties/engine",
           "type": "string",
-          "title": "Engine version",
+          "title": "engine version",
           "description": "This indicates which engine version will be used",
           "default": "",
           "examples": ["engine-5.4"],
@@ -2810,7 +2810,7 @@
               "path": {
                 "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
-                "title": "Plugin name",
+                "title": "plugin name",
                 "description": "Required plugin's name",
                 "examples": [
                   "CryDefaultEntities",
@@ -2826,7 +2826,7 @@
               "type": {
                 "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
-                "title": "Plugin type",
+                "title": "plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
                 "default": "",
                 "examples": ["EPluginType::Native", "EPluginType::Managed"],
@@ -2838,7 +2838,7 @@
                 "items": {
                   "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
-                  "title": "This plugin will be used only by these platforms",
+                  "title": "this plugin will be used only by these platforms",
                   "default": "",
                   "examples": ["PS4"],
                   "enum": ["pc", "ps4", "xboxone", "linux"]
@@ -2861,7 +2861,7 @@
     "version": {
       "$id": "/properties/version",
       "type": "integer",
-      "title": "Project version",
+      "title": "project version",
       "default": 1,
       "examples": [1]
     },
@@ -2880,7 +2880,7 @@
           "value": {
             "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
-            "title": "Value of the command",
+            "title": "value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",
             "default": ""
           }
@@ -2890,6 +2890,6 @@
     }
   },
   "required": ["content", "info", "require", "version"],
-  "title": "CryProj schema",
+  "title": "cryproj schema",
   "type": "object"
 }

--- a/src/schemas/json/cryproj.55.schema.json
+++ b/src/schemas/json/cryproj.55.schema.json
@@ -5,7 +5,7 @@
     "cvars": {
       "$id": "/definitions/cvars",
       "type": "string",
-      "title": "Variable name",
+      "title": "variable name",
       "description": "CVar name",
       "default": "sys_target_platforms",
       "enum": [
@@ -2475,7 +2475,7 @@
     "commands": {
       "$id": "/definitions/commands",
       "type": "string",
-      "title": "Command name",
+      "title": "command name",
       "description": "Console command name",
       "default": "",
       "enum": [
@@ -2688,7 +2688,7 @@
           "value": {
             "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
-            "title": "Value of the CVar",
+            "title": "value of the cvar",
             "description": "The default value of the CVar",
             "default": "pc,ps4,xboxone,linux"
           }
@@ -2706,7 +2706,7 @@
           "items": {
             "$id": "/properties/content/properties/assets/items",
             "type": "string",
-            "title": "Assets folder",
+            "title": "assets folder",
             "description": "This indicates where the assets are stored",
             "default": "Assets",
             "examples": ["Assets"]
@@ -2718,7 +2718,7 @@
           "items": {
             "$id": "/properties/content/properties/code/items",
             "type": "string",
-            "title": "Code folder",
+            "title": "code folder",
             "description": "This indicates where the code is stored",
             "default": "Code",
             "examples": ["Code"]
@@ -2734,7 +2734,7 @@
               "name": {
                 "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
-                "title": "Lib's name",
+                "title": "lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
@@ -2745,21 +2745,21 @@
                   "any": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
-                    "title": "Lib's name to import for all the supported platforms",
+                    "title": "lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x64 platform",
+                    "title": "lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x86 platform",
+                    "title": "lib's name to import for the win_x86 platform",
                     "default": "",
                     "examples": ["bin/win_x86/Game.dll"]
                   }
@@ -2778,7 +2778,7 @@
         "name": {
           "$id": "/properties/info/properties/name",
           "type": "string",
-          "title": "Project name",
+          "title": "project name",
           "description": "This indicates the project name",
           "default": "",
           "examples": ["MyFancyProject"]
@@ -2786,7 +2786,7 @@
         "guid": {
           "$id": "/properties/info/properties/guid",
           "type": "string",
-          "title": "Project GUID",
+          "title": "project guid",
           "default": "",
           "pattern": "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
         }
@@ -2800,7 +2800,7 @@
         "engine": {
           "$id": "/properties/require/properties/engine",
           "type": "string",
-          "title": "Engine version",
+          "title": "engine version",
           "description": "This indicates which engine version will be used",
           "default": "",
           "examples": ["engine-5.4"],
@@ -2816,7 +2816,7 @@
               "path": {
                 "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
-                "title": "Plugin name",
+                "title": "plugin name",
                 "description": "Required plugin's name",
                 "examples": [
                   "CryDefaultEntities",
@@ -2832,7 +2832,7 @@
               "type": {
                 "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
-                "title": "Plugin type",
+                "title": "plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
                 "default": "",
                 "examples": ["EPluginType::Native", "EPluginType::Managed"],
@@ -2844,7 +2844,7 @@
                 "items": {
                   "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
-                  "title": "This plugin will be used only by these platforms",
+                  "title": "this plugin will be used only by these platforms",
                   "default": "",
                   "examples": ["PS4"],
                   "enum": ["pc", "ps4", "xboxone", "linux"]
@@ -2867,7 +2867,7 @@
     "version": {
       "$id": "/properties/version",
       "type": "integer",
-      "title": "Project version",
+      "title": "project version",
       "default": 1,
       "examples": [1]
     },
@@ -2886,7 +2886,7 @@
           "value": {
             "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
-            "title": "Value of the command",
+            "title": "value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",
             "default": ""
           }
@@ -2896,6 +2896,6 @@
     }
   },
   "required": ["content", "info", "require", "version"],
-  "title": "CryProj schema",
+  "title": "cryproj schema",
   "type": "object"
 }

--- a/src/schemas/json/cryproj.dev.schema.json
+++ b/src/schemas/json/cryproj.dev.schema.json
@@ -5,7 +5,7 @@
     "cvars": {
       "$id": "/definitions/cvars",
       "type": "string",
-      "title": "Variable name",
+      "title": "variable name",
       "description": "CVar name",
       "default": "sys_target_platforms",
       "enum": [
@@ -2475,7 +2475,7 @@
     "commands": {
       "$id": "/definitions/commands",
       "type": "string",
-      "title": "Command name",
+      "title": "command name",
       "description": "Console command name",
       "default": "",
       "enum": [
@@ -2688,7 +2688,7 @@
           "value": {
             "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
-            "title": "Value of the CVar",
+            "title": "value of the cvar",
             "description": "The default value of the CVar",
             "default": "pc,ps4,xboxone,linux"
           }
@@ -2706,7 +2706,7 @@
           "items": {
             "$id": "/properties/content/properties/assets/items",
             "type": "string",
-            "title": "Assets folder",
+            "title": "assets folder",
             "description": "This indicates where the assets are stored",
             "default": "Assets",
             "examples": ["Assets"]
@@ -2718,7 +2718,7 @@
           "items": {
             "$id": "/properties/content/properties/code/items",
             "type": "string",
-            "title": "Code folder",
+            "title": "code folder",
             "description": "This indicates where the code is stored",
             "default": "Code",
             "examples": ["Code"]
@@ -2734,7 +2734,7 @@
               "name": {
                 "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
-                "title": "Lib's name",
+                "title": "lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
@@ -2745,21 +2745,21 @@
                   "any": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
-                    "title": "Lib's name to import for all the supported platforms",
+                    "title": "lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x64 platform",
+                    "title": "lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x86 platform",
+                    "title": "lib's name to import for the win_x86 platform",
                     "default": "",
                     "examples": ["bin/win_x86/Game.dll"]
                   }
@@ -2778,7 +2778,7 @@
         "name": {
           "$id": "/properties/info/properties/name",
           "type": "string",
-          "title": "Project name",
+          "title": "project name",
           "description": "This indicates the project name",
           "default": "",
           "examples": ["MyFancyProject"]
@@ -2786,7 +2786,7 @@
         "guid": {
           "$id": "/properties/info/properties/guid",
           "type": "string",
-          "title": "Project GUID",
+          "title": "project guid",
           "default": "",
           "pattern": "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
         }
@@ -2800,7 +2800,7 @@
         "engine": {
           "$id": "/properties/require/properties/engine",
           "type": "string",
-          "title": "Engine version",
+          "title": "engine version",
           "description": "This indicates which engine version will be used",
           "default": "",
           "examples": ["engine-5.4"],
@@ -2816,7 +2816,7 @@
               "path": {
                 "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
-                "title": "Plugin name",
+                "title": "plugin name",
                 "description": "Required plugin's name",
                 "examples": [
                   "CryDefaultEntities",
@@ -2832,7 +2832,7 @@
               "type": {
                 "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
-                "title": "Plugin type",
+                "title": "plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
                 "default": "",
                 "examples": ["EPluginType::Native", "EPluginType::Managed"],
@@ -2844,7 +2844,7 @@
                 "items": {
                   "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
-                  "title": "This plugin will be used only by these platforms",
+                  "title": "this plugin will be used only by these platforms",
                   "default": "",
                   "examples": ["PS4"],
                   "enum": ["pc", "ps4", "xboxone", "linux"]
@@ -2867,7 +2867,7 @@
     "version": {
       "$id": "/properties/version",
       "type": "integer",
-      "title": "Project version",
+      "title": "project version",
       "default": 1,
       "examples": [1]
     },
@@ -2886,7 +2886,7 @@
           "value": {
             "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
-            "title": "Value of the command",
+            "title": "value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",
             "default": ""
           }
@@ -2896,6 +2896,6 @@
     }
   },
   "required": ["content", "info", "require", "version"],
-  "title": "CryProj schema",
+  "title": "cryproj schema",
   "type": "object"
 }

--- a/src/schemas/json/cryproj.json
+++ b/src/schemas/json/cryproj.json
@@ -5,7 +5,7 @@
     "cvars": {
       "$id": "/definitions/cvars",
       "type": "string",
-      "title": "Variable name",
+      "title": "variable name",
       "description": "CVar name",
       "default": "sys_target_platforms",
       "enum": [
@@ -2475,7 +2475,7 @@
     "commands": {
       "$id": "/definitions/commands",
       "type": "string",
-      "title": "Command name",
+      "title": "command name",
       "description": "Console command name",
       "default": "",
       "enum": [
@@ -2688,7 +2688,7 @@
           "value": {
             "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
-            "title": "Value of the CVar",
+            "title": "value of the cvar",
             "description": "The default value of the CVar",
             "default": "pc,ps4,xboxone,linux"
           }
@@ -2706,7 +2706,7 @@
           "items": {
             "$id": "/properties/content/properties/assets/items",
             "type": "string",
-            "title": "Assets folder",
+            "title": "assets folder",
             "description": "This indicates where the assets are stored",
             "default": "Assets",
             "examples": ["Assets"]
@@ -2718,7 +2718,7 @@
           "items": {
             "$id": "/properties/content/properties/code/items",
             "type": "string",
-            "title": "Code folder",
+            "title": "code folder",
             "description": "This indicates where the code is stored",
             "default": "Code",
             "examples": ["Code"]
@@ -2734,7 +2734,7 @@
               "name": {
                 "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
-                "title": "Lib's name",
+                "title": "lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
@@ -2745,21 +2745,21 @@
                   "any": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
-                    "title": "Lib's name to import for all the supported platforms",
+                    "title": "lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x64 platform",
+                    "title": "lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
                     "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
-                    "title": "Lib's name to import for the win_x86 platform",
+                    "title": "lib's name to import for the win_x86 platform",
                     "default": "",
                     "examples": ["bin/win_x86/Game.dll"]
                   }
@@ -2778,7 +2778,7 @@
         "name": {
           "$id": "/properties/info/properties/name",
           "type": "string",
-          "title": "Project name",
+          "title": "project name",
           "description": "This indicates the project name",
           "default": "",
           "examples": ["MyFancyProject"]
@@ -2786,7 +2786,7 @@
         "guid": {
           "$id": "/properties/info/properties/guid",
           "type": "string",
-          "title": "Project GUID",
+          "title": "project guid",
           "default": "",
           "pattern": "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
         }
@@ -2800,7 +2800,7 @@
         "engine": {
           "$id": "/properties/require/properties/engine",
           "type": "string",
-          "title": "Engine version",
+          "title": "engine version",
           "description": "This indicates which engine version will be used",
           "default": "",
           "examples": ["engine-5.4"],
@@ -2822,7 +2822,7 @@
               "path": {
                 "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
-                "title": "Plugin name",
+                "title": "plugin name",
                 "description": "Required plugin's name",
                 "examples": [
                   "CryDefaultEntities",
@@ -2838,7 +2838,7 @@
               "type": {
                 "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
-                "title": "Plugin type",
+                "title": "plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
                 "default": "",
                 "examples": ["EPluginType::Native", "EPluginType::Managed"],
@@ -2850,7 +2850,7 @@
                 "items": {
                   "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
-                  "title": "This plugin will be used only by these platforms",
+                  "title": "this plugin will be used only by these platforms",
                   "default": "",
                   "examples": ["PS4"],
                   "enum": ["pc", "ps4", "xboxone", "linux"]
@@ -2873,7 +2873,7 @@
     "version": {
       "$id": "/properties/version",
       "type": "integer",
-      "title": "Project version",
+      "title": "project version",
       "default": 1,
       "examples": [1]
     },
@@ -2892,7 +2892,7 @@
           "value": {
             "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
-            "title": "Value of the command",
+            "title": "value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",
             "default": ""
           }
@@ -2902,6 +2902,6 @@
     }
   },
   "required": ["content", "info", "require", "version"],
-  "title": "CryProj schema",
+  "title": "cryproj schema",
   "type": "object"
 }

--- a/src/schemas/json/csscomb.json
+++ b/src/schemas/json/csscomb.json
@@ -122,6 +122,6 @@
       "type": "string"
     }
   },
-  "title": "A CSS Comb config schema",
+  "title": "a css comb config schema",
   "type": "object"
 }

--- a/src/schemas/json/csslintrc.json
+++ b/src/schemas/json/csslintrc.json
@@ -101,6 +101,6 @@
       "$ref": "#/definitions/rule"
     }
   },
-  "title": "JSON schema for CSS Lint configuration files",
+  "title": "json schema for css lint configuration files",
   "type": "object"
 }

--- a/src/schemas/json/dart-build.json
+++ b/src/schemas/json/dart-build.json
@@ -129,7 +129,7 @@
         },
         "target": {
           "type": "string",
-          "title": "The name of the dart_library target that contains the import",
+          "title": "the name of the dart_library target that contains the import",
           "deprecated": true,
           "deprecationMessage": "May be null or unreliable and should not be used."
         }
@@ -237,7 +237,7 @@
     },
     "builderOptions": {
       "type": "object",
-      "title": "Options to apply to a builder",
+      "title": "options to apply to a builder",
       "description": "An arbitrary Map<String, dynamic> of configuration options exposed by the individual builders. See the documentation for the builder you are configuring for guidance.",
       "additionalProperties": true
     },
@@ -253,13 +253,13 @@
     },
     "targetKey": {
       "type": "string",
-      "title": "An identifier for a target",
+      "title": "an identifier for a target",
       "description": "A target key has two parts, a package and a name. They are separated by a colon.",
       "pattern": "^(?:\\w+:)?\\w+|\\$default$"
     },
     "builderKey": {
       "type": "string",
-      "title": "An identifier for a builder",
+      "title": "an identifier for a builder",
       "description": "To construct a key, you join the package name and the builder name with a colon.",
       "pattern": "^(?:\\w*:)?\\w+$"
     },

--- a/src/schemas/json/dart-test.json
+++ b/src/schemas/json/dart-test.json
@@ -8,19 +8,19 @@
       "oneOf": [
         {
           "enum": ["none"],
-          "title": "No timeout",
+          "title": "no timeout",
           "description": "Indicates that tests should never time out."
         },
         {
           "type": "string",
-          "title": "Exact timeout",
+          "title": "exact timeout",
           "description": "Exact timeout duration for a test.",
           "pattern": "^(?:[^a-df-zA-DF-Z\\s]+(?:[umUM][sS]|[dhmsDHMS])\\s?)+$",
           "examples": ["1m", "30s", "1m 30s"]
         },
         {
           "type": "string",
-          "title": "Multiplicative timeout",
+          "title": "multiplicative timeout",
           "description": "Timeout is applied as a multiple of the default value (30 seconds)",
           "pattern": "^[^a-df-zA-DF-Z\\s]+[xX]$",
           "examples": ["12x", "1.5X"]
@@ -31,11 +31,11 @@
       "oneOf": [
         {
           "type": "boolean",
-          "title": "Skip the test if true"
+          "title": "skip the test if true"
         },
         {
           "type": "string",
-          "title": "Reason for skipping the test"
+          "title": "reason for skipping the test"
         }
       ]
     },
@@ -45,12 +45,12 @@
     },
     "browserAndNodeSettings": {
       "type": "object",
-      "title": "Settings for browsers and Node.js",
+      "title": "settings for browsers and node.js",
       "additionalProperties": false,
       "properties": {
         "arguments": {
           "type": "string",
-          "title": "Extra arguments to the executable",
+          "title": "extra arguments to the executable",
           "description": "The arguments are parsed in the same way as the POSIX shell"
         },
         "executable": {
@@ -77,7 +77,7 @@
         },
         "headless": {
           "type": "boolean",
-          "title": "Run the browser in headless mode"
+          "title": "run the browser in headless mode"
         }
       }
     },
@@ -118,18 +118,18 @@
         },
         "verbose_trace": {
           "type": "boolean",
-          "title": "Remove internal stack frames",
+          "title": "remove internal stack frames",
           "description": "This field controls whether or not traces caused by errors are trimmed to remove internal stack frames. This includes frames from the Dart core libraries, the stack_trace package, and the test package itself.",
           "default": false
         },
         "chain_stack_traces": {
           "type": "boolean",
-          "title": "Whether stack traces are chained",
+          "title": "whether stack traces are chained",
           "description": "Disabling stack trace chaining will improve performance for heavily async code at the cost of debuggability."
         },
         "js_trace": {
           "type": "boolean",
-          "title": "Convert JS traces to Dart traces",
+          "title": "convert js traces to dart traces",
           "description": "Whether or not stack traces caused by errors while running Dart compiled to JS are converted back to Dart style.",
           "default": false
         },

--- a/src/schemas/json/datalogic-scan2deploy-android.json
+++ b/src/schemas/json/datalogic-scan2deploy-android.json
@@ -7,12 +7,12 @@
     "layout": {
       "$id": "#/properties/layout",
       "type": "object",
-      "title": "Layout Schema",
+      "title": "layout schema",
       "properties": {
         "description": {
           "$id": "#/properties/layout/properties/description",
           "type": "string",
-          "title": "Description Schema",
+          "title": "description schema",
           "default": "none",
           "examples": ["This is for our Android devices"],
           "maxLength": 350
@@ -20,7 +20,7 @@
         "enroll": {
           "$id": "#/properties/layout/properties/enroll",
           "type": "boolean",
-          "title": "Enroll Schema",
+          "title": "enroll schema",
           "default": false,
           "examples": [true]
         }
@@ -29,13 +29,13 @@
     "padlock": {
       "$id": "#/properties/padlock",
       "type": "object",
-      "title": "Padlock Schema",
+      "title": "padlock schema",
       "description": "Section used to configure the staging locking feature",
       "properties": {
         "valid-until": {
           "$id": "#/properties/padlock/properties/valid-until",
           "type": "string",
-          "title": "Valid-Until Schema",
+          "title": "valid-until schema",
           "description": "Specifies the expiration date of the barcode sequence. Device date must be synchronized/configured for expiration date to work properly.",
           "default": "20991231235959",
           "examples": ["20991231235959"]
@@ -43,7 +43,7 @@
         "key": {
           "$id": "#/properties/padlock/properties/key",
           "type": "string",
-          "title": "Key Schema",
+          "title": "key schema",
           "description": "Padlock key to be used. If value doesn't match the device, the barcode is rejected. Empty string means no key.",
           "default": "",
           "examples": ["ihavenomouthandimustscream"]
@@ -52,7 +52,7 @@
           "$id": "#/properties/padlock/properties/state",
           "type": "string",
           "enum": ["locked", "unlocked"],
-          "title": "State Schema",
+          "title": "state schema",
           "description": "Configures the padlock state",
           "default": "undefined",
           "examples": ["locked"]
@@ -60,7 +60,7 @@
         "hide-from-launcher": {
           "$id": "#/properties/padlock/properties/hide-from-launcher",
           "type": "boolean",
-          "title": "Hide-From-Launcher Schema",
+          "title": "hide-from-launcher schema",
           "description": "Indicates if Scan2Deploy should be disabled after staging is complete. Once disabled, factory reset required to reenable.",
           "default": false,
           "examples": [false]
@@ -70,34 +70,34 @@
     "global": {
       "$id": "#/properties/global",
       "type": "object",
-      "title": "Global Schema",
+      "title": "global schema",
       "description": "Section used to configure application scoped settings",
       "properties": {
         "target-path": {
           "$id": "#/properties/global/properties/target-path",
           "type": "string",
-          "title": "Target-Path Schema",
+          "title": "target-path schema",
           "description": "Base destination folder where any archive/fill will be inflated/written. Default is device internal SD-card root",
           "examples": ["/mnt/sdcard/airwatch"]
         },
         "install-path": {
           "$id": "#/properties/global/properties/install-path",
           "type": "string",
-          "title": "Install-Path Schema",
+          "title": "install-path schema",
           "description": "Folder where the application expects auto-installed/auto-updated APKs to be found. Default is value specified in 'target path'.",
           "examples": ["/mnt/sdcard/airwatch"]
         },
         "update-path": {
           "$id": "#/properties/global/properties/update-path",
           "type": "string",
-          "title": "Update-Path Schema",
+          "title": "update-path schema",
           "description": "Folder where the application expects auto-updated OTA packages to be found. Default is value specified in 'target path'.",
           "examples": ["/mnt/sdcard/airwatch"]
         },
         "purge-target-path": {
           "$id": "#/properties/global/properties/purge-target-path",
           "type": "boolean",
-          "title": "Purge-Target-Path Schema",
+          "title": "purge-target-path schema",
           "description": "Indicates if target specified in 'target-path' needs to be purged (deleted) prior to inflation of the deployment archive",
           "default": true,
           "examples": [true]
@@ -105,7 +105,7 @@
         "auto-scan": {
           "$id": "#/properties/global/properties/auto-scan",
           "type": "boolean",
-          "title": "Auto-Scan Schema",
+          "title": "auto-scan schema",
           "description": "Enables/Disables the auto-update of APKs and OTA packages",
           "default": false,
           "examples": [true]
@@ -113,7 +113,7 @@
         "download-preinstalled": {
           "$id": "#/properties/global/properties/download-preinstalled",
           "type": "boolean",
-          "title": "Download-Preinstalled Schema",
+          "title": "download-preinstalled schema",
           "description": "Used to force the downgrade of pre-installed application (even System app), if required",
           "default": false,
           "examples": [false]
@@ -121,12 +121,12 @@
         "script": {
           "$id": "#/properties/global/properties/script",
           "type": ["string", "array"],
-          "title": "Script Schema",
+          "title": "script schema",
           "description": "A string specifying the absolute/relative path of a file, or a JSON array of strings describing the file content line-by-line. The script file will be interpreted last in staging process.",
           "items": {
             "$id": "#/properties/global/properties/script/items",
             "type": "string",
-            "title": "Items Schema",
+            "title": "items schema",
             "default": "",
             "examples": [
               "[Install]",
@@ -148,7 +148,7 @@
             "factory-reset",
             "reset"
           ],
-          "title": "Action Schema",
+          "title": "action schema",
           "description": "Specifies the final action performed by the application at the end of the staging process.",
           "default": "none",
           "examples": ["close"]
@@ -156,7 +156,7 @@
         "backup-to-enterprise": {
           "$id": "#/properties/global/properties/backup-to-enterprise",
           "type": "boolean",
-          "title": "Backup-To-Enterprise Schema",
+          "title": "backup-to-enterprise schema",
           "description": "Activates the enterprise backup persistence for the staging data, resulting in both the staging script and archive being copied to the enterprise partition",
           "default": false,
           "examples": [true]
@@ -166,13 +166,13 @@
     "settings": {
       "$id": "#/properties/settings",
       "type": "object",
-      "title": "Settings Schema",
+      "title": "settings schema",
       "description": "Section used to control inner device settings that typically need to be changed from the Android defaults",
       "properties": {
         "date-time": {
           "$id": "#/properties/settings/properties/date-time",
           "type": "string",
-          "title": "Date-Time Schema",
+          "title": "date-time schema",
           "description": "String representation in RFC-1123 format of the date to be set",
           "default": "null",
           "examples": ["Thu, 19 Apr 2018 07:51:37 GMT"]
@@ -180,7 +180,7 @@
         "auto-time": {
           "$id": "#/properties/settings/properties/auto-time",
           "type": "boolean",
-          "title": "Auto-Time Schema",
+          "title": "auto-time schema",
           "description": "Controls the 'Date & Time' automatic date-time adjustment setting",
           "default": true,
           "examples": [false]
@@ -188,7 +188,7 @@
         "auto-time-zone": {
           "$id": "#/properties/settings/properties/auto-time-zone",
           "type": "boolean",
-          "title": "Auto-Time-Zone Schema",
+          "title": "auto-time-zone schema",
           "description": "Controls the 'Date & Time' automatic time-zone adjustment setting",
           "default": true,
           "examples": [false]
@@ -196,7 +196,7 @@
         "auto-time-server": {
           "$id": "#/properties/settings/properties/auto-time-server",
           "type": "string",
-          "title": "Auto-Time-Server Schema",
+          "title": "auto-time-server schema",
           "description": "Address of the NTP server to be used for date-time synchronization",
           "default": "null",
           "examples": ["pool.ntp.org"]
@@ -204,7 +204,7 @@
         "debug-bridge": {
           "$id": "#/properties/settings/properties/debug-bridge",
           "type": "boolean",
-          "title": "Debug-Bridge Schema",
+          "title": "debug-bridge schema",
           "description": "Controls the state of 'Android Debug Bridge'",
           "default": true,
           "examples": [false]
@@ -212,7 +212,7 @@
         "lock-screen": {
           "$id": "#/properties/settings/properties/lock-screen",
           "type": "boolean",
-          "title": " Lock-Screen Schema",
+          "title": " lock-screen schema",
           "description": "Controls the state of Android's lock-screen, requiring the user to swipe the display to unlock the device",
           "default": true,
           "examples": [false]
@@ -220,7 +220,7 @@
         "status-bar": {
           "$id": "#/properties/settings/properties/status-bar",
           "type": "boolean",
-          "title": "Status-Bar Schema",
+          "title": "status-bar schema",
           "description": "Controls the display of the top status-bar. Note: hiding the status-bar will make notification disappear.",
           "default": true,
           "examples": [false]
@@ -228,7 +228,7 @@
         "navigation-bar": {
           "$id": "#/properties/settings/properties/navigation-bar",
           "type": "boolean",
-          "title": "Navigation-Bar Schema",
+          "title": "navigation-bar schema",
           "description": "Controls the display of the bottom navigation-bar",
           "default": true,
           "examples": [true]
@@ -236,7 +236,7 @@
         "charge-threshold": {
           "$id": "#/properties/settings/properties/charge-threshold",
           "type": "integer",
-          "title": "Charge-Threshold Schema",
+          "title": "charge-threshold schema",
           "description": "Indicates the charge threshold a battery exhausted device needs to reach to automatically boot when recharging",
           "default": 5,
           "examples": [0],
@@ -247,7 +247,7 @@
           "$id": "#/properties/settings/properties/usb-profile",
           "type": "string",
           "enum": ["NONE", "BOTH", "DATA", "CHARGE"],
-          "title": "Usb-Profile Schema",
+          "title": "usb-profile schema",
           "description": "USB communication profile in use",
           "default": "BOTH",
           "examples": ["NONE"]
@@ -256,7 +256,7 @@
           "$id": "#/properties/settings/properties/usb-function",
           "type": "string",
           "enum": ["MTP", "PTP", "CHARGING"],
-          "title": "Usb-Function Schema",
+          "title": "usb-function schema",
           "description": "USB communication function in use",
           "default": "CHARGING",
           "examples": ["CHARGING"]
@@ -266,13 +266,13 @@
     "network": {
       "$id": "#/properties/network",
       "type": "object",
-      "title": "Network Schema",
+      "title": "network schema",
       "description": "Section used to configure the device Wi-Fi network",
       "properties": {
         "essid": {
           "$id": "#/properties/network/properties/essid",
           "type": "string",
-          "title": "Essid Schema",
+          "title": "essid schema",
           "description": "Wireless network ESSID",
           "default": "tsunami",
           "examples": ["TESTTKIP"]
@@ -280,7 +280,7 @@
         "hidden": {
           "$id": "#/properties/network/properties/hidden",
           "type": "boolean",
-          "title": "Hidden Schema",
+          "title": "hidden schema",
           "description": "Indicates if the wireless network is using a hidden ESSID",
           "default": false,
           "examples": [false]
@@ -297,7 +297,7 @@
             "wpa-eap",
             "wpa2-eap"
           ],
-          "title": "Mode Schema",
+          "title": "mode schema",
           "description": "Wireless connection mode",
           "default": "open",
           "examples": ["wpa-psk"]
@@ -305,7 +305,7 @@
         "mode-key": {
           "$id": "#/properties/network/properties/mode-key",
           "type": "string",
-          "title": "Mode-Key Schema",
+          "title": "mode-key schema",
           "description": "Wireless network key, if needed",
           "default": "",
           "examples": ["datalogic"]
@@ -313,7 +313,7 @@
         "mode-key-encrypted": {
           "$id": "#/properties/network/properties/mode-key-encrypted",
           "type": "boolean",
-          "title": "Mode-Key-Encrypted Schema",
+          "title": "mode-key-encrypted schema",
           "description": "Indicates if 'mode-key' is written in plain-text or encrypted with a custom encryption algorithm",
           "default": false,
           "examples": [false]
@@ -331,7 +331,7 @@
             "aka",
             "aka-prime"
           ],
-          "title": "Eap-Method Schema",
+          "title": "eap-method schema",
           "description": "Configures the EAP authentication method",
           "default": "none",
           "examples": ["none"]
@@ -340,7 +340,7 @@
           "$id": "#/properties/network/properties/eap-phase2",
           "type": "string",
           "enum": ["none", "pap", "mschap", "mschapv2", "gtc"],
-          "title": "Eap-Phase2 Schema",
+          "title": "eap-phase2 schema",
           "description": "Configures the EAP phase 2 authentication method",
           "default": "none",
           "examples": ["none"]
@@ -348,7 +348,7 @@
         "eap-identity": {
           "$id": "#/properties/network/properties/eap-identity",
           "type": "string",
-          "title": "Eap-Identity Schema",
+          "title": "eap-identity schema",
           "description": "Indicates the EAP identity",
           "default": "",
           "examples": [""]
@@ -356,7 +356,7 @@
         "eap-anonymous-identity": {
           "$id": "#/properties/network/properties/eap-anonymous-identity",
           "type": "string",
-          "title": "Eap-Anonymous-Identity Schema",
+          "title": "eap-anonymous-identity schema",
           "description": "Indicates the EAP anonymous identity, used as the unencrypted identity with certain EAP types",
           "default": "",
           "examples": [""]
@@ -364,7 +364,7 @@
         "eap-password": {
           "$id": "#/properties/network/properties/eap-password",
           "type": "string",
-          "title": "Eap-Password Schema",
+          "title": "eap-password schema",
           "description": "EAP password, if needed",
           "default": "",
           "examples": [""]
@@ -372,7 +372,7 @@
         "eap-password-encrypted": {
           "$id": "#/properties/network/properties/eap-password-encrypted",
           "type": "boolean",
-          "title": "Eap-Password-Encrypted Schema",
+          "title": "eap-password-encrypted schema",
           "description": "Indicates if the 'eap-password' is encrypted with a custom encryption algorithm",
           "default": false,
           "examples": [false]
@@ -380,7 +380,7 @@
         "eap-certificate": {
           "$id": "#/properties/network/properties/eap-certificate",
           "type": "string",
-          "title": "Eap-Certificate Schema",
+          "title": "eap-certificate schema",
           "description": "Base64 representation of the EAP certificate to use",
           "default": "",
           "examples": [""]
@@ -388,7 +388,7 @@
         "proxy-host": {
           "$id": "#/properties/network/properties/proxy-host",
           "type": "string",
-          "title": "Proxy-Host Schema",
+          "title": "proxy-host schema",
           "description": "Server name or IP address of the proxy to be used for HTTP/HTTPS communications",
           "default": "",
           "examples": [""]
@@ -396,7 +396,7 @@
         "proxy-port": {
           "$id": "#/properties/network/properties/proxy-port",
           "type": "integer",
-          "title": "Proxy-Port Schema",
+          "title": "proxy-port schema",
           "description": "Server IP port of the proxy for HTTP/HTTPS communications",
           "default": 0,
           "examples": [0],
@@ -406,7 +406,7 @@
         "purge": {
           "$id": "#/properties/network/properties/purge",
           "type": "boolean",
-          "title": "Purge Schema",
+          "title": "purge schema",
           "description": "Indicates if any currently configured wireless network needs to be removed. Can be useful to avoid profile roaming.",
           "default": true,
           "examples": [true]
@@ -414,7 +414,7 @@
         "reconfigure": {
           "$id": "#/properties/network/properties/reconfigure",
           "type": "boolean",
-          "title": "Reconfigure Schema",
+          "title": "reconfigure schema",
           "description": "If true, will reconfigure any existing and matching network. If false, will leave existing network untouched. Setting used when 'purge' is set to false.",
           "default": true,
           "examples": [false]
@@ -422,7 +422,7 @@
         "sleep-policy": {
           "$id": "#/properties/network/properties/sleep-policy",
           "type": "integer",
-          "title": "Sleep-Policy Schema",
+          "title": "sleep-policy schema",
           "description": "Wireless sleep policy for Android's Settings.Global parameter (0-WIFI_SLEEP_POLICY_DEFAULT, 1-WIFI_SLEEP_POLICY_NEVER_WHILE_PLUGGED, 2-WIFI_SLEEP_POLICY_NEVER)",
           "default": 2,
           "examples": [2],
@@ -433,7 +433,7 @@
           "$id": "#/properties/network/properties/frequency-band",
           "type": "string",
           "enum": ["auto", "5ghz", "2ghz"],
-          "title": "Frequency-Band Schema",
+          "title": "frequency-band schema",
           "description": "Controls the frequency bands supported by the device",
           "default": "auto",
           "examples": ["auto"]
@@ -441,7 +441,7 @@
         "save-to-file": {
           "$id": "#/properties/network/properties/save-to-file",
           "type": "string",
-          "title": "Save-To-File Schema",
+          "title": "save-to-file schema",
           "description": "Absolute path to the file where the current network configuration will be saved, empty string indicates network configuration won't be serialized to a file",
           "default": "",
           "examples": [""]
@@ -449,7 +449,7 @@
         "ephemeral": {
           "$id": "#/properties/network/properties/ephemeral",
           "type": "boolean",
-          "title": "Ephemeral Schema",
+          "title": "ephemeral schema",
           "description": "If true, wireless connection profile will be used during staging process, then deleted after staging. If false, wireless connection profile will still be present after staging process.",
           "default": true,
           "examples": [false]
@@ -457,7 +457,7 @@
         "wait-for-connection": {
           "$id": "#/properties/network/properties/wait-for-connection",
           "type": "boolean",
-          "title": "Wait-For-Connection Schema",
+          "title": "wait-for-connection schema",
           "description": "Indicates whether a valid Wi-Fi connection has to be waited once the network configuration is complete. Can be useful when device needs to be configured but a valid Wi-Fi connection is not ready yet.",
           "default": true,
           "examples": [true]
@@ -477,14 +477,14 @@
     "deployment": {
       "$id": "#/properties/deployment",
       "type": "object",
-      "title": "Deployment Schema",
+      "title": "deployment schema",
       "description": "Section can be used to download a ZIP archive from a server and inflate it to the 'target-path' folder",
       "properties": {
         "scheme": {
           "$id": "#/properties/deployment/properties/scheme",
           "type": "string",
           "enum": ["http", "https"],
-          "title": "Scheme Schema",
+          "title": "scheme schema",
           "description": "Deployment download scheme to use",
           "default": "http",
           "examples": ["http"]
@@ -492,14 +492,14 @@
         "host": {
           "$id": "#/properties/deployment/properties/host",
           "type": "string",
-          "title": "Host Schema",
+          "title": "host schema",
           "description": "Host-name or internet-protocol address of the server from which the resource is to be fetched",
           "examples": ["172.19.0.77"]
         },
         "port": {
           "$id": "#/properties/deployment/properties/port",
           "type": "integer",
-          "title": "Port Schema",
+          "title": "port schema",
           "description": "TCP/IP port to be used to contact the server",
           "default": 80,
           "examples": [8080],
@@ -509,7 +509,7 @@
         "path": {
           "$id": "#/properties/deployment/properties/path",
           "type": "string",
-          "title": "Path Schema",
+          "title": "path schema",
           "description": "Path to the server resource to download, complete with query string if needed",
           "default": "",
           "examples": ["/airwatch.zip"]
@@ -517,7 +517,7 @@
         "fetch-timeout": {
           "$id": "#/properties/deployment/properties/fetch-timeout",
           "type": "integer",
-          "title": "Fetch-Timeout Schema",
+          "title": "fetch-timeout schema",
           "description": "The timeout value used when fetching resource from host",
           "default": 60000,
           "examples": [60000]
@@ -525,7 +525,7 @@
         "check-timeout": {
           "$id": "#/properties/deployment/properties/check-timeout",
           "type": "integer",
-          "title": "Check-Timeout Schema",
+          "title": "check-timeout schema",
           "description": "The timeout value used when attempting to reach the host server",
           "default": 1000,
           "examples": [1000]
@@ -533,7 +533,7 @@
         "working-archive": {
           "$id": "#/properties/deployment/properties/working-archive",
           "type": "string",
-          "title": "Working-Archive Schema",
+          "title": "working-archive schema",
           "description": "String representation of the archive path-file name, once downloaded",
           "default": "/mnt/sdcard/scan2deploy.archive",
           "examples": ["/mnt/sdcard/target.zip"]
@@ -541,7 +541,7 @@
         "skip-inflation": {
           "$id": "#/properties/deployment/properties/skip-inflation",
           "type": "boolean",
-          "title": "Skip-Inflation Schema",
+          "title": "skip-inflation schema",
           "description": "Instructs the application not to inflate the deployment archive once downloaded, can be useful to speed the OTA update process up",
           "default": false,
           "examples": [true]
@@ -552,25 +552,25 @@
     "blobs": {
       "$id": "#/properties/blobs",
       "type": "array",
-      "title": "Blobs Schema",
+      "title": "blobs schema",
       "description": "Section used to transfer binary data to newly created file on device",
       "items": {
         "$id": "#/properties/blobs/items",
         "type": "object",
-        "title": "Items Schema",
+        "title": "items schema",
         "required": ["file", "content"],
         "properties": {
           "file": {
             "$id": "#/properties/blobs/items/properties/file",
             "type": "string",
-            "title": "File Schema",
+            "title": "file schema",
             "description": "Path to the file to be created. Can be either absolute or relative to the global/target-path parameter value. During file de-serialization, any required (parent) path is automatically created.",
             "examples": ["/mnt/sdcard/airwatch/credentials.bin"]
           },
           "content": {
             "$id": "#/properties/blobs/items/properties/content",
             "type": "string",
-            "title": "Content Schema",
+            "title": "content schema",
             "description": "Base64 representation of the actual file content",
             "examples": [
               "fd09B1iL/k4jRWrjrP0/sO44teY+B3UafBLsMsCEqd1KOv6b6JYBXLVv70FmHdZhIVoEOQvHu7O4PUJStpZQ+4PYjPqCO+NQr81M7GOF421Ke8L2u4EYyqDE5qXfLy2shEgaRwRpr2f35/38WZkh6edyiWZQJjyLeZcuI7WiaJPpw7Jcw7ye7mb7Rl+ePNFmfvUrpeRFtN+5kUsx/SbB1v0gDyOOuoep"
@@ -580,6 +580,6 @@
       }
     }
   },
-  "title": "Android-Scan2Deploy Schema",
+  "title": "android-scan2deploy schema",
   "type": "object"
 }

--- a/src/schemas/json/datalogic-scan2deploy-ce.json
+++ b/src/schemas/json/datalogic-scan2deploy-ce.json
@@ -7,12 +7,12 @@
     "layout": {
       "$id": "#/properties/layout",
       "type": "object",
-      "title": "Layout Schema",
+      "title": "layout schema",
       "properties": {
         "description": {
           "$id": "#/properties/layout/properties/description",
           "type": "string",
-          "title": "Description Schema",
+          "title": "description schema",
           "default": "none",
           "examples": ["This is for our WEC7 devices"],
           "maxLength": 350
@@ -22,13 +22,13 @@
     "global": {
       "$id": "#/properties/global",
       "type": "object",
-      "title": "Global-Section Schema",
+      "title": "global-section schema",
       "description": "Section used to configure application scoped settings",
       "properties": {
         "target-path": {
           "$id": "#/properties/global/properties/target-path",
           "type": "string",
-          "title": "Target-Path Schema",
+          "title": "target-path schema",
           "description": "Base destination folder where archive/folder will be inflated",
           "default": "\\FlashDisk",
           "examples": ["\\FlashDisk"]
@@ -37,7 +37,7 @@
           "$id": "#/properties/global/properties/action",
           "type": "string",
           "enum": ["stay", "close", "warm-boot", "cold-boot", "clean-boot"],
-          "title": "Action Schema",
+          "title": "action schema",
           "description": "Specifies final action performed by the application at the end of the staging process",
           "default": "cold-boot",
           "examples": ["warm-boot"]
@@ -45,7 +45,7 @@
         "ping-timeout": {
           "$id": "#/properties/global/properties/ping-timeout",
           "type": "integer",
-          "title": "Ping-Timeout Schema",
+          "title": "ping-timeout schema",
           "description": "The timeout value used when attempting to reach the host server",
           "default": 1000,
           "examples": [1000],
@@ -57,7 +57,7 @@
     "settings": {
       "$id": "#/properties/settings",
       "type": "object",
-      "title": "Settings-Section Schema",
+      "title": "settings-section schema",
       "description": "Section used to configure inner device settings",
       "properties": {
         "usb-function": {
@@ -69,7 +69,7 @@
             "usblan",
             "mass-storage"
           ],
-          "title": "USB-Function Schema",
+          "title": "usb-function schema",
           "description": "USB communication function to use",
           "default": "active-sync-usb",
           "examples": ["usblan"]
@@ -79,13 +79,13 @@
     "network": {
       "$id": "#/properties/network",
       "type": "object",
-      "title": "Network-Section Schema",
+      "title": "network-section schema",
       "description": "Section used to configure device Wi-Fi network",
       "properties": {
         "profile": {
           "$id": "#/properties/network/properties/profile",
           "type": "string",
-          "title": "Profile Schema",
+          "title": "profile schema",
           "description": "\"Friendly\" name to associate with the network connection",
           "default": "datalogic",
           "examples": ["my_fast"]
@@ -93,7 +93,7 @@
         "essid": {
           "$id": "#/properties/network/properties/essid",
           "type": "string",
-          "title": "Essid Schema",
+          "title": "essid schema",
           "description": "Wireless network ESSID",
           "default": "tsunami",
           "examples": ["eapfast"]
@@ -110,7 +110,7 @@
             "wpa-tkip",
             "wpa2-aes"
           ],
-          "title": "Mode Schema",
+          "title": "mode schema",
           "description": "Wireless connection mode",
           "default": "open",
           "examples": ["wpa2-aes"]
@@ -118,7 +118,7 @@
         "mode-key": {
           "$id": "#/properties/network/properties/mode-key",
           "type": "string",
-          "title": "Mode-Key Schema",
+          "title": "mode-key schema",
           "description": "Wireless network key for 'wep-40', 'wep-104', 'wpa-psk', and 'wpa2-psk' networks",
           "default": "",
           "examples": ["0123456789"],
@@ -128,7 +128,7 @@
         "index": {
           "$id": "#/properties/network/properties/index",
           "type": "integer",
-          "title": "Index Schema",
+          "title": "index schema",
           "description": "Wireless network key index for 'wep-40' and 'wep-104' networks",
           "default": 1,
           "examples": [1],
@@ -139,7 +139,7 @@
           "$id": "#/properties/network/properties/eap-method",
           "type": "string",
           "enum": ["none", "peap", "tls", "ttls", "fast", "leap"],
-          "title": "Eap-Method Schema",
+          "title": "eap-method schema",
           "description": "Configures the EAP authentication method",
           "default": "none",
           "examples": ["fast"]
@@ -147,7 +147,7 @@
         "eap-username": {
           "$id": "#/properties/network/properties/eap-username",
           "type": "string",
-          "title": "Eap-Username Schema",
+          "title": "eap-username schema",
           "description": "Username for the EAP method",
           "default": "",
           "examples": ["eapfast"]
@@ -155,7 +155,7 @@
         "eap-password": {
           "$id": "#/properties/network/properties/eap-password",
           "type": "string",
-          "title": "Eap-Password Schema",
+          "title": "eap-password schema",
           "description": "Password for EAP method",
           "default": "",
           "examples": ["1234567890"]
@@ -164,7 +164,7 @@
           "$id": "#/properties/network/properties/credentials-type",
           "type": "string",
           "enum": ["password", "token", "certificate", "unknown"],
-          "title": "Credentials-Type Schema",
+          "title": "credentials-type schema",
           "description": "Indicates the EAP credentials type",
           "default": "password",
           "examples": ["password"]
@@ -173,7 +173,7 @@
           "$id": "#/properties/network/properties/credentials-source",
           "type": "string",
           "enum": ["user", "logon", "profile", "auto", "unknown"],
-          "title": "Credentials-Source Schema",
+          "title": "credentials-source schema",
           "description": "Indicates the EAP credentials source",
           "default": "user",
           "examples": ["profile"]
@@ -181,7 +181,7 @@
         "validate-server": {
           "$id": "#/properties/network/properties/validate-server",
           "type": "boolean",
-          "title": "Validate-Server Schema",
+          "title": "validate-server schema",
           "description": "Indicates if the server certificate should be validated",
           "default": false,
           "examples": [false]
@@ -189,7 +189,7 @@
         "connect-to-server": {
           "$id": "#/properties/network/properties/connect-to-server",
           "type": "boolean",
-          "title": "Connect-To-Server Schema",
+          "title": "connect-to-server schema",
           "description": "Indicates if only the servers listed in the 'connect-to-server-names' list should be connected to",
           "default": false,
           "examples": [false]
@@ -197,7 +197,7 @@
         "connect-to-server-names": {
           "$id": "#/properties/network/properties/connect-to-server-names",
           "type": "string",
-          "title": "Connect-To-Server-Names Schema",
+          "title": "connect-to-server-names schema",
           "description": "Semi-colon separated list of servers that are valid to connect to during server certificate validation",
           "default": "",
           "examples": [""]
@@ -205,7 +205,7 @@
         "server-cert-name": {
           "$id": "#/properties/network/properties/server-cert-name",
           "type": "string",
-          "title": "Server-Cert-Name Schema",
+          "title": "server-cert-name schema",
           "description": "\"Friendly\" name of the server digital certificate that should be validated",
           "default": "",
           "examples": [""]
@@ -213,7 +213,7 @@
         "outer-identity": {
           "$id": "#/properties/network/properties/outer-identity",
           "type": "string",
-          "title": "Outer-Identity Schema",
+          "title": "outer-identity schema",
           "description": "The outer-identity of the EAP method",
           "default": "",
           "examples": [""]
@@ -221,7 +221,7 @@
         "fast-reconnect": {
           "$id": "#/properties/network/properties/fast-reconnect",
           "type": "boolean",
-          "title": "Fast-Reconnect Schema",
+          "title": "fast-reconnect schema",
           "description": "Indicate if fast reconnect should be enabled",
           "default": false,
           "examples": [false]
@@ -230,7 +230,7 @@
           "$id": "#/properties/network/properties/inner-method",
           "type": "string",
           "enum": ["eap-tls", "eap-MsChapV2", "eap-gtc"],
-          "title": "Inner-Method Schema",
+          "title": "inner-method schema",
           "description": "Inner EAP authentication method to use",
           "default": "eap-tls",
           "examples": ["eap-MsChapV2"]
@@ -238,7 +238,7 @@
         "auto-pac": {
           "$id": "#/properties/network/properties/auto-pac",
           "type": "boolean",
-          "title": "Auto-Pac Schema",
+          "title": "auto-pac schema",
           "description": "Indicates if automatic PAC provisioning is used for an EAP-FAST network",
           "default": false,
           "examples": [true]
@@ -246,7 +246,7 @@
         "pac-file-path": {
           "$id": "#/properties/network/properties/pac-file-path",
           "type": "string",
-          "title": "Pac-File-Path Schema",
+          "title": "pac-file-path schema",
           "description": "Full path to the PAC file for manual PAC provisioning",
           "default": "",
           "examples": [""]
@@ -254,7 +254,7 @@
         "pac-aid-info": {
           "$id": "#/properties/network/properties/pac-aid-info",
           "type": "string",
-          "title": "Pac-Aid-Info Schema",
+          "title": "pac-aid-info schema",
           "description": "PAC authority identity (AID) information used to select PAC from a list of PACs on the device",
           "default": "",
           "examples": [""]
@@ -274,14 +274,14 @@
     "deployment": {
       "$id": "#/properties/deployment",
       "type": "object",
-      "title": "Deployment-Section Schema",
+      "title": "deployment-section schema",
       "description": "Section used to download a ZIP archive from a server and inflate it to the 'target-path' folder",
       "properties": {
         "scheme": {
           "$id": "#/properties/deployment/properties/scheme",
           "type": "string",
           "enum": ["http", "https"],
-          "title": "Scheme Schema",
+          "title": "scheme schema",
           "description": "Deployment download scheme to use",
           "default": "http",
           "examples": ["http"]
@@ -289,7 +289,7 @@
         "host": {
           "$id": "#/properties/deployment/properties/host",
           "type": "string",
-          "title": "Host Schema",
+          "title": "host schema",
           "description": "Host name or internet protocol address of the server from which the resource is to be fetched",
           "default": "",
           "examples": ["10.1.20.123"]
@@ -297,7 +297,7 @@
         "port": {
           "$id": "#/properties/deployment/properties/port",
           "type": "integer",
-          "title": "Port Schema",
+          "title": "port schema",
           "description": "TCP/IP port to be used to contact the server",
           "default": 80,
           "examples": [8080],
@@ -307,7 +307,7 @@
         "path": {
           "$id": "#/properties/deployment/properties/path",
           "type": "string",
-          "title": "Path Schema",
+          "title": "path schema",
           "description": "Path to server resource to download, complete with query string if needed",
           "default": "",
           "examples": ["target.zip"]
@@ -318,25 +318,25 @@
     "shell": {
       "$id": "#/properties/shell",
       "type": "object",
-      "title": "Shell-Section Schema",
+      "title": "shell-section schema",
       "description": "Section for executable shell commands to be performed in the final staging phase",
       "required": ["cmds"],
       "properties": {
         "cmds": {
           "$id": "#/properties/shell/properties/cmds",
           "type": "array",
-          "title": "Cmds Schema",
+          "title": "cmds schema",
           "description": "Each object in 'cmds' is a shell command to execute in the final phase of staging",
           "items": {
             "$id": "#/properties/shell/properties/cmds/items",
             "type": "object",
-            "title": "Items Schema",
+            "title": "items schema",
             "required": ["app-name"],
             "properties": {
               "app-name": {
                 "$id": "#/properties/shell/properties/cmds/items/properties/app-name",
                 "type": "string",
-                "title": "App-Name Schema",
+                "title": "app-name schema",
                 "description": "Full path to the application to be executed",
                 "default": "",
                 "examples": ["\\windows\\dldxu.exe"]
@@ -344,7 +344,7 @@
               "args": {
                 "$id": "#/properties/shell/properties/cmds/items/properties/args",
                 "type": "string",
-                "title": "Args Schema",
+                "title": "args schema",
                 "description": "Command line arguments",
                 "default": "",
                 "examples": ["\\FlashDisk\\target\\config.dxu"]
@@ -355,6 +355,6 @@
       }
     }
   },
-  "title": "CE-Scan2Deploy Schema",
+  "title": "ce-scan2deploy schema",
   "type": "object"
 }

--- a/src/schemas/json/deadpendency.json
+++ b/src/schemas/json/deadpendency.json
@@ -213,6 +213,6 @@
       }
     }
   },
-  "title": "GitHub Deadpendency config",
+  "title": "github deadpendency config",
   "type": "object"
 }

--- a/src/schemas/json/debugsettings.json
+++ b/src/schemas/json/debugsettings.json
@@ -87,6 +87,6 @@
       }
     }
   },
-  "title": "JSON schema for the ASP.NET DebugSettings.json files.",
+  "title": "json schema for the asp.net debugsettings.json files.",
   "type": "object"
 }

--- a/src/schemas/json/dein.json
+++ b/src/schemas/json/dein.json
@@ -3,7 +3,7 @@
   "additionalProperties": false,
   "definitions": {
     "Plugin": {
-      "title": "Pattern for a definition of vim plugin",
+      "title": "pattern for a definition of vim plugin",
       "type": "object",
       "required": ["repo"],
       "additionalProperties": false,
@@ -423,7 +423,7 @@
       }
     },
     "MultiplePlugins": {
-      "title": "Pattern for multiple definition of vim plugin",
+      "title": "pattern for multiple definition of vim plugin",
       "type": "object",
       "required": ["plugins"],
       "additionalProperties": false,
@@ -544,7 +544,7 @@
   "description": "A schema for config of dein.vim (https://github.com/Shougo/dein.vim/blob/f93be8c/doc/dein.txt#L963)",
   "properties": {
     "plugins": {
-      "title": "Definition properties table for installing a vim plugin",
+      "title": "definition properties table for installing a vim plugin",
       "description": "Definition properties table for installing a vim plugin.\nIt is converted to |dein#add()|.",
       "type": "array",
       "items": {
@@ -597,7 +597,7 @@
       }
     },
     "multiple_plugins": {
-      "title": "It is converted to |dein-toml-hook_add|",
+      "title": "it is converted to |dein-toml-hook_add|",
       "description": "It is converted to |dein-toml-hook_add|\n\"plugins\" key is needed.",
       "type": "array",
       "items": {

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -331,7 +331,7 @@
     "updates": {
       "type": "array",
       "items": {
-        "title": "Package Ecosystem",
+        "title": "package ecosystem",
         "description": "Element for each one package manager that you want GitHub Dependabot to monitor for new versions",
         "$ref": "#/definitions/update"
       }
@@ -342,6 +342,6 @@
     }
   },
   "required": ["version", "updates"],
-  "title": "GitHub Dependabot v2 config",
+  "title": "github dependabot v2 config",
   "type": "object"
 }

--- a/src/schemas/json/dependabot.json
+++ b/src/schemas/json/dependabot.json
@@ -221,6 +221,6 @@
     }
   },
   "required": ["version", "update_configs"],
-  "title": "Dependabot configuration file",
+  "title": "dependabot configuration file",
   "type": "object"
 }

--- a/src/schemas/json/devinit.schema-1.0.json
+++ b/src/schemas/json/devinit.schema-1.0.json
@@ -7,7 +7,7 @@
       "required": ["tool"],
       "properties": {
         "tool": {
-          "title": "The tool name",
+          "title": "the tool name",
           "description": "The name of the tool to run.",
           "type": "string",
           "enum": [
@@ -41,7 +41,7 @@
           ]
         },
         "input": {
-          "title": "The tool input",
+          "title": "the tool input",
           "description": "The input varies by tool. For example, the required version number, the package-id, the input source file or source directory.",
           "anyOf": [
             {
@@ -53,7 +53,7 @@
           ]
         },
         "additionalOptions": {
-          "title": "Additional options",
+          "title": "additional options",
           "description": "Additional Options to be appended to the tool's command line.",
           "anyOf": [
             {
@@ -65,7 +65,7 @@
           ]
         },
         "comments": {
-          "title": "Comments",
+          "title": "comments",
           "description": "Comments for this tool item. For documentation only; ignored by the tool.",
           "anyOf": [
             {
@@ -85,7 +85,7 @@
       "type": "string"
     },
     "run": {
-      "title": "The list of tools to run",
+      "title": "the list of tools to run",
       "description": "'devinit.exe init' runs this list of tools sequentially. See also 'devinit.exe run'.",
       "items": {
         "allOf": [
@@ -101,7 +101,7 @@
       }
     },
     "comments": {
-      "title": "Comments",
+      "title": "comments",
       "description": "Comments for this file. For documentation only; ignored by the tool.",
       "anyOf": [
         {
@@ -114,6 +114,6 @@
     }
   },
   "required": ["run"],
-  "title": "Codespaces DevInit Configuration",
+  "title": "codespaces devinit configuration",
   "type": "object"
 }

--- a/src/schemas/json/devinit.schema-2.0.json
+++ b/src/schemas/json/devinit.schema-2.0.json
@@ -7,7 +7,7 @@
       "required": ["tool"],
       "properties": {
         "tool": {
-          "title": "The tool name",
+          "title": "the tool name",
           "description": "The name of the tool to run.",
           "type": "string",
           "enum": [
@@ -42,7 +42,7 @@
           ]
         },
         "input": {
-          "title": "The tool input",
+          "title": "the tool input",
           "description": "The input varies by tool. For example, the required version number, the package-id, the input source file or source directory.",
           "anyOf": [
             {
@@ -54,7 +54,7 @@
           ]
         },
         "additionalOptions": {
-          "title": "Additional options",
+          "title": "additional options",
           "description": "Additional Options to be appended to the tool's command line.",
           "anyOf": [
             {
@@ -66,7 +66,7 @@
           ]
         },
         "comments": {
-          "title": "Comments",
+          "title": "comments",
           "description": "Comments for this tool item. For documentation only; ignored by the tool.",
           "anyOf": [
             {
@@ -86,19 +86,19 @@
       "type": "string"
     },
     "run": {
-      "title": "The list of tools to run",
+      "title": "the list of tools to run",
       "description": "'devinit.exe init' runs this list of tools sequentially. See also 'devinit.exe run'.",
       "items": {
         "$ref": "#/definitions/runObject"
       }
     },
     "comments": {
-      "title": "Comments",
+      "title": "comments",
       "description": "Comments for this file. For documentation only; ignored by the tool.",
       "type": ["null", "string"]
     }
   },
   "required": ["run"],
-  "title": "Codespaces DevInit Configuration",
+  "title": "codespaces devinit configuration",
   "type": "object"
 }

--- a/src/schemas/json/devinit.schema-3.0.json
+++ b/src/schemas/json/devinit.schema-3.0.json
@@ -7,7 +7,7 @@
       "required": ["tool"],
       "properties": {
         "tool": {
-          "title": "The tool name",
+          "title": "the tool name",
           "description": "The name of the tool to run.",
           "type": "string",
           "enum": [
@@ -43,7 +43,7 @@
           ]
         },
         "input": {
-          "title": "The tool input",
+          "title": "the tool input",
           "description": "The input varies by tool. For example, the required version number, the package-id, the input source file or source directory.",
           "anyOf": [
             {
@@ -55,7 +55,7 @@
           ]
         },
         "additionalOptions": {
-          "title": "Additional options",
+          "title": "additional options",
           "description": "Additional Options to be appended to the tool's command line.",
           "anyOf": [
             {
@@ -67,7 +67,7 @@
           ]
         },
         "comments": {
-          "title": "Comments",
+          "title": "comments",
           "description": "Comments for this tool item. For documentation only; ignored by the tool.",
           "anyOf": [
             {
@@ -87,7 +87,7 @@
       "type": "string"
     },
     "run": {
-      "title": "The list of tools to run",
+      "title": "the list of tools to run",
       "description": "'devinit.exe init' runs this list of tools sequentially. See also 'devinit.exe run'.",
       "items": {
         "allOf": [
@@ -103,7 +103,7 @@
       }
     },
     "comments": {
-      "title": "Comments",
+      "title": "comments",
       "description": "Comments for this file. For documentation only; ignored by the tool.",
       "anyOf": [
         {
@@ -116,6 +116,6 @@
     }
   },
   "required": ["run"],
-  "title": "Codespaces DevInit Configuration",
+  "title": "codespaces devinit configuration",
   "type": "object"
 }

--- a/src/schemas/json/devinit.schema-4.0.json
+++ b/src/schemas/json/devinit.schema-4.0.json
@@ -7,7 +7,7 @@
       "required": ["tool"],
       "properties": {
         "tool": {
-          "title": "The tool name",
+          "title": "the tool name",
           "description": "The name of the tool to run.",
           "type": "string",
           "enum": [
@@ -45,7 +45,7 @@
           ]
         },
         "input": {
-          "title": "The tool input",
+          "title": "the tool input",
           "description": "The input varies by tool. For example, the required version number, the package-id, the input source file or source directory.",
           "anyOf": [
             {
@@ -57,7 +57,7 @@
           ]
         },
         "additionalOptions": {
-          "title": "Additional options",
+          "title": "additional options",
           "description": "Additional Options to be appended to the tool's command line.",
           "anyOf": [
             {
@@ -69,7 +69,7 @@
           ]
         },
         "comments": {
-          "title": "Comments",
+          "title": "comments",
           "description": "Comments for this tool item. For documentation only; ignored by the tool.",
           "anyOf": [
             {
@@ -89,7 +89,7 @@
       "type": "string"
     },
     "run": {
-      "title": "The list of tools to run",
+      "title": "the list of tools to run",
       "description": "'devinit.exe init' runs this list of tools sequentially. See also 'devinit.exe run'.",
       "items": {
         "allOf": [
@@ -105,7 +105,7 @@
       }
     },
     "comments": {
-      "title": "Comments",
+      "title": "comments",
       "description": "Comments for this file. For documentation only; ignored by the tool.",
       "anyOf": [
         {
@@ -118,6 +118,6 @@
     }
   },
   "required": ["run"],
-  "title": "Codespaces DevInit Configuration",
+  "title": "codespaces devinit configuration",
   "type": "object"
 }

--- a/src/schemas/json/devinit.schema-5.0.json
+++ b/src/schemas/json/devinit.schema-5.0.json
@@ -7,7 +7,7 @@
       "required": ["tool"],
       "properties": {
         "tool": {
-          "title": "The tool name",
+          "title": "the tool name",
           "description": "The name of the tool to run.",
           "type": "string",
           "enum": [
@@ -43,7 +43,7 @@
           ]
         },
         "input": {
-          "title": "The tool input",
+          "title": "the tool input",
           "description": "The input varies by tool. For example, the required version number, the package-id, the input source file or source directory.",
           "anyOf": [
             {
@@ -55,7 +55,7 @@
           ]
         },
         "additionalOptions": {
-          "title": "Additional options",
+          "title": "additional options",
           "description": "Additional Options to be appended to the tool's command line.",
           "anyOf": [
             {
@@ -67,7 +67,7 @@
           ]
         },
         "comments": {
-          "title": "Comments",
+          "title": "comments",
           "description": "Comments for this tool item. For documentation only; ignored by the tool.",
           "anyOf": [
             {
@@ -87,7 +87,7 @@
       "type": "string"
     },
     "run": {
-      "title": "The list of tools to run",
+      "title": "the list of tools to run",
       "description": "'devinit.exe init' runs this list of tools sequentially. See also 'devinit.exe run'.",
       "items": {
         "allOf": [
@@ -103,7 +103,7 @@
       }
     },
     "comments": {
-      "title": "Comments",
+      "title": "comments",
       "description": "Comments for this file. For documentation only; ignored by the tool.",
       "anyOf": [
         {
@@ -116,6 +116,6 @@
     }
   },
   "required": ["run"],
-  "title": "Codespaces DevInit Configuration",
+  "title": "codespaces devinit configuration",
   "type": "object"
 }

--- a/src/schemas/json/devinit.schema-6.0.json
+++ b/src/schemas/json/devinit.schema-6.0.json
@@ -7,7 +7,7 @@
       "required": ["tool"],
       "properties": {
         "tool": {
-          "title": "The tool name",
+          "title": "the tool name",
           "description": "The name of the tool to run.",
           "type": "string",
           "enum": [
@@ -45,7 +45,7 @@
           ]
         },
         "input": {
-          "title": "The tool input",
+          "title": "the tool input",
           "description": "The input varies by tool. For example, the required version number, the package-id, the input source file or source directory.",
           "anyOf": [
             {
@@ -57,7 +57,7 @@
           ]
         },
         "additionalOptions": {
-          "title": "Additional options",
+          "title": "additional options",
           "description": "Additional Options to be appended to the tool's command line.",
           "anyOf": [
             {
@@ -69,7 +69,7 @@
           ]
         },
         "comments": {
-          "title": "Comments",
+          "title": "comments",
           "description": "Comments for this tool item. For documentation only; ignored by the tool.",
           "anyOf": [
             {
@@ -89,7 +89,7 @@
       "type": "string"
     },
     "run": {
-      "title": "The list of tools to run",
+      "title": "the list of tools to run",
       "description": "'devinit.exe init' runs this list of tools sequentially. See also 'devinit.exe run'.",
       "items": {
         "allOf": [
@@ -105,7 +105,7 @@
       }
     },
     "comments": {
-      "title": "Comments",
+      "title": "comments",
       "description": "Comments for this file. For documentation only; ignored by the tool.",
       "anyOf": [
         {
@@ -118,6 +118,6 @@
     }
   },
   "required": ["run"],
-  "title": "Codespaces DevInit Configuration",
+  "title": "codespaces devinit configuration",
   "type": "object"
 }

--- a/src/schemas/json/docfx.json
+++ b/src/schemas/json/docfx.json
@@ -464,6 +464,6 @@
       "$ref": "#/definitions/buildConfig"
     }
   },
-  "title": "DocFx configuration file",
+  "title": "docfx configuration file",
   "type": "object"
 }

--- a/src/schemas/json/dockerd.json
+++ b/src/schemas/json/dockerd.json
@@ -467,6 +467,6 @@
       "type": "string"
     }
   },
-  "title": "Docker Daemon configuration schema",
+  "title": "docker daemon configuration schema",
   "type": "object"
 }

--- a/src/schemas/json/dotnet-releases-index.json
+++ b/src/schemas/json/dotnet-releases-index.json
@@ -33,7 +33,7 @@
       "properties": {
         "channel-version": {
           "type": "string",
-          "title": "ProductVersion",
+          "title": "productversion",
           "description": "The version of the product, e.g '5.0' or '1.1'",
           "pattern": "^[0-9]+\\.[0-9]+$"
         },
@@ -46,37 +46,37 @@
               "type": "null"
             }
           ],
-          "title": "EndOfLifeDate",
+          "title": "endoflifedate",
           "description": "The end-of-life (EOL) date for this Product when it is considered to be out of support. The value may be `null` if the EOL date is undetermined, e.g. when a product is still a prerelease."
         },
         "security": {
           "type": "boolean",
-          "title": "LatestReleaseIncludesSecurityUpdate",
+          "title": "latestreleaseincludessecurityupdate",
           "description": "`true` if the latest release of this product includes a security update, `false` otherwise."
         },
         "latest-release-date": {
           "$ref": "#/definitions/dateYYYYMMDD",
-          "title": "LatestReleaseDate",
+          "title": "latestreleasedate",
           "description": "The date of the latest release of this product."
         },
         "latest-release": {
           "$ref": "#/definitions/releaseVersion",
-          "title": "LatestReleaseVersion",
+          "title": "latestreleaseversion",
           "description": "The version of the latest release"
         },
         "latest-runtime": {
           "$ref": "#/definitions/releaseVersion",
-          "title": "LatestRuntimeVersion",
+          "title": "latestruntimeversion",
           "description": "The version of the runtime included in the latest release"
         },
         "latest-sdk": {
           "$ref": "#/definitions/releaseVersion",
-          "title": "LatestSdkVersion",
+          "title": "latestsdkversion",
           "description": "The version of the SDK included in the latest release.  This is usually the SDK with the highest feature band. A ProductRelease may include multiple SDKs across different feature bands, all of which carry the same runtime version."
         },
         "product": {
           "type": "string",
-          "title": "ProductName",
+          "title": "productname",
           "description": "The name of the product."
         },
         "releases.json": {
@@ -115,6 +115,6 @@
     }
   },
   "required": ["releases-index"],
-  "title": "JSON schema for .NET product collection manifests",
+  "title": "json schema for .net product collection manifests",
   "type": "object"
 }

--- a/src/schemas/json/dotnetcli.host.json
+++ b/src/schemas/json/dotnetcli.host.json
@@ -36,6 +36,6 @@
       }
     }
   },
-  "title": "JSON schema for .NET CLI template host files",
+  "title": "json schema for .net cli template host files",
   "type": "object"
 }

--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -842,6 +842,6 @@
     }
   },
   "required": ["kind"],
-  "title": "Drone CI configuration file",
+  "title": "drone ci configuration file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-breakpoints.json
+++ b/src/schemas/json/drupal-breakpoints.json
@@ -5,20 +5,20 @@
     "additionalProperties": false,
     "properties": {
       "label": {
-        "title": "A human readable label for the breakpoint",
+        "title": "a human readable label for the breakpoint",
         "type": "string"
       },
       "mediaQuery": {
-        "title": "Media query text proper",
+        "title": "media query text proper",
         "examples": ["all and (min-width: 851px)"],
         "type": "string"
       },
       "weight": {
-        "title": "Positional weight (order) for the breakpoint",
+        "title": "positional weight (order) for the breakpoint",
         "type": "integer"
       },
       "multipliers": {
-        "title": " Supported pixel resolution multipliers",
+        "title": " supported pixel resolution multipliers",
         "type": "array",
         "items": {
           "type": "string",
@@ -27,11 +27,11 @@
         "uniqueItems": true
       },
       "group": {
-        "title": "Breakpoint group",
+        "title": "breakpoint group",
         "type": "string"
       }
     }
   },
-  "title": "JSON schema for Drupal breakpoints file",
+  "title": "json schema for drupal breakpoints file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-config.json
+++ b/src/schemas/json/drupal-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": {
-    "title": "Configuration item",
+    "title": "configuration item",
     "$ref": "#/definitions/configItem"
   },
   "definitions": {
@@ -9,7 +9,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "title": "The type of the value",
+          "title": "the type of the value",
           "type": "string",
           "examples": [
             "boolean",
@@ -27,35 +27,35 @@
           ]
         },
         "label": {
-          "title": "User interface label for the value",
+          "title": "user interface label for the value",
           "type": "string"
         },
         "translatable": {
-          "title": "Whether the defined type is translatable",
+          "title": "whether the defined type is translatable",
           "type": "boolean"
         },
         "translation context": {
-          "title": "The translation context the source string belongs to",
+          "title": "the translation context the source string belongs to",
           "type": "string"
         },
         "nullable": {
-          "title": "Whether the value can be empty",
+          "title": "whether the value can be empty",
           "type": "boolean"
         },
         "class": {
-          "title": "The class implementing parsing",
+          "title": "the class implementing parsing",
           "type": "string"
         },
         "definition_class": {
-          "title": "The definition class",
+          "title": "the definition class",
           "type": "string"
         },
         "orderby": {
-          "title": "Determines how the sequence should be sorted",
+          "title": "determines how the sequence should be sorted",
           "type": "string"
         },
         "constraints": {
-          "title": "Validation constrains",
+          "title": "validation constrains",
           "type": "object"
         },
         "sequence": {
@@ -71,6 +71,6 @@
       "additionalProperties": false
     }
   },
-  "title": "JSON schema for Drupal configuration schema file",
+  "title": "json schema for drupal configuration schema file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-info.json
+++ b/src/schemas/json/drupal-info.json
@@ -12,7 +12,7 @@
       "then": {
         "properties": {
           "configure": {
-            "title": "A route name of the configuration form",
+            "title": "a route name of the configuration form",
             "type": "string"
           },
           "dependencies": {
@@ -22,7 +22,7 @@
             }
           },
           "test_dependencies": {
-            "title": "Dependencies that are needed to run certain automated tests for this extension",
+            "title": "dependencies that are needed to run certain automated tests for this extension",
             "type": "array",
             "items": {
               "$ref": "#/definitions/dependency"
@@ -42,7 +42,7 @@
       "then": {
         "properties": {
           "base theme": {
-            "title": "Base theme",
+            "title": "base theme",
             "default": "classy",
             "oneOf": [
               {
@@ -54,7 +54,7 @@
             ]
           },
           "libraries": {
-            "title": "A list of libraries to add to all pages where the theme is active",
+            "title": "a list of libraries to add to all pages where the theme is active",
             "type": "array",
             "items": {
               "type": "string",
@@ -62,7 +62,7 @@
             }
           },
           "libraries-override": {
-            "title": "A collection of libraries and assets to override",
+            "title": "a collection of libraries and assets to override",
             "type": "object",
             "additionalProperties": {
               "oneOf": [
@@ -79,39 +79,39 @@
             }
           },
           "libraries-extend": {
-            "title": "A collection of libraries and assets to add whenever a library is attached",
+            "title": "a collection of libraries and assets to add whenever a library is attached",
             "type": "object",
             "additionalProperties": {
               "type": "array"
             }
           },
           "engine": {
-            "title": "The theme engine",
+            "title": "the theme engine",
             "default": "twig",
             "type": "string"
           },
           "logo": {
-            "title": "The path to logo relative to the theme's .info.yml",
+            "title": "the path to logo relative to the theme's .info.yml",
             "type": "string"
           },
           "screenshot": {
-            "title": "The path to screenshot relative to the theme's .info.yml file",
+            "title": "the path to screenshot relative to the theme's .info.yml file",
             "type": "string"
           },
           "regions": {
-            "title": "A list of theme regions",
+            "title": "a list of theme regions",
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
           },
           "regions_hidden": {
-            "title": "A list of inherited regions to remove",
+            "title": "a list of inherited regions to remove",
             "type": "array",
             "uniqueItems": true
           },
           "features": {
-            "title": "A list of features to expose on the theme 'Settings' page",
+            "title": "a list of features to expose on the theme 'settings' page",
             "type": "array",
             "items": {
               "type": "string"
@@ -119,7 +119,7 @@
             "uniqueItems": true
           },
           "stylesheets-remove": {
-            "title": "A list of stylesheets from other modules or themes to remove from all pages where the theme is active",
+            "title": "a list of stylesheets from other modules or themes to remove from all pages where the theme is active",
             "type": "array",
             "items": {
               "type": "string"
@@ -127,7 +127,7 @@
             "uniqueItems": true
           },
           "ckeditor_stylesheets": {
-            "title": "A list of stylesheets to add to the CKEditor frame",
+            "title": "a list of stylesheets to add to the ckeditor frame",
             "type": "array",
             "items": {
               "type": "string"
@@ -147,18 +147,18 @@
       "then": {
         "properties": {
           "distribution": {
-            "title": "Declare the installation profile as a distribution",
+            "title": "declare the installation profile as a distribution",
             "type": "object",
             "properties": {
               "name": {
-                "title": "The distribution name",
+                "title": "the distribution name",
                 "type": "string"
               },
               "install": {
                 "type": "object",
                 "properties": {
                   "theme": {
-                    "title": "The theme for the distribution installation",
+                    "title": "the theme for the distribution installation",
                     "$ref": "#/definitions/machine_name"
                   }
                 }
@@ -169,7 +169,7 @@
             }
           },
           "dependencies": {
-            "title": "Required modules",
+            "title": "required modules",
             "type": "array",
             "items": {
               "$ref": "#/definitions/machine_name"
@@ -177,7 +177,7 @@
             "uniqueItems": true
           },
           "install": {
-            "title": "Modules to install to support the profile",
+            "title": "modules to install to support the profile",
             "type": "array",
             "items": {
               "$ref": "#/definitions/dependency"
@@ -185,7 +185,7 @@
             "uniqueItems": true
           },
           "theme": {
-            "title": "List any themes that should be installed as part of the profile installation",
+            "title": "list any themes that should be installed as part of the profile installation",
             "type": "array",
             "items": {
               "$ref": "#/definitions/machine_name"
@@ -198,19 +198,19 @@
   ],
   "definitions": {
     "dependency": {
-      "title": "Extension dependency",
+      "title": "extension dependency",
       "type": "string",
       "pattern": "^[a-z0-9_]+:[a-z0-9_]+( \\(.+\\))?$"
     },
     "machine_name": {
-      "title": "Machine name",
+      "title": "machine name",
       "type": "string",
       "pattern": "^[a-z0-9_]+$"
     }
   },
   "properties": {
     "name": {
-      "title": "The human-readable name",
+      "title": "the human-readable name",
       "type": "string"
     },
     "type": {
@@ -222,35 +222,35 @@
       "pattern": "^\\d\\.x$"
     },
     "core_version_requirement": {
-      "title": "Semantic core version requirement",
+      "title": "semantic core version requirement",
       "type": "string"
     },
     "description": {
-      "title": "Extension description",
+      "title": "extension description",
       "type": "string"
     },
     "package": {
-      "title": "A key that allows to group extension together an administrative pages",
+      "title": "a key that allows to group extension together an administrative pages",
       "type": "string"
     },
     "version": {
-      "title": "The version of the extension",
+      "title": "the version of the extension",
       "type": "string"
     },
     "project": {
-      "title": "The machine name of extension project on drupal.org",
+      "title": "the machine name of extension project on drupal.org",
       "type": "string"
     },
     "datestamp": {
-      "title": "The date and time when the extension was packaged",
+      "title": "the date and time when the extension was packaged",
       "type": "integer"
     },
     "hidden": {
-      "title": "Do not the extension in admin interface",
+      "title": "do not the extension in admin interface",
       "type": "boolean"
     },
     "php": {
-      "title": "The minimal PHP version that is required for this extension",
+      "title": "the minimal php version that is required for this extension",
       "oneOf": [
         {
           "type": "string",
@@ -263,6 +263,6 @@
     }
   },
   "required": ["type", "core_version_requirement", "name"],
-  "title": "JSON schema for Drupal extension info file",
+  "title": "json schema for drupal extension info file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-layouts.json
+++ b/src/schemas/json/drupal-layouts.json
@@ -4,40 +4,40 @@
     "type": "object",
     "properties": {
       "label": {
-        "title": "The human-readable name",
+        "title": "the human-readable name",
         "type": "string"
       },
       "description": {
-        "title": "A description for advanced layouts",
+        "title": "a description for advanced layouts",
         "type": "string"
       },
       "category": {
-        "title": "The human-readable category name",
+        "title": "the human-readable category name",
         "type": "string"
       },
       "template": {
-        "title": "The template file to render this layout",
+        "title": "the template file to render this layout",
         "type": "string"
       },
       "theme_hook": {
-        "title": "The theme hook used to render this layout",
+        "title": "the theme hook used to render this layout",
         "default": "layout",
         "type": "string"
       },
       "path": {
-        "title": "Path to resources like icon or template",
+        "title": "path to resources like icon or template",
         "type": "string"
       },
       "library": {
-        "title": "The asset library",
+        "title": "the asset library",
         "type": "string"
       },
       "icon": {
-        "title": "The path to the preview image",
+        "title": "the path to the preview image",
         "type": "string"
       },
       "icon_map": {
-        "title": "The icon map",
+        "title": "the icon map",
         "type": "array",
         "items": {
           "type": "array",
@@ -47,13 +47,13 @@
         }
       },
       "regions": {
-        "title": "List of regions in this layout",
+        "title": "list of regions in this layout",
         "type": "object",
         "additionalProperties": {
           "type": "object",
           "properties": {
             "label": {
-              "title": "The human-readable name",
+              "title": "the human-readable name",
               "type": "string"
             }
           },
@@ -61,16 +61,16 @@
         }
       },
       "default_region": {
-        "title": "The default region",
+        "title": "the default region",
         "type": "string"
       },
       "class": {
-        "title": "Plugin class",
+        "title": "plugin class",
         "type": "string"
       }
     },
     "additionalProperties": false
   },
-  "title": "JSON schema for Drupal layouts file",
+  "title": "json schema for drupal layouts file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-libraries.json
+++ b/src/schemas/json/drupal-libraries.json
@@ -5,7 +5,7 @@
     "additionalProperties": false,
     "properties": {
       "version": {
-        "title": "The library version",
+        "title": "the library version",
         "oneOf": [
           {
             "type": "string"
@@ -16,7 +16,7 @@
         ]
       },
       "remote": {
-        "title": "The library repository URL",
+        "title": "the library repository url",
         "type": "string"
       },
       "license": {
@@ -24,29 +24,29 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "The human-readable name of the license",
+            "title": "the human-readable name of the license",
             "type": "string"
           },
           "url": {
-            "title": "The URL of the license file/information for the version of the library used",
+            "title": "the url of the license file/information for the version of the library used",
             "type": "string"
           },
           "gpl-compatible": {
-            "title": "A boolean for whether this library is GPL compatible",
+            "title": "a boolean for whether this library is gpl compatible",
             "type": "boolean"
           }
         }
       },
       "header": {
-        "title": "A boolean for whether the script must be included in the header",
+        "title": "a boolean for whether the script must be included in the header",
         "type": "boolean"
       },
       "drupalSettings": {
-        "title": "Settings that needs to be attached to drupalSettings object in JavaScript",
+        "title": "settings that needs to be attached to drupalsettings object in javascript",
         "type": "object"
       },
       "js": {
-        "title": "List of JavaScript files to load",
+        "title": "list of javascript files to load",
         "type": "object",
         "additionalProperties": {
           "type": "object",
@@ -60,7 +60,7 @@
         }
       },
       "css": {
-        "title": "List of CSS files to load",
+        "title": "list of css files to load",
         "type": "object",
         "properties": {
           "base": {
@@ -81,7 +81,7 @@
         }
       },
       "dependencies": {
-        "title": "List libraries that should be loaded along with this library",
+        "title": "list libraries that should be loaded along with this library",
         "type": "array",
         "items": {
           "type": "string",
@@ -95,30 +95,30 @@
       "type": "object",
       "properties": {
         "attributes": {
-          "title": "Optional attributes",
+          "title": "optional attributes",
           "type": "object"
         },
         "browsers": {
-          "title": "Load asset conditionally based on browser",
+          "title": "load asset conditionally based on browser",
           "type": "object"
         },
         "minified": {
-          "title": "Whether the asset is already minified",
+          "title": "whether the asset is already minified",
           "type": "boolean"
         },
         "external": {
           "type": "boolean"
         },
         "type": {
-          "title": "The source of the asset",
+          "title": "the source of the asset",
           "type": "string"
         },
         "preprocess": {
-          "title": "Whether the assets should be aggregated",
+          "title": "whether the assets should be aggregated",
           "type": "boolean"
         },
         "weight": {
-          "title": "The order relative to other assets",
+          "title": "the order relative to other assets",
           "type": "integer"
         }
       }
@@ -130,11 +130,11 @@
         "$ref": "#/definitions/file",
         "properties": {
           "group": {
-            "title": "The SMACSS group in which the asset is placed",
+            "title": "the smacss group in which the asset is placed",
             "type": "integer"
           },
           "media": {
-            "title": "Media type",
+            "title": "media type",
             "type": "string",
             "enum": ["all", "screen", "print", "speech"]
           }
@@ -143,6 +143,6 @@
       }
     }
   },
-  "title": "JSON schema for Drupal libraries file",
+  "title": "json schema for drupal libraries file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-links-action.json
+++ b/src/schemas/json/drupal-links-action.json
@@ -4,46 +4,46 @@
     "type": "object",
     "properties": {
       "title": {
-        "title": "The static title for the local action",
+        "title": "the static title for the local action",
         "type": "string"
       },
       "title_context": {
-        "title": "The translation context for the title value.",
+        "title": "the translation context for the title value.",
         "type": "string"
       },
       "route_name": {
-        "title": "The route name used to generate a link",
+        "title": "the route name used to generate a link",
         "type": "string"
       },
       "route_parameters": {
-        "title": "Route parameters for generating a link",
+        "title": "route parameters for generating a link",
         "type": "object"
       },
       "weight": {
-        "title": "The weight of the local action",
+        "title": "the weight of the local action",
         "type": "integer"
       },
       "options": {
-        "title": "Array of link options",
+        "title": "array of link options",
         "type": "object"
       },
       "appears_on": {
-        "title": "The route names where this local action appears",
+        "title": "the route names where this local action appears",
         "type": "array",
         "items": {
           "type": "string"
         }
       },
       "class": {
-        "title": "Class for local action implementations",
+        "title": "class for local action implementations",
         "type": "string"
       },
       "deriver": {
-        "title": "Deriver class",
+        "title": "deriver class",
         "type": "string"
       },
       "cache_tags": {
-        "title": "Cache tags",
+        "title": "cache tags",
         "type": "array",
         "items": {
           "type": "string"
@@ -51,6 +51,6 @@
       }
     }
   },
-  "title": "JSON schema for Drupal action links file",
+  "title": "json schema for drupal action links file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-links-contextual.json
+++ b/src/schemas/json/drupal-links-contextual.json
@@ -4,43 +4,43 @@
     "type": "object",
     "properties": {
       "title": {
-        "title": "The static title for the local action",
+        "title": "the static title for the local action",
         "type": "string"
       },
       "title_context": {
-        "title": "The translation context for the title value.",
+        "title": "the translation context for the title value.",
         "type": "string"
       },
       "route_name": {
-        "title": "The route name used to generate a link",
+        "title": "the route name used to generate a link",
         "type": "string"
       },
       "route_parameters": {
-        "title": "Route parameters for generating a link",
+        "title": "route parameters for generating a link",
         "type": "object"
       },
       "group": {
-        "title": "The contextual links group",
+        "title": "the contextual links group",
         "type": "string"
       },
       "weight": {
-        "title": "The weight of the local action",
+        "title": "the weight of the local action",
         "type": "integer"
       },
       "options": {
-        "title": "Array of link options",
+        "title": "array of link options",
         "type": "object"
       },
       "class": {
-        "title": "Class for local action implementations",
+        "title": "class for local action implementations",
         "type": "string"
       },
       "deriver": {
-        "title": "Deriver class",
+        "title": "deriver class",
         "type": "string"
       },
       "cache_tags": {
-        "title": "Cache tags",
+        "title": "cache tags",
         "type": "array",
         "items": {
           "type": "string"
@@ -49,6 +49,6 @@
     },
     "additionalProperties": false
   },
-  "title": "JSON schema for Drupal contextual links file",
+  "title": "json schema for drupal contextual links file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-links-menu.json
+++ b/src/schemas/json/drupal-links-menu.json
@@ -4,60 +4,60 @@
     "type": "object",
     "properties": {
       "title": {
-        "title": "The static title for the menu link",
+        "title": "the static title for the menu link",
         "type": "string"
       },
       "title_context": {
-        "title": "The translation context for the title value.",
+        "title": "the translation context for the title value.",
         "type": "string"
       },
       "description": {
-        "title": "The description",
+        "title": "the description",
         "type": "string"
       },
       "description_context": {
-        "title": "The translation context for the description value.",
+        "title": "the translation context for the description value.",
         "type": "string"
       },
       "route_name": {
-        "title": "The name of the route this links to, unless it's external",
+        "title": "the name of the route this links to, unless it's external",
         "type": "string"
       },
       "route_parameters": {
-        "title": "Parameters for route variables when generating a link",
+        "title": "parameters for route variables when generating a link",
         "type": "object"
       },
       "parent": {
-        "title": "The plugin ID of the parent tab",
+        "title": "the plugin id of the parent tab",
         "type": "string"
       },
       "menu_name": {
-        "title": "The name of the menu for this link",
+        "title": "the name of the menu for this link",
         "default": "tools",
         "type": "string"
       },
       "url": {
-        "title": "The external URL if this link has one",
+        "title": "the external url if this link has one",
         "type": "string"
       },
       "weight": {
-        "title": "The weight of the link",
+        "title": "the weight of the link",
         "type": "integer"
       },
       "options": {
-        "title": "Array of link options",
+        "title": "array of link options",
         "type": "object"
       },
       "class": {
-        "title": "Class for task implementations",
+        "title": "class for task implementations",
         "type": "string"
       },
       "form_class": {
-        "title": "Class for task implementations",
+        "title": "class for task implementations",
         "type": "string"
       },
       "provider": {
-        "title": "The name of the module providing this link",
+        "title": "the name of the module providing this link",
         "type": "string"
       },
       "metadata": {
@@ -65,7 +65,7 @@
         "type": "array"
       },
       "expanded": {
-        "title": "Show the link as expanded",
+        "title": "show the link as expanded",
         "oneOf": [
           {
             "type": "boolean"
@@ -76,7 +76,7 @@
         ]
       },
       "enabled": {
-        "title": "The status of the link",
+        "title": "the status of the link",
         "oneOf": [
           {
             "type": "boolean"
@@ -87,7 +87,7 @@
         ]
       },
       "deriver": {
-        "title": "Deriver class",
+        "title": "deriver class",
         "type": "string"
       },
       "position": {
@@ -95,7 +95,7 @@
         "type": "string"
       },
       "cache_tags": {
-        "title": "Cache tags",
+        "title": "cache tags",
         "type": "array",
         "items": {
           "type": "string"
@@ -104,6 +104,6 @@
     },
     "additionalProperties": false
   },
-  "title": "JSON schema for Drupal menu links file",
+  "title": "json schema for drupal menu links file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-links-task.json
+++ b/src/schemas/json/drupal-links-task.json
@@ -4,47 +4,47 @@
     "type": "object",
     "properties": {
       "title": {
-        "title": "The static title for the local task",
+        "title": "the static title for the local task",
         "type": "string"
       },
       "title_context": {
-        "title": "The translation context for the title value.",
+        "title": "the translation context for the title value.",
         "type": "string"
       },
       "route_name": {
-        "title": "The name of the route this task links to",
+        "title": "the name of the route this task links to",
         "type": "string"
       },
       "route_parameters": {
-        "title": "Parameters for route variables when generating a link",
+        "title": "parameters for route variables when generating a link",
         "type": "object"
       },
       "base_route": {
-        "title": "The route name where the root tab appears",
+        "title": "the route name where the root tab appears",
         "type": "string"
       },
       "parent_id": {
-        "title": "The plugin ID of the parent tab",
+        "title": "the plugin id of the parent tab",
         "type": "string"
       },
       "weight": {
-        "title": "The weight of the tab",
+        "title": "the weight of the tab",
         "type": "integer"
       },
       "options": {
-        "title": "Array of link options",
+        "title": "array of link options",
         "type": "object"
       },
       "class": {
-        "title": "Class for task implementations",
+        "title": "class for task implementations",
         "type": "string"
       },
       "deriver": {
-        "title": "Deriver class",
+        "title": "deriver class",
         "type": "string"
       },
       "cache_tags": {
-        "title": "Cache tags",
+        "title": "cache tags",
         "type": "array",
         "items": {
           "type": "string"
@@ -53,6 +53,6 @@
     },
     "additionalProperties": false
   },
-  "title": "JSON schema for Drupal task links file",
+  "title": "json schema for drupal task links file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-migration.json
+++ b/src/schemas/json/drupal-migration.json
@@ -2,19 +2,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "id": {
-      "title": "The migration ID (machine name)",
+      "title": "the migration id (machine name)",
       "type": "string"
     },
     "label": {
-      "title": "The human-readable label for the migration",
+      "title": "the human-readable label for the migration",
       "type": "string"
     },
     "audit": {
-      "title": "Whether the migration is auditable",
+      "title": "whether the migration is auditable",
       "type": "boolean"
     },
     "migration_tags": {
-      "title": "List of tags, used by the plugin manager for filtering",
+      "title": "list of tags, used by the plugin manager for filtering",
       "type": "array",
       "items": {
         "type": "string"
@@ -22,41 +22,41 @@
       "uniqueItems": true
     },
     "deriver": {
-      "title": "Deriver class",
+      "title": "deriver class",
       "type": "string"
     },
     "source": {
-      "title": "The source plugin configuration",
+      "title": "the source plugin configuration",
       "type": "object",
       "properties": {
         "plugin": {
-          "title": "Source plugin ID",
+          "title": "source plugin id",
           "type": "string"
         }
       },
       "required": ["plugin"]
     },
     "process": {
-      "title": "The configuration describing the process plugins",
+      "title": "the configuration describing the process plugins",
       "type": "object"
     },
     "destination": {
-      "title": "The destination plugin configuration",
+      "title": "the destination plugin configuration",
       "type": ["object"],
       "properties": {
         "plugin": {
-          "title": "Destination plugin ID",
+          "title": "destination plugin id",
           "type": ["string", "null"]
         }
       },
       "required": ["plugin"]
     },
     "migration_dependencies": {
-      "title": "Migrations to run before this migration",
+      "title": "migrations to run before this migration",
       "type": "object",
       "properties": {
         "required": {
-          "title": "List of migration IDs that must be run before this migration",
+          "title": "list of migration ids that must be run before this migration",
           "type": "array",
           "items": {
             "type": "string"
@@ -64,7 +64,7 @@
           "uniqueItems": true
         },
         "optional": {
-          "title": "List of migration IDs that, if they exist, must be run before",
+          "title": "list of migration ids that, if they exist, must be run before",
           "type": "array",
           "items": {
             "type": "string"
@@ -74,7 +74,7 @@
       }
     },
     "dependencies": {
-      "title": "The migration's dependencies",
+      "title": "the migration's dependencies",
       "type": "object",
       "properties": {
         "config": {
@@ -143,7 +143,7 @@
       "additionalProperties": false
     },
     "provider": {
-      "title": "List of plugin providers",
+      "title": "list of plugin providers",
       "type": "array",
       "items": {
         "type": "string"
@@ -151,10 +151,10 @@
       "uniqueItems": true
     },
     "class": {
-      "title": "Class for migration implementation",
+      "title": "class for migration implementation",
       "type": ["string", "null"]
     }
   },
-  "title": "JSON schema for Drupal migration files",
+  "title": "json schema for drupal migration files",
   "type": "object"
 }

--- a/src/schemas/json/drupal-permissions.json
+++ b/src/schemas/json/drupal-permissions.json
@@ -1,20 +1,20 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": {
-    "title": "Permission definition",
+    "title": "permission definition",
     "type": "object",
     "required": ["title"],
     "properties": {
       "title": {
-        "title": "The human-readable name of the permission",
+        "title": "the human-readable name of the permission",
         "type": "string"
       },
       "description": {
-        "title": "A description of what the permission does",
+        "title": "a description of what the permission does",
         "type": "string"
       },
       "restrict access": {
-        "title": "Restrict access to this permission to trusted users",
+        "title": "restrict access to this permission to trusted users",
         "description": "This should be used for permissions that have inherent security risks across a variety of potential use cases (for example, the \"administer filters\" and \"bypass node access\" permissions provided by Drupal core).",
         "type": "boolean"
       }
@@ -23,15 +23,15 @@
   },
   "properties": {
     "permission_callbacks": {
-      "title": "List of permission callbacks",
+      "title": "list of permission callbacks",
       "type": "array",
       "items": {
-        "title": "A callback that return array of permissions",
+        "title": "a callback that return array of permissions",
         "type": "string"
       },
       "uniqueItems": true
     }
   },
-  "title": "JSON schema for Drupal permissions file",
+  "title": "json schema for drupal permissions file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-routing.json
+++ b/src/schemas/json/drupal-routing.json
@@ -4,15 +4,15 @@
     "type": "object",
     "properties": {
       "path": {
-        "title": "Route path",
+        "title": "route path",
         "type": "string"
       },
       "defaults": {
-        "title": "Default route parameters",
+        "title": "default route parameters",
         "type": "object",
         "properties": {
           "_controller": {
-            "title": "A controller to execute when the route is matched",
+            "title": "a controller to execute when the route is matched",
             "type": "string"
           },
           "_form": {
@@ -39,7 +39,7 @@
         }
       },
       "requirements": {
-        "title": "List of requirements that makes a specific route only match under specific conditions",
+        "title": "list of requirements that makes a specific route only match under specific conditions",
         "type": "object",
         "properties": {
           "_access": {
@@ -78,7 +78,7 @@
         }
       },
       "methods": {
-        "title": "Method of the incoming request to match the route",
+        "title": "method of the incoming request to match the route",
         "type": "array",
         "items": {
           "type": "string",
@@ -87,7 +87,7 @@
         "uniqueItems": true
       },
       "options": {
-        "title": "Additional route options",
+        "title": "additional route options",
         "type": "object",
         "properties": {
           "no_cache": {
@@ -122,7 +122,7 @@
   },
   "properties": {
     "route_callbacks": {
-      "title": "List of callbacks to provide routes",
+      "title": "list of callbacks to provide routes",
       "type": "array",
       "items": {
         "type": "string"
@@ -130,6 +130,6 @@
       "uniqueItems": true
     }
   },
-  "title": "JSON schema for Drupal routing file",
+  "title": "json schema for drupal routing file",
   "type": "object"
 }

--- a/src/schemas/json/drupal-services.json
+++ b/src/schemas/json/drupal-services.json
@@ -3,7 +3,7 @@
   "additionalProperties": false,
   "properties": {
     "parameters": {
-      "title": "Service parameters",
+      "title": "service parameters",
       "type": "object"
     },
     "services": {
@@ -12,15 +12,15 @@
         "type": "object",
         "properties": {
           "class": {
-            "title": "Service class",
+            "title": "service class",
             "type": "string"
           },
           "parent": {
-            "title": "Parent service to extend",
+            "title": "parent service to extend",
             "type": "string"
           },
           "factory": {
-            "title": "A factory to create the object",
+            "title": "a factory to create the object",
             "oneOf": [
               {
                 "type": "string"
@@ -31,47 +31,47 @@
             ]
           },
           "decorates": {
-            "title": "Service name to decorate",
+            "title": "service name to decorate",
             "type": "string"
           },
           "deprecated": {
-            "title": "A flag indicating that the service is deprecated",
+            "title": "a flag indicating that the service is deprecated",
             "type": "string"
           },
           "lazy": {
-            "title": "Lazy service instantiation",
+            "title": "lazy service instantiation",
             "type": "boolean"
           },
           "shared": {
-            "title": "Shared service",
+            "title": "shared service",
             "type": "boolean"
           },
           "abstract": {
-            "title": "Abstract service",
+            "title": "abstract service",
             "type": "boolean"
           },
           "public": {
-            "title": "A flag indication that the service cannot be accessed directly from the container object",
+            "title": "a flag indication that the service cannot be accessed directly from the container object",
             "type": "boolean"
           },
           "alias": {
-            "title": "A shortcut to access some services",
+            "title": "a shortcut to access some services",
             "type": "string"
           },
           "arguments": {
-            "title": "Service arguments",
+            "title": "service arguments",
             "type": "array",
             "uniqueItems": true
           },
           "configurator": {
-            "title": "A callable to configure a service after its instantiation",
+            "title": "a callable to configure a service after its instantiation",
             "type": "array",
             "items": {
               "type": "string"
             }
           },
           "tags": {
-            "title": "List of tags tell Drupal that your service can be processed in some special way",
+            "title": "list of tags tell drupal that your service can be processed in some special way",
             "examples": [
               "event_subscriber",
               "service_collector",
@@ -126,7 +126,7 @@
             }
           },
           "calls": {
-            "title": "Methods to set optional dependencies",
+            "title": "methods to set optional dependencies",
             "type": "array",
             "uniqueItems": true
           }
@@ -134,6 +134,6 @@
       }
     }
   },
-  "title": "JSON schema for Drupal services file",
+  "title": "json schema for drupal services file",
   "type": "object"
 }

--- a/src/schemas/json/drush.site.yml.json
+++ b/src/schemas/json/drush.site.yml.json
@@ -4,55 +4,55 @@
     "type": "object",
     "properties": {
       "root": {
-        "title": "The Drupal root for this site",
+        "title": "the drupal root for this site",
         "default": "/path/to/drupal/root",
         "type": "string"
       },
       "host": {
-        "title": "The fully-qualified domain name of the remote system hosting the Drupal instance",
+        "title": "the fully-qualified domain name of the remote system hosting the drupal instance",
         "default": "my-server.com",
         "type": "string"
       },
       "uri": {
-        "title": "Site URI",
+        "title": "site uri",
         "description": "The value of uri should always be the same as when the site is being accessed from a web browser",
         "default": "https://example.com",
         "type": "string"
       },
       "user": {
-        "title": "The username to log in as when using ssh or rsync",
+        "title": "the username to log in as when using ssh or rsync",
         "type": "string"
       },
       "os": {
-        "title": "The operating system of the remote server",
+        "title": "the operating system of the remote server",
         "type": "string",
         "enum": ["Windows", "Linux"]
       },
       "ssh": {
-        "title": "Contains settings used to control how ssh commands are generated when running remote commands",
+        "title": "contains settings used to control how ssh commands are generated when running remote commands",
         "type": "object",
         "properties": {
           "options": {
-            "title": "Additional commandline options for the ssh command itself",
+            "title": "additional commandline options for the ssh command itself",
             "type": "string"
           },
           "tty": {
-            "title": "A flag to force Drush to always or never create a tty",
+            "title": "a flag to force drush to always or never create a tty",
             "type": "boolean"
           }
         }
       },
       "paths": {
-        "title": "Aliases for common rsync targets",
+        "title": "aliases for common rsync targets",
         "type": "object",
         "properties": {
           "drush-script": {
-            "title": "Path to the remote Drush command",
+            "title": "path to the remote drush command",
             "default": "/path/to/drush",
             "type": "string"
           },
           "alias-path": {
-            "title": "A list of paths where Drush will search for alias files",
+            "title": "a list of paths where drush will search for alias files",
             "type": "array",
             "items": {
               "type": "string"
@@ -68,7 +68,7 @@
         }
       },
       "command": {
-        "title": "Contains options for specific commands",
+        "title": "contains options for specific commands",
         "type": "object",
         "additionalProperties": {
           "type": "object"
@@ -78,24 +78,24 @@
         "type": "object",
         "properties": {
           "service": {
-            "title": "The name of the container to run on",
+            "title": "the name of the container to run on",
             "type": "string"
           },
           "exec": {
             "type": "object",
             "options": {
-              "title": "Options for exec command",
+              "title": "options for exec command",
               "type": "string"
             }
           }
         }
       },
       "vagrant": {
-        "title": "Vagrant transport",
+        "title": "vagrant transport",
         "type": "null"
       }
     }
   },
-  "title": "JSON Schema for Drush site aliases",
+  "title": "json schema for drush site aliases",
   "type": "object"
 }

--- a/src/schemas/json/electron-builder.json
+++ b/src/schemas/json/electron-builder.json
@@ -102,7 +102,7 @@
           "type": "string"
         }
       },
-      "title": "AppImageOptions",
+      "title": "appimageoptions",
       "type": "object"
     },
     "AppXOptions": {
@@ -234,7 +234,7 @@
           "type": "boolean"
         }
       },
-      "title": "AppXOptions",
+      "title": "appxoptions",
       "type": "object"
     },
     "AsarOptions": {
@@ -254,7 +254,7 @@
           "type": "boolean"
         }
       },
-      "title": "AsarOptions",
+      "title": "asaroptions",
       "type": "object"
     },
     "BintrayOptions": {
@@ -318,7 +318,7 @@
         }
       },
       "required": ["provider"],
-      "title": "BintrayOptions",
+      "title": "bintrayoptions",
       "type": "object"
     },
     "CustomPublishOptions": {
@@ -351,7 +351,7 @@
         }
       },
       "required": ["provider"],
-      "title": "CustomPublishOptions",
+      "title": "custompublishoptions",
       "type": "object"
     },
     "DebOptions": {
@@ -508,7 +508,7 @@
           "type": ["null", "string"]
         }
       },
-      "title": "DebOptions",
+      "title": "deboptions",
       "type": "object"
     },
     "DmgContent": {
@@ -534,7 +534,7 @@
         }
       },
       "required": ["x", "y"],
-      "title": "DmgContent",
+      "title": "dmgcontent",
       "type": "object"
     },
     "DmgOptions": {
@@ -647,7 +647,7 @@
           "description": "The DMG windows position and size."
         }
       },
-      "title": "DmgOptions",
+      "title": "dmgoptions",
       "type": "object"
     },
     "DmgWindow": {
@@ -672,7 +672,7 @@
           "type": "number"
         }
       },
-      "title": "DmgWindow",
+      "title": "dmgwindow",
       "type": "object"
     },
     "ElectronDownloadOptions": {
@@ -709,7 +709,7 @@
           "type": "string"
         }
       },
-      "title": "ElectronDownloadOptions",
+      "title": "electrondownloadoptions",
       "type": "object"
     },
     "FileAssociation": {
@@ -757,7 +757,7 @@
         }
       },
       "required": ["ext"],
-      "title": "FileAssociation",
+      "title": "fileassociation",
       "type": "object"
     },
     "FileSet": {
@@ -786,7 +786,7 @@
           "type": "string"
         }
       },
-      "title": "FileSet",
+      "title": "fileset",
       "type": "object"
     },
     "GenericServerOptions": {
@@ -834,7 +834,7 @@
         }
       },
       "required": ["provider", "url"],
-      "title": "GenericServerOptions",
+      "title": "genericserveroptions",
       "type": "object"
     },
     "GithubOptions": {
@@ -921,7 +921,7 @@
         }
       },
       "required": ["provider"],
-      "title": "GithubOptions",
+      "title": "githuboptions",
       "type": "object"
     },
     "LinuxConfiguration": {
@@ -1241,7 +1241,7 @@
           "type": ["null", "string"]
         }
       },
-      "title": "LinuxConfiguration",
+      "title": "linuxconfiguration",
       "type": "object"
     },
     "LinuxTargetSpecificOptions": {
@@ -1394,7 +1394,7 @@
           "type": ["null", "string"]
         }
       },
-      "title": "LinuxTargetSpecificOptions",
+      "title": "linuxtargetspecificoptions",
       "type": "object"
     },
     "MacConfiguration": {
@@ -1807,7 +1807,7 @@
           "description": "Whether to sign app for development or for distribution."
         }
       },
-      "title": "MacConfiguration",
+      "title": "macconfiguration",
       "type": "object"
     },
     "MasConfiguration": {
@@ -2215,7 +2215,7 @@
           "description": "Whether to sign app for development or for distribution."
         }
       },
-      "title": "MasConfiguration",
+      "title": "masconfiguration",
       "type": "object"
     },
     "MetadataDirectories": {
@@ -2236,7 +2236,7 @@
           "type": ["null", "string"]
         }
       },
-      "title": "MetadataDirectories",
+      "title": "metadatadirectories",
       "type": "object"
     },
     "MsiOptions": {
@@ -2343,7 +2343,7 @@
           "type": "boolean"
         }
       },
-      "title": "MsiOptions",
+      "title": "msioptions",
       "type": "object"
     },
     "NsisOptions": {
@@ -2577,7 +2577,7 @@
           "type": "boolean"
         }
       },
-      "title": "NsisOptions",
+      "title": "nsisoptions",
       "type": "object"
     },
     "NsisWebOptions": {
@@ -2816,7 +2816,7 @@
           "type": "boolean"
         }
       },
-      "title": "NsisWebOptions",
+      "title": "nsisweboptions",
       "type": "object"
     },
     "PkgBackgroundOptions": {
@@ -2864,7 +2864,7 @@
           "description": "Scaling of the background image.\nOptions are: tofit, none, proportional"
         }
       },
-      "title": "PkgBackgroundOptions",
+      "title": "pkgbackgroundoptions",
       "type": "object"
     },
     "PkgOptions": {
@@ -3023,7 +3023,7 @@
           "type": ["null", "string"]
         }
       },
-      "title": "PkgOptions",
+      "title": "pkgoptions",
       "type": "object"
     },
     "PlugDescriptor": {
@@ -3038,7 +3038,7 @@
           }
         ]
       },
-      "title": "PlugDescriptor",
+      "title": "plugdescriptor",
       "type": "object"
     },
     "PortableOptions": {
@@ -3131,7 +3131,7 @@
           "type": "string"
         }
       },
-      "title": "PortableOptions",
+      "title": "portableoptions",
       "type": "object"
     },
     "Protocol": {
@@ -3157,12 +3157,12 @@
         }
       },
       "required": ["name", "schemes"],
-      "title": "Protocol",
+      "title": "protocol",
       "type": "object"
     },
     "PublishProvider": {
       "enum": ["bintray", "custom", "generic", "github", "s3", "spaces"],
-      "title": "PublishProvider",
+      "title": "publishprovider",
       "type": "string"
     },
     "ReleaseInfo": {
@@ -3185,7 +3185,7 @@
           "type": ["null", "string"]
         }
       },
-      "title": "ReleaseInfo",
+      "title": "releaseinfo",
       "type": "object"
     },
     "S3Options": {
@@ -3279,7 +3279,7 @@
         }
       },
       "required": ["bucket", "provider"],
-      "title": "S3Options",
+      "title": "s3options",
       "type": "object"
     },
     "SnapOptions": {
@@ -3500,7 +3500,7 @@
           "type": "boolean"
         }
       },
-      "title": "SnapOptions",
+      "title": "snapoptions",
       "type": "object"
     },
     "SpacesOptions": {
@@ -3566,7 +3566,7 @@
         }
       },
       "required": ["name", "provider", "region"],
-      "title": "SpacesOptions",
+      "title": "spacesoptions",
       "type": "object"
     },
     "SquirrelWindowsOptions": {
@@ -3658,7 +3658,7 @@
           "type": "boolean"
         }
       },
-      "title": "SquirrelWindowsOptions",
+      "title": "squirrelwindowsoptions",
       "type": "object"
     },
     "TargetConfiguration": {
@@ -3686,7 +3686,7 @@
         }
       },
       "required": ["target"],
-      "title": "TargetConfiguration",
+      "title": "targetconfiguration",
       "type": "object"
     },
     "WindowsConfiguration": {
@@ -4052,7 +4052,7 @@
           "type": "boolean"
         }
       },
-      "title": "WindowsConfiguration",
+      "title": "windowsconfiguration",
       "type": "object"
     }
   },

--- a/src/schemas/json/embrace-config-schema-1.0.0.json
+++ b/src/schemas/json/embrace-config-schema-1.0.0.json
@@ -134,6 +134,6 @@
     }
   },
   "required": ["app_id", "api_token"],
-  "title": "Embrace Config Schema",
+  "title": "embrace config schema",
   "type": "object"
 }

--- a/src/schemas/json/epr-manifest.json
+++ b/src/schemas/json/epr-manifest.json
@@ -66,6 +66,6 @@
     }
   },
   "required": ["rules"],
-  "title": "JSON schema for Entry Point Regulation manifest files",
+  "title": "json schema for entry point regulation manifest files",
   "type": "object"
 }

--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -1502,6 +1502,6 @@
       }
     }
   },
-  "title": "JSON schema for ESLint configuration files",
+  "title": "json schema for eslint configuration files",
   "type": "object"
 }

--- a/src/schemas/json/esmrc.json
+++ b/src/schemas/json/esmrc.json
@@ -123,5 +123,5 @@
       "default": false
     }
   },
-  "title": "Configuration files for the esm module/package in Node.js"
+  "title": "configuration files for the esm module/package in node.js"
 }

--- a/src/schemas/json/esquio.json
+++ b/src/schemas/json/esquio.json
@@ -63,6 +63,6 @@
     }
   },
   "required": ["Esquio"],
-  "title": "JSON schema for Esquio configuration files",
+  "title": "json schema for esquio configuration files",
   "type": "object"
 }

--- a/src/schemas/json/expo-37.0.0.json
+++ b/src/schemas/json/expo-37.0.0.json
@@ -1223,6 +1223,6 @@
     }
   },
   "required": ["expo"],
-  "title": "JSON schema for Expo SDK 37 app manifest",
+  "title": "json schema for expo sdk 37 app manifest",
   "type": "object"
 }

--- a/src/schemas/json/expo-38.0.0.json
+++ b/src/schemas/json/expo-38.0.0.json
@@ -1011,6 +1011,6 @@
     }
   },
   "required": ["expo"],
-  "title": "JSON schema for Expo SDK 40 app manifest",
+  "title": "json schema for expo sdk 40 app manifest",
   "type": "object"
 }

--- a/src/schemas/json/expo-39.0.0.json
+++ b/src/schemas/json/expo-39.0.0.json
@@ -1038,6 +1038,6 @@
     }
   },
   "required": ["expo"],
-  "title": "JSON schema for Expo SDK 40 app manifest",
+  "title": "json schema for expo sdk 40 app manifest",
   "type": "object"
 }

--- a/src/schemas/json/expo-40.0.0.json
+++ b/src/schemas/json/expo-40.0.0.json
@@ -1644,6 +1644,6 @@
     }
   },
   "required": ["expo"],
-  "title": "JSON schema for Expo SDK 40 app manifest",
+  "title": "json schema for expo sdk 40 app manifest",
   "type": "object"
 }

--- a/src/schemas/json/expo-41.0.0.json
+++ b/src/schemas/json/expo-41.0.0.json
@@ -1676,6 +1676,6 @@
     }
   },
   "required": ["expo"],
-  "title": "JSON schema for Expo SDK 41 app manifest",
+  "title": "json schema for expo sdk 41 app manifest",
   "type": "object"
 }

--- a/src/schemas/json/expo-42.0.0.json
+++ b/src/schemas/json/expo-42.0.0.json
@@ -1661,6 +1661,6 @@
     }
   },
   "required": ["expo"],
-  "title": "JSON schema for Expo SDK 42 app manifest",
+  "title": "json schema for expo sdk 42 app manifest",
   "type": "object"
 }

--- a/src/schemas/json/expo-46.0.0.json
+++ b/src/schemas/json/expo-46.0.0.json
@@ -1680,6 +1680,6 @@
     }
   },
   "required": ["expo"],
-  "title": "JSON schema for Expo SDK 46 app manifest",
+  "title": "json schema for expo sdk 46 app manifest",
   "type": "object"
 }

--- a/src/schemas/json/factorial-drupal-breakpoints-css-0.2.0.json
+++ b/src/schemas/json/factorial-drupal-breakpoints-css-0.2.0.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "drupal-breakpoints-css": {
-      "title": "Drupal breakpoints to CSS configuration",
+      "title": "drupal breakpoints to css configuration",
       "description": "https://github.com/factorial-io/drupal-breakpoints-css",
       "type": "object",
       "additionalProperties": false,
@@ -27,7 +27,7 @@
       "required": ["drupal"]
     },
     "drupal": {
-      "title": "Drupal configuration",
+      "title": "drupal configuration",
       "description": "https://github.com/factorial-io/drupal-breakpoints-css",
       "type": "object",
       "additionalProperties": false,
@@ -42,7 +42,7 @@
       "required": ["breakpointsPath", "themeName"]
     },
     "js": {
-      "title": "JavaScript configuration",
+      "title": "javascript configuration",
       "description": "https://github.com/factorial-io/drupal-breakpoints-css",
       "type": "object",
       "additionalProperties": false,
@@ -59,7 +59,7 @@
       }
     },
     "css": {
-      "title": "CSS configuration",
+      "title": "css configuration",
       "description": "https://github.com/factorial-io/drupal-breakpoints-css",
       "type": "object",
       "additionalProperties": false,
@@ -82,7 +82,7 @@
       }
     },
     "options": {
-      "title": "Toggle available extraction options",
+      "title": "toggle available extraction options",
       "description": "https://github.com/factorial-io/drupal-breakpoints-css",
       "type": "object",
       "additionalProperties": false,
@@ -102,7 +102,7 @@
       }
     },
     "prettier": {
-      "title": "Prettier options",
+      "title": "prettier options",
       "description": "https://github.com/factorial-io/drupal-breakpoints-css",
       "type": "object",
       "additionalProperties": false,

--- a/src/schemas/json/feed-1.json
+++ b/src/schemas/json/feed-1.json
@@ -300,6 +300,6 @@
     }
   },
   "required": ["items", "title", "version"],
-  "title": "JSON schema for the JSON Feed format",
+  "title": "json schema for the json feed format",
   "type": "object"
 }

--- a/src/schemas/json/feed.json
+++ b/src/schemas/json/feed.json
@@ -164,6 +164,6 @@
     }
   },
   "required": ["items", "title", "version"],
-  "title": "JSON schema for the JSON Feed format",
+  "title": "json schema for the json feed format",
   "type": "object"
 }

--- a/src/schemas/json/first-timers.json
+++ b/src/schemas/json/first-timers.json
@@ -5,21 +5,21 @@
   "description": "A bot that helps onboarding new open-source contributors.",
   "properties": {
     "labels": {
-      "title": "Labels",
+      "title": "labels",
       "description": "Sets the labels if \"first-timers-only\" is not what you are looking for.",
       "type": "array",
       "items": {
-        "title": "Label",
+        "title": "label",
         "type": "string"
       }
     },
     "template": {
-      "title": "Template",
+      "title": "template",
       "description": "The path to your template, relative from the repository root.",
       "type": "string"
     },
     "repository": {
-      "title": "Repository",
+      "title": "repository",
       "description": "Specify a different repository than where the problem is. The bot must be installed on the configured repository.",
       "type": "string"
     }

--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -395,7 +395,7 @@
     },
     "additionalProperties": true
   },
-  "title": "Fly.io config schema (fly.toml)",
+  "title": "fly.io config schema (fly.toml)",
   "type": "object",
   "x-taplo-info": {
     "authors": ["Joshua Sierles (https://github.com/jsierles)"],

--- a/src/schemas/json/foundryvtt-manifest.json
+++ b/src/schemas/json/foundryvtt-manifest.json
@@ -219,6 +219,6 @@
     }
   },
   "required": ["name", "title", "description", "version", "compatibility"],
-  "title": "JSON schema for Foundry VTT system.json and module.json files.",
+  "title": "json schema for foundry vtt system.json and module.json files.",
   "type": "object"
 }

--- a/src/schemas/json/foundryvtt-template.json
+++ b/src/schemas/json/foundryvtt-template.json
@@ -52,6 +52,6 @@
       "description": "The top level data schema for Item types."
     }
   },
-  "title": "JSON schema for Foundry VTT template.json files.",
+  "title": "json schema for foundry vtt template.json files.",
   "type": "object"
 }

--- a/src/schemas/json/function.json
+++ b/src/schemas/json/function.json
@@ -648,6 +648,6 @@
       }
     }
   },
-  "title": "JSON schema for Azure Functions function.json files",
+  "title": "json schema for azure functions function.json files",
   "type": "object"
 }

--- a/src/schemas/json/geojson.json
+++ b/src/schemas/json/geojson.json
@@ -3,7 +3,7 @@
   "additionalProperties": true,
   "definitions": {
     "coordinates": {
-      "title": "Coordinates",
+      "title": "coordinates",
       "type": "array",
       "items": {
         "oneOf": [
@@ -17,7 +17,7 @@
       }
     },
     "geometry": {
-      "title": "Geometry",
+      "title": "geometry",
       "description": "A geometry is a GeoJSON object where the type member's value is one of the following strings: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, or `GeometryCollection`.",
       "properties": {
         "type": {
@@ -34,7 +34,7 @@
       }
     },
     "feature": {
-      "title": "Feature",
+      "title": "feature",
       "description": "A GeoJSON object with the type `Feature` is a feature object.\n\n* A feature object must have a member with the name `geometry`. The value of the geometry member is a geometry object as defined above or a JSON null value.\n\n* A feature object must have a member with the name `properties`. The value of the properties member is an object (any JSON object or a JSON null value).\n\n* If a feature has a commonly used identifier, that identifier should be included as a member of the feature object with the name `id`.",
       "required": ["geometry", "properties"],
       "properties": {
@@ -42,7 +42,7 @@
           "enum": ["Feature"]
         },
         "geometry": {
-          "title": "Geometry",
+          "title": "geometry",
           "oneOf": [
             {
               "$ref": "#/definitions/geometry"
@@ -53,7 +53,7 @@
           ]
         },
         "properties": {
-          "title": "Properties",
+          "title": "properties",
           "oneOf": [
             {
               "type": "object"
@@ -67,7 +67,7 @@
       }
     },
     "linearRingCoordinates": {
-      "title": "Linear Ring Coordinates",
+      "title": "linear ring coordinates",
       "description": "A LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
       "allOf": [
         {
@@ -79,7 +79,7 @@
       ]
     },
     "lineStringCoordinates": {
-      "title": "Line String Coordinates",
+      "title": "line string coordinates",
       "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.",
       "allOf": [
         {
@@ -94,7 +94,7 @@
       ]
     },
     "polygonCoordinates": {
-      "title": "Polygon Coordinates",
+      "title": "polygon coordinates",
       "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
       "allOf": [
         {
@@ -108,7 +108,7 @@
       ]
     },
     "position": {
-      "title": "Position",
+      "title": "position",
       "type": "array",
       "description": "A position is the fundamental geometry construct. The `coordinates` member of a geometry object is composed of one position (in the case of a Point geometry), an array of positions (LineString or MultiPoint geometries), an array of arrays of positions (Polygons, MultiLineStrings), or a multidimensional array of positions (MultiPolygon).\n\nA position is represented by an array of numbers. There must be at least two elements, and may be more. The order of elements must follow x, y, z order (easting, northing, altitude for coordinates in a projected coordinate reference system, or longitude, latitude, altitude for coordinates in a geographic coordinate reference system). Any number of additional elements are allowed -- interpretation and meaning of additional elements is beyond the scope of this specification.",
       "minItems": 2,
@@ -121,7 +121,7 @@
   "id": "https://json.schemastore.org/geojson",
   "oneOf": [
     {
-      "title": "Point",
+      "title": "point",
       "description": "For type `Point`, the `coordinates` member must be a single position.",
       "required": ["coordinates"],
       "properties": {
@@ -146,7 +146,7 @@
       ]
     },
     {
-      "title": "Multi Point Geometry",
+      "title": "multi point geometry",
       "description": "For type `MultiPoint`, the `coordinates` member must be an array of positions.",
       "required": ["coordinates"],
       "properties": {
@@ -173,7 +173,7 @@
       ]
     },
     {
-      "title": "Line String",
+      "title": "line string",
       "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.\n\nA LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
       "required": ["coordinates"],
       "properties": {
@@ -191,7 +191,7 @@
       ]
     },
     {
-      "title": "MultiLineString",
+      "title": "multilinestring",
       "description": "For type `MultiLineString`, the `coordinates` member must be an array of LineString coordinate arrays.",
       "required": ["coordinates"],
       "properties": {
@@ -218,7 +218,7 @@
       ]
     },
     {
-      "title": "Polygon",
+      "title": "polygon",
       "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
       "required": ["coordinates"],
       "properties": {
@@ -236,7 +236,7 @@
       ]
     },
     {
-      "title": "Multi-Polygon Geometry",
+      "title": "multi-polygon geometry",
       "description": "For type `MultiPolygon`, the `coordinates` member must be an array of Polygon coordinate arrays.",
       "required": ["coordinates"],
       "properties": {
@@ -263,7 +263,7 @@
       ]
     },
     {
-      "title": "Geometry Collection",
+      "title": "geometry collection",
       "description": "A GeoJSON object with type `GeometryCollection` is a geometry object which represents a collection of geometry objects.\n\nA geometry collection must have a member with the name `geometries`. The value corresponding to `geometries` is an array. Each element in this array is a GeoJSON geometry object.",
       "required": ["geometries"],
       "properties": {
@@ -271,7 +271,7 @@
           "enum": ["GeometryCollection"]
         },
         "geometries": {
-          "title": "Geometries",
+          "title": "geometries",
           "type": "array",
           "items": {
             "$ref": "#/definitions/geometry"
@@ -288,7 +288,7 @@
       "$ref": "#/definitions/feature"
     },
     {
-      "title": "Feature Collection",
+      "title": "feature collection",
       "description": "A GeoJSON object with the type `FeatureCollection` is a feature collection object.\n\nAn object of type `FeatureCollection` must have a member with the name `features`. The value corresponding to `features` is an array. Each element in the array is a feature object as defined above.",
       "required": ["features"],
       "properties": {
@@ -296,7 +296,7 @@
           "enum": ["FeatureCollection"]
         },
         "features": {
-          "title": "Features",
+          "title": "features",
           "type": "array",
           "items": {
             "$ref": "#/definitions/feature"
@@ -307,7 +307,7 @@
   ],
   "properties": {
     "type": {
-      "title": "Type",
+      "title": "type",
       "type": "string",
       "description": "The type of GeoJSON object.",
       "enum": [
@@ -323,7 +323,7 @@
       ]
     },
     "crs": {
-      "title": "Coordinate Reference System (CRS)",
+      "title": "coordinate reference system (crs)",
       "description": "The coordinate reference system (CRS) of a GeoJSON object is determined by its `crs` member (referred to as the CRS object below). If an object has no crs member, then its parent or grandparent object's crs member may be acquired. If no crs member can be so acquired, the default CRS shall apply to the GeoJSON object.\n\n* The default CRS is a geographic coordinate reference system, using the WGS84 datum, and with longitude and latitude units of decimal degrees.\n\n* The value of a member named `crs` must be a JSON object (referred to as the CRS object below) or JSON null. If the value of CRS is null, no CRS can be assumed.\n\n* The crs member should be on the top-level GeoJSON object in a hierarchy (in feature collection, feature, geometry order) and should not be repeated or overridden on children or grandchildren of the object.\n\n* A non-null CRS object has two mandatory members: `type` and `properties`.\n\n* The value of the type member must be a string, indicating the type of CRS object.\n\n* The value of the properties member must be an object.\n\n* CRS shall not change coordinate ordering.",
       "oneOf": [
         {
@@ -334,13 +334,13 @@
           "required": ["type", "properties"],
           "properties": {
             "type": {
-              "title": "CRS Type",
+              "title": "crs type",
               "type": "string",
               "description": "The value of the type member must be a string, indicating the type of CRS object.",
               "minLength": 1
             },
             "properties": {
-              "title": "CRS Properties",
+              "title": "crs properties",
               "type": "object"
             }
           }
@@ -373,7 +373,7 @@
               },
               "properties": {
                 "not": {
-                  "title": "Link Object",
+                  "title": "link object",
                   "type": "object",
                   "required": ["href"],
                   "properties": {
@@ -384,7 +384,7 @@
                       "format": "uri"
                     },
                     "type": {
-                      "title": "Link Object Type",
+                      "title": "link object type",
                       "type": "string",
                       "description": "The value of the optional `type` member must be a string that hints at the format used to represent CRS parameters at the provided URI. Suggested values are: `proj4`, `ogcwkt`, `esriwkt`, but others can be used."
                     }
@@ -397,7 +397,7 @@
       }
     },
     "bbox": {
-      "title": "Bounding Box",
+      "title": "bounding box",
       "type": "array",
       "description": "To include information on the coordinate range for geometries, features, or feature collections, a GeoJSON object may have a member named `bbox`. The value of the bbox member must be a 2*n array where n is the number of dimensions represented in the contained geometries, with the lowest values for all axes followed by the highest values. The axes order of a bbox follows the axes order of geometries. In addition, the coordinate reference system for the bbox is assumed to match the coordinate reference system of the GeoJSON object of which it is a member.",
       "minItems": 4,
@@ -407,6 +407,6 @@
     }
   },
   "required": ["type"],
-  "title": "GeoJSON Object",
+  "title": "geojson object",
   "type": "object"
 }

--- a/src/schemas/json/github-funding.json
+++ b/src/schemas/json/github-funding.json
@@ -16,13 +16,13 @@
   "description": "You can add a sponsor button in your repository to increase the visibility of funding options for your open source project.",
   "properties": {
     "community_bridge": {
-      "title": "CommunityBridge",
+      "title": "communitybridge",
       "description": "Project name on CommunityBridge.",
       "$ref": "#/definitions/nullable_string",
       "minLength": 1
     },
     "github": {
-      "title": "GitHub Sponsors",
+      "title": "github sponsors",
       "description": "Username or usernames on GitHub.",
       "oneOf": [
         {
@@ -39,55 +39,55 @@
       ]
     },
     "issuehunt": {
-      "title": "IssueHunt",
+      "title": "issuehunt",
       "description": "Username on IssueHunt.",
       "$ref": "#/definitions/nullable_string",
       "minLength": 1
     },
     "ko_fi": {
-      "title": "Ko-fi",
+      "title": "ko-fi",
       "description": "Username on Ko-fi.",
       "$ref": "#/definitions/nullable_string",
       "minLength": 1
     },
     "liberapay": {
-      "title": "Liberapay",
+      "title": "liberapay",
       "description": "Username on Liberapay.",
       "$ref": "#/definitions/nullable_string",
       "minLength": 1
     },
     "open_collective": {
-      "title": "Open Collective",
+      "title": "open collective",
       "description": "Username on Open Collective.",
       "$ref": "#/definitions/nullable_string",
       "minLength": 1
     },
     "otechie": {
-      "title": "Otechie",
+      "title": "otechie",
       "description": "Username on Otechie.",
       "$ref": "#/definitions/nullable_string",
       "minLength": 1
     },
     "patreon": {
-      "title": "Patreon",
+      "title": "patreon",
       "description": "Username on Pateron.",
       "$ref": "#/definitions/nullable_string",
       "minLength": 1,
       "maxLength": 100
     },
     "tidelift": {
-      "title": "Tidelift",
+      "title": "tidelift",
       "description": "Platform and package on Tidelift.",
       "$ref": "#/definitions/nullable_string",
       "pattern": "^(npm|pypi|rubygems|maven|packagist|nuget)/.+$"
     },
     "custom": {
-      "title": "Custom URL",
+      "title": "custom url",
       "description": "Link or links where funding is accepted on external locations.",
       "type": ["string", "array", "null"],
       "format": "uri-reference",
       "items": {
-        "title": "Link",
+        "title": "link",
         "description": "Link to an external location.",
         "type": "string",
         "format": "uri-reference"
@@ -95,6 +95,6 @@
       "uniqueItems": true
     }
   },
-  "title": "GitHub Funding",
+  "title": "github funding",
   "type": "object"
 }

--- a/src/schemas/json/github-issue-config.json
+++ b/src/schemas/json/github-issue-config.json
@@ -39,6 +39,6 @@
     },
     "additionalProperties": false
   },
-  "title": "GitHub issue template chooser config file schema",
+  "title": "github issue template chooser config file schema",
   "type": "object"
 }

--- a/src/schemas/json/github-issue-forms.json
+++ b/src/schemas/json/github-issue-forms.json
@@ -1284,6 +1284,6 @@
     }
   },
   "required": ["name", "description", "body"],
-  "title": "GitHub issue forms config file schema",
+  "title": "github issue forms config file schema",
   "type": "object"
 }

--- a/src/schemas/json/github-workflow-template-properties.json
+++ b/src/schemas/json/github-workflow-template-properties.json
@@ -910,6 +910,6 @@
     }
   },
   "required": ["name", "description"],
-  "title": "GitHub starter workflow config file schema",
+  "title": "github starter workflow config file schema",
   "type": "object"
 }

--- a/src/schemas/json/gitversion.json
+++ b/src/schemas/json/gitversion.json
@@ -7,7 +7,7 @@
     "Major": {
       "$id": "#/properties/Major",
       "type": "integer",
-      "title": "Major version part",
+      "title": "major version part",
       "description": "",
       "default": 0,
       "examples": [0]
@@ -15,7 +15,7 @@
     "Minor": {
       "$id": "#/properties/Minor",
       "type": "integer",
-      "title": "Minor version part",
+      "title": "minor version part",
       "description": "",
       "default": 0,
       "examples": [7]
@@ -23,7 +23,7 @@
     "Patch": {
       "$id": "#/properties/Patch",
       "type": "integer",
-      "title": "Patch version part",
+      "title": "patch version part",
       "description": "",
       "default": 0,
       "examples": [1]
@@ -31,7 +31,7 @@
     "PreReleaseTag": {
       "$id": "#/properties/PreReleaseTag",
       "type": "string",
-      "title": "Pre-release tag",
+      "title": "pre-release tag",
       "description": "",
       "default": "",
       "examples": ["alpha"]
@@ -39,7 +39,7 @@
     "PreReleaseTagWithDash": {
       "$id": "#/properties/PreReleaseTagWithDash",
       "type": "string",
-      "title": "Pre-release tag with dash",
+      "title": "pre-release tag with dash",
       "description": "",
       "default": "",
       "examples": ["-alpha"]
@@ -47,7 +47,7 @@
     "PreReleaseLabel": {
       "$id": "#/properties/PreReleaseLabel",
       "type": "string",
-      "title": "Pre-release label",
+      "title": "pre-release label",
       "description": "",
       "default": "",
       "examples": ["alpha"]
@@ -55,7 +55,7 @@
     "PreReleaseNumber": {
       "$id": "#/properties/PreReleaseNumber",
       "type": "integer",
-      "title": "Pre-release number",
+      "title": "pre-release number",
       "description": "",
       "default": 0,
       "examples": [1]
@@ -63,7 +63,7 @@
     "WeightedPreReleaseNumber": {
       "$id": "#/properties/WeightedPreReleaseNumber",
       "type": "integer",
-      "title": "Weighted pre-release number",
+      "title": "weighted pre-release number",
       "description": "A summation of branch specific pre-release-weight and the PreReleaseNumber. It can be used to obtain a monotonically increasing version number across the branches",
       "default": 0,
       "examples": [55001]
@@ -71,7 +71,7 @@
     "BuildMetaData": {
       "$id": "#/properties/BuildMetaData",
       "type": "string",
-      "title": "Build metadata",
+      "title": "build metadata",
       "description": "",
       "default": "",
       "examples": [""]
@@ -79,7 +79,7 @@
     "BuildMetaDataPadded": {
       "$id": "#/properties/BuildMetaDataPadded",
       "type": "string",
-      "title": "Build metadata, padded",
+      "title": "build metadata, padded",
       "description": "",
       "default": "",
       "examples": [""]
@@ -87,7 +87,7 @@
     "FullBuildMetaData": {
       "$id": "#/properties/FullBuildMetaData",
       "type": "string",
-      "title": "Full build metadata",
+      "title": "full build metadata",
       "description": "Includes branch and commit hash",
       "default": "",
       "examples": ["Branch.master.Sha.3a34284b9e04010912f491ce662c813ebfdcae0b"]
@@ -95,7 +95,7 @@
     "MajorMinorPatch": {
       "$id": "#/properties/MajorMinorPatch",
       "type": "string",
-      "title": "Major.Minor.Patch version",
+      "title": "major.minor.patch version",
       "description": "",
       "default": "",
       "examples": ["0.7.1"]
@@ -103,7 +103,7 @@
     "SemVer": {
       "$id": "#/properties/SemVer",
       "type": "string",
-      "title": "Semantic version",
+      "title": "semantic version",
       "description": "",
       "default": "",
       "examples": ["0.7.1-alpha.1"]
@@ -111,7 +111,7 @@
     "LegacySemVer": {
       "$id": "#/properties/LegacySemVer",
       "type": "string",
-      "title": "Legacy semantic version",
+      "title": "legacy semantic version",
       "description": "For pre v2.0 compatibility",
       "default": "",
       "examples": ["0.7.1-alpha1"]
@@ -119,7 +119,7 @@
     "LegacySemVerPadded": {
       "$id": "#/properties/LegacySemVerPadded",
       "type": "string",
-      "title": "Legacy semantic version, padded",
+      "title": "legacy semantic version, padded",
       "description": "",
       "default": "",
       "examples": ["0.7.1-alpha0001"]
@@ -127,7 +127,7 @@
     "AssemblySemVer": {
       "$id": "#/properties/AssemblySemVer",
       "type": "string",
-      "title": "Assembly semantic version",
+      "title": "assembly semantic version",
       "description": "Semantic version for windows/.NET assembly use. If configured as Major.Minor, gives you the ability to roll out hot fixes to your assembly without breaking existing applications that may be referencing it.",
       "default": "",
       "examples": ["0.7.0.0"]
@@ -135,7 +135,7 @@
     "AssemblySemFileVer": {
       "$id": "#/properties/AssemblySemFileVer",
       "type": "string",
-      "title": "Semantic version for windows/.NET assembly file use. May be used to contain the full version number when AssemblyVersion is set to Major.Minor",
+      "title": "semantic version for windows/.net assembly file use. may be used to contain the full version number when assemblyversion is set to major.minor",
       "description": "",
       "default": "",
       "examples": ["0.7.1.0"]
@@ -143,7 +143,7 @@
     "FullSemVer": {
       "$id": "#/properties/FullSemVer",
       "type": "string",
-      "title": "Full semantic version",
+      "title": "full semantic version",
       "description": "",
       "default": "",
       "examples": ["0.7.1-alpha.1"]
@@ -151,7 +151,7 @@
     "InformationalVersion": {
       "$id": "#/properties/InformationalVersion",
       "type": "string",
-      "title": "Informational version",
+      "title": "informational version",
       "description": "Combined version and build metadata",
       "default": "",
       "examples": [
@@ -161,7 +161,7 @@
     "BranchName": {
       "$id": "#/properties/BranchName",
       "type": "string",
-      "title": "Branch name",
+      "title": "branch name",
       "description": "Repository branch name",
       "default": "",
       "examples": ["master"]
@@ -169,7 +169,7 @@
     "EscapedBranchName": {
       "$id": "#/properties/EscapedBranchName",
       "type": "string",
-      "title": "Escaped branch name",
+      "title": "escaped branch name",
       "description": "Repository branch name, containing only alphanumeric characters and -",
       "default": "",
       "examples": ["master"]
@@ -177,7 +177,7 @@
     "Sha": {
       "$id": "#/properties/Sha",
       "type": "string",
-      "title": "SHA",
+      "title": "sha",
       "description": "The commit hash that was used for the build",
       "default": "",
       "examples": ["3a34284b9e04010912f491ce662c813ebfdcae0b"],
@@ -187,7 +187,7 @@
     "ShortSha": {
       "$id": "#/properties/ShortSha",
       "type": "string",
-      "title": "Short SHA",
+      "title": "short sha",
       "description": "A shorter representation of the build commit hash",
       "default": "",
       "examples": ["3a34284"],
@@ -197,7 +197,7 @@
     "NuGetVersionV2": {
       "$id": "#/properties/NuGetVersionV2",
       "type": "string",
-      "title": "NuGet version v2",
+      "title": "nuget version v2",
       "description": "NuGet package version string, using semantic version v2.0",
       "default": "",
       "examples": ["0.7.1-alpha0001"]
@@ -205,7 +205,7 @@
     "NuGetVersion": {
       "$id": "#/properties/NuGetVersion",
       "type": "string",
-      "title": "NuGet version",
+      "title": "nuget version",
       "description": "NuGet package version string, without semantic version v2.0 format",
       "default": "",
       "examples": ["0.7.1-alpha0001"]
@@ -213,7 +213,7 @@
     "NuGetPreReleaseTagV2": {
       "$id": "#/properties/NuGetPreReleaseTagV2",
       "type": "string",
-      "title": "NuGet pre-release tag v2",
+      "title": "nuget pre-release tag v2",
       "description": "NuGet package pre-release tag for semantic version v2.0",
       "default": "",
       "examples": ["alpha0001"]
@@ -221,7 +221,7 @@
     "NuGetPreReleaseTag": {
       "$id": "#/properties/NuGetPreReleaseTag",
       "type": "string",
-      "title": "NuGetPreReleaseTag",
+      "title": "nugetprereleasetag",
       "description": "NuGet package pre-release tag, without semantic version v2.0 format",
       "default": "",
       "examples": ["alpha0001"]
@@ -229,7 +229,7 @@
     "VersionSourceSha": {
       "$id": "#/properties/VersionSourceSha",
       "type": "string",
-      "title": "Version source SHA",
+      "title": "version source sha",
       "description": "The hash of the commit used as version source",
       "default": "",
       "examples": ["1014284b9e04010912f491ce662c813ebfdcaccd"]
@@ -237,7 +237,7 @@
     "CommitsSinceVersionSource": {
       "$id": "#/properties/CommitsSinceVersionSource",
       "type": "integer",
-      "title": "Commits since version source",
+      "title": "commits since version source",
       "description": "The number of commits made since the version source commit",
       "default": 0,
       "examples": [1]
@@ -245,7 +245,7 @@
     "CommitsSinceVersionSourcePadded": {
       "$id": "#/properties/CommitsSinceVersionSourcePadded",
       "type": "string",
-      "title": "Commits since version source, padded",
+      "title": "commits since version source, padded",
       "description": "The number of commits made since the version source commit (zero-padded)",
       "default": "",
       "examples": ["0001"],
@@ -255,7 +255,7 @@
     "CommitDate": {
       "$id": "#/properties/CommitDate",
       "type": "string",
-      "title": "Commit date",
+      "title": "commit date",
       "description": "",
       "default": "",
       "examples": ["2020-05-09"]
@@ -294,6 +294,6 @@
     "CommitsSinceVersionSourcePadded",
     "CommitDate"
   ],
-  "title": "GitVersion Variables",
+  "title": "gitversion variables",
   "type": "object"
 }

--- a/src/schemas/json/global.json
+++ b/src/schemas/json/global.json
@@ -33,6 +33,6 @@
       }
     }
   },
-  "title": "JSON schema for the .NET global configuration file",
+  "title": "json schema for the .net global configuration file",
   "type": "object"
 }

--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -1958,7 +1958,7 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "title": "The rule name"
+                    "title": "the rule name"
                   },
                   "disabled": {
                     "type": "boolean"

--- a/src/schemas/json/gpc.json
+++ b/src/schemas/json/gpc.json
@@ -4,22 +4,22 @@
   "description": "Configuration for GPC, so a site can convey its support for the Global Privacy Control.",
   "properties": {
     "gpc": {
-      "title": "Global Privacy Control",
+      "title": "global privacy control",
       "description": "Indicates that the server intends to abide by GPC requests.",
       "type": "boolean"
     },
     "version": {
-      "title": "Version",
+      "title": "version",
       "type": "integer",
       "default": 1
     },
     "lastUpdate": {
-      "title": "Last Update",
+      "title": "last update",
       "description": "This indicates the time at which the statement of support was made, such that later changes to the meaning of the GPC standard should not affect the interpretation of the resource for legal purposes. If the member is not in a valid ISO 8601 format, the last update date and time is unknown.",
       "type": "string"
     }
   },
   "required": ["gpc"],
-  "title": "Global Privacy Control",
+  "title": "global privacy control",
   "type": "object"
 }

--- a/src/schemas/json/grafana-dashboard-5.x.json
+++ b/src/schemas/json/grafana-dashboard-5.x.json
@@ -253,6 +253,6 @@
       "type": "boolean"
     }
   },
-  "title": "Grafana Dashboard 5.x",
+  "title": "grafana dashboard 5.x",
   "type": "object"
 }

--- a/src/schemas/json/grunt-clean-task.json
+++ b/src/schemas/json/grunt-clean-task.json
@@ -47,6 +47,6 @@
       "$ref": "#/definitions/options"
     }
   },
-  "title": "JSON schema for the Grunt clean task",
+  "title": "json schema for the grunt clean task",
   "type": "object"
 }

--- a/src/schemas/json/grunt-copy-task.json
+++ b/src/schemas/json/grunt-copy-task.json
@@ -41,6 +41,6 @@
       "$ref": "#/definitions/options"
     }
   },
-  "title": "JSON schema for the Grunt clean task",
+  "title": "json schema for the grunt clean task",
   "type": "object"
 }

--- a/src/schemas/json/grunt-cssmin-task.json
+++ b/src/schemas/json/grunt-cssmin-task.json
@@ -45,6 +45,6 @@
       "$ref": "#/definitions/options"
     }
   },
-  "title": "JSON schema for the Grunt cssmin task",
+  "title": "json schema for the grunt cssmin task",
   "type": "object"
 }

--- a/src/schemas/json/grunt-jshint-task.json
+++ b/src/schemas/json/grunt-jshint-task.json
@@ -44,6 +44,6 @@
       "$ref": "#/definitions/options"
     }
   },
-  "title": "JSON schema for the Grunt JSHint task",
+  "title": "json schema for the grunt jshint task",
   "type": "object"
 }

--- a/src/schemas/json/grunt-task.json
+++ b/src/schemas/json/grunt-task.json
@@ -111,6 +111,6 @@
       "type": "object"
     }
   },
-  "title": "JSON schema for any Grunt task",
+  "title": "json schema for any grunt task",
   "type": "object"
 }

--- a/src/schemas/json/grunt-watch-task.json
+++ b/src/schemas/json/grunt-watch-task.json
@@ -120,6 +120,6 @@
       "$ref": "#/definitions/options"
     }
   },
-  "title": "JSON schema for the Grunt Watch task",
+  "title": "json schema for the grunt watch task",
   "type": "object"
 }

--- a/src/schemas/json/hammerkit.json
+++ b/src/schemas/json/hammerkit.json
@@ -419,6 +419,6 @@
       "$ref": "#/definitions/buildFileReferences"
     }
   },
-  "title": "JSON Schema for hammerkit's build file",
+  "title": "json schema for hammerkit's build file",
   "type": "object"
 }

--- a/src/schemas/json/haxelib.json
+++ b/src/schemas/json/haxelib.json
@@ -1,4 +1,4 @@
 {
   "$ref": "https://raw.githubusercontent.com/HaxeFoundation/haxelib/master/schema.json",
-  "title": "Haxelib project configuration"
+  "title": "haxelib project configuration"
 }

--- a/src/schemas/json/helmfile.json
+++ b/src/schemas/json/helmfile.json
@@ -511,5 +511,5 @@
       }
     }
   },
-  "title": "Helmfile config schema"
+  "title": "helmfile config schema"
 }

--- a/src/schemas/json/hemtt-0.6.2.json
+++ b/src/schemas/json/hemtt-0.6.2.json
@@ -31,7 +31,7 @@
     "name": {
       "$id": "#/properties/name",
       "type": "string",
-      "title": "The Name Schema",
+      "title": "the name schema",
       "default": "",
       "description": "Long name of your project.",
       "examples": ["Advanced Banana Environment"],
@@ -40,7 +40,7 @@
     "prefix": {
       "$id": "#/properties/prefix",
       "type": "string",
-      "title": "The Prefix Schema",
+      "title": "the prefix schema",
       "default": "",
       "description": "Prefix used for CBA macros and the release directory name.",
       "examples": ["ABE3"],
@@ -49,7 +49,7 @@
     "author": {
       "$id": "#/properties/author",
       "type": "string",
-      "title": "The Author Schema",
+      "title": "the author schema",
       "default": "",
       "description": "Author of the project.",
       "examples": ["ACE Mod Team"],
@@ -58,7 +58,7 @@
     "version": {
       "$id": "#/properties/version",
       "type": "string",
-      "title": "The Version Schema",
+      "title": "the version schema",
       "default": "",
       "description": "HEMTT will look for ```addons/main/script_version.hpp``` and use it for the version number. If you are not using the CBA project structure or do not have that file you can add a version number in the HEMTT project file.",
       "examples": ["1.0.0.0"],
@@ -67,13 +67,13 @@
     "files": {
       "$id": "#/properties/files",
       "type": "array",
-      "title": "The Files Schema",
+      "title": "the files schema",
       "default": null,
       "description": "HEMTT will copy the files to the release directory after a successful release build. Supports glob patterns.",
       "items": {
         "$id": "#/properties/files/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": ["mod.cpp", "logo.paa", "*.dll"],
         "pattern": "^(.*)$"
@@ -82,13 +82,13 @@
     "include": {
       "$id": "#/properties/include",
       "type": "array",
-      "title": "The Include Schema",
+      "title": "the include schema",
       "default": null,
       "description": "HEMTT will include matching relative or absolute paths when building.",
       "items": {
         "$id": "#/properties/include/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": ["./include"],
         "pattern": "^(.*)$"
@@ -97,13 +97,13 @@
     "exclude": {
       "$id": "#/properties/exclude",
       "type": "array",
-      "title": "The Exclude Schema",
+      "title": "the exclude schema",
       "default": null,
       "description": "HEMTT will exclude matching files when building.",
       "items": {
         "$id": "#/properties/exclude/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": ["*.psd", "*.png", "*.tga"],
         "pattern": "^(.*)$"
@@ -112,13 +112,13 @@
     "optionals": {
       "$id": "#/properties/optionals",
       "type": "array",
-      "title": "The Optionals Schema",
+      "title": "the optionals schema",
       "default": null,
       "description": "HEMTT will build the specified addons from the ./optionals folder.",
       "items": {
         "$id": "#/properties/optionals/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": ["tracers", "particles"],
         "pattern": "^(.*)$"
@@ -127,7 +127,7 @@
     "folder_optionals": {
       "$id": "#/properties/folder_optionals",
       "type": "boolean",
-      "title": "The Folder_optionals Schema",
+      "title": "the folder_optionals schema",
       "description": "HEMTT will by default build optionals into their own mod folders, which can be directly launched by the user. This can be turned off to build optional PBOs directly into optionals folder.",
       "default": false,
       "examples": [false]
@@ -135,13 +135,13 @@
     "skip": {
       "$id": "#/properties/skip",
       "type": "array",
-      "title": "The Skip Schema",
+      "title": "the skip schema",
       "default": null,
       "description": "HEMTT will skip building the specified addons.",
       "items": {
         "$id": "#/properties/skip/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": ["hearing", "zeus"],
         "pattern": "^(.*)$"
@@ -150,13 +150,13 @@
     "headerexts": {
       "$id": "#/properties/headerexts",
       "type": "array",
-      "title": "The Headerexts Schema",
+      "title": "the headerexts schema",
       "default": null,
       "description": "HEMTT will apply specified header extensions to each PBO. Supports templating.",
       "items": {
         "$id": "#/properties/headerexts/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": ["author=me"],
         "pattern": "^(.*)$"
@@ -165,7 +165,7 @@
     "modname": {
       "$id": "#/properties/modname",
       "type": "string",
-      "title": "The Modname Schema",
+      "title": "the modname schema",
       "description": "HEMTT will use the specified mod name (without @) to form @mod folder. Supports templating.",
       "default": "",
       "examples": ["my_mod"],
@@ -174,7 +174,7 @@
     "keyname": {
       "$id": "#/properties/keyname",
       "type": "string",
-      "title": "The Keyname Schema",
+      "title": "the keyname schema",
       "description": "HEMTT will use the specified key name for .bikey and .biprivatekey names. Supports templating.",
       "default": "",
       "examples": ["my_key"],
@@ -183,7 +183,7 @@
     "signame": {
       "$id": "#/properties/signame",
       "type": "string",
-      "title": "The Signame Schema",
+      "title": "the signame schema",
       "description": "HEMTT will use the specified signature name as part of the full signature (.bisign) name. Supports templating.",
       "default": "",
       "examples": ["my_custom_name"],
@@ -192,7 +192,7 @@
     "sigversion": {
       "$id": "#/properties/sigversion",
       "type": "integer",
-      "title": "The Sigversion Schema",
+      "title": "the sigversion schema",
       "description": "HEMTT will use the specified signature version. Currently Supported: V2, V3 (Experimental).",
       "default": 2,
       "examples": [3]
@@ -200,7 +200,7 @@
     "reuse_private_key": {
       "$id": "#/properties/reuse_private_key",
       "type": "boolean",
-      "title": "The Reuse_private_key Schema",
+      "title": "the reuse_private_key schema",
       "description": "If set to true, HEMTT will use (and re-use) releases/keys/{keyname}.biprivatekey. It will be generated if it doesn't exist. The default behaviour is to generate a new private key each time and discard it immediately. HEMTT strongly recommends that you only re-use the key if you are making a client-side mod where it will not matter if clients are running different versions of the mod.",
       "default": false,
       "examples": [false]
@@ -208,12 +208,12 @@
     "postbuild": {
       "$id": "#/properties/postbuild",
       "type": "array",
-      "title": "The Postbuild Schema",
+      "title": "the postbuild schema",
       "default": null,
       "items": {
         "$id": "#/properties/postbuild/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": [""],
         "pattern": "^(.*)$"
@@ -222,12 +222,12 @@
     "prebuild": {
       "$id": "#/properties/prebuild",
       "type": "array",
-      "title": "The Prebuild Schema",
+      "title": "the prebuild schema",
       "default": null,
       "items": {
         "$id": "#/properties/prebuild/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": [""],
         "pattern": "^(.*)$"
@@ -236,12 +236,12 @@
     "releasebuild": {
       "$id": "#/properties/releasebuild",
       "type": "array",
-      "title": "The Releasebuild Schema",
+      "title": "the releasebuild schema",
       "default": null,
       "items": {
         "$id": "#/properties/releasebuild/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "default": "",
         "examples": [""],
         "pattern": "^(.*)$"
@@ -250,23 +250,23 @@
     "scripts": {
       "$id": "#/properties/scripts",
       "type": "object",
-      "title": "The Scripts Schema",
+      "title": "the scripts schema",
       "default": null,
       "additionalProperties": {
         "$id": "#/properties/scripts/properties/",
         "type": "object",
-        "title": "The  Schema",
+        "title": "the  schema",
         "default": null,
         "properties": {
           "steps": {
             "$id": "#/properties/scripts/properties//properties/steps",
             "type": "array",
-            "title": "The Steps Schema",
+            "title": "the steps schema",
             "default": null,
             "items": {
               "$id": "#/properties/scripts/properties//properties/steps/items",
               "type": "string",
-              "title": "The Items Schema",
+              "title": "the items schema",
               "default": "",
               "examples": ["echo {{addon}} took {{time}} ms to build."],
               "pattern": "^(.*)$"
@@ -275,13 +275,13 @@
           "steps_linux": {
             "$id": "#/properties/scripts/properties//properties/steps_linux",
             "type": "array",
-            "title": "The Steps_linux Schema",
+            "title": "the steps_linux schema",
             "default": null,
             "description": "steps_windows and steps_linux can be used to run different steps on the respective platforms.",
             "items": {
               "$id": "#/properties/scripts/properties//properties/steps_linux/items",
               "type": "string",
-              "title": "The Items Schema",
+              "title": "the items schema",
               "default": "",
               "examples": [""],
               "pattern": "^(.*)$"
@@ -290,13 +290,13 @@
           "steps_windows": {
             "$id": "#/properties/scripts/properties//properties/steps_windows",
             "type": "array",
-            "title": "The Steps_windows Schema",
+            "title": "the steps_windows schema",
             "default": null,
             "description": "steps_windows and steps_linux can be used to run different steps on the respective platforms.",
             "items": {
               "$id": "#/properties/scripts/properties//properties/steps_windows/items",
               "type": "string",
-              "title": "The Items Schema",
+              "title": "the items schema",
               "default": "",
               "examples": [""],
               "pattern": "^(.*)$"
@@ -305,7 +305,7 @@
           "show_output": {
             "$id": "#/properties/scripts/properties//properties/show_output",
             "type": "boolean",
-            "title": "The Show_output Schema",
+            "title": "the show_output schema",
             "description": "All output is hidden by default. Setting show_output will display the command being executed and its output.",
             "default": false,
             "examples": [true]
@@ -313,7 +313,7 @@
           "foreach": {
             "$id": "#/properties/scripts/properties//properties/foreach",
             "type": "boolean",
-            "title": "The Foreach Schema",
+            "title": "the foreach schema",
             "default": false,
             "description": "Scripts can be ran for each addons. Inside prebuild the script will be ran for each addon that HEMTT will build, including addons that will be skipped if they are already built. Inside postbuild and releasebuild only addons that were successfully built with be used, excluding addons that were skipped for being up to date.",
             "examples": [true]
@@ -321,7 +321,7 @@
           "parallel": {
             "$id": "#/properties/scripts/properties//properties/parallel",
             "type": "boolean",
-            "title": "The Parallel Schema",
+            "title": "the parallel schema",
             "description": "Requires foreach to be true. If a script is thread safe parallel can be used to process multiple addons at a time.",
             "default": false,
             "examples": [true]
@@ -336,6 +336,6 @@
     }
   },
   "required": ["name", "prefix", "author"],
-  "title": "The Root Schema",
+  "title": "the root schema",
   "type": "object"
 }

--- a/src/schemas/json/host-meta.json
+++ b/src/schemas/json/host-meta.json
@@ -67,6 +67,6 @@
     }
   },
   "required": ["subject"],
-  "title": "JSON schema for host-meta files",
+  "title": "json schema for host-meta files",
   "type": "object"
 }

--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -1393,6 +1393,6 @@
       "$ref": "#/definitions/version-2"
     }
   ],
-  "title": "JSON schema for Azure Functions host.json files",
+  "title": "json schema for azure functions host.json files",
   "type": "object"
 }

--- a/src/schemas/json/htmlhint.json
+++ b/src/schemas/json/htmlhint.json
@@ -122,6 +122,6 @@
       "default": false
     }
   },
-  "title": "JSON schema for HTMLHint configuration files",
+  "title": "json schema for htmlhint configuration files",
   "type": "object"
 }

--- a/src/schemas/json/httpmockrc.json
+++ b/src/schemas/json/httpmockrc.json
@@ -50,6 +50,6 @@
     }
   },
   "required": ["mockFileName", "routes"],
-  "title": "Http-mocker configuration.",
+  "title": "http-mocker configuration.",
   "type": "object"
 }

--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -734,7 +734,7 @@
           "pattern": "^#(\\d|[ABCDEFabcdef]){6}$"
         },
         "exif": {
-          "title": "Exif options",
+          "title": "exif options",
           "description": "Exif options\nhttps://gohugo.io/content-management/image-processing/#image-processing-config",
           "type": "object",
           "properties": {
@@ -869,7 +869,7 @@
       },
       "properties": {
         "asciidocExt": {
-          "title": "AsciidocExt options",
+          "title": "asciidocext options",
           "description": "AsciidocExt options\nhttps://docs.asciidoctor.org/asciidoctor/latest/cli/man1/asciidoctor/#processing-information",
           "type": "object",
           "properties": {
@@ -945,7 +945,7 @@
           "additionalProperties": false
         },
         "blackfriday": {
-          "title": "Blackfriday options",
+          "title": "blackfriday options",
           "description": "Blackfriday options\nhttps://gohugo.io/getting-started/configuration-markup#blackfriday",
           "type": "object",
           "properties": {
@@ -1044,7 +1044,7 @@
           "enum": ["goldmark", "blackfriday"]
         },
         "goldmark": {
-          "title": "Goldmark options",
+          "title": "goldmark options",
           "description": "Goldmark options\nhttps://gohugo.io/getting-started/configuration-markup#goldmark",
           "type": "object",
           "default": {
@@ -3161,6 +3161,6 @@
       "default": false
     }
   },
-  "title": "Hugo static site generator config file schema",
+  "title": "hugo static site generator config file schema",
   "type": "object"
 }

--- a/src/schemas/json/huskyrc.json
+++ b/src/schemas/json/huskyrc.json
@@ -13,12 +13,12 @@
       "type": "string"
     },
     "skipCI": {
-      "title": "Skipping Git hooks installation.",
+      "title": "skipping git hooks installation.",
       "type": "boolean",
       "default": false
     },
     "hooks": {
-      "title": "Git hooks.",
+      "title": "git hooks.",
       "type": "object",
       "properties": {
         "applypatch-msg": {
@@ -152,6 +152,6 @@
     }
   },
   "required": ["hooks"],
-  "title": "Husky configuration.",
+  "title": "husky configuration.",
   "type": "object"
 }

--- a/src/schemas/json/hws-config.json
+++ b/src/schemas/json/hws-config.json
@@ -579,6 +579,6 @@
       "$ref": "#/definitions/sequential"
     }
   },
-  "title": "Hardware Sentry configuration file",
+  "title": "hardware sentry configuration file",
   "type": "object"
 }

--- a/src/schemas/json/ide.host.json
+++ b/src/schemas/json/ide.host.json
@@ -252,6 +252,6 @@
       }
     }
   },
-  "title": "JSON schema for IDE template host files",
+  "title": "json schema for ide template host files",
   "type": "object"
 }

--- a/src/schemas/json/imgbotconfig.json
+++ b/src/schemas/json/imgbotconfig.json
@@ -3,16 +3,16 @@
   "default": {},
   "properties": {
     "schedule": {
-      "title": "Limits the PRs from Imgbot to once a day, once a week, or once a month respectively. The default behavior is to receive Imgbot PRs as images require optimization.",
+      "title": "limits the prs from imgbot to once a day, once a week, or once a month respectively. the default behavior is to receive imgbot prs as images require optimization.",
       "type": "string",
       "enum": ["daily", "weekly", "monthly"],
       "default": ""
     },
     "ignoredFiles": {
-      "title": "Limits the images optimized by Imgbot by essentially ignoring them",
+      "title": "limits the images optimized by imgbot by essentially ignoring them",
       "type": "array",
       "items": {
-        "title": "Accepts the syntax for searchPattern on Directory.EnumerateFiles()",
+        "title": "accepts the syntax for searchpattern on directory.enumeratefiles()",
         "type": "string",
         "pattern": "^/?([^/]+/)*[^/]+/?$",
         "default": ""
@@ -20,7 +20,7 @@
       "default": []
     },
     "aggressiveCompression": {
-      "title": "Opt in to use lossy compression algorithms. The default behaviour without this setting is loss less compression.",
+      "title": "opt in to use lossy compression algorithms. the default behaviour without this setting is loss less compression.",
       "oneOf": [
         {
           "type": "boolean"
@@ -33,7 +33,7 @@
       "default": false
     },
     "compressWiki": {
-      "title": "Opt in to also compress wiki repo. The default behaviour is opt out.",
+      "title": "opt in to also compress wiki repo. the default behaviour is opt out.",
       "oneOf": [
         {
           "type": "boolean"
@@ -46,11 +46,11 @@
       "default": false
     },
     "minKBReduced": {
-      "title": "Can be used to limit the frequency of PRs Imgbot will open over time",
+      "title": "can be used to limit the frequency of prs imgbot will open over time",
       "type": "number",
       "default": 10
     }
   },
-  "title": "JSON Schema for configuration for ImgBot",
+  "title": "json schema for configuration for imgbot",
   "type": "object"
 }

--- a/src/schemas/json/importmap.json
+++ b/src/schemas/json/importmap.json
@@ -20,6 +20,6 @@
       }
     }
   },
-  "title": "JSON schema for Import Maps files",
+  "title": "json schema for import maps files",
   "type": "object"
 }

--- a/src/schemas/json/install.json
+++ b/src/schemas/json/install.json
@@ -10,7 +10,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "title": "Which HTML element your resource should be inserted as.",
+          "title": "which html element your resource should be inserted as.",
           "enum": ["script", "style"]
         },
         "src": {
@@ -18,7 +18,7 @@
         },
         "if": {
           "type": "string",
-          "title": "Conditionally include resource",
+          "title": "conditionally include resource",
           "description": "Specify that a resource should be conditionally included. Prefix the option's name with a ! to invert the match."
         }
       },
@@ -28,7 +28,7 @@
       }
     },
     "optionDeclarationCommonProperties": {
-      "title": "An object containing your app's install options.",
+      "title": "an object containing your app's install options.",
       "description": "Each declaration will appear in your app's installer for end-user customization. Their choices will accessible in your app's JavaScript resources as the constant `INSTALL_OPTIONS`.",
       "additionalProperties": {
         "required": ["order", "type"],
@@ -41,7 +41,7 @@
           }
         ],
         "type": "object",
-        "title": "The key which your option will be defined under.",
+        "title": "the key which your option will be defined under.",
         "description": "The key should be camelCased.",
         "default": {
           "order": 0,
@@ -51,21 +51,21 @@
         "properties": {
           "title": {
             "type": "string",
-            "title": "The title related to your form field.",
+            "title": "the title related to your form field.",
             "description": "Each word should be capitalized."
           },
           "description": {
             "type": "string",
-            "title": "The description which appears next to your form field.",
+            "title": "the description which appears next to your form field.",
             "description": "This should be omitted unless the field needs further detail. Descriptions often pose a question e.g. \"Where should the button appear on your site?\"\nSupports sanitized HTML. External links should be used sparingly e.g.\n\t<a target=\"_blank\" href=\"https://example.com\">External Link</a>"
           },
           "helpvalue": {
             "type": "string",
-            "title": "Extra instructions or context to the install process.",
+            "title": "extra instructions or context to the install process.",
             "description": "Unlike every other option type, this doesn't collect any input nor set any value on the INSTALL_OPTIONS object.\n**This should be used sparingly.** If you believe your install option needs more context, consider separating the installation flow in to more steps, or move this content into the app configuration page \"Additional Install Instructions\" field."
           },
           "services": {
-            "title": "Service alias",
+            "title": "service alias",
             "description": "An string alias defined in the Cloudflare service creator.\nhttps://www.cloudflare.com/apps/services/new",
             "type": "array",
             "minItems": 1,
@@ -76,19 +76,19 @@
           },
           "showIf": {
             "type": ["string", "object"],
-            "title": "Conditionally show a field",
+            "title": "conditionally show a field",
             "description": "The `showIf` property can accept a boolean option property key:\n\n\n\t\"showIf\": \"optionName\"\n\nAn object with a property key, operator, and expected value can also be used for more complex matching:\n\t\"showIf\": {\"optionName\": {\"op\": \"==\", \"value\": \"foo\"}}\nThe showIf property can also accept multiple criteria, all of which must be matched for the field to be visible.\nYou can also use `showIf` to show options based on the current product the customer has elected to purchase:\n\t\"showIf\": {\"INSTALL_PRODUCT.id\": \"business\"}",
             "additionalProperties": {
-              "title": "A string matching another defined option key, or `INSTALL_PRODUCT.id`",
+              "title": "a string matching another defined option key, or `install_product.id`",
               "additionalProperties": false,
               "properties": {
                 "op": {
                   "type": "string",
-                  "title": "JavaScript operator",
+                  "title": "javascript operator",
                   "enum": ["==", "!=", "<", ">", "<=", ">="]
                 },
                 "value": {
-                  "title": "Expected value",
+                  "title": "expected value",
                   "type": ["string", "number", "null"]
                 }
               }
@@ -96,11 +96,11 @@
           },
           "required": {
             "type": "boolean",
-            "title": "Require field"
+            "title": "require field"
           },
           "enum": {
             "type": "array",
-            "title": "Declare a list of values to select from",
+            "title": "declare a list of values to select from",
             "description": "Presented as a <select> element with enum strings as <option>s. \nDeclare \"enumNames\" for human-readable names\nDeclare \"format\": \"radios\" for radio buttons.",
             "items": {
               "type": "string"
@@ -108,7 +108,7 @@
           },
           "enumNames": {
             "type": "object",
-            "title": "Declare human readable names",
+            "title": "declare human readable names",
             "description": "Used with \"enum\"",
             "additionalProperties": {
               "type": "string"
@@ -116,34 +116,34 @@
           },
           "order": {
             "type": "number",
-            "title": "The order the option appears in the install form.",
+            "title": "the order the option appears in the install form.",
             "description": "Note that JavaScript does **not** retain the order of keys in an object. This property must be added to ensure your options are rendered in the right order."
           },
           "properties": {
             "$ref": "#/definitions/optionDeclarationCommonProperties"
           },
           "maxItems": {
-            "title": "Specify the max number of entries in an array object.",
+            "title": "specify the max number of entries in an array object.",
             "type": "number"
           },
           "minimum": {
-            "title": "The minimum number allowed in the field.",
+            "title": "the minimum number allowed in the field.",
             "type": "number"
           },
           "maximum": {
-            "title": "The maximum number allowed in the field.",
+            "title": "the maximum number allowed in the field.",
             "type": "number"
           },
           "step": {
-            "title": "Declare the increment of a slider. Used with {\"type\": \"number\", \"format\": \"slider\"}",
+            "title": "declare the increment of a slider. used with {\"type\": \"number\", \"format\": \"slider\"}",
             "type": "number"
           },
           "products": {
             "type": ["array", "object"],
-            "title": "Limit this option to a set of eligible products.",
+            "title": "limit this option to a set of eligible products.",
             "description": "Most option types can be limited to a set of eligible products with an array of qualifying product IDs:\n\t{\"products\": [\"pro\", \"enterprise\"]}\nRadio options can be limited to specific products with products. Much like `enumNames`, each key in the object is a string from the enum array. However the value is an array containing a string `productId` for each eligible product:\n\t\"{enumNames\":{\n\t\"announcement\": \"Just show a message\",\n\t\"cta\": \"Redirect them to a special page\",\n\t\"signup\": \"Gather emails to sign visitors up for your newsletter\"\n\t},\n\t\"products\": {\n\t\"cta\": [\"plus\", \"pro\"],\n\t\"signup\": [\"pro\"]\n\t}",
             "items": {
-              "title": "An array containing a `productId` for each eligible product.",
+              "title": "an array containing a `productid` for each eligible product.",
               "type": "string"
             },
             "additionalProperties": {
@@ -151,7 +151,7 @@
             }
           },
           "units": {
-            "title": "Declare which units the installer can choose. Used with {\"type\": \"object\", \"format\": \"number\"}",
+            "title": "declare which units the installer can choose. used with {\"type\": \"object\", \"format\": \"number\"}",
             "description": "Presented as a floating-point number input and unit selector. This is useful when a customer has to set a specific size on an element.",
             "type": "array",
             "default": ["px", "em", "%"],
@@ -161,7 +161,7 @@
           },
           "type": {
             "type": "string",
-            "title": "Declares the type this option will use in your app's INSTALL_OPTIONS constant.",
+            "title": "declares the type this option will use in your app's install_options constant.",
             "default": "string",
             "enum": [
               "array",
@@ -176,20 +176,20 @@
           },
           "placeholder": {
             "type": "string",
-            "title": "A value that describes what should be provided in the form field.",
+            "title": "a value that describes what should be provided in the form field.",
             "description": "Many developers duplicate the placeholder content as a default text in their app. This allows customers to always have sane default labels that can be overridden for localization. If this proves cumbersome, we recommend importing the install.json contents into your app JavaScript with Webpack."
           },
           "default": {
-            "title": "A default value that appears the form field.",
+            "title": "a default value that appears the form field.",
             "description": "Ensure that your app renders correctly without the default value. Alternatively, use a \"placeholder\" property.",
             "properties": {
               "selector": {
-                "title": "CSS selector matching an element on the page.",
+                "title": "css selector matching an element on the page.",
                 "description": "Used with the \"selector\" and \"element\" formats.",
                 "default": "body"
               },
               "method": {
-                "title": "The insertion strategy used by `INSTALL.createElement(optionName, [previousElement])`",
+                "title": "the insertion strategy used by `install.createelement(optionname, [previouselement])`",
                 "description": "`INSTALL` provides a method, `createElement`, which can turn this resulting object into a new element on the page in the specified location. To use it, pass the value of the element option into the method.",
                 "default": "prepend",
                 "enum": ["before", "after", "prepend", "replace"]
@@ -198,7 +198,7 @@
           },
           "format": {
             "type": "string",
-            "title": "The format your input will appear as in the install form.",
+            "title": "the format your input will appear as in the install form.",
             "enum": [
               "account",
               "code",
@@ -221,22 +221,22 @@
           },
           "add": {
             "type": "object",
-            "title": "Add item button declaration",
+            "title": "add item button declaration",
             "properties": {
               "description": {
-                "title": "Modal description"
+                "title": "modal description"
               },
               "properties": {
                 "$ref": "#/definitions/optionDeclarationCommonProperties"
               },
               "buttonLabel": {
                 "type": "string",
-                "title": "Button label"
+                "title": "button label"
               }
             }
           },
           "items": {
-            "title": "Declarations for each item in an array.",
+            "title": "declarations for each item in an array.",
             "type": "object",
             "description": "Used with {\"type\": \"array\"}. Must have \"properties\" key.",
             "default": {
@@ -258,13 +258,13 @@
   },
   "properties": {
     "resources": {
-      "title": "Files included in your app to be inserted onto HTML pages.",
+      "title": "files included in your app to be inserted onto html pages.",
       "description": "Each resource should be unminified and human-readable.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "head": {
-          "title": "JavaScript and CSS files included in the <head> of a site.",
+          "title": "javascript and css files included in the <head> of a site.",
           "description": "<head> resources block the page from rendering while your code executes.",
           "type": "array",
           "minItems": 1,
@@ -273,7 +273,7 @@
           }
         },
         "body": {
-          "title": "JavaScript and CSS files included in the <body> of the site.",
+          "title": "javascript and css files included in the <body> of the site.",
           "description": "<body> resources load and execute asynchronously. This is useful if your code should allow the page to render first.",
           "type": "array",
           "minItems": 1,
@@ -282,7 +282,7 @@
           }
         },
         "preview": {
-          "title": "(Alpha) JavaScript files executed in the install preview.",
+          "title": "(alpha) javascript files executed in the install preview.",
           "description": "Preview resources can be used for local hook events, allowing your app to modify the install record e.g. fetching an API key with an OAuth token, then storing the key on an option.",
           "type": "array",
           "minItems": 1,
@@ -298,7 +298,7 @@
       }
     },
     "preview": {
-      "title": "Configuration of the installer preview experience.",
+      "title": "configuration of the installer preview experience.",
       "description": "Preview options can be used to declare handlers that execute after an event has been triggered.",
       "default": {
         "handlers": [
@@ -311,19 +311,19 @@
       "properties": {
         "handlers": {
           "type": "array",
-          "title": "Declarations for each group of matching options and their executing function. Multiple update handlers are useful when an app has options that have different updating procedures.",
+          "title": "declarations for each group of matching options and their executing function. multiple update handlers are useful when an app has options that have different updating procedures.",
           "items": {
             "properties": {
               "options": {
                 "type": "array",
-                "title": "The options section is an array of property keys which this handler should apply to. When any of those options are changed during a preview, this handler will be triggered. A given property may have multiple handlers.\nOptions can also be handled using special keys:\n\"_default\": Trigger when any property that hasn't yet been handled by a more specific entry changes.\n\"_any\": Trigger when any property changes, regardless of any other entry.\n\"_product\": Trigger when the customer changes their chosen product.",
+                "title": "the options section is an array of property keys which this handler should apply to. when any of those options are changed during a preview, this handler will be triggered. a given property may have multiple handlers.\noptions can also be handled using special keys:\n\"_default\": trigger when any property that hasn't yet been handled by a more specific entry changes.\n\"_any\": trigger when any property changes, regardless of any other entry.\n\"_product\": trigger when the customer changes their chosen product.",
                 "items": {
                   "type": "string"
                 }
               },
               "execute": {
                 "type": "string",
-                "title": "A function to execute when a matching option has changed. This function should be defined in your app's JavaScript. e.g.\n\twindow.INSTALL_SCOPE = { updateOptions (nextOptions) { } }",
+                "title": "a function to execute when a matching option has changed. this function should be defined in your app's javascript. e.g.\n\twindow.install_scope = { updateoptions (nextoptions) { } }",
                 "default": "INSTALL_SCOPE.updateOptions(INSTALL_OPTIONS)"
               }
             }
@@ -331,7 +331,7 @@
         },
         "hide": {
           "type": "boolean",
-          "title": "Hide the preview pane.",
+          "title": "hide the preview pane.",
           "default": true,
           "description": "Some apps don't add anything visually to the site they're being installed upon. Showing a preview when nothing visually on the site has changed can be confusing to the customer, leading them to think your app is broken.\nOften it still makes sense to embed a message on the previewed page to explain to the customer what is being installed and how it works. For example, if you are building an analytics tool you could take the customer through a tour of the types of things which would be measured.\nIf you can't find such an opportunity however, you can disable the preview to prevent any confusion."
         }
@@ -339,36 +339,36 @@
     },
     "hooks": {
       "type": "array",
-      "title": "Hook declarations",
+      "title": "hook declarations",
       "description": "A Cloudflare hook is similar to other WebHooks, the key difference being that Cloudflare hooks are two-way: you can alter the install with your response. Hook events includes information about the customer, their site, and the action that triggered it.\nHook events can be handled with preview resources, or by an external server configured as a \"service\". You can optionally respond with changes we should make to that customer's installation experience.",
       "items": {
         "type": "object",
         "properties": {
           "endpoint": {
             "type": "string",
-            "title": "URL to a server handling the POST request triggered from the event.",
+            "title": "url to a server handling the post request triggered from the event.",
             "default": "https://"
           },
           "block": {
             "type": "boolean",
-            "title": "Show a loading indicator until your response has been loaded. Your changes **will** be ignored if you do not set this property.",
+            "title": "show a loading indicator until your response has been loaded. your changes **will** be ignored if you do not set this property.",
             "description": "Unlike most other WebHook implementations, Cloudflare hooks allow you to modify the elements you are being notified about. For example, you might choose to show a new option when the customer has selected a specific entry in one of your option's dropdowns. You may also wish to use the hooks feature to support OAuth-based login in your app."
           },
           "events": {
             "type": "array",
-            "title": "Event names that trigger a hook event.",
+            "title": "event names that trigger a hook event.",
             "items": {
               "type": "string",
-              "title": "Event name."
+              "title": "event name."
             }
           },
           "authenticate": {
             "type": "array",
-            "title": "Matching option keys of OAuth account fields.",
+            "title": "matching option keys of oauth account fields.",
             "description": "This option should contain:\n\t{\"type\": \"object\", \"format\": \"account\"}",
             "items": {
               "type": "string",
-              "title": "A string matching another defined option key."
+              "title": "a string matching another defined option key."
             }
           }
         }
@@ -376,19 +376,19 @@
     },
     "dns": {
       "type": "array",
-      "title": "DNS Record declarations",
+      "title": "dns record declarations",
       "description": "Cloudflare DNS record to be created upon installing a Cloudflare App. Note all other records previously created by the app on the site will be removed. Following the Cloudflare API https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record.",
       "items": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
-            "title": "Name of the DNS Record.",
+            "title": "name of the dns record.",
             "description": "For example sub for sub.example.com max length: 255"
           },
           "content": {
             "type": "string",
-            "title": "Content of the DNS record.",
+            "title": "content of the dns record.",
             "description": "Varies depending on the record type.",
             "examples": [
               "198.51.100.4",
@@ -397,23 +397,23 @@
           },
           "type": {
             "type": "string",
-            "title": "Type of the DNS Record",
+            "title": "type of the dns record",
             "description": "valid values: A, AAAA, CNAME, TXT, SRV, LOC, MX, NS, SPF, CERT, DNSKEY, DS, NAPTR, SMIMEA, SSHFP, TLSA, URI"
           },
           "proxied": {
             "type": "boolean",
-            "title": "Event names that trigger a hook event.",
+            "title": "event names that trigger a hook event.",
             "description": "Whether the record is receiving the performance and security benefits of Cloudflare.",
             "default": false
           },
           "priority": {
             "type": "number",
-            "title": "Priority",
+            "title": "priority",
             "description": "Used with some records like MX and SRV to determine priority."
           },
           "ttl": {
             "type": "number",
-            "title": "Matching option keys of OAuth account fields.",
+            "title": "matching option keys of oauth account fields.",
             "description": "Time to live for DNS record.",
             "default": "1"
           },
@@ -427,7 +427,7 @@
     "workers": {
       "type": "array",
       "description": "Cloudflare workers declarations to be installed through an app onto a site.",
-      "title": "Cloudflare Workers",
+      "title": "cloudflare workers",
       "items": {
         "type": "object",
         "properties": {
@@ -438,7 +438,7 @@
       }
     },
     "options": {
-      "title": "A parent object containing your app's install options.",
+      "title": "a parent object containing your app's install options.",
       "description": "Must contain a \"properties\" object.",
       "type": "object",
       "required": ["properties"],
@@ -449,6 +449,6 @@
       }
     }
   },
-  "title": "JSON schema for configuring Cloudflare Apps install.json files",
+  "title": "json schema for configuring cloudflare apps install.json files",
   "type": "object"
 }

--- a/src/schemas/json/jasmine.json
+++ b/src/schemas/json/jasmine.json
@@ -102,5 +102,5 @@
     }
   },
   "id": "https://json.schemastore.org/jasmine.json",
-  "title": "Schema for jasmine JSON config file"
+  "title": "schema for jasmine json config file"
 }

--- a/src/schemas/json/jasonette.json
+++ b/src/schemas/json/jasonette.json
@@ -120,12 +120,12 @@
       "type": "object"
     },
     "advancedTitle": {
-      "title": "Advanced Title",
+      "title": "advanced title",
       "type": "object",
       "additionalProperties": false,
       "oneOf": [
         {
-          "title": "Title with Image",
+          "title": "title with image",
           "properties": {
             "type": {
               "type": "string",
@@ -150,7 +150,7 @@
           "required": ["type", "url"]
         },
         {
-          "title": "Title with Label",
+          "title": "title with label",
           "properties": {
             "type": {
               "type": "string",

--- a/src/schemas/json/jdt.json
+++ b/src/schemas/json/jdt.json
@@ -98,6 +98,6 @@
       }
     }
   },
-  "title": "JSON schema for JSON Document Transforms",
+  "title": "json schema for json document transforms",
   "type": "object"
 }

--- a/src/schemas/json/jfrog-pipelines.json
+++ b/src/schemas/json/jfrog-pipelines.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "JFrog-Pipelines": {
-      "title": "JFrog-Pipelines",
+      "title": "jfrog-pipelines",
       "description": "https://www.jfrog.com/confluence/display/JFROG/Pipelines+Developer+Guide",
       "type": "object",
       "additionalProperties": false,
@@ -37,7 +37,7 @@
       ]
     },
     "Resource": {
-      "title": "Resource",
+      "title": "resource",
       "description": "https://www.jfrog.com/confluence/display/JFROG/Pipelines+Resources",
       "type": "object",
       "properties": {
@@ -987,7 +987,7 @@
       }
     },
     "Pipeline": {
-      "title": "Pipeline",
+      "title": "pipeline",
       "description": "https://www.jfrog.com/confluence/display/JFROG/Creating+Pipelines",
       "type": "object",
       "properties": {
@@ -1227,7 +1227,7 @@
       "additionalProperties": false
     },
     "Step": {
-      "title": "Step",
+      "title": "step",
       "description": "https://www.jfrog.com/confluence/display/JFROG/Pipelines+Steps",
       "type": "object",
       "properties": {

--- a/src/schemas/json/jovo-language-model.json
+++ b/src/schemas/json/jovo-language-model.json
@@ -208,6 +208,6 @@
     }
   },
   "required": ["invocation"],
-  "title": "JSON Schema for Jovo language Models",
+  "title": "json schema for jovo language models",
   "type": "object"
 }

--- a/src/schemas/json/jsbeautifyrc-nested.json
+++ b/src/schemas/json/jsbeautifyrc-nested.json
@@ -61,6 +61,6 @@
     }
   ],
   "id": "https://json.schemastore.org/jsbeautifyrc-nested",
-  "title": "JSON schema for beautifyrc",
+  "title": "json schema for beautifyrc",
   "type": "object"
 }

--- a/src/schemas/json/jsbeautifyrc.json
+++ b/src/schemas/json/jsbeautifyrc.json
@@ -343,6 +343,6 @@
     }
   },
   "id": "https://json.schemastore.org/jsbeautifyrc",
-  "title": "JSON schema for beautifyrc",
+  "title": "json schema for beautifyrc",
   "type": "object"
 }

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -1060,6 +1060,6 @@
       }
     }
   },
-  "title": "JSON schema for a JavaScript project using TypeScript tooling",
+  "title": "json schema for a javascript project using typescript tooling",
   "type": "object"
 }

--- a/src/schemas/json/jscsrc.json
+++ b/src/schemas/json/jscsrc.json
@@ -3645,6 +3645,6 @@
       ]
     }
   },
-  "title": "JSON schema for JSCS configuration files",
+  "title": "json schema for jscs configuration files",
   "type": "object"
 }

--- a/src/schemas/json/jsdoc-1.0.0.json
+++ b/src/schemas/json/jsdoc-1.0.0.json
@@ -3,21 +3,21 @@
   "properties": {
     "plugins": {
       "type": "array",
-      "title": "Configuring plugins",
+      "title": "configuring plugins",
       "description": "Enables plugins for JSDoc",
       "default": [],
       "examples": [["plugins/markdown", "plugins/summarize"]]
     },
     "recurseDepth": {
       "type": "integer",
-      "title": "Specifying recursion depth",
+      "title": "specifying recursion depth",
       "default": 10,
       "$comment": "Is used only if `jsdoc` command is invoked with `-r` flag",
       "description": "Controls recursion depth for source files and tutorials"
     },
     "source": {
       "type": "object",
-      "title": "Specifying input files",
+      "title": "specifying input files",
       "description": "Determines the set of input files",
       "properties": {
         "include": {
@@ -25,27 +25,27 @@
             ["myProject/a.js", "myProject/lib", "myProject/_private"]
           ],
           "type": "array",
-          "title": "Input files paths",
+          "title": "input files paths",
           "description": "An array of paths to input files",
           "$comment": "`-r` flag for `jsdoc` command will recurse in subdirectories of paths listed"
         },
         "exclude": {
           "examples": [["myProject/lib/ignore.js"]],
           "type": "array",
-          "title": "Input files exclusion paths",
+          "title": "input files exclusion paths",
           "description": "An array of paths to exclude from input",
           "$comment": "With JSDoc ^3.3.0 may include subdirectories of include"
         },
         "includePattern": {
           "type": "string",
-          "title": "Inclusion RegExp",
+          "title": "inclusion regexp",
           "default": ".+\\.js(doc|x)?$",
           "$comment": "By default, .js, .jsx, .jsdoc files are included",
           "description": "Forces input filenames to match regular expression"
         },
         "excludePattern": {
           "type": "string",
-          "title": "Exclusion RegExp",
+          "title": "exclusion regexp",
           "default": "(^|\\/|\\\\)_",
           "$comment": "By default, underscored files and folders are excluded",
           "description": "Forces input filenames to match regular expression"
@@ -57,13 +57,13 @@
       "type": "string",
       "enum": ["module", "script"],
       "default": "module",
-      "title": "Specifying source type",
+      "title": "specifying source type",
       "description": "Determines how input files are parsed"
     },
     "opts": {
       "$comment": "The command line options take precedence over config file",
       "type": "object",
-      "title": "Incorporating CLI options",
+      "title": "incorporating cli options",
       "description": "Determines flags that `jsdoc` command will be invoked with",
       "additionalProperties": false,
       "properties": {
@@ -72,73 +72,73 @@
           "default": "all",
           "description": "Only display symbols with the given `access` property",
           "enum": ["all", "private", "protected", "public", "undefined"],
-          "title": "Symbol access",
+          "title": "symbol access",
           "type": "string"
         },
         "debug": {
           "$comment": "Equivalent to `--debug` flag",
           "description": "Log information that can help debug issues in JSDoc itself",
-          "title": "Log debug info",
+          "title": "log debug info",
           "type": "boolean"
         },
         "destination": {
           "$comment": "Equivalent to `-d` flag",
           "default": "./out/",
           "description": "The path to the output folder for the generated documentation",
-          "title": "Output folder",
+          "title": "output folder",
           "type": "string"
         },
         "encoding": {
           "$comment": "Equivalent to `-e` flag",
           "default": "utf8",
           "description": "Assume this encoding when reading all source files",
-          "title": "Input files encoding",
+          "title": "input files encoding",
           "type": "string"
         },
         "package": {
           "$comment": "Equivalent to `-p` flag",
           "description": "The `package.json` file that contains the project name, version, and other details",
-          "title": "Package",
+          "title": "package",
           "type": "string"
         },
         "pedantic": {
           "default": false,
           "description": "Treat errors as fatal errors, and treat warnings as errors",
-          "title": "Pedantic",
+          "title": "pedantic",
           "type": "boolean"
         },
         "readme": {
           "$comment": "Equivalent to `-R` flag",
           "description": "The README.md file to include in the generated documentation",
-          "title": "README.md",
+          "title": "readme.md",
           "type": "string"
         },
         "recurse": {
           "$comment": "Equivalent to `-r` flag",
           "default": false,
           "description": "Recurses to subdirectories when searching input files",
-          "title": "Recurse to subdirectories",
+          "title": "recurse to subdirectories",
           "type": "boolean"
         },
         "template": {
           "$comment": "Equivalent to `-t` flag",
           "default": "templates/default",
           "description": "The path to the template to use for generating output",
-          "title": "Output template",
+          "title": "output template",
           "type": "string"
         },
         "test": {
           "$comment": "Equivalent to `-T` flag. Won't work if installed via NPM",
           "default": false,
           "description": "Run JSDoc's test suite, and print the results to the console",
-          "title": "Run tests",
+          "title": "run tests",
           "type": "boolean"
         },
         "tutorials": {
           "$comment": "Equivalent to `-u` flag",
           "description": "Directory in which JSDoc should search for tutorials",
           "examples": ["path/to/tutorials", "./docs/tutorials"],
-          "title": "Tutorials path",
+          "title": "tutorials path",
           "type": "string"
         }
       }
@@ -152,10 +152,10 @@
           "default": true,
           "description": "Determines how to handle unrecognized tags",
           "items": {
-            "title": "JSDoc tag",
+            "title": "jsdoc tag",
             "type": "string"
           },
-          "title": "Unknown tags",
+          "title": "unknown tags",
           "type": ["boolean", "array"],
           "uniqueItems": true
         },
@@ -165,14 +165,14 @@
             "$comment": "^3.3.0 two dictionaries: JSDoc and Closure Compiler",
             "default": ["jsdoc", "closure"],
             "enum": ["jsdoc", "closure"],
-            "title": "Dictionary",
+            "title": "dictionary",
             "type": "string"
           },
-          "title": "JSDoc dictionaries",
+          "title": "jsdoc dictionaries",
           "type": "array"
         }
       },
-      "title": "Configuring tags and tag dictionaries",
+      "title": "configuring tags and tag dictionaries",
       "type": "object"
     },
     "templates": {
@@ -182,7 +182,7 @@
           "$comment": "If `true`, text of @link tag that is a URL will be rendered in normal font, else in monospace",
           "default": false,
           "description": "Controls @link tag text rendering",
-          "title": "@link URL",
+          "title": "@link url",
           "type": "boolean"
         },
         "default": {
@@ -191,21 +191,21 @@
               "$comment": "^3.3.0 can be set to `false` to omit current date",
               "default": true,
               "description": "Controls if current date is displayed in the footer of documentation",
-              "title": "Showing the current date",
+              "title": "showing the current date",
               "type": "boolean"
             },
             "layoutFile": {
               "$comment": "^3.4.0 can be set to custom layout file",
               "default": "layout.tmpl",
               "description": "Path to layout file to use for documentation template",
-              "title": "Overriding layout file",
+              "title": "overriding layout file",
               "type": "string"
             },
             "outputSourceFiles": {
               "$comment": "^3.3.0 can be set to `false` to remove links to source files",
               "default": true,
               "description": "Disables pretty-printed source files",
-              "title": "Generating pretty-printed source files",
+              "title": "generating pretty-printed source files",
               "type": "boolean"
             },
             "staticFiles": {
@@ -234,14 +234,14 @@
                   "type": "string"
                 }
               },
-              "title": "Copying static files",
+              "title": "copying static files",
               "type": "object"
             },
             "useLongnameInNav": {
               "$comment": "^3.4.0 can be set to `true` to use longhands",
               "default": false,
               "description": "Controls if shortened or longhand version of a symbol will be shown in documentation",
-              "title": "Showing longnames",
+              "title": "showing longnames",
               "type": "boolean"
             }
           }
@@ -254,10 +254,10 @@
           "type": "boolean"
         }
       },
-      "title": "Configuring templates",
+      "title": "configuring templates",
       "type": "object"
     }
   },
-  "title": "JSON Schema for JSDoc configuration files",
+  "title": "json schema for jsdoc configuration files",
   "type": "object"
 }

--- a/src/schemas/json/jshintrc.json
+++ b/src/schemas/json/jshintrc.json
@@ -361,6 +361,6 @@
       }
     }
   },
-  "title": "JSON schema for JSHint configuration files",
+  "title": "json schema for jshint configuration files",
   "type": "object"
 }

--- a/src/schemas/json/jsinspectrc.json
+++ b/src/schemas/json/jsinspectrc.json
@@ -33,6 +33,6 @@
       "type": "integer"
     }
   },
-  "title": "JSON schema for JSInspect configuration files",
+  "title": "json schema for jsinspect configuration files",
   "type": "object"
 }

--- a/src/schemas/json/json-api-1.0.json
+++ b/src/schemas/json/json-api-1.0.json
@@ -376,5 +376,5 @@
       "$ref": "#/definitions/info"
     }
   ],
-  "title": "JSON API Schema"
+  "title": "json api schema"
 }

--- a/src/schemas/json/json-patch.json
+++ b/src/schemas/json/json-patch.json
@@ -59,6 +59,6 @@
       }
     ]
   },
-  "title": "JSON schema for JSONPatch files",
+  "title": "json schema for jsonpatch files",
   "type": "array"
 }

--- a/src/schemas/json/jsone.json
+++ b/src/schemas/json/jsone.json
@@ -103,6 +103,6 @@
       "$ref": "#"
     }
   },
-  "title": "JSON-e templates",
+  "title": "json-e templates",
   "type": "object"
 }

--- a/src/schemas/json/jsonld.json
+++ b/src/schemas/json/jsonld.json
@@ -99,6 +99,6 @@
       }
     }
   },
-  "title": "Schema for JSON-LD",
+  "title": "schema for json-ld",
   "type": ["object", "array"]
 }

--- a/src/schemas/json/kode-ci-build-1.0.0.json
+++ b/src/schemas/json/kode-ci-build-1.0.0.json
@@ -296,6 +296,6 @@
     }
   },
   "required": ["jobs"],
-  "title": "KoDE/CI Build Spec",
+  "title": "kode/ci build spec",
   "type": "object"
 }

--- a/src/schemas/json/label-commenter-config.json
+++ b/src/schemas/json/label-commenter-config.json
@@ -6,19 +6,19 @@
       "type": "object",
       "properties": {
         "body": {
-          "title": "Body",
+          "title": "body",
           "type": "string"
         },
         "action": {
-          "title": "Action",
+          "title": "action",
           "type": "string"
         },
         "locking": {
-          "title": "Locking",
+          "title": "locking",
           "enum": ["lock", "unlock"]
         },
         "lock_reason": {
-          "title": "Lock Reason",
+          "title": "lock reason",
           "type": "string"
         }
       }
@@ -27,11 +27,11 @@
       "type": "object",
       "properties": {
         "issue": {
-          "title": "Issue",
+          "title": "issue",
           "$ref": "#/definitions/labelItem"
         },
         "pr": {
-          "title": "Pull Request",
+          "title": "pull request",
           "$ref": "#/definitions/labelItem"
         }
       }
@@ -40,11 +40,11 @@
       "type": "object",
       "properties": {
         "labeled": {
-          "title": "Labeled",
+          "title": "labeled",
           "$ref": "#/definitions/labelFor"
         },
         "unlabeled": {
-          "title": "Unlabeled",
+          "title": "unlabeled",
           "$ref": "#/definitions/labelFor"
         }
       }
@@ -53,28 +53,28 @@
   "description": "Configuration for Actions Label Commenter, for posting messages triggered by labels.",
   "properties": {
     "comment": {
-      "title": "Comment",
+      "title": "comment",
       "type": "object",
       "properties": {
         "header": {
-          "title": "Header",
+          "title": "header",
           "type": "string"
         },
         "footer": {
-          "title": "Footer",
+          "title": "footer",
           "type": "string"
         }
       }
     },
     "labels": {
-      "title": "Labels",
+      "title": "labels",
       "type": "array",
       "items": {
-        "title": "Label",
+        "title": "label",
         "$ref": "#/definitions/labelType",
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "type": "string"
           }
         }

--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -230,6 +230,6 @@
       ]
     }
   },
-  "title": "JSON schema for the Visual Studio LaunchSettings.json file.",
+  "title": "json schema for the visual studio launchsettings.json file.",
   "type": "object"
 }

--- a/src/schemas/json/lerna.json
+++ b/src/schemas/json/lerna.json
@@ -124,6 +124,6 @@
       }
     }
   },
-  "title": "A JSON schema for lerna.json files",
+  "title": "a json schema for lerna.json files",
   "type": "object"
 }

--- a/src/schemas/json/lgtm.json
+++ b/src/schemas/json/lgtm.json
@@ -3,25 +3,25 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "queryItem": {
-      "title": "Query",
+      "title": "query",
       "type": "object",
       "properties": {
         "id": {
-          "title": "ID",
+          "title": "id",
           "description": "Use to identify a specific query whose results you want to include or exclude from display on LGTM.",
           "type": "string"
         },
         "severity": {
-          "title": "Severity",
+          "title": "severity",
           "description": "Use to specify a single level of severity (error, warning or recommendation) for queries whose results you want to include or exclude from display.",
           "type": "string"
         },
         "tags": {
-          "title": "Tags",
+          "title": "tags",
           "description": "Use to specify one or more tags for queries whose results you want to include or exclude from display.",
           "type": "array",
           "items": {
-            "title": "Tag",
+            "title": "tag",
             "type": "string"
           }
         }
@@ -31,7 +31,7 @@
   "description": "Configuration file for lgtm, for continuous security analysis.",
   "properties": {
     "path_classifiers": {
-      "title": "Path Classifiers",
+      "title": "path classifiers",
       "description": "Defines the tag that you want to modify. Usually this is a built-in tag, but you can define your own tags.",
       "type": "object",
       "additionalProperties": {
@@ -41,7 +41,7 @@
           "type": ["string", "object"],
           "properties": {
             "exclude": {
-              "title": "Exclude",
+              "title": "exclude",
               "description": "Do not classify files on this path with the parent tag.",
               "type": "string"
             }
@@ -50,18 +50,18 @@
       }
     },
     "queries": {
-      "title": "Queries",
+      "title": "queries",
       "type": ["array", "null"],
       "items": {
-        "title": "Query",
+        "title": "query",
         "properties": {
           "exclude": {
-            "title": "Exclude",
+            "title": "exclude",
             "description": "Hide the results for queries with the specified properties.",
             "$ref": "#/definitions/queryItem"
           },
           "include": {
-            "title": "Include",
+            "title": "include",
             "description": "Show the results for queries with the specified properties.",
             "$ref": "#/definitions/queryItem"
           }
@@ -69,29 +69,29 @@
       }
     },
     "extraction": {
-      "title": "Extraction",
+      "title": "extraction",
       "type": "object",
       "additionalProperties": {
         "type": "object",
         "properties": {
           "prepare": {
-            "title": "Prepare",
+            "title": "prepare",
             "description": "Customizable step used by all languages.",
             "type": "object",
             "properties": {
               "packages": {
-                "title": "Packages",
+                "title": "packages",
                 "description": "One or more packages to install.",
                 "type": "array",
                 "items": {
-                  "title": "Package",
+                  "title": "package",
                   "type": "string"
                 }
               }
             }
           },
           "after_prepare": {
-            "title": "After Prepare",
+            "title": "after prepare",
             "description": "Customizable step used by all languages.",
             "type": "array",
             "items": {
@@ -99,7 +99,7 @@
             }
           },
           "before_index": {
-            "title": "Before Index",
+            "title": "before index",
             "description": "Customizable step used by all languages.",
             "type": "array",
             "items": {
@@ -107,52 +107,52 @@
             }
           },
           "index": {
-            "title": "Index",
+            "title": "index",
             "description": "Customizable step used by all languages.",
             "type": "object",
             "properties": {
               "all_solutions": {
-                "title": "All Solutions",
+                "title": "all solutions",
                 "description": "Specify that all project or solution files should be used for extraction.",
                 "type": "boolean",
                 "default": false
               },
               "build_command": {
-                "title": "Build Command",
+                "title": "build command",
                 "type": ["array", "string"],
                 "items": {
                   "type": "string"
                 }
               },
               "buildless": {
-                "title": "Buildless",
+                "title": "buildless",
                 "description": "Specify whether or not to extract the codebase without building the code.",
                 "type": "boolean",
                 "default": false
               },
               "dotnet": {
-                "title": ".NET",
+                "title": ".net",
                 "type": "object",
                 "properties": {
                   "arguments": {
-                    "title": "Arguments",
+                    "title": "arguments",
                     "description": "Specify a list of additional arguments to dotnet build.",
                     "type": "array",
                     "items": {
-                      "title": "Argument",
+                      "title": "argument",
                       "type": "string"
                     },
                     "default": []
                   },
                   "version": {
-                    "title": "Version",
+                    "title": "version",
                     "description": "Specify the version of the .NET Core SDK to use.",
                     "type": "string"
                   }
                 }
               },
               "exclude": {
-                "title": "Exclude",
+                "title": "exclude",
                 "description": "Specify a list of files and folders to exclude from extraction. Each path is specified by defining paths relative to LGTM_SRC.",
                 "type": "array",
                 "items": {
@@ -160,24 +160,24 @@
                 }
               },
               "filetypes": {
-                "title": "Filetypes",
+                "title": "filetypes",
                 "description": "Specify additional file types to extract.",
                 "additionalProperties": {
                   "type": "string"
                 }
               },
               "gradle": {
-                "title": "Gradle",
+                "title": "gradle",
                 "type": "object",
                 "properties": {
                   "version": {
-                    "title": "Version",
+                    "title": "version",
                     "type": ["string", "number"]
                   }
                 }
               },
               "include": {
-                "title": "Include",
+                "title": "include",
                 "description": "Specify a list of files and folders to scan for files to extract.",
                 "type": "array",
                 "items": {
@@ -185,57 +185,57 @@
                 }
               },
               "java_version": {
-                "title": "Java Version",
+                "title": "java version",
                 "description": "Specify the Java version required to build the project.",
                 "type": ["string", "number"]
               },
               "maven": {
-                "title": "Maven",
+                "title": "maven",
                 "description": "Specify Maven settings to use by specifying one or more of the maven subproperties detailed below.",
                 "type": "object",
                 "properties": {
                   "settings_file": {
-                    "title": "Settings File",
+                    "title": "settings file",
                     "description": "Specify the path (absolute or relative) of a Maven settings file to use.",
                     "type": "string"
                   },
                   "toolchains_file": {
-                    "title": "Toolchains File",
+                    "title": "toolchains file",
                     "description": "Specify the path of a Maven toolchains file to use.",
                     "type": "string"
                   },
                   "version": {
-                    "title": "Version",
+                    "title": "version",
                     "description": "Specify the required Maven version.",
                     "type": ["string", "number"]
                   }
                 }
               },
               "msbuild": {
-                "title": "MSBuild",
+                "title": "msbuild",
                 "type": "object",
                 "properties": {
                   "arguments": {
-                    "title": "Arguments",
+                    "title": "arguments",
                     "description": "Specify a list of additional arguments to MSBuild.",
                     "type": "array",
                     "items": {
-                      "title": "Argument",
+                      "title": "argument",
                       "type": "string"
                     }
                   },
                   "configuration": {
-                    "title": "Configuration",
+                    "title": "configuration",
                     "description": "Specify the MSBuild configuration to use, for example, debug or release.",
                     "type": "string"
                   },
                   "platform": {
-                    "title": "Platform",
+                    "title": "platform",
                     "description": "Specify the platform to target, for example: x86, x64, or Any CPU.",
                     "type": "string"
                   },
                   "target": {
-                    "title": "Target",
+                    "title": "target",
                     "description": "Specify the MSBuild target.",
                     "type": "string",
                     "default": "rebuild"
@@ -243,19 +243,19 @@
                 }
               },
               "nuget_restore": {
-                "title": "NuGet Restore",
+                "title": "nuget restore",
                 "description": "Specify whether or not to perform a NuGet restore for extraction.",
                 "type": "boolean",
                 "default": true
               },
               "properties_files": {
-                "title": "Properties Files",
+                "title": "properties files",
                 "description": "Specify whether .properties files are extracted.",
                 "type": "boolean",
                 "default": false
               },
               "solution": {
-                "title": "Solution",
+                "title": "solution",
                 "description": "Specify a list of one or more project or solution files for extraction.",
                 "type": "array",
                 "items": {
@@ -263,25 +263,25 @@
                 }
               },
               "typescript": {
-                "title": "TypeScript",
+                "title": "typescript",
                 "description": "pecify how TypeScript files should be extracted.",
                 "enum": ["none", "basic", "full"],
                 "default": "full"
               },
               "xml_mode": {
-                "title": "XML Mode",
+                "title": "xml mode",
                 "description": "Specify how XML files should be extracted.",
                 "enum": ["all", "default", "disabled"]
               }
             }
           },
           "configure": {
-            "title": "Configure",
+            "title": "configure",
             "description": "Customizable step used only by C/C++ extraction.",
             "type": "object",
             "properties": {
               "command": {
-                "title": "Command",
+                "title": "command",
                 "description": "Override the default process by specifying a list of commands to run to generate the build configuration.",
                 "type": ["array", "null"],
                 "items": {
@@ -291,30 +291,30 @@
             }
           },
           "python_setup": {
-            "title": "Python Setup",
+            "title": "python setup",
             "description": "This step is used only by Python blocks. It sets up the Python interpreter and virtual environment, ready for the index step to extract the codebase.",
             "type": "object",
             "properties": {
               "exclude_requirements": {
-                "title": "Exclude Requirements",
+                "title": "exclude requirements",
                 "description": "Specify packages to exclude from extraction/analysis.",
                 "type": "array",
                 "items": {
-                  "title": "Package",
+                  "title": "package",
                   "type": "string"
                 }
               },
               "requirements": {
-                "title": "Requirements",
+                "title": "requirements",
                 "description": "Specify a list of pip packages to install. If any of these packages cannot be installed, the extraction will fail.",
                 "type": "array",
                 "items": {
-                  "title": "Package",
+                  "title": "package",
                   "type": "string"
                 }
               },
               "requirements_files": {
-                "title": "Requirement Files",
+                "title": "requirement files",
                 "description": "Specify a list of requirements text files to use to set up the environment, or false for none.",
                 "type": ["array", "boolean"],
                 "items": {
@@ -322,12 +322,12 @@
                 }
               },
               "setup_py": {
-                "title": "Setup Python",
+                "title": "setup python",
                 "description": "Specify a setup.py file to use to set up the environment, or false for none.",
                 "type": "string"
               },
               "version": {
-                "title": "Version",
+                "title": "version",
                 "description": "Override the version of the Python interpreter used for setup and extraction.",
                 "type": ["string", "number"],
                 "default": 3

--- a/src/schemas/json/libman.json
+++ b/src/schemas/json/libman.json
@@ -110,6 +110,6 @@
     }
   },
   "required": ["libraries"],
-  "title": "JSON schema for client-side library config files",
+  "title": "json schema for client-side library config files",
   "type": "object"
 }

--- a/src/schemas/json/license-report-config.json
+++ b/src/schemas/json/license-report-config.json
@@ -100,6 +100,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for license report tool configuration file",
+  "title": "json schema for license report tool configuration file",
   "type": "object"
 }

--- a/src/schemas/json/linkinator-config.json
+++ b/src/schemas/json/linkinator-config.json
@@ -84,6 +84,6 @@
       "type": "array"
     }
   },
-  "title": "JSON schema for Linkinator",
+  "title": "json schema for linkinator",
   "type": "object"
 }

--- a/src/schemas/json/local.settings.json
+++ b/src/schemas/json/local.settings.json
@@ -68,6 +68,6 @@
       "description": "A collection. Don't use this collection for the connection strings used by your function bindings. This collection is used only by frameworks that typically get connection strings from the ConnectionStrings section of a configuration file, like Entity Framework. Connection strings in this object are added to the environment with the provider type of System.Data.SqlClient. Items in this collection aren't published to Azure with other app settings. You must explicitly add these values to the Connection strings collection of your function app settings. If you're creating a SqlConnection in your function code, you should store the connection string value with your other connections in Application Settings in the portal."
     }
   },
-  "title": "JSON schema for Azure Functions local.settings.json files",
+  "title": "json schema for azure functions local.settings.json files",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-0.7.json
+++ b/src/schemas/json/lsdlschema-0.7.json
@@ -1207,6 +1207,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-1.0.json
+++ b/src/schemas/json/lsdlschema-1.0.json
@@ -1318,6 +1318,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-1.2.json
+++ b/src/schemas/json/lsdlschema-1.2.json
@@ -1336,6 +1336,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-2.0.json
+++ b/src/schemas/json/lsdlschema-2.0.json
@@ -1443,6 +1443,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-3.0.json
+++ b/src/schemas/json/lsdlschema-3.0.json
@@ -1506,6 +1506,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-3.1.json
+++ b/src/schemas/json/lsdlschema-3.1.json
@@ -1511,6 +1511,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-3.2.json
+++ b/src/schemas/json/lsdlschema-3.2.json
@@ -1538,6 +1538,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-3.3.json
+++ b/src/schemas/json/lsdlschema-3.3.json
@@ -1550,6 +1550,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema-3.4.json
+++ b/src/schemas/json/lsdlschema-3.4.json
@@ -1611,6 +1611,6 @@
     }
   },
   "required": ["Version", "Language"],
-  "title": "LSDL Schema",
+  "title": "lsdl schema",
   "type": "object"
 }

--- a/src/schemas/json/lsdlschema.json
+++ b/src/schemas/json/lsdlschema.json
@@ -30,5 +30,5 @@
     }
   ],
   "description": "Linguistic Schema Definition Language schema",
-  "title": "LSDL Schema"
+  "title": "lsdl schema"
 }

--- a/src/schemas/json/markdownlint.json
+++ b/src/schemas/json/markdownlint.json
@@ -1,4 +1,4 @@
 {
   "$ref": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
-  "title": "JSON schema markdownlint"
+  "title": "json schema markdownlint"
 }

--- a/src/schemas/json/mboats-config-0.1.json
+++ b/src/schemas/json/mboats-config-0.1.json
@@ -14,7 +14,7 @@
         }
       },
       "required": ["mboats", "app"],
-      "title": "Properties"
+      "title": "properties"
     },
     "Application": {
       "type": "object",
@@ -30,7 +30,7 @@
         }
       },
       "required": ["appId", "appName"],
-      "title": "Application Properties"
+      "title": "application properties"
     },
     "MBOATS": {
       "type": "object",
@@ -111,7 +111,7 @@
         }
       },
       "required": [],
-      "title": "MBOATS Properties",
+      "title": "mboats properties",
       "definitions": {
         "AWSEC2": {
           "type": "object",
@@ -125,7 +125,7 @@
             }
           },
           "required": ["publicName", "serverPort"],
-          "title": "AWS EC2 Configuration"
+          "title": "aws ec2 configuration"
         },
         "AWSS3": {
           "type": "object",
@@ -158,7 +158,7 @@
             "region",
             "secretAccessKey"
           ],
-          "title": "AWS S3 Configuration"
+          "title": "aws s3 configuration"
         },
         "CucumberOptions": {
           "type": "object",
@@ -175,7 +175,7 @@
             }
           },
           "required": ["featuresPath", "stepdefsPackage", "tagExpression"],
-          "title": "CucumberOptions"
+          "title": "cucumberoptions"
         },
         "Email": {
           "type": "object",
@@ -192,7 +192,7 @@
             }
           },
           "required": ["auth", "invitationLinkRegex", "oktaTokenRegex"],
-          "title": "Email Configuration",
+          "title": "email configuration",
           "definitions": {
             "Auth": {
               "type": "object",
@@ -218,7 +218,7 @@
                 "$refreshToken",
                 "$refreshUrl"
               ],
-              "title": "Auth"
+              "title": "auth"
             }
           }
         },
@@ -253,7 +253,7 @@
             "password",
             "username"
           ],
-          "title": "MongoDB Configuration",
+          "title": "mongodb configuration",
           "definitions": {
             "Collection": {
               "type": "object",
@@ -264,7 +264,7 @@
                 }
               },
               "required": ["report"],
-              "title": "Collection"
+              "title": "collection"
             }
           }
         },
@@ -283,7 +283,7 @@
             }
           },
           "required": ["enabled", "request", "response"],
-          "title": "NetworkLogs",
+          "title": "networklogs",
           "definitions": {
             "Request": {
               "type": "object",
@@ -300,7 +300,7 @@
                 }
               },
               "required": ["body", "cookies", "headers"],
-              "title": "Request"
+              "title": "request"
             }
           }
         },
@@ -313,7 +313,7 @@
             }
           },
           "required": ["server"],
-          "title": "Threadbare Configuration"
+          "title": "threadbare configuration"
         },
         "Video": {
           "type": "object",
@@ -333,7 +333,7 @@
             }
           },
           "required": ["enabled", "format", "location", "prefix"],
-          "title": "Video"
+          "title": "video"
         }
       }
     }

--- a/src/schemas/json/mboats-config-0.2.json
+++ b/src/schemas/json/mboats-config-0.2.json
@@ -93,7 +93,7 @@
         }
       },
       "required": ["appId", "appName"],
-      "title": "MBOATS Framework Properties",
+      "title": "mboats framework properties",
       "definitions": {
         "AWSEC2": {
           "type": "object",
@@ -107,7 +107,7 @@
             }
           },
           "required": ["publicName", "serverPort"],
-          "title": "AWS EC2 Configuration"
+          "title": "aws ec2 configuration"
         },
         "AWSS3": {
           "type": "object",
@@ -140,7 +140,7 @@
             "region",
             "secretAccessKey"
           ],
-          "title": "AWS S3 Configuration"
+          "title": "aws s3 configuration"
         },
         "CucumberOptions": {
           "type": "object",
@@ -157,7 +157,7 @@
             }
           },
           "required": ["featuresPath", "stepdefsPackage", "tagExpression"],
-          "title": "CucumberOptions"
+          "title": "cucumberoptions"
         },
         "Email": {
           "type": "object",
@@ -174,7 +174,7 @@
             }
           },
           "required": ["auth", "invitationLinkRegex", "oktaTokenRegex"],
-          "title": "Email Configuration",
+          "title": "email configuration",
           "definitions": {
             "Auth": {
               "type": "object",
@@ -200,7 +200,7 @@
                 "$refreshToken",
                 "$refreshUrl"
               ],
-              "title": "Auth"
+              "title": "auth"
             }
           }
         },
@@ -235,7 +235,7 @@
             "password",
             "username"
           ],
-          "title": "MongoDB Configuration",
+          "title": "mongodb configuration",
           "definitions": {
             "Collection": {
               "type": "object",
@@ -246,7 +246,7 @@
                 }
               },
               "required": ["report"],
-              "title": "Collection"
+              "title": "collection"
             }
           }
         },
@@ -265,7 +265,7 @@
             }
           },
           "required": ["enabled", "request", "response"],
-          "title": "NetworkLogs",
+          "title": "networklogs",
           "definitions": {
             "Request": {
               "type": "object",
@@ -282,7 +282,7 @@
                 }
               },
               "required": ["body", "cookies", "headers"],
-              "title": "Request"
+              "title": "request"
             }
           }
         },
@@ -295,7 +295,7 @@
             }
           },
           "required": ["server"],
-          "title": "Threadbare Configuration"
+          "title": "threadbare configuration"
         },
         "Video": {
           "type": "object",
@@ -315,7 +315,7 @@
             }
           },
           "required": ["enabled", "format", "location", "prefix"],
-          "title": "Video"
+          "title": "video"
         }
       }
     }

--- a/src/schemas/json/micro.json
+++ b/src/schemas/json/micro.json
@@ -342,6 +342,6 @@
       "default": false
     }
   },
-  "title": "A micro editor config schema",
+  "title": "a micro editor config schema",
   "type": "object"
 }

--- a/src/schemas/json/mimetypes.json
+++ b/src/schemas/json/mimetypes.json
@@ -7,6 +7,6 @@
       "pattern": "^[\\w-_.]+/[\\w-_.]+$"
     }
   },
-  "title": "JSON Schema for mime type collections",
+  "title": "json schema for mime type collections",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -7,7 +7,7 @@
       "type": ["string", "boolean", "number", "array", "object"],
       "properties": {
         "extra": {
-          "title": "Extra",
+          "title": "extra",
           "description": "A list of additional raw JSON text components to be displayed after this one.",
           "type": "array",
           "items": {
@@ -16,7 +16,7 @@
           }
         },
         "color": {
-          "title": "Color",
+          "title": "color",
           "description": "The color to render the content in.",
           "type": "string",
           "anyOf": [
@@ -47,48 +47,48 @@
           ]
         },
         "font": {
-          "title": "Font",
+          "title": "font",
           "description": "The resource location of the font for this component in the resource pack within assets/<namespace>/font.",
           "type": "string",
           "default": "minecraft:default"
         },
         "bold": {
-          "title": "Bold",
+          "title": "bold",
           "description": "Whether to render the content in bold.",
           "type": "boolean"
         },
         "italic": {
-          "title": "Italic",
+          "title": "italic",
           "description": "Whether to render the content in italics. Note that text that is italicized by default, such as custom item names, can be unitalicized by setting this to false.",
           "type": "boolean"
         },
         "underlined": {
-          "title": "Underlined",
+          "title": "underlined",
           "description": "Whether to underline the content.",
           "type": "boolean"
         },
         "strikethrough": {
-          "title": "Strikethrough",
+          "title": "strikethrough",
           "description": "Whether to strikethrough the content.",
           "type": "boolean"
         },
         "obfuscated": {
-          "title": "Obfuscated",
+          "title": "obfuscated",
           "description": "Whether to render the content obfuscated.",
           "type": "boolean"
         },
         "insertion": {
-          "title": "Insertions",
+          "title": "insertions",
           "description": "When the text is shift-clicked by a player, this string is inserted in their chat input. It does not overwrite any existing text the player was writing. This only works in chat messages.",
           "type": "string"
         },
         "clickEvent": {
-          "title": "Click Event",
+          "title": "click event",
           "description": "Allows for events to occur when the player clicks on text. Only work in chat messages and written books, unless specified otherwise.",
           "type": "object",
           "properties": {
             "action": {
-              "title": "Action",
+              "title": "action",
               "description": "The action to perform when clicked.",
               "type": "string",
               "enum": [
@@ -101,47 +101,47 @@
               ]
             },
             "value": {
-              "title": "Value",
+              "title": "value",
               "description": "The URL, file path, chat, command or book page used by the specified action.",
               "type": "string"
             }
           }
         },
         "hoverEvent": {
-          "title": "Hover Event",
+          "title": "hover event",
           "description": "Allows for a tooltip to be displayed when the player hovers their mouse over text.",
           "type": "object",
           "properties": {
             "action": {
-              "title": "Action",
+              "title": "action",
               "description": "The type of tooltip to show.",
               "type": "string",
               "enum": ["show_text", "show_item", "show_entity"]
             },
             "value": {
-              "title": "Value",
+              "title": "value",
               "description": "The formatting and type of this tag varies depending on the action.",
               "type": "string"
             },
             "contents": {
-              "title": "Contents",
+              "title": "contents",
               "description": "The formatting of this tag varies depending on the action.",
               "type": "object"
             }
           }
         },
         "text": {
-          "title": "Text",
+          "title": "text",
           "description": "A string containing plain text to display directly. Can also be a number or boolean that is displayed directly.",
           "type": ["string", "number", "boolean"]
         },
         "translate": {
-          "title": "Translate",
+          "title": "translate",
           "description": "A translation identifier, corresponding to the identifiers found in loaded language files. Displayed as the corresponding text in the player's selected language. If no corresponding translation can be found, the identifier itself is used as the translated text.",
           "type": "string"
         },
         "with": {
-          "title": "With",
+          "title": "with",
           "description": "A list of raw JSON text components to be inserted into slots in the translation text.",
           "type": "array",
           "items": {
@@ -155,63 +155,63 @@
   "description": "Configuration file defining an advancement for a data pack for Minecraft.",
   "properties": {
     "display": {
-      "title": "Display",
+      "title": "display",
       "description": "The display data.",
       "type": "object",
       "properties": {
         "icon": {
-          "title": "Icon",
+          "title": "icon",
           "description": "The data for the icon.",
           "type": "object",
           "properties": {
             "item": {
-              "title": "Item",
+              "title": "item",
               "description": "The item ID.",
               "type": "string"
             },
             "nbt": {
-              "title": "Named Binary Tag",
+              "title": "named binary tag",
               "description": "The Named Binary Tag (NBT) data of the item.",
               "type": "string"
             }
           }
         },
         "title": {
-          "title": "Title",
+          "title": "title",
           "description": "The title for this advancement.",
           "$ref": "#/definitions/jsonTextComponent"
         },
         "frame": {
-          "title": "Frame",
+          "title": "frame",
           "description": "The type of frame for the icon.",
           "type": "string",
           "enum": ["challenge", "goal", "task"],
           "default": "task"
         },
         "background": {
-          "title": "Background",
+          "title": "background",
           "description": "The directory for the background to use in this advancement tab (used only for the root advancement).",
           "type": "string"
         },
         "description": {
-          "title": "Description",
+          "title": "description",
           "description": "The description of the advancement.",
           "$ref": "#/definitions/jsonTextComponent"
         },
         "show_toast": {
-          "title": "Show Toast",
+          "title": "show toast",
           "description": "Whether or not to show the toast pop up after completing this advancement.",
           "type": "boolean",
           "default": true
         },
         "annouce_to_chat": {
-          "title": "Annouce to Chat",
+          "title": "annouce to chat",
           "description": "Whether or not to announce in the chat when this advancement has been completed.",
           "type": "boolean",
           "default": true
         },
         "hidden": {
-          "title": "Hidden",
+          "title": "hidden",
           "description": "Whether or not to hide this advancement and all its children from the advancement screen until this advancement have been completed. Has no effect on root advancements themselves, but still affects all their children.",
           "type": "boolean",
           "default": false
@@ -219,24 +219,24 @@
       }
     },
     "parent": {
-      "title": "Parent",
+      "title": "parent",
       "description": "The parent advancement directory of this advancement. If this field is absent, this advancement is a root advancement. Circular references cause a loading failure.",
       "type": "string"
     },
     "criteria": {
-      "title": "Criteria",
+      "title": "criteria",
       "description": "The required criteria that have to be met.",
       "type": "object",
       "additionalProperties": {
         "type": "object",
         "properties": {
           "trigger": {
-            "title": "Trigger",
+            "title": "trigger",
             "description": "The trigger for this advancement; specifies what the game should check for the advancement.",
             "type": "string"
           },
           "conditions": {
-            "title": "Conditions",
+            "title": "conditions",
             "description": "All the conditions that need to be met when the trigger gets activated.",
             "type": "object"
           }
@@ -244,7 +244,7 @@
       }
     },
     "requirements": {
-      "title": "Requirements",
+      "title": "requirements",
       "description": "A list of requirements (all the <criteriaNames>). If all criteria are required, this may be omitted. With multiple criteria: requirements contains a list of lists with criteria (all criteria need to be mentioned). If all of the lists each have any criteria met, the advancement is complete. (basically AND grouping of OR groups)",
       "type": "array",
       "items": {
@@ -255,12 +255,12 @@
       }
     },
     "rewards": {
-      "title": "Rewards",
+      "title": "rewards",
       "description": "The rewards provided when this advancement is obtained.",
       "type": "object",
       "properties": {
         "recipes": {
-          "title": "Recipes",
+          "title": "recipes",
           "description": "A list of recipes to unlock.",
           "type": "array",
           "items": {
@@ -269,7 +269,7 @@
           }
         },
         "loot": {
-          "title": "Loot",
+          "title": "loot",
           "description": "A list of loot tables to give to the player.",
           "type": "array",
           "items": {
@@ -278,18 +278,18 @@
           }
         },
         "experience": {
-          "title": "Experience",
+          "title": "experience",
           "description": "An amount of experience.",
           "type": "integer"
         },
         "function": {
-          "title": "Function",
+          "title": "function",
           "description": "A function to run. Function tags are not allowed.",
           "type": "string"
         }
       }
     }
   },
-  "title": "Minecraft Data Pack Advancement",
+  "title": "minecraft data pack advancement",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -487,7 +487,7 @@
           "type": "string"
         },
         "mood_sound": {
-          "title": "Mood Sound",
+          "title": "mood sound",
           "description": "Settings for mood sound\nhttps://minecraft.fandom.com/wiki/Custom_biome",
           "type": "object",
           "properties": {
@@ -508,7 +508,7 @@
           }
         },
         "additions_sound": {
-          "title": "Additions Sound",
+          "title": "additions sound",
           "description": "Settings for additions sound\nhttps://minecraft.fandom.com/wiki/Custom_biome",
           "type": "object",
           "properties": {
@@ -517,13 +517,13 @@
               "type": "string"
             },
             "tick_chance": {
-              "title": "Tick Chance",
+              "title": "tick chance",
               "type": "integer"
             }
           }
         },
         "music": {
-          "title": "Music",
+          "title": "music",
           "description": "Specific music that should be played in the biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
           "type": "object",
           "properties": {
@@ -551,7 +551,7 @@
       "type": "string"
     },
     "carvers": {
-      "title": "Carvers",
+      "title": "carvers",
       "description": "The carvers to use\nhttps://minecraft.fandom.com/wiki/Custom_biome",
       "type": "object",
       "properties": {
@@ -589,12 +589,12 @@
       }
     },
     "spawners": {
-      "title": "Spawners",
+      "title": "spawners",
       "description": "Entity spawning settings\nhttps://minecraft.fandom.com/wiki/Custom_biome",
       "type": "object"
     },
     "spawn_costs": {
-      "title": "Spawn Costs",
+      "title": "spawn costs",
       "description": "List of entity IDs\nhttps://minecraft.fandom.com/wiki/Custom_biome",
       "additionalProperties": {
         "properties": {
@@ -608,6 +608,6 @@
       }
     }
   },
-  "title": "Minecraft Data Pack Biome",
+  "title": "minecraft data pack biome",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-configured-carver.json
+++ b/src/schemas/json/minecraft-configured-carver.json
@@ -33,6 +33,6 @@
       }
     }
   },
-  "title": "A Minecraft carver config schema",
+  "title": "a minecraft carver config schema",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-dimension-type.json
+++ b/src/schemas/json/minecraft-dimension-type.json
@@ -4,43 +4,43 @@
   "description": "Configuration file defining a dimension type for a data pack for Minecraft.",
   "properties": {
     "name": {
-      "title": "Name",
+      "title": "name",
       "description": "The resource location used for the dimension type.",
       "type": "string"
     },
     "ultrawarm": {
-      "title": "Ultrawarm",
+      "title": "ultrawarm",
       "description": "Whether the dimensions behaves like the nether (water evaporates and sponges dry) or not. Also lets stalactites drip lava and causes lava to spread faster and thinner.",
       "type": "boolean"
     },
     "natural": {
-      "title": "Natural",
+      "title": "natural",
       "description": "When true, nether portals can spawn zombified piglins. When false, compasses spin randomly, and using a bed to set the respawn point or sleep, is disabled.",
       "type": "boolean"
     },
     "coordinate_scale": {
-      "title": "Coordinate Scale",
+      "title": "coordinate scale",
       "description": "The multiplier applied to coordinates when traveling to the dimension.",
       "type": "number"
     },
     "has_skylight": {
-      "title": "Has Skylight",
+      "title": "has skylight",
       "description": "Whether the dimension has skylight access or not.",
       "type": "boolean"
     },
     "has_ceiling": {
-      "title": "Has Ceiling",
+      "title": "has ceiling",
       "description": "Whether the dimension has a bedrock ceiling or not.",
       "type": "boolean"
     },
     "ambient_light": {
-      "title": "Ambient Light",
+      "title": "ambient light",
       "description": "How much light the dimension has.",
       "type": "number",
       "default": 0.5
     },
     "fixed_time": {
-      "title": "Fixed Time",
+      "title": "fixed time",
       "description": "If this is set to a number, the time of the day is the specified value.",
       "anyOf": [
         {
@@ -55,32 +55,32 @@
       ]
     },
     "piglin_safe": {
-      "title": "Piglin Safe",
+      "title": "piglin safe",
       "description": "Whether piglins shake and transform to zombified piglins.",
       "type": "boolean"
     },
     "bed_works": {
-      "title": "Bed Words",
+      "title": "bed words",
       "description": "When false, the bed blows up when trying to sleep.",
       "type": "boolean"
     },
     "respawn_anchor_works": {
-      "title": "Respawn Anchor Works",
+      "title": "respawn anchor works",
       "description": "Whether players can charge and use respawn anchors.",
       "type": "boolean"
     },
     "has_raids": {
-      "title": "Has Raids",
+      "title": "has raids",
       "description": "Whether players with the Bad Omen effect can cause a raid.",
       "type": "boolean"
     },
     "logical_height": {
-      "title": "Logical Height",
+      "title": "logical height",
       "description": "The maximum height to which chorus fruits and nether portals can bring players within this dimension. This excludes portals that were already built above the limit as they still connect normally.",
       "type": "integer"
     },
     "min_y": {
-      "title": "Minimum Y",
+      "title": "minimum y",
       "description": "The minimum height in which blocks can exist within this dimension.",
       "type": "integer",
       "minimum": -2032,
@@ -88,7 +88,7 @@
       "multipleOf": 16
     },
     "height": {
-      "title": "Height",
+      "title": "height",
       "description": "The total height in which blocks can exist within this dimension.",
       "type": "integer",
       "minimum": 0,
@@ -96,12 +96,12 @@
       "multipleOf": 16
     },
     "infiniburn": {
-      "title": "Infiniburn",
+      "title": "infiniburn",
       "description": "A resource location defining what block tag to use for infiniburn.",
       "type": "string"
     },
     "effects": {
-      "title": "Effects",
+      "title": "effects",
       "description": "Determines the dimension effect used for this dimension.",
       "type": "string",
       "enum": [
@@ -112,6 +112,6 @@
       "default": "minecraft:overworld"
     }
   },
-  "title": "Minecraft Data Pack Dimension Type",
+  "title": "minecraft data pack dimension type",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-dimension.json
+++ b/src/schemas/json/minecraft-dimension.json
@@ -6,13 +6,13 @@
       "type": "object",
       "properties": {
         "firstOctave": {
-          "title": "First Octave",
+          "title": "first octave",
           "description": "The lower the value, the smoother the changes in altitude will be, making biome edges smoother.",
           "type": "integer",
           "default": -7
         },
         "amplitudes": {
-          "title": "Amplitudes",
+          "title": "amplitudes",
           "description": "A list of floats. Using more values allows for greater precision. Higher absolute values seem to make the altitude reach greater absolute values.",
           "type": "array",
           "items": {
@@ -24,48 +24,48 @@
     },
     "dimensionType": {
       "$comment": "https://minecraft.fandom.com/wiki/Custom_dimension#Dimension_type",
-      "title": "Minecraft Data Pack Dimension Type",
+      "title": "minecraft data pack dimension type",
       "description": "Configuration file defining a dimension type for a data pack for Minecraft.",
       "type": "object",
       "properties": {
         "name": {
-          "title": "Name",
+          "title": "name",
           "description": "The resource location used for the dimension type.",
           "type": "string"
         },
         "ultrawarm": {
-          "title": "Ultrawarm",
+          "title": "ultrawarm",
           "description": "Whether the dimensions behaves like the nether (water evaporates and sponges dry) or not. Also lets stalactites drip lava and causes lava to spread faster and thinner.",
           "type": "boolean"
         },
         "natural": {
-          "title": "Natural",
+          "title": "natural",
           "description": "When true, nether portals can spawn zombified piglins. When false, compasses spin randomly, and using a bed to set the respawn point or sleep, is disabled.",
           "type": "boolean"
         },
         "coordinate_scale": {
-          "title": "Coordinate Scale",
+          "title": "coordinate scale",
           "description": "The multiplier applied to coordinates when traveling to the dimension.",
           "type": "number"
         },
         "has_skylight": {
-          "title": "Has Skylight",
+          "title": "has skylight",
           "description": "Whether the dimension has skylight access or not.",
           "type": "boolean"
         },
         "has_ceiling": {
-          "title": "Has Ceiling",
+          "title": "has ceiling",
           "description": "Whether the dimension has a bedrock ceiling or not.",
           "type": "boolean"
         },
         "ambient_light": {
-          "title": "Ambient Light",
+          "title": "ambient light",
           "description": "How much light the dimension has.",
           "type": "number",
           "default": 0.5
         },
         "fixed_time": {
-          "title": "Fixed Time",
+          "title": "fixed time",
           "description": "If this is set to a number, the time of the day is the specified value.",
           "anyOf": [
             {
@@ -80,32 +80,32 @@
           ]
         },
         "piglin_safe": {
-          "title": "Piglin Safe",
+          "title": "piglin safe",
           "description": "Whether piglins shake and transform to zombified piglins.",
           "type": "boolean"
         },
         "bed_works": {
-          "title": "Bed Words",
+          "title": "bed words",
           "description": "When false, the bed blows up when trying to sleep.",
           "type": "boolean"
         },
         "respawn_anchor_works": {
-          "title": "Respawn Anchor Works",
+          "title": "respawn anchor works",
           "description": "Whether players can charge and use respawn anchors.",
           "type": "boolean"
         },
         "has_raids": {
-          "title": "Has Raids",
+          "title": "has raids",
           "description": "Whether players with the Bad Omen effect can cause a raid.",
           "type": "boolean"
         },
         "logical_height": {
-          "title": "Logical Height",
+          "title": "logical height",
           "description": "The maximum height to which chorus fruits and nether portals can bring players within this dimension. This excludes portals that were already built above the limit as they still connect normally.",
           "type": "integer"
         },
         "min_y": {
-          "title": "Minimum Y",
+          "title": "minimum y",
           "description": "The minimum height in which blocks can exist within this dimension.",
           "type": "integer",
           "minimum": -2032,
@@ -113,7 +113,7 @@
           "multipleOf": 16
         },
         "height": {
-          "title": "Height",
+          "title": "height",
           "description": "The total height in which blocks can exist within this dimension.",
           "type": "integer",
           "minimum": 0,
@@ -121,12 +121,12 @@
           "multipleOf": 16
         },
         "infiniburn": {
-          "title": "Infiniburn",
+          "title": "infiniburn",
           "description": "A resource location defining what block tag to use for infiniburn.",
           "type": "string"
         },
         "effects": {
-          "title": "Effects",
+          "title": "effects",
           "description": "Determines the dimension effect used for this dimension.",
           "type": "string",
           "enum": [
@@ -142,7 +142,7 @@
   "description": "Configuration file defining a dimension for a data pack for Minecraft.",
   "properties": {
     "type": {
-      "title": "Type",
+      "title": "type",
       "description": "The namespaced ID of the dimension type.",
       "anyOf": [
         {
@@ -160,12 +160,12 @@
       ]
     },
     "generator": {
-      "title": "Generator",
+      "title": "generator",
       "description": "Generation settings used for that dimension.",
       "type": "object",
       "properties": {
         "type": {
-          "title": "Type",
+          "title": "type",
           "description": "The ID of the generator.",
           "type": "string",
           "enum": ["minecraft:flat", "minecraft:noise", "minecraft:debug"]
@@ -183,12 +183,12 @@
           "then": {
             "properties": {
               "settings": {
-                "title": "Settings",
+                "title": "settings",
                 "description": "Superflat settings.",
                 "type": "object",
                 "properties": {
                   "layers": {
-                    "title": "Layers",
+                    "title": "layers",
                     "description": "Layer settings.",
                     "type": "array",
                     "items": {
@@ -196,12 +196,12 @@
                       "type": "object",
                       "properties": {
                         "height": {
-                          "title": "Height",
+                          "title": "height",
                           "description": "The number of blocks in the layer.",
                           "type": "integer"
                         },
                         "block": {
-                          "title": "Block",
+                          "title": "block",
                           "description": "The block the layer is made of.",
                           "type": "string"
                         }
@@ -209,65 +209,65 @@
                     }
                   },
                   "biome": {
-                    "title": "Biome",
+                    "title": "biome",
                     "description": "The single biome of the world.",
                     "type": "string"
                   },
                   "lakes": {
-                    "title": "Lakes",
+                    "title": "lakes",
                     "description": "Whether or not to generate lakes. If set to true, then water and lava lakes generate often even in biomes where lakes don't normally generate. Lava lakes generate surrounded by different types of stone and ores from the overworld.",
                     "type": "boolean"
                   },
                   "features": {
-                    "title": "Features",
+                    "title": "features",
                     "description": "Whether or not to generate biome-specific decorations like trees, grass, flowers, cacti, etc.",
                     "type": "boolean"
                   },
                   "structures": {
-                    "title": "Structures",
+                    "title": "structures",
                     "description": "Structure settings.",
                     "type": "object",
                     "properties": {
                       "stronghold": {
-                        "title": "Stronghold",
+                        "title": "stronghold",
                         "description": "Settings for how strongholds should be spawned.",
                         "type": "object",
                         "properties": {
                           "distance": {
-                            "title": "Distance",
+                            "title": "distance",
                             "description": "Controls how far apart the strongholds are.",
                             "type": "integer"
                           },
                           "count": {
-                            "title": "Count",
+                            "title": "count",
                             "description": "How many strongholds to generate.",
                             "type": "integer"
                           },
                           "spread": {
-                            "title": "Spread",
+                            "title": "spread",
                             "type": "integer"
                           }
                         }
                       },
                       "structures": {
-                        "title": "Structures",
+                        "title": "structures",
                         "description": "Map of structures to use in this dimension.",
                         "type": "object",
                         "additionalProperties": {
                           "type": "object",
                           "properties": {
                             "spacing": {
-                              "title": "Spacing",
+                              "title": "spacing",
                               "description": "Average distance between two structure placement attempts of this type in chunks.",
                               "type": "integer"
                             },
                             "seperation": {
-                              "title": "Seperation",
+                              "title": "seperation",
                               "description": "Minimum distance between two structures of this type in chunks; must be less than spacing.",
                               "type": "integer"
                             },
                             "salt": {
-                              "title": "Salt",
+                              "title": "salt",
                               "description": "A number that assists in randomization.",
                               "type": "integer"
                             }
@@ -292,32 +292,32 @@
           "then": {
             "properties": {
               "seed": {
-                "title": "Seed",
+                "title": "seed",
                 "description": "The seed used to generate the dimension. In most cases, this is exactly the same as the world seed, but can be different and the dimension generated is based upon this seed and not the world seed.",
                 "type": "integer"
               },
               "settings": {
-                "title": "Settings",
+                "title": "settings",
                 "description": "The noise settings used in the terrain generator. Can be set to a string to use a preset defined in the worldgen/noise_settings folder with a list of customized options.",
                 "type": ["string", "object"]
               },
               "biome_source": {
-                "title": "Biome Source",
+                "title": "biome source",
                 "description": "Settings dictating which biomes and biome shapes.",
                 "type": "object",
                 "properties": {
                   "seed": {
-                    "title": "Seed",
+                    "title": "seed",
                     "description": "The seed used for biome generation.",
                     "type": "integer"
                   },
                   "biomes": {
-                    "title": "Biomes",
+                    "title": "biomes",
                     "description": "A list of biome IDs to generate.",
                     "type": "array"
                   },
                   "type": {
-                    "title": "Type",
+                    "title": "type",
                     "description": "The type of biome generation.",
                     "type": "string",
                     "allOf": [
@@ -333,12 +333,12 @@
                           "description": "Default and large biome generation used in the overworld.",
                           "properties": {
                             "large_biomes": {
-                              "title": "Large Biomes",
+                              "title": "large biomes",
                               "description": "Whether the biomes are large.",
                               "type": "boolean"
                             },
                             "legacy_biome_init_layer": {
-                              "title": "Legacy Biome Init Layer",
+                              "title": "legacy biome init layer",
                               "description": "Whether the world was default_1_1.",
                               "type": "boolean"
                             }
@@ -357,7 +357,7 @@
                           "description": "A single biome.",
                           "properties": {
                             "biome": {
-                              "title": "Biome",
+                              "title": "biome",
                               "description": "The single biome to generate.",
                               "type": "string"
                             }
@@ -376,12 +376,12 @@
                           "description": "A biome generation in which biomes are square (or close to square) and repeat along the diagonals.",
                           "properties": {
                             "biomes": {
-                              "title": "Biomes",
+                              "title": "biomes",
                               "description": "A list of biomes that repeat along the diagonals.",
                               "type": "array"
                             },
                             "scale": {
-                              "title": "Scale",
+                              "title": "scale",
                               "description": "Determines the size of the squares on an exponential scale.",
                               "type": "integer",
                               "minimum": 0,
@@ -402,22 +402,22 @@
                           "description": "3D biome generation used in the nether.",
                           "properties": {
                             "altitude_noise": {
-                              "title": "Altitude Noise",
+                              "title": "altitude noise",
                               "description": "How the altitude parameter is spread in the world.",
                               "$ref": "#/definitions/noise"
                             },
                             "weirdness_noise": {
-                              "title": "Weirdness Noise",
+                              "title": "weirdness noise",
                               "description": "Similar to altitude_noise for the weirdness parameter.",
                               "$ref": "#/definitions/noise"
                             },
                             "temperature_noise": {
-                              "title": "Temperature Noise",
+                              "title": "temperature noise",
                               "description": "Similar to altitude_noise for the temperature parameter.",
                               "$ref": "#/definitions/noise"
                             },
                             "humidity_noise": {
-                              "title": "Humidity Noise",
+                              "title": "humidity noise",
                               "description": "Similar to altitude_noise for the humidity parameter.",
                               "$ref": "#/definitions/noise"
                             }
@@ -426,7 +426,7 @@
                             {
                               "properties": {
                                 "preset": {
-                                  "title": "Preset",
+                                  "title": "preset",
                                   "description": "A preset of the set of biomes to be used.",
                                   "type": "string",
                                   "enum": ["minecraft:nether"]
@@ -436,7 +436,7 @@
                             {
                               "properties": {
                                 "biomes": {
-                                  "title": "Biomes",
+                                  "title": "biomes",
                                   "description": "A list of biomes, including their likelihood.",
                                   "type": "array",
                                   "items": {
@@ -444,45 +444,45 @@
                                     "description": "A biome and its properties.",
                                     "properties": {
                                       "biome": {
-                                        "title": "Biome",
+                                        "title": "biome",
                                         "description": "The biome.",
                                         "type": "string"
                                       },
                                       "parameters": {
-                                        "title": "Parameters",
+                                        "title": "parameters",
                                         "description": "Represent optimal conditions for where the biome should be placed. These values do not affect the generation of terrain within biomes; they affect where the game chooses to place biomes.",
                                         "type": "object",
                                         "properties": {
                                           "altitude": {
-                                            "title": "Altitude",
+                                            "title": "altitude",
                                             "description": "Used to place similar biomes near each other.",
                                             "type": "number",
                                             "minimum": -2,
                                             "maximum": 2
                                           },
                                           "weirdness": {
-                                            "title": "Weirdness",
+                                            "title": "weirdness",
                                             "description": "Defines how weird the biome is going to appear next to other biomes.",
                                             "type": "number",
                                             "minimum": -2,
                                             "maximum": 2
                                           },
                                           "offset": {
-                                            "title": "Offset",
+                                            "title": "offset",
                                             "description": " Similar to the other parameters but offset is 0 everywhere, thus setting this parameter nearer to 0 gives the biome a greater edge over others, all else being equal.",
                                             "type": "number",
                                             "minimum": 0,
                                             "maximum": 1
                                           },
                                           "temperature": {
-                                            "title": "Temperature",
+                                            "title": "temperature",
                                             "description": "Used to place similar biomes near each other. This is NOT the same as the temperature value listed on Biome, it does NOT affect rain/snow or the color of leaves and grass.",
                                             "type": "number",
                                             "minimum": -2,
                                             "maximum": 2
                                           },
                                           "humidity": {
-                                            "title": "Humidity",
+                                            "title": "humidity",
                                             "description": "Used to place similar biomes near each other.",
                                             "type": "number",
                                             "minimum": -2,
@@ -520,6 +520,6 @@
       ]
     }
   },
-  "title": "Minecraft Data Pack Dimension",
+  "title": "minecraft data pack dimension",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-item-modifier.json
+++ b/src/schemas/json/minecraft-item-modifier.json
@@ -9,7 +9,7 @@
       "$comment": "https://minecraft.fandom.com/wiki/Loot_table#Number_Providers",
       "properties": {
         "type": {
-          "title": "Type",
+          "title": "type",
           "description": "The number provider type.",
           "type": "string",
           "enum": [
@@ -33,7 +33,7 @@
             "description": "A constant value.",
             "properties": {
               "value": {
-                "title": "Value",
+                "title": "value",
                 "description": "The exact value.",
                 "type": "number"
               }
@@ -52,13 +52,13 @@
             "description": "A random number following a uniform distribution between two values (inclusive).",
             "properties": {
               "min": {
-                "title": "Minimum",
+                "title": "minimum",
                 "description": "The minimum value.",
                 "type": ["number", "object"],
                 "$ref": "#/definitions/numberProvider"
               },
               "max": {
-                "title": "Max",
+                "title": "max",
                 "description": "The maximum value.",
                 "type": ["number", "object"],
                 "$ref": "#/definitions/numberProvider"
@@ -103,13 +103,13 @@
             "description": "A scoreboard value.",
             "properties": {
               "target": {
-                "title": "Target",
+                "title": "target",
                 "description": "Scoreboard name provider.",
                 "type": ["string", "object"],
                 "enum": ["this", "killer", "direct_killer", "player_killer"],
                 "properties": {
                   "type": {
-                    "title": "Type",
+                    "title": "type",
                     "description": "Resource location.",
                     "type": "string",
                     "enum": ["fixed", "context"]
@@ -127,7 +127,7 @@
                     "then": {
                       "properties": {
                         "name": {
-                          "title": "Name",
+                          "title": "name",
                           "description": "A UUID or player name.",
                           "type": "string"
                         }
@@ -145,7 +145,7 @@
                     "then": {
                       "properties": {
                         "target": {
-                          "title": "Target",
+                          "title": "target",
                           "type": "string",
                           "enum": [
                             "this",
@@ -160,12 +160,12 @@
                 ]
               },
               "score": {
-                "title": "Score",
+                "title": "score",
                 "description": "The scoreboard objective.",
                 "type": "string"
               },
               "scale": {
-                "title": "Scale",
+                "title": "scale",
                 "description": "Scale to multiply the score before returning it.",
                 "type": "number"
               }
@@ -179,7 +179,7 @@
   "items": {
     "properties": {
       "function": {
-        "title": "Function",
+        "title": "function",
         "description": "Namespaced ID of the function to apply.",
         "type": "string",
         "enum": [
@@ -223,12 +223,12 @@
           "type": "object",
           "properties": {
             "enchantment": {
-              "title": "Enchantment",
+              "title": "enchantment",
               "description": "Enchantment ID used for level calculation.",
               "type": "string"
             },
             "formula": {
-              "title": "Forumla",
+              "title": "forumla",
               "type": "string",
               "enum": [
                 "binomial_with_bonus_count",
@@ -237,22 +237,22 @@
               ]
             },
             "parameters": {
-              "title": "Parameters",
+              "title": "parameters",
               "description": "Values required for the formula.",
               "type": "object",
               "properties": {
                 "extra": {
-                  "title": "Extra",
+                  "title": "extra",
                   "description": "For formula 'binomial_with_bonus_count', the extra value.",
                   "type": "integer"
                 },
                 "probability": {
-                  "title": "Probability",
+                  "title": "probability",
                   "description": "For formula 'binomial_with_bonus_count', the probability.",
                   "type": "number"
                 },
                 "bonusMultiplier": {
-                  "title": "Bonus Multiplier",
+                  "title": "bonus multiplier",
                   "description": "For formula 'uniform_bonus_count', the bonus multiplier.",
                   "type": "number"
                 }
@@ -274,7 +274,7 @@
           "type": "object",
           "properties": {
             "source": {
-              "title": "Source",
+              "title": "source",
               "type": "string",
               "enum": ["block_entity"],
               "default": "block_entity"
@@ -295,7 +295,7 @@
           "type": "object",
           "properties": {
             "source": {
-              "title": "Source",
+              "title": "source",
               "anyOf": [
                 {
                   "type": "string",
@@ -308,7 +308,7 @@
                   "type": "object",
                   "properties": {
                     "type": {
-                      "title": "Type",
+                      "title": "type",
                       "description": "NBT provider type.",
                       "type": "string",
                       "enum": ["minecraft:context", "minecraft:storage"]
@@ -326,7 +326,7 @@
                       "then": {
                         "properties": {
                           "target": {
-                            "title": "Target",
+                            "title": "target",
                             "description": "Same as source above.",
                             "type": "string"
                           }
@@ -344,7 +344,7 @@
                       "then": {
                         "properties": {
                           "target": {
-                            "title": "Source",
+                            "title": "source",
                             "description": "A resource location specifying the storage ID.",
                             "type": "string"
                           }
@@ -356,24 +356,24 @@
               ]
             },
             "ops": {
-              "title": "Operations",
+              "title": "operations",
               "description": "A list of copy operations.",
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
                   "source": {
-                    "title": "Source",
+                    "title": "source",
                     "description": "The NBT path to copy from.",
                     "type": "string"
                   },
                   "target": {
-                    "title": "Target",
+                    "title": "target",
                     "description": "The NBT path to copy to, starting from the item's tag tag.",
                     "type": "string"
                   },
                   "op": {
-                    "title": "Operation",
+                    "title": "operation",
                     "description": "Can be replace to replace any existing contents of the target, append to append to a list, or merge to merge into a compound tag.",
                     "type": "string"
                   }
@@ -395,16 +395,16 @@
           "description": "Copies state properties from dropped block to the item's BlockStateTag tag.",
           "properties": {
             "block": {
-              "title": "Block",
+              "title": "block",
               "description": "A block ID. Function fails if the block doesn't match.",
               "type": "string"
             },
             "properties": {
-              "title": "Properties",
+              "title": "properties",
               "description": "A list of property names to copy.",
               "type": "array",
               "items": {
-                "title": "Property",
+                "title": "property",
                 "description": "A block state name to copy.",
                 "type": "string"
               }
@@ -424,7 +424,7 @@
           "description": "Enchants the item with one randomly-selected enchantment. The level of the enchantment, if applicable, is random.",
           "properties": {
             "enchantments": {
-              "title": "Enchantments",
+              "title": "enchantments",
               "description": "List of enchantment IDs to choose from.",
               "type": "array"
             }
@@ -443,12 +443,12 @@
           "description": "Enchants the item, with the specified enchantment level (roughly equivalent to using an enchantment table at that level).",
           "properties": {
             "treasure": {
-              "title": "Treasure",
+              "title": "treasure",
               "description": "Determines whether treasure enchantments are allowed on this item.",
               "type": "boolean"
             },
             "levels": {
-              "title": "Levels",
+              "title": "levels",
               "description": "Specifies the exact enchantment level to use.",
               "type": ["integer", "object"],
               "$ref": "#/definitions/numberProvider"
@@ -468,29 +468,29 @@
           "description": "Converts an empty map into an explorer map leading to a nearby generated structure.",
           "properties": {
             "destination": {
-              "title": "Destination",
+              "title": "destination",
               "description": "The type of generated structure to locate. Accepts any of the StructureTypes used by the /locate command (case insensitive).",
               "type": "string"
             },
             "decoration": {
-              "title": "Decoration",
+              "title": "decoration",
               "description": "The icon used to mark the destination on the map. Accepts any of the map icon text IDs (case insensitive).",
               "type": "string"
             },
             "zoom": {
-              "title": "Zoom",
+              "title": "zoom",
               "description": "The zoom level of the resulting map.",
               "type": "integer",
               "default": 2
             },
             "search_radius": {
-              "title": "Search Radius",
+              "title": "search radius",
               "description": "The size, in chunks, of the area to search for structures. The area checked is square, not circular.",
               "type": "integer",
               "default": 50
             },
             "skip_existing_chunks": {
-              "title": "Skip Existing Chunks",
+              "title": "skip existing chunks",
               "description": "Don't search in chunks that have already been generated.",
               "type": "boolean",
               "default": true
@@ -534,7 +534,7 @@
           "description": "Adds required item tags of a player head.",
           "properties": {
             "entity": {
-              "title": "Entity",
+              "title": "entity",
               "description": "Specifies an entity to be used for the player head.",
               "type": "string"
             }
@@ -553,19 +553,19 @@
           "description": "Limits the count of every item stack.",
           "properties": {
             "limit": {
-              "title": "Limit",
+              "title": "limit",
               "description": "Specifies the exact limit to use.",
               "type": ["integer", "object"],
               "$ref": "#/definitions/numberProvider",
               "properties": {
                 "min": {
-                  "title": "Minimum",
+                  "title": "minimum",
                   "description": "Minimum limit to use.",
                   "type": ["integer", "object"],
                   "$ref": "#/definitions/numberProvider"
                 },
                 "max": {
-                  "title": "Max",
+                  "title": "max",
                   "description": "Max limit to use.",
                   "type": ["integer", "object"],
                   "$ref": "#/definitions/numberProvider"
@@ -587,13 +587,13 @@
           "description": "Adjusts the stack size based on the level of the Looting enchantment on the killer entity.",
           "properties": {
             "count": {
-              "title": "Count",
+              "title": "count",
               "description": "Specifies the number of additional items per level of looting.",
               "type": ["integer", "object"],
               "$ref": "#/definitions/numberProvider"
             },
             "limit": {
-              "title": "Limit",
+              "title": "limit",
               "description": "Specifies the maximum amount of items in the stack after the looting calculation. If the value is 0, no limit is applied.",
               "type": "integer"
             }
@@ -612,40 +612,40 @@
           "description": "Add attribute modifiers to the item.",
           "properties": {
             "modifiers": {
-              "title": "Modifiers",
+              "title": "modifiers",
               "type": "array",
               "items": {
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
                     "name": {
-                      "title": "Name",
+                      "title": "name",
                       "description": "Name of the modifer.",
                       "type": "string"
                     },
                     "attribute": {
-                      "title": "Attribute",
+                      "title": "attribute",
                       "description": "The name of the attribute this modifer is to act upon.",
                       "type": "string"
                     },
                     "operation": {
-                      "title": "Operation",
+                      "title": "operation",
                       "type": "string",
                       "enum": ["addition", "multiply_base", "multiply_total"]
                     },
                     "amount": {
-                      "title": "Amount",
+                      "title": "amount",
                       "description": "Specifies the amount of the modifier.",
                       "type": ["number", "object"],
                       "$ref": "#/definitions/numberProvider"
                     },
                     "id": {
-                      "title": "ID",
+                      "title": "id",
                       "description": "UUID of the modifier following.",
                       "type": "string"
                     },
                     "slot": {
-                      "title": "Slot",
+                      "title": "slot",
                       "description": "Slots the item must be in for the modifier to take effect.",
                       "type": ["string", "array"],
                       "$ref": "#/definitions/slotEnum",
@@ -673,7 +673,7 @@
           "description": "Sets tags needed for banner patterns.",
           "properties": {
             "patterns": {
-              "title": "Patterns",
+              "title": "patterns",
               "description": "List of patterns.",
               "type": "array",
               "items": {
@@ -682,12 +682,12 @@
                   "type": "object",
                   "properties": {
                     "pattern": {
-                      "title": "Pattern",
+                      "title": "pattern",
                       "description": "The pattern type.",
                       "type": "string"
                     },
                     "color": {
-                      "title": "Color",
+                      "title": "color",
                       "description": "The color for this pattern.",
                       "type": "string",
                       "enum": [
@@ -714,7 +714,7 @@
               }
             },
             "append": {
-              "title": "Append",
+              "title": "append",
               "description": "If true, new patterns will be appended to existing ones.",
               "type": "boolean"
             }
@@ -733,7 +733,7 @@
           "description": "For loot tables of type 'block', sets the contents of a container block item to a list of entries.",
           "properties": {
             "entries": {
-              "title": "Entries",
+              "title": "entries",
               "description": "The entries to use as contents.",
               "type": "array"
             }
@@ -752,13 +752,13 @@
           "description": "Sets the stack size.",
           "properties": {
             "count": {
-              "title": "Count",
+              "title": "count",
               "description": "Specifies the stack size to set.",
               "type": ["integer", "object"],
               "$ref": "#/definitions/numberProvider"
             },
             "add": {
-              "title": "Add",
+              "title": "add",
               "description": "If true, change will be relative to the current count.",
               "type": "boolean"
             }
@@ -777,13 +777,13 @@
           "description": "Sets the item's damage value (durability) for tools.",
           "properties": {
             "damage": {
-              "title": "Damage",
+              "title": "damage",
               "description": "Specifies the damage fraction to set (1.0 is undamaged, 0.0 is zero durability left).",
               "type": ["number", "object"],
               "$ref": "#/definitions/numberProvider"
             },
             "add": {
-              "title": "Add",
+              "title": "add",
               "description": "If true, change will be relative to current damage.",
               "type": "boolean"
             }
@@ -802,7 +802,7 @@
           "description": "Sets the item's enchantments.",
           "properties": {
             "enchantments": {
-              "title": "Enchantments",
+              "title": "enchantments",
               "description": "Enchantments to add.",
               "type": "object",
               "additionalProperties": {
@@ -812,7 +812,7 @@
               }
             },
             "add": {
-              "title": "Add",
+              "title": "add",
               "description": "If true, change will be relative to current level.",
               "type": "boolean"
             }
@@ -831,12 +831,12 @@
           "description": "Sets the loot table for a container (chest etc.).",
           "properties": {
             "name": {
-              "title": "Name",
+              "title": "name",
               "description": "Specifies the resource location of the loot table to be used.",
               "type": "string"
             },
             "seed": {
-              "title": "Seed",
+              "title": "seed",
               "description": "Specifies the loot table seed. If absent or set to 0, a random seed will be used.",
               "type": "integer"
             }
@@ -855,7 +855,7 @@
           "description": "Adds lore to the item.",
           "properties": {
             "lore": {
-              "title": "Lore",
+              "title": "lore",
               "description": "List of JSON text components. Each list entry represents one line of the lore. Advanced components are resolved only if entity successfully targets an entity.",
               "type": "array",
               "items": {
@@ -863,12 +863,12 @@
               }
             },
             "entity": {
-              "title": "Entity",
+              "title": "entity",
               "description": "Specifies the entity to act as the source @s in the JSON text component.",
               "type": "string"
             },
             "replace": {
-              "title": "Replace",
+              "title": "replace",
               "description": "If true, replaces all existing lines of lore, if false appends the list.",
               "type": "boolean"
             }
@@ -887,12 +887,12 @@
           "description": "Adds display name of the item.",
           "properties": {
             "name": {
-              "title": "Name",
+              "title": "name",
               "description": "A JSON text component name, allowing color, translations, etc. Advanced components are resolved only if entity successfully targets an entity.",
               "type": ["array", "object", "string"]
             },
             "entity": {
-              "title": "Entity",
+              "title": "entity",
               "description": "Specifies an entity to act as source @s in the JSON text component.",
               "type": "string"
             }
@@ -911,7 +911,7 @@
           "description": "Adds NBT data to the item.",
           "properties": {
             "tag": {
-              "title": "Tag",
+              "title": "tag",
               "description": "Tag string to add, similar to those used by commands. Note that the first bracket is required and quotation marks need to be escaped using a backslash (\\).",
               "type": "string"
             }
@@ -930,7 +930,7 @@
           "description": "Sets the status effects for suspicious stew.",
           "properties": {
             "effects": {
-              "title": "Effects",
+              "title": "effects",
               "description": "The effects to apply.",
               "type": "array",
               "items": {
@@ -939,12 +939,12 @@
                   "type": "object",
                   "properties": {
                     "type": {
-                      "title": "Type",
+                      "title": "type",
                       "description": "The effect ID.",
                       "type": "string"
                     },
                     "duration": {
-                      "title": "Duration",
+                      "title": "duration",
                       "description": "The duration of the effect.",
                       "type": ["integer", "object"],
                       "$ref": "#/definitions/numberProvider"
@@ -958,6 +958,6 @@
       }
     ]
   },
-  "title": "Minecraft Data Pack Item Modifier",
+  "title": "minecraft data pack item modifier",
   "type": "array"
 }

--- a/src/schemas/json/minecraft-loot-table.json
+++ b/src/schemas/json/minecraft-loot-table.json
@@ -6,7 +6,7 @@
       "$comment": "https://minecraft.fandom.com/wiki/Loot_table#Number_Providers",
       "properties": {
         "type": {
-          "title": "Type",
+          "title": "type",
           "description": "The number provider type.",
           "type": "string",
           "enum": [
@@ -30,7 +30,7 @@
             "description": "A constant value.",
             "properties": {
               "value": {
-                "title": "Value",
+                "title": "value",
                 "description": "The exact value.",
                 "type": "number"
               }
@@ -49,13 +49,13 @@
             "description": "A random number following a uniform distribution between two values (inclusive).",
             "properties": {
               "min": {
-                "title": "Minimum",
+                "title": "minimum",
                 "description": "The minimum value.",
                 "type": ["number", "object"],
                 "$ref": "#/definitions/numberProvider"
               },
               "max": {
-                "title": "Max",
+                "title": "max",
                 "description": "The maximum value.",
                 "type": ["number", "object"],
                 "$ref": "#/definitions/numberProvider"
@@ -100,13 +100,13 @@
             "description": "A scoreboard value.",
             "properties": {
               "target": {
-                "title": "Target",
+                "title": "target",
                 "description": "Scoreboard name provider.",
                 "type": ["string", "object"],
                 "enum": ["this", "killer", "direct_killer", "player_killer"],
                 "properties": {
                   "type": {
-                    "title": "Type",
+                    "title": "type",
                     "description": "Resource location.",
                     "type": "string",
                     "enum": ["fixed", "context"]
@@ -124,7 +124,7 @@
                     "then": {
                       "properties": {
                         "name": {
-                          "title": "Name",
+                          "title": "name",
                           "description": "A UUID or player name.",
                           "type": "string"
                         }
@@ -142,7 +142,7 @@
                     "then": {
                       "properties": {
                         "target": {
-                          "title": "Target",
+                          "title": "target",
                           "type": "string",
                           "enum": [
                             "this",
@@ -157,12 +157,12 @@
                 ]
               },
               "score": {
-                "title": "Score",
+                "title": "score",
                 "description": "The scoreboard objective.",
                 "type": "string"
               },
               "scale": {
-                "title": "Scale",
+                "title": "scale",
                 "description": "Scale to multiply the score before returning it.",
                 "type": "number"
               }
@@ -175,7 +175,7 @@
   "description": "Configuration file defining a loot table for a data pack for Minecraft.",
   "properties": {
     "type": {
-      "title": "Type",
+      "title": "type",
       "type": "string",
       "enum": [
         "minecraft:empty",
@@ -205,7 +205,7 @@
       ]
     },
     "functions": {
-      "title": "Functions",
+      "title": "functions",
       "description": " Applies functions to all item stacks produced by this table. Functions are applied in order, so for example looting_enchant must be after set_count to work correctly.",
       "type": "array",
       "items": {
@@ -215,12 +215,12 @@
           "type": "object",
           "properties": {
             "function": {
-              "title": "Function",
+              "title": "function",
               "description": "Namespaced ID of the function to apply.",
               "type": "string"
             },
             "conditions": {
-              "title": "Conditions",
+              "title": "conditions",
               "description": "Determines conditions for this function to be applied. If multiple conditions are specified, all must pass.",
               "type": "array",
               "items": {
@@ -230,7 +230,7 @@
                   "type": "object",
                   "properties": {
                     "condition": {
-                      "title": "Condition",
+                      "title": "condition",
                       "description": "Namespaced ID of condition.",
                       "type": "string"
                     }
@@ -243,7 +243,7 @@
       }
     },
     "pools": {
-      "title": "Pools",
+      "title": "pools",
       "description": "A list of all pools for this loot table. Each pool used generates items from its list of items based on the number of rolls. Pools are applied in order.",
       "type": "array",
       "items": {
@@ -251,7 +251,7 @@
         "type": "object",
         "properties": {
           "conditions": {
-            "title": "Conditions",
+            "title": "conditions",
             "description": "Determines conditions for this pool to be used. If multiple conditions are specified, all must pass.",
             "type": "array",
             "items": {
@@ -260,7 +260,7 @@
                 "description": "A condition.",
                 "properties": {
                   "condition": {
-                    "title": "Condition",
+                    "title": "condition",
                     "description": "Namespaced ID of condition.",
                     "type": "string"
                   }
@@ -269,7 +269,7 @@
             }
           },
           "functions": {
-            "title": "Functions",
+            "title": "functions",
             "description": "Applies functions to all item stacks produced by this pool. Functions are applied in order, so for example looting_enchant must be after set_count to work correctly.",
             "type": "array",
             "items": {
@@ -278,12 +278,12 @@
                 "description": "A function.",
                 "properties": {
                   "function": {
-                    "title": "Function",
+                    "title": "function",
                     "description": "Namespaced ID of the function to apply.",
                     "type": "string"
                   },
                   "conditions": {
-                    "title": "Conditions",
+                    "title": "conditions",
                     "description": "Determines conditions for this function to be applied. If multiple conditions are specified, all must pass.",
                     "type": "array",
                     "items": {
@@ -291,7 +291,7 @@
                       "type": "object",
                       "properties": {
                         "condition": {
-                          "title": "Condition",
+                          "title": "condition",
                           "description": "Namespaced ID of condition.",
                           "type": "string"
                         }
@@ -303,19 +303,19 @@
             }
           },
           "rolls": {
-            "title": "Rolls",
+            "title": "rolls",
             "description": "Specifies the number of rolls on the pool.",
             "type": ["integer", "object"],
             "$ref": "#/definitions/numberProvider"
           },
           "bonus_rolls": {
-            "title": "Bonus Rolls",
+            "title": "bonus rolls",
             "description": "Specifies the number of bonus rolls on the pool per point of luck. Rounded down after multiplying.",
             "type": ["number", "object"],
             "$ref": "#/definitions/numberProvider"
           },
           "entries": {
-            "title": "Entries",
+            "title": "entries",
             "description": "A list of all things that can be produced by this pool. One entry is chosen per roll as a weighted random selection from all entries without failing conditions.",
             "type": "array",
             "items": {
@@ -323,7 +323,7 @@
               "type": "object",
               "properties": {
                 "conditions": {
-                  "title": "Conditions",
+                  "title": "conditions",
                   "description": "Determines conditions for this entry to be used. If multiple conditions are specified, all must pass.",
                   "type": "array",
                   "items": {
@@ -332,7 +332,7 @@
                       "description": "A condition.",
                       "properties": {
                         "condition": {
-                          "title": "Condition",
+                          "title": "condition",
                           "description": "Namespaced ID of condition.",
                           "type": "string"
                         }
@@ -341,7 +341,7 @@
                   }
                 },
                 "functions": {
-                  "title": "Functions",
+                  "title": "functions",
                   "description": "Applies functions to the item stack or item stacks being produced. Functions are applied in order, so for example looting_enchant must be after set_count to work correctly.",
                   "type": "array",
                   "items": {
@@ -350,12 +350,12 @@
                       "description": "A function.",
                       "properties": {
                         "function": {
-                          "title": "Function",
+                          "title": "function",
                           "description": "Namespaced ID of the function to apply.",
                           "type": "string"
                         },
                         "conditions": {
-                          "title": "Conditions",
+                          "title": "conditions",
                           "description": "Determines conditions for this function to be applied. If multiple conditions are specified, all must pass.",
                           "type": "array",
                           "items": {
@@ -363,7 +363,7 @@
                             "type": "object",
                             "properties": {
                               "condition": {
-                                "title": "Condition",
+                                "title": "condition",
                                 "description": "Namespaced ID of condition.",
                                 "type": "string"
                               }
@@ -375,7 +375,7 @@
                   }
                 },
                 "type": {
-                  "title": "Type",
+                  "title": "type",
                   "description": "Namespaced ID type of entry.",
                   "type": "string",
                   "enum": [
@@ -390,25 +390,25 @@
                   ]
                 },
                 "name": {
-                  "title": "Name",
+                  "title": "name",
                   "type": "string"
                 },
                 "children": {
-                  "title": "Children",
+                  "title": "children",
                   "type": "array"
                 },
                 "expand": {
-                  "title": "Expand",
+                  "title": "expand",
                   "description": "For type 'tag', if set to true, it chooses one item of the tag, each with the same weight and quality. If false, it generates one of each of the items in the tag.",
                   "type": "boolean"
                 },
                 "weight": {
-                  "title": "Weight",
+                  "title": "weight",
                   "description": "Determines how often this entry is chosen out of all the entries in the pool. Entries with higher weights are used more often (chance is this entry's weight⁄total of all considered entries' weights).",
                   "type": "integer"
                 },
                 "quality": {
-                  "title": "Quality",
+                  "title": "quality",
                   "description": "Modifies the entry's weight based on the killing/opening/fishing player's luck attribute. Formula is floor( weight + (quality * generic.luck)).",
                   "type": "integer"
                 }
@@ -419,5 +419,5 @@
       }
     }
   },
-  "title": "Minecraft Data Pack Loot Table"
+  "title": "minecraft data pack loot table"
 }

--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -4,15 +4,15 @@
   "description": "Configuration file defining the metadata of a data pack for Minecraft.",
   "properties": {
     "pack": {
-      "title": "Pack",
+      "title": "pack",
       "type": "object",
       "properties": {
         "pack_format": {
-          "title": "Pack Format",
+          "title": "pack format",
           "type": "number"
         },
         "description": {
-          "title": "Description",
+          "title": "description",
           "oneOf": [
             {
               "type": "string"
@@ -21,7 +21,7 @@
               "type": "object",
               "properties": {
                 "translate": {
-                  "title": "Translate",
+                  "title": "translate",
                   "type": "string"
                 }
               }
@@ -31,6 +31,6 @@
       }
     }
   },
-  "title": "Minecraft Data Pack Metadata",
+  "title": "minecraft data pack metadata",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-predicate.json
+++ b/src/schemas/json/minecraft-predicate.json
@@ -13,7 +13,7 @@
       "then": {
         "properties": {
           "terms": {
-            "title": "Terms",
+            "title": "terms",
             "description": "A list of conditions to join using 'or'.",
             "type": "object"
           }
@@ -31,12 +31,12 @@
       "then": {
         "properties": {
           "block": {
-            "title": "Block",
+            "title": "block",
             "description": "A block ID.",
             "type": "string"
           },
           "properties": {
-            "title": "Properties",
+            "title": "properties",
             "description": "A map of block property names to values.",
             "type": "object",
             "additionalProperties": {
@@ -57,7 +57,7 @@
       "then": {
         "properties": {
           "predicate": {
-            "title": "Predicate",
+            "title": "predicate",
             "description": "Predicate applied to the damage source.",
             "$ref": "#/definitions/tagsCommonToAllDamageTypes"
           }
@@ -76,13 +76,13 @@
         "description": "Test properties of an entity.",
         "properties": {
           "entity": {
-            "title": "Entity",
+            "title": "entity",
             "description": "Specifies the entity to check for the condition.",
             "type": "string",
             "enum": ["this", "killer", "killer_player"]
           },
           "predicate": {
-            "title": "Predicate",
+            "title": "predicate",
             "description": "Predicate applied to entity.",
             "$ref": "#/definitions/tagsCommonToAllEntities"
           }
@@ -101,13 +101,13 @@
         "description": "Test the scoreboard scores of an entity.",
         "properties": {
           "entity": {
-            "title": "Entity",
+            "title": "entity",
             "description": "Specifies the entity to check for the condition.",
             "type": "string",
             "enum": ["this", "killer", "killer_player"]
           },
           "scores": {
-            "title": "Scores",
+            "title": "scores",
             "description": "Scores to check. All specified scores must pass for the condition to pass.",
             "type": "object",
             "additionalProperties": {
@@ -130,7 +130,7 @@
         "description": "Inverts condition from parameter term.",
         "properties": {
           "term": {
-            "title": "Term",
+            "title": "term",
             "description": "The condition to be negated.",
             "type": "object"
           }
@@ -149,7 +149,7 @@
         "description": "Test if a killer_player entity is available.",
         "properties": {
           "inverse": {
-            "title": "Inverse",
+            "title": "inverse",
             "description": "If true, the condition passes if killer_player is not available.",
             "type": "boolean"
           }
@@ -168,22 +168,22 @@
         "description": "Checks if the current location matches.",
         "properties": {
           "offsetX": {
-            "title": "Offset X",
+            "title": "offset x",
             "description": "Offsets to location.",
             "type": "integer"
           },
           "offsetY": {
-            "title": "Offset Y",
+            "title": "offset y",
             "description": "Offsets to location.",
             "type": "integer"
           },
           "offsetZ": {
-            "title": "Offset Z",
+            "title": "offset z",
             "description": "Offsets to location.",
             "type": "integer"
           },
           "predicate": {
-            "title": "Predicate",
+            "title": "predicate",
             "description": "Predicate applied to location.",
             "$ref": "#/definitions/tagsCommonToAllLocations"
           }
@@ -202,7 +202,7 @@
         "description": "Checks tool.",
         "properties": {
           "predicate": {
-            "title": "Predicate",
+            "title": "predicate",
             "description": "Predicate applied to item.",
             "$ref": "#/definitions/tagsCommonToAllItems"
           }
@@ -221,7 +221,7 @@
         "description": "Test if a random number 0.0–1.0 is less than a specified value.",
         "properties": {
           "chance": {
-            "title": "Chance",
+            "title": "chance",
             "description": "Success rate.",
             "type": "number",
             "minimum": 0,
@@ -242,12 +242,12 @@
         "description": "Test if a random number 0.0–1.0 is less than a specified value, affected by the level of Looting on the killer entity.",
         "properties": {
           "chance": {
-            "title": "Chance",
+            "title": "chance",
             "description": "Base success rate.",
             "type": "number"
           },
           "looting_multiplier": {
-            "title": "Looting Multiplier",
+            "title": "looting multiplier",
             "description": "Looting adjustment to the base success rate. Formula is chance + (looting_level * looting_multiplier).",
             "type": "number"
           }
@@ -266,7 +266,7 @@
         "description": "Test if another referred condition (predicate) passes.",
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The namespaced ID of the condition (predicate) referred to. A cyclic reference causes a parsing failure.",
             "type": "string"
           }
@@ -297,12 +297,12 @@
         "description": "Passes with probability picked from table, indexed by enchantment level.",
         "properties": {
           "enchantment": {
-            "title": "Enchantment",
+            "title": "enchantment",
             "description": "Id of enchantment.",
             "type": "integer"
           },
           "chances": {
-            "title": "Chances",
+            "title": "chances",
             "description": "List of probabilities for enchantment level, indexed from 0.",
             "type": "array"
           }
@@ -321,13 +321,13 @@
         "description": "Checks the current time.",
         "properties": {
           "value": {
-            "title": "Value",
+            "title": "value",
             "description": "The time value in ticks.",
             "type": ["integer", "object"],
             "$ref": "#/definitions/integerRange"
           },
           "period": {
-            "title": "Period",
+            "title": "period",
             "description": "Time gets modulo-divided by this value (for example, if set to 24000, value operates on a time period of daytime ticks just like /time query daytime).",
             "type": "integer"
           }
@@ -346,12 +346,12 @@
         "description": "Checks for a current weather state.",
         "properties": {
           "raining": {
-            "title": "Raining",
+            "title": "raining",
             "description": "If true, the condition evaluates to true only if it's raining or thundering.",
             "type": "boolean"
           },
           "thundering": {
-            "title": "Thundering",
+            "title": "thundering",
             "description": "If true, the condition evaluates to true only if it's thundering.",
             "type": "boolean"
           }
@@ -370,13 +370,13 @@
         "description": "Checks for range of value.",
         "properties": {
           "value": {
-            "title": "Value",
+            "title": "value",
             "description": "The value to test.",
             "type": ["integer", "object"],
             "$ref": "#/definitions/numberProvider"
           },
           "range": {
-            "title": "Range",
+            "title": "range",
             "description": "If true, the condition evaluates to true only if it's thundering.",
             "type": ["integer", "object"],
             "$ref": "#/definitions/integerRange"
@@ -390,12 +390,12 @@
       "type": "object",
       "properties": {
         "max": {
-          "title": "Max",
+          "title": "max",
           "description": "The max value.",
           "type": "number"
         },
         "min": {
-          "title": "Minimum",
+          "title": "minimum",
           "description": "The minimum value.",
           "type": "number"
         }
@@ -404,13 +404,13 @@
     "integerRange": {
       "properties": {
         "max": {
-          "title": "Max",
+          "title": "max",
           "description": "The max value.",
           "type": ["integer", "object"],
           "$ref": "#/definitions/numberProvider"
         },
         "min": {
-          "title": "Minimum",
+          "title": "minimum",
           "description": "The minimum value.",
           "type": ["integer", "object"],
           "$ref": "#/definitions/numberProvider"
@@ -421,7 +421,7 @@
       "$comment": "https://minecraft.fandom.com/wiki/Loot_table#Number_Providers",
       "properties": {
         "type": {
-          "title": "Type",
+          "title": "type",
           "description": "The number provider type.",
           "type": "string",
           "enum": [
@@ -445,7 +445,7 @@
             "description": "A constant value.",
             "properties": {
               "value": {
-                "title": "Value",
+                "title": "value",
                 "description": "The exact value.",
                 "type": "number"
               }
@@ -464,13 +464,13 @@
             "description": "A random number following a uniform distribution between two values (inclusive).",
             "properties": {
               "min": {
-                "title": "Minimum",
+                "title": "minimum",
                 "description": "The minimum value.",
                 "type": ["number", "object"],
                 "$ref": "#/definitions/numberProvider"
               },
               "max": {
-                "title": "Max",
+                "title": "max",
                 "description": "The maximum value.",
                 "type": ["number", "object"],
                 "$ref": "#/definitions/numberProvider"
@@ -515,13 +515,13 @@
             "description": "A scoreboard value.",
             "properties": {
               "target": {
-                "title": "Target",
+                "title": "target",
                 "description": "Scoreboard name provider.",
                 "type": ["string", "object"],
                 "enum": ["this", "killer", "direct_killer", "player_killer"],
                 "properties": {
                   "type": {
-                    "title": "Type",
+                    "title": "type",
                     "description": "Resource location.",
                     "type": "string",
                     "enum": ["fixed", "context"]
@@ -539,7 +539,7 @@
                     "then": {
                       "properties": {
                         "name": {
-                          "title": "Name",
+                          "title": "name",
                           "description": "A UUID or player name.",
                           "type": "string"
                         }
@@ -557,7 +557,7 @@
                     "then": {
                       "properties": {
                         "target": {
-                          "title": "Target",
+                          "title": "target",
                           "type": "string",
                           "enum": [
                             "this",
@@ -572,12 +572,12 @@
                 ]
               },
               "score": {
-                "title": "Score",
+                "title": "score",
                 "description": "The scoreboard objective.",
                 "type": "string"
               },
               "scale": {
-                "title": "Scale",
+                "title": "scale",
                 "description": "Scale to multiply the score before returning it.",
                 "type": "number"
               }
@@ -589,16 +589,16 @@
     "enchantments": {
       "type": "array",
       "items": {
-        "title": "Enchantment",
+        "title": "enchantment",
         "type": "object",
         "properties": {
           "enchantment": {
-            "title": "Enchantment",
+            "title": "enchantment",
             "description": "An enchantment ID.",
             "type": "string"
           },
           "levels": {
-            "title": "Levels",
+            "title": "levels",
             "description": "The level of the enchantment.",
             "type": ["integer", "object"],
             "$ref": "#/definitions/integerRange"
@@ -610,52 +610,52 @@
       "type": "object",
       "properties": {
         "bypasses_armor": {
-          "title": "Bypasses Armor",
+          "title": "bypasses armor",
           "description": "Checks if the damage bypassed the armor of the player (suffocation damage predominantly).",
           "type": "boolean"
         },
         "bypasses_invulnerability": {
-          "title": "Bypasses Invulnerability",
+          "title": "bypasses invulnerability",
           "description": "Checks if the damage bypassed the invulnerability status of the player (void or /kill damage).",
           "type": "boolean"
         },
         "bypasses_magic": {
-          "title": "Bypasses Magic",
+          "title": "bypasses magic",
           "description": "Checks if the damage was caused by starvation.",
           "type": "boolean"
         },
         "direct_entity": {
-          "title": "Direct Entity",
+          "title": "direct entity",
           "description": "The entity that was the direct cause of the damage.",
           "type": "object"
         },
         "is_explosion": {
-          "title": "Is Explosion",
+          "title": "is explosion",
           "description": "Checks if the damage originated from an explosion.",
           "type": "boolean"
         },
         "is_fire": {
-          "title": "Is Fire",
+          "title": "is fire",
           "description": "Checks if the damage originated from fire.",
           "type": "boolean"
         },
         "is_magic": {
-          "title": "Is Magic",
+          "title": "is magic",
           "description": "Checks if the damage originated from magic.",
           "type": "boolean"
         },
         "is_projectile": {
-          "title": "Is Projectile",
+          "title": "is projectile",
           "description": "Checks if the damage originated from a projectile.",
           "type": "boolean"
         },
         "is_lightning": {
-          "title": "Is Lightning",
+          "title": "is lightning",
           "description": "Checks if the damage originated from lightning.",
           "type": "boolean"
         },
         "source_entity": {
-          "title": "Source Entity",
+          "title": "source entity",
           "description": "Checks the entity that was the source of the damage (for example: The skeleton that shot the arrow).",
           "$ref": "#/definitions/tagsCommonToAllEntities"
         }
@@ -665,44 +665,44 @@
       "type": "object",
       "properties": {
         "count": {
-          "title": "Count",
+          "title": "count",
           "description": "The amount of the item.",
           "type": ["integer", "object"],
           "$ref": "#/definitions/integerRange"
         },
         "durability": {
-          "title": "Durability",
+          "title": "durability",
           "description": "The durability of the item.",
           "type": ["integer", "object"],
           "$ref": "#/definitions/integerRange"
         },
         "enchantments": {
-          "title": "Enchantments",
+          "title": "enchantments",
           "description": "List of enchantments.",
           "$ref": "#/definitions/enchantments"
         },
         "stored_enchantments": {
-          "title": "Stored Enchantments",
+          "title": "stored enchantments",
           "description": "List of stored enchantments.",
           "$ref": "#/definitions/enchantments"
         },
         "items": {
-          "title": "Items",
+          "title": "items",
           "description": "List of item IDs.",
           "type": "array"
         },
         "nbt": {
-          "title": "NBT",
+          "title": "nbt",
           "description": "An NBT string.",
           "type": "string"
         },
         "potion": {
-          "title": "Potion",
+          "title": "potion",
           "description": "A brewed potion ID.",
           "type": "string"
         },
         "tag": {
-          "title": "Tag",
+          "title": "tag",
           "description": "An item data pack tag.",
           "type": "string"
         }
@@ -712,7 +712,7 @@
       "type": "object",
       "properties": {
         "biome": {
-          "title": "Biome",
+          "title": "biome",
           "description": "The biome the entity is currently in.",
           "type": "string",
           "enum": [
@@ -792,32 +792,32 @@
           ]
         },
         "block": {
-          "title": "Block",
+          "title": "block",
           "description": "The block at the location.",
           "type": "object",
           "properties": {
             "blocks": {
-              "title": "Blocks",
+              "title": "blocks",
               "description": "A list of block IDs.",
               "type": "array"
             },
             "tag": {
-              "title": "Tag",
+              "title": "tag",
               "description": "The block tag.",
               "type": "string"
             },
             "nbt": {
-              "title": "NBT",
+              "title": "nbt",
               "description": "The block NBT.",
               "type": "string"
             },
             "state": {
-              "title": "State",
+              "title": "state",
               "description": "A map of block property names to values. Test will fail if the block doesn't match.",
               "type": "object",
               "properties": {
                 "key": {
-                  "title": "Key",
+                  "title": "key",
                   "description": "Block property key and value pair.",
                   "type": ["boolean", "integer", "string", "object"],
                   "$ref": "#/definitions/integerRange"
@@ -827,12 +827,12 @@
           }
         },
         "dimension": {
-          "title": "Dimension",
+          "title": "dimension",
           "description": "The dimension the entity is currently in.",
           "type": "string"
         },
         "feature": {
-          "title": "Feature",
+          "title": "feature",
           "description": "Name of a structure.",
           "type": "string",
           "enum": [
@@ -854,22 +854,22 @@
           ]
         },
         "fluid": {
-          "title": "Fluid",
+          "title": "fluid",
           "description": "The fluid at the location.",
           "type": "object",
           "properties": {
             "fluid": {
-              "title": "Fluid",
+              "title": "fluid",
               "description": "The fluid ID.",
               "type": "string"
             },
             "tag": {
-              "title": "Tag",
+              "title": "tag",
               "description": "The fluid tag.",
               "type": "string"
             },
             "state": {
-              "title": "State",
+              "title": "state",
               "description": "A map of fluid property names to values. Test will fail if the fluid doesn't match.",
               "type": ["boolean", "integer", "string", "object"],
               "$ref": "#/definitions/integerRange"
@@ -877,12 +877,12 @@
           }
         },
         "light": {
-          "title": "Light",
+          "title": "light",
           "description": "The light at the location.",
           "type": "object",
           "properties": {
             "light": {
-              "title": "Light",
+              "title": "light",
               "description": "The light Level of visible light. Calculated using: (max(sky-darkening,block)).",
               "type": ["integer", "object"],
               "$ref": "#/definitions/integerRange"
@@ -890,28 +890,28 @@
           }
         },
         "position": {
-          "title": "Position",
+          "title": "position",
           "type": "object",
           "properties": {
             "x": {
-              "title": "X",
+              "title": "x",
               "description": "The X position.",
               "$ref": "#/definitions/numberRange"
             },
             "y": {
-              "title": "Y",
+              "title": "y",
               "description": "The Y position.",
               "$ref": "#/definitions/numberRange"
             },
             "z": {
-              "title": "Z",
+              "title": "z",
               "description": "The Z position.",
               "$ref": "#/definitions/numberRange"
             }
           }
         },
         "smokey": {
-          "title": "Smokey",
+          "title": "smokey",
           "description": "True if the block is closely above a campfire or soul campfire.",
           "type": "boolean"
         }
@@ -921,58 +921,58 @@
       "type": "object",
       "properties": {
         "distance": {
-          "title": "Distance",
+          "title": "distance",
           "type": "object",
           "properties": {
             "absolute": {
-              "title": "Absolute",
+              "title": "absolute",
               "$ref": "#/definitions/numberRange"
             },
             "horizontal": {
-              "title": "Horizontal",
+              "title": "horizontal",
               "$ref": "#/definitions/numberRange"
             },
             "x": {
-              "title": "X",
+              "title": "x",
               "$ref": "#/definitions/numberRange"
             },
             "y": {
-              "title": "Y",
+              "title": "y",
               "$ref": "#/definitions/numberRange"
             },
             "z": {
-              "title": "Z",
+              "title": "z",
               "$ref": "#/definitions/numberRange"
             }
           }
         },
         "effects": {
-          "title": "Effects",
+          "title": "effects",
           "description": "A map of status effects.",
           "additionalProperties": {
-            "title": "Effect",
+            "title": "effect",
             "description": "A status effect with the key name being the status effect name.",
             "type": "object",
             "properties": {
               "ambient": {
-                "title": "Ambient",
+                "title": "ambient",
                 "description": "Whether the effect is from a beacon.",
                 "type": "boolean"
               },
               "amplifier": {
-                "title": "Amplifier",
+                "title": "amplifier",
                 "description": "The effect amplifier.",
                 "type": ["integer", "object"],
                 "$ref": "#/definitions/integerRange"
               },
               "duration": {
-                "title": "Duration",
+                "title": "duration",
                 "description": "The effect duration in ticks.",
                 "type": ["integer", "object"],
                 "$ref": "#/definitions/integerRange"
               },
               "visible": {
-                "title": "Visible",
+                "title": "visible",
                 "description": "Whether the effect has visible particles.",
                 "type": "boolean"
               }
@@ -980,109 +980,109 @@
           }
         },
         "equipment": {
-          "title": "Equipment",
+          "title": "equipment",
           "type": "object",
           "properties": {
             "mainhand": {
-              "title": "Mainhand",
+              "title": "mainhand",
               "$ref": "#/definitions/tagsCommonToAllItems"
             },
             "offhand": {
-              "title": "Offhand",
+              "title": "offhand",
               "$ref": "#/definitions/tagsCommonToAllItems"
             },
             "head": {
-              "title": "Head",
+              "title": "head",
               "$ref": "#/definitions/tagsCommonToAllItems"
             },
             "chest": {
-              "title": "Chest",
+              "title": "chest",
               "$ref": "#/definitions/tagsCommonToAllItems"
             },
             "legs": {
-              "title": "Legs",
+              "title": "legs",
               "$ref": "#/definitions/tagsCommonToAllItems"
             },
             "feet": {
-              "title": "Feet",
+              "title": "feet",
               "$ref": "#/definitions/tagsCommonToAllItems"
             }
           }
         },
         "flags": {
-          "title": "Flags",
+          "title": "flags",
           "description": "Predicate Flags to be checked.",
           "type": "object",
           "properties": {
             "is_on_fire": {
-              "title": "Is on Fire",
+              "title": "is on fire",
               "description": "Test whether the entity is or is not on fire."
             },
             "is_sneaking": {
-              "title": "Is Sneaking",
+              "title": "is sneaking",
               "description": "Test whether the entity is or is not sneaking.",
               "type": "boolean"
             },
             "is_sprinting": {
-              "title": "Is Sprinting",
+              "title": "is sprinting",
               "description": "Test whether the entity is or is not sprinting.",
               "type": "boolean"
             },
             "is_swimming": {
-              "title": "Is Swimming",
+              "title": "is swimming",
               "description": "Test whether the entity is or is not swimming.",
               "type": "boolean"
             },
             "is_baby": {
-              "title": "Is Baby",
+              "title": "is baby",
               "description": "Test whether the entity is or is not a baby variant.",
               "type": "boolean"
             }
           }
         },
         "lightning_bolt": {
-          "title": "Lightning Bolt",
+          "title": "lightning bolt",
           "description": "Lightning bolt properties to be checked. Fails when entity is not a lightning bolt.",
           "type": "object",
           "properties": {
             "blocks_set_on_fire": {
-              "title": "Blocks Set on Fire",
+              "title": "blocks set on fire",
               "description": "Number of blocks set on fire by this lightning bolt.",
               "type": "integer"
             },
             "entity_struck": {
-              "title": "Entity Struck",
+              "title": "entity struck",
               "description": "Entity properties of entities struck by this lightning bolt. If present, this tag must match one or more entities.",
               "$ref": "#/definitions/tagsCommonToAllEntities"
             }
           }
         },
         "location": {
-          "title": "Location",
+          "title": "location",
           "$ref": "#/definitions/tagsCommonToAllLocations"
         },
         "nbt": {
-          "title": "NBT",
+          "title": "nbt",
           "description": "An NBT string.",
           "type": "string"
         },
         "passenger": {
-          "title": "Passanger",
+          "title": "passanger",
           "description": "The entity directly riding this entity.",
           "$ref": "#/definitions/tagsCommonToAllEntities"
         },
         "player": {
-          "title": "Player",
+          "title": "player",
           "description": "Player properties to be checked. Fails when entity is not a player.",
           "type": "object",
           "properties": {
             "looking_at": {
-              "title": "Looking At",
+              "title": "looking at",
               "description": "The entity that the player is looking at, as long as it is visible and within a radius of 100 blocks.",
               "$ref": "#/definitions/tagsCommonToAllEntities"
             },
             "advancements": {
-              "title": "Advancements",
+              "title": "advancements",
               "description": "A map of advancements to check.",
               "type": "object",
               "additionalProperties": {
@@ -1094,19 +1094,19 @@
               }
             },
             "gamemode": {
-              "title": "Game Mode",
+              "title": "game mode",
               "description": "The game mode of the player.",
               "type": "string",
               "enum": ["survival", "adventure", "creative", "spectator"]
             },
             "level": {
-              "title": "Level",
+              "title": "level",
               "description": "The level of the player.",
               "type": ["integer", "object"],
               "$ref": "#/definitions/integerRange"
             },
             "recipes": {
-              "title": "Recipies",
+              "title": "recipies",
               "description": "A map of recipies to check.",
               "type": "object",
               "additionalProperties": {
@@ -1114,14 +1114,14 @@
               }
             },
             "stats": {
-              "title": "Stats",
+              "title": "stats",
               "description": "List of statistics to match.",
               "type": "object",
               "additionalProperties": {
                 "type": "object",
                 "properties": {
                   "type": {
-                    "title": "Type",
+                    "title": "type",
                     "description": "The statistic base.",
                     "type": "string",
                     "enum": [
@@ -1137,12 +1137,12 @@
                     ]
                   },
                   "stat": {
-                    "title": "Stat",
+                    "title": "stat",
                     "description": "The statistic ID. Mostly mimics the criteria used for defining scoreboard objectives.",
                     "type": "string"
                   },
                   "value": {
-                    "title": "Value",
+                    "title": "value",
                     "description": "The value of the statistic.",
                     "type": ["integer", "object"],
                     "$ref": "#/definitions/integerRange"
@@ -1153,27 +1153,27 @@
           }
         },
         "stepping_on": {
-          "title": "Stepping On",
+          "title": "stepping on",
           "description": "Location predicate for the block the entity is standing on.",
           "$ref": "#/definitions/tagsCommonToAllLocations"
         },
         "team": {
-          "title": "Team",
+          "title": "team",
           "description": "The team the entity belongs to.",
           "type": "string"
         },
         "type": {
-          "title": "Type",
+          "title": "type",
           "description": "An entity ID.",
           "type": "string"
         },
         "targeted_entity": {
-          "title": "Targeted Entity",
+          "title": "targeted entity",
           "description": "The entity which this entity is targeting for attacks.",
           "$ref": "#/definitions/tagsCommonToAllEntities"
         },
         "vehicle": {
-          "title": "Vehicle",
+          "title": "vehicle",
           "description": " The vehicle that the entity is riding on.",
           "$ref": "#/definitions/tagsCommonToAllEntities"
         }
@@ -1183,7 +1183,7 @@
   "description": "Configuration file defining a predicate for a data pack for Minecraft.",
   "properties": {
     "conditions": {
-      "title": "Conditions",
+      "title": "conditions",
       "description": "The condition's ID.",
       "type": "string",
       "enum": [
@@ -1207,6 +1207,6 @@
       ]
     }
   },
-  "title": "Minecraft Data Pack Predicate",
+  "title": "minecraft data pack predicate",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-tag.json
+++ b/src/schemas/json/minecraft-tag.json
@@ -33,6 +33,6 @@
     }
   },
   "required": ["values"],
-  "title": "Minecraft Data Pack Tag",
+  "title": "minecraft data pack tag",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-template-pool.json
+++ b/src/schemas/json/minecraft-template-pool.json
@@ -4,35 +4,35 @@
   "description": "Configuration file defining a template pool for a data pack for Minecraft.",
   "properties": {
     "name": {
-      "title": "Name",
+      "title": "name",
       "description": "The namespaced ID of the pool.",
       "type": "string"
     },
     "fallback": {
-      "title": "Fallback",
+      "title": "fallback",
       "description": "Can set to another template pool, which generates when the original pool cannot generate at the end of all layers.",
       "type": "string"
     },
     "elements": {
-      "title": "Elements",
+      "title": "elements",
       "description": "A list of structures to choose from.",
       "type": "array",
       "items": {
-        "title": "Element",
+        "title": "element",
         "type": "object",
         "properties": {
           "weight": {
-            "title": "Weight",
+            "title": "weight",
             "description": "How likely this element is to be chosen when using this pool.",
             "type": "integer"
           },
           "element": {
-            "title": "Element",
+            "title": "element",
             "description": "The properties of this element.",
             "type": "object",
             "properties": {
               "element_type": {
-                "title": "Element Type",
+                "title": "element type",
                 "type": "string",
                 "enum": [
                   "minecraft:empty_pool_element",
@@ -43,35 +43,35 @@
                 ]
               },
               "feature": {
-                "title": "Feature",
+                "title": "feature",
                 "description": "The namespaced id of the feature.",
                 "type": "string"
               },
               "location": {
-                "title": "Location",
+                "title": "location",
                 "description": "The namespaced id of the structure to place.",
                 "type": "string"
               },
               "projection": {
-                "title": "Projection",
+                "title": "projection",
                 "type": "string",
                 "enum": ["rigid", "terrain_matching"]
               },
               "processors": {
-                "title": "Processors",
+                "title": "processors",
                 "description": "The namespaced ID of a processor if this is a string.",
                 "type": ["string", "object"],
                 "properties": {
                   "processors": {
-                    "title": "Processors",
+                    "title": "processors",
                     "description": "A list of processors to use.",
                     "type": "array",
                     "items": {
-                      "title": "Processor",
+                      "title": "processor",
                       "type": "object",
                       "properties": {
                         "processor_type": {
-                          "title": "Processor Type",
+                          "title": "processor type",
                           "description": "The namespaced id of the processor to use.",
                           "type": "string"
                         }
@@ -81,26 +81,26 @@
                 }
               },
               "elements": {
-                "title": "Elements",
+                "title": "elements",
                 "description": "A list of structures to choose from.",
                 "type": "array",
                 "items": {
-                  "title": "Element",
+                  "title": "element",
                   "type": "object",
                   "properties": {
                     "weight": {},
                     "location": {
-                      "title": "Location",
+                      "title": "location",
                       "description": "The namespaced id of the structure to place.",
                       "type": "string"
                     },
                     "projection": {
-                      "title": "Projection",
+                      "title": "projection",
                       "type": "string",
                       "enum": ["rigid", "terrain_matching"]
                     },
                     "element_type": {
-                      "title": "Element Type",
+                      "title": "element type",
                       "type": "string",
                       "enum": [
                         "minecraft:empty_pool_element",
@@ -110,20 +110,20 @@
                       ]
                     },
                     "processors": {
-                      "title": "Processors",
+                      "title": "processors",
                       "description": "The namespaced ID of a processor if this is a string.",
                       "type": ["string", "object"],
                       "properties": {
                         "processors": {
-                          "title": "Processors",
+                          "title": "processors",
                           "description": "A list of processors to use.",
                           "type": "array",
                           "items": {
-                            "title": "Processor",
+                            "title": "processor",
                             "type": "object",
                             "properties": {
                               "processor_type": {
-                                "title": "Processor Type",
+                                "title": "processor type",
                                 "description": "The namespaced id of the processor to use.",
                                 "type": "string"
                               }
@@ -141,6 +141,6 @@
       }
     }
   },
-  "title": "Minecraft Data Pack Template Pool",
+  "title": "minecraft data pack template pool",
   "type": "object"
 }

--- a/src/schemas/json/mocharc.json
+++ b/src/schemas/json/mocharc.json
@@ -144,6 +144,6 @@
       "$ref": "#/definitions/bool"
     }
   },
-  "title": "Mocha JS Configuration File Schema",
+  "title": "mocha js configuration file schema",
   "type": "object"
 }

--- a/src/schemas/json/modernizrrc.json
+++ b/src/schemas/json/modernizrrc.json
@@ -302,6 +302,6 @@
       }
     }
   },
-  "title": "JSON Schema for Webpack's modernizr-loader configuration file",
+  "title": "json schema for webpack's modernizr-loader configuration file",
   "type": "object"
 }

--- a/src/schemas/json/mongodb-atlas-search-index-definition.json
+++ b/src/schemas/json/mongodb-atlas-search-index-definition.json
@@ -32,7 +32,7 @@
         }
       },
       "required": ["name", "tokenizer"],
-      "title": "Analyzer"
+      "title": "analyzer"
     },
     "Tokenizer": {
       "type": "object",
@@ -53,7 +53,7 @@
         }
       },
       "required": ["type"],
-      "title": "Tokenizer",
+      "title": "tokenizer",
       "description": "Tokenizer to use to create tokens."
     },
     "TokenFilter": {
@@ -82,7 +82,7 @@
         }
       },
       "required": ["type"],
-      "title": "TokenFilter"
+      "title": "tokenfilter"
     },
     "CharFilter": {
       "type": "object",
@@ -126,7 +126,7 @@
         },
         "required": ["mappings"]
       },
-      "title": "CharFilter"
+      "title": "charfilter"
     },
     "Mappings": {
       "type": "object",
@@ -168,7 +168,7 @@
           "required": ["fields"]
         }
       ],
-      "title": "Mappings",
+      "title": "mappings",
       "description": "Specifies how to index fields at different paths for this index."
     },
     "MappingsField": {
@@ -423,7 +423,7 @@
           "required": ["exclude"]
         }
       ],
-      "title": "StoredSource"
+      "title": "storedsource"
     },
     "Synonym": {
       "type": "object",
@@ -540,6 +540,6 @@
     }
   },
   "required": ["mappings"],
-  "title": "JSON schema for MongoDB Atlas Search index definition",
+  "title": "json schema for mongodb atlas search index definition",
   "type": "object"
 }

--- a/src/schemas/json/monika-config-schema.json
+++ b/src/schemas/json/monika-config-schema.json
@@ -18,13 +18,13 @@
       "default": 5
     },
     "interval": {
-      "title": "Interval",
+      "title": "interval",
       "type": "integer",
       "description": "The number of seconds to repeat the probe",
       "default": 10
     },
     "postgres": {
-      "title": "Postgres",
+      "title": "postgres",
       "type": "array",
       "description": "Monitor postgres readiness",
       "items": {
@@ -35,7 +35,7 @@
             "additionalProperties": false,
             "properties": {
               "uri": {
-                "title": "URI connection",
+                "title": "uri connection",
                 "type": "string",
                 "description": "Postgres uri connection configuration",
                 "examples": ["postgres://user:password@172.1.0.1:5432/mydb"]
@@ -52,25 +52,25 @@
                 "default": "172.15.0.1"
               },
               "port": {
-                "title": "Port",
+                "title": "port",
                 "type": "integer",
                 "description": "Postgres port to connect to",
                 "default": "5432"
               },
               "database": {
-                "title": "Database",
+                "title": "database",
                 "type": "string",
                 "description": "Name of the database",
                 "default": ""
               },
               "username": {
-                "title": "Username",
+                "title": "username",
                 "type": "string",
                 "description": "Username with access to the database",
                 "default": ""
               },
               "password": {
-                "title": "Password",
+                "title": "password",
                 "type": "string",
                 "description": "User's database password",
                 "default": ""
@@ -81,7 +81,7 @@
       }
     },
     "redis": {
-      "title": "Redis",
+      "title": "redis",
       "type": "array",
       "description": "Monitor redis health ",
       "items": {
@@ -90,26 +90,26 @@
         "required": ["host", "port"],
         "properties": {
           "host": {
-            "title": "Redis host",
+            "title": "redis host",
             "description": "The hostname or IP address of the redis server",
             "type": "string",
             "default": "172.15.0.1",
             "examples": ["localhost", "192.168.0.1"]
           },
           "port": {
-            "title": "Port number",
+            "title": "port number",
             "description": "Port number used for the redis",
             "type": "integer",
             "default": "6379"
           },
           "password": {
-            "title": "Password",
+            "title": "password",
             "description": "Password used for the redis AUTH, if set.",
             "type": "string",
             "default": ""
           },
           "username": {
-            "title": "Username",
+            "title": "username",
             "description": "Username used for the redis AUTH, if set.",
             "type": "string",
             "default": ""
@@ -118,7 +118,7 @@
       }
     },
     "mongo": {
-      "title": "MongoDB",
+      "title": "mongodb",
       "type": "array",
       "description": "Monitor MongoDB health ",
       "items": {
@@ -127,34 +127,34 @@
         "required": [],
         "properties": {
           "uri": {
-            "title": "MongoDB URI",
+            "title": "mongodb uri",
             "description": "The hostname or IP address of the MongoDB server",
             "type": "string",
             "examples": ["mongodb://user:password@127.0.0.1:27017/database"],
             "default": "mongodb://127.0.0.1:27017"
           },
           "host": {
-            "title": "MongoDB host",
+            "title": "mongodb host",
             "description": "The hostname or IP address of the MongoDB server",
             "type": "string",
             "examples": ["localhost", "127.0.0.1"],
             "default": "0.0.0.0.0"
           },
           "port": {
-            "title": "Port number",
+            "title": "port number",
             "description": "Port number used for the MongoDB",
             "type": "integer",
             "examples": ["27017"],
             "default": "27017"
           },
           "password": {
-            "title": "Password",
+            "title": "password",
             "description": "Password used for the MongoDB AUTH, if set.",
             "type": "string",
             "default": ""
           },
           "username": {
-            "title": "Username",
+            "title": "username",
             "description": "Username used for the MongoDB AUTH, if set.",
             "type": "string",
             "default": ""
@@ -163,7 +163,7 @@
       }
     },
     "mariadb": {
-      "title": "MariaDB/Mysql",
+      "title": "mariadb/mysql",
       "type": "array",
       "description": "Monitor MariaDB/Mysql health ",
       "items": {
@@ -172,39 +172,39 @@
         "required": ["host", "port", "username", "password", "database"],
         "properties": {
           "host": {
-            "title": "Database host",
+            "title": "database host",
             "description": "The hostname or IP address of the database server",
             "type": "string",
             "examples": ["localhost", "127.0.0.1", "172.11.0.1"],
             "default": "0.0.0.0"
           },
           "port": {
-            "title": "Port number",
+            "title": "port number",
             "description": "Port number used by your database server",
             "type": "integer",
             "default": "3306"
           },
           "username": {
-            "title": "Username",
+            "title": "username",
             "description": "User with access to the database",
             "type": "string",
             "default": ""
           },
           "password": {
-            "title": "Password",
+            "title": "password",
             "description": "User password for authentication",
             "type": "string",
             "default": ""
           },
           "database": {
-            "title": "Database",
+            "title": "database",
             "default": "Name of the database"
           }
         }
       }
     },
     "requests": {
-      "title": "Requests",
+      "title": "requests",
       "type": "array",
       "description": "The http or ping request to probe for",
       "items": {
@@ -213,27 +213,27 @@
         "required": ["url"],
         "properties": {
           "method": {
-            "title": "HTTP Method",
+            "title": "http method",
             "type": "string",
             "description": "The http method",
             "enum": ["GET", "POST", "DELETE", "PUT", "PATCH"],
             "default": "GET"
           },
           "url": {
-            "title": "Url",
+            "title": "url",
             "type": "string",
             "description": "The remote URL address to probe",
             "default": "https://api.github.com/zen",
             "examples": ["https://github.com", "https://httpbin.org/status/200"]
           },
           "timeout": {
-            "title": "Timeout",
+            "title": "timeout",
             "type": "integer",
             "description": "Set the timeout for the request in milliseconds, default is 10 seconds",
             "default": 10000
           },
           "saveBody": {
-            "title": "SaveBody",
+            "title": "savebody",
             "type": "boolean",
             "description": "Should response body be saved in the database",
             "default": false
@@ -242,12 +242,12 @@
             "$ref": "#/definitions/alerts"
           },
           "ping": {
-            "title": "Ping",
+            "title": "ping",
             "type": "boolean",
             "description": "If defined and to true, the request is an ICMP ping"
           },
           "allowUnauthorized": {
-            "title": "AllowUnauthorized",
+            "title": "allowunauthorized",
             "type": "boolean",
             "description": "If defined and to true, the request will ignore SSL certificate validity"
           },
@@ -261,7 +261,7 @@
       }
     },
     "socket": {
-      "title": "Socket",
+      "title": "socket",
       "type": "object",
       "description": "Socket is a TCP type request",
       "additionalProperties": false,
@@ -272,19 +272,19 @@
           "description": "Address to your host"
         },
         "port": {
-          "title": "Port",
+          "title": "port",
           "type": "integer",
           "description": "Host port to connect to"
         },
         "data": {
-          "title": "Data",
+          "title": "data",
           "type": "string",
           "description": "Data payload for the request"
         }
       }
     },
     "alerts": {
-      "title": "Alerts",
+      "title": "alerts",
       "type": "array",
       "description": "The condition which will trigger an alert and the subsequent notification",
       "items": {
@@ -295,13 +295,13 @@
             "additionalProperties": false,
             "properties": {
               "assertion": {
-                "title": "Assertion",
+                "title": "assertion",
                 "type": "string",
                 "description": "An expression that will trigger an alert when its is logically true. See the assertions here: https://monika.hyperjump.tech/guides/alerts#alert-query",
                 "default": "response.status != 200"
               },
               "message": {
-                "title": "Message",
+                "title": "message",
                 "type": "string",
                 "description": "Message that will be sent to the notification channel",
                 "default": "Http Response status code is not 200!"
@@ -313,13 +313,13 @@
             "additionalProperties": false,
             "properties": {
               "query": {
-                "title": "Query",
+                "title": "query",
                 "type": "string",
                 "description": "Note: Query is deprecated, please use assertion",
                 "default": "response.status != 200"
               },
               "message": {
-                "title": "Message",
+                "title": "message",
                 "type": "string",
                 "description": "Message that will be sent to the notification channel",
                 "default": "Http Response status code is not 200!"
@@ -330,11 +330,11 @@
       }
     },
     "body": {
-      "title": "Body",
+      "title": "body",
       "description": "The data bytes transmitted in an HTTP transaction message immediately following the headers if there are any"
     },
     "headers": {
-      "title": "Headers",
+      "title": "headers",
       "type": "object",
       "description": "A list of strings sent and received by both the client program and server on every HTTP request and response",
       "additionalProperties": true,
@@ -393,7 +393,7 @@
   "description": "Monika monitoring configuration schema",
   "properties": {
     "probes": {
-      "title": "Probes",
+      "title": "probes",
       "type": "array",
       "description": "Probe is a description of the target, methods, timing and payloads to begin monitoring/probing a target.",
       "items": {
@@ -402,21 +402,21 @@
         "required": ["id"],
         "properties": {
           "id": {
-            "title": "Id",
+            "title": "id",
             "type": "string",
             "description": "Unique string identification of the probe",
             "examples": ["probe-01", "login-probe-01"],
             "default": "probe-01"
           },
           "name": {
-            "title": "Name",
+            "title": "name",
             "type": "string",
             "description": "A human-readible probe name",
             "examples": ["get-user", "login-check", "web-heatlh-check"],
             "default": "zen-check-01"
           },
           "description": {
-            "title": "Description",
+            "title": "description",
             "type": "string",
             "description": "Description of the probe",
             "examples": ["ensure service health is good"],
@@ -459,13 +459,13 @@
       }
     },
     "notifications": {
-      "title": "Notifications",
+      "title": "notifications",
       "type": "array",
       "description": "Alerts of incidents and recoveries will be sent via these notification channels",
       "items": {
         "anyOf": [
           {
-            "title": "Desktop",
+            "title": "desktop",
             "type": "object",
             "required": ["id", "type"],
             "additionalProperties": false,
@@ -481,7 +481,7 @@
             }
           },
           {
-            "title": "Discord",
+            "title": "discord",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -512,7 +512,7 @@
             }
           },
           {
-            "title": "Workplace",
+            "title": "workplace",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -544,7 +544,7 @@
             }
           },
           {
-            "title": "Google Chat",
+            "title": "google chat",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -575,7 +575,7 @@
             }
           },
           {
-            "title": "Lark",
+            "title": "lark",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -606,7 +606,7 @@
             }
           },
           {
-            "title": "Mailgun",
+            "title": "mailgun",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -643,7 +643,7 @@
             }
           },
           {
-            "title": "Microsoft Teams",
+            "title": "microsoft teams",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -671,7 +671,7 @@
             }
           },
           {
-            "title": "Monika Notification",
+            "title": "monika notification",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -702,7 +702,7 @@
             }
           },
           {
-            "title": "Pagerduty",
+            "title": "pagerduty",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -734,7 +734,7 @@
             }
           },
           {
-            "title": "Sendgrid",
+            "title": "sendgrid",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -773,7 +773,7 @@
             }
           },
           {
-            "title": "Slack",
+            "title": "slack",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -802,7 +802,7 @@
             }
           },
           {
-            "title": "SMTP",
+            "title": "smtp",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -855,7 +855,7 @@
             }
           },
           {
-            "title": "Statuspage",
+            "title": "statuspage",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -887,7 +887,7 @@
             }
           },
           {
-            "title": "Telegram",
+            "title": "telegram",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -919,7 +919,7 @@
             }
           },
           {
-            "title": "Webhook",
+            "title": "webhook",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -948,7 +948,7 @@
             }
           },
           {
-            "title": "WhatsApp for Business",
+            "title": "whatsapp for business",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -991,7 +991,7 @@
             }
           },
           {
-            "title": "Dingtalk",
+            "title": "dingtalk",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -1019,7 +1019,7 @@
             }
           },
           {
-            "title": "Pushover",
+            "title": "pushover",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -1051,7 +1051,7 @@
             }
           },
           {
-            "title": "Gotify",
+            "title": "gotify",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -1083,7 +1083,7 @@
             }
           },
           {
-            "title": "Opsgenie",
+            "title": "opsgenie",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -1111,7 +1111,7 @@
             }
           },
           {
-            "title": "Pushbullet",
+            "title": "pushbullet",
             "type": "object",
             "required": ["id", "type", "data"],
             "additionalProperties": false,
@@ -1170,12 +1170,12 @@
     },
     "status-notification": {
       "type": "string",
-      "title": "Status notification",
+      "title": "status notification",
       "description": "Sends status notification periodically according to a cron schedule. Set to false to disable.",
       "default": "0 6 * * *"
     },
     "certificate": {
-      "title": "Certificate",
+      "title": "certificate",
       "type": "object",
       "description": "Check validity of your TLS certificate(s).",
       "additionalProperties": false,

--- a/src/schemas/json/mycode.json
+++ b/src/schemas/json/mycode.json
@@ -65,6 +65,6 @@
       ]
     }
   },
-  "title": "JSON schema for mycode.js files",
+  "title": "json schema for mycode.js files",
   "type": "object"
 }

--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -403,6 +403,6 @@
       "default": {}
     }
   },
-  "title": "Nest CLI configuration",
+  "title": "nest cli configuration",
   "type": "object"
 }

--- a/src/schemas/json/netlify.json
+++ b/src/schemas/json/netlify.json
@@ -261,6 +261,6 @@
     }
   },
   "required": ["backend", "media_folder", "collections"],
-  "title": "Netlify config schema",
+  "title": "netlify config schema",
   "type": "object"
 }

--- a/src/schemas/json/ninjs-1.0.json
+++ b/src/schemas/json/ninjs-1.0.json
@@ -311,6 +311,6 @@
       }
     }
   },
-  "title": "IPTC ninjs - News in JSON - version 1.0 (approved on 23 October 2013)",
+  "title": "iptc ninjs - news in json - version 1.0 (approved on 23 october 2013)",
   "type": "object"
 }

--- a/src/schemas/json/ninjs-1.1.json
+++ b/src/schemas/json/ninjs-1.1.json
@@ -325,6 +325,6 @@
     }
   },
   "required": ["uri"],
-  "title": "IPTC ninjs - News in JSON - version 1.1 (approved, 2014-03-12) / document revision of 2017-09-05: syntax error corrected",
+  "title": "iptc ninjs - news in json - version 1.1 (approved, 2014-03-12) / document revision of 2017-09-05: syntax error corrected",
   "type": "object"
 }

--- a/src/schemas/json/ninjs-1.2.json
+++ b/src/schemas/json/ninjs-1.2.json
@@ -5,25 +5,25 @@
   "id": "http://www.iptc.org/std/ninjs/ninjs-schema_1.2.json#",
   "patternProperties": {
     "^description_[a-zA-Z0-9_]+": {
-      "title": "Description",
+      "title": "description",
       "description": "A free-form textual description of the content of the item. (The string appended to description_ in the property name should reflect the format of the text). nar:description",
       "type": "string"
     },
     "^body_[a-zA-Z0-9_]+": {
-      "title": "Body",
+      "title": "body",
       "description": "The textual content of the news object. (The string appended to body_ in the property name should reflect the format of the text). nar:inlineData or nar:inlineXML",
       "type": "string"
     }
   },
   "properties": {
     "uri": {
-      "title": "Uniform Resource Identifier",
+      "title": "uniform resource identifier",
       "description": "The identifier for this news object. nar:newsItem@guid",
       "type": "string",
       "format": "uri"
     },
     "type": {
-      "title": "Type",
+      "title": "type",
       "description": "The generic news type of this news object. (Value 'component' added in version 1.2 as issue #21.). nar:itemClass",
       "type": "string",
       "enum": [
@@ -37,82 +37,82 @@
       ]
     },
     "mimetype": {
-      "title": "MIME type",
+      "title": "mime type",
       "description": "A MIME type which applies to this news object. nar:contentType",
       "type": "string"
     },
     "representationtype": {
-      "title": "Representation type",
+      "title": "representation type",
       "description": "Indicates how complete this representation of a news item is. No mapping to nar. Specific for ninjs.",
       "type": "string",
       "enum": ["complete", "incomplete"]
     },
     "profile": {
-      "title": "Profile",
+      "title": "profile",
       "description": "An identifier for the kind of content of this news object. This can be any string but we suggest something identifying the content such as 'text-only' or 'text-photo'. (Investigate if this align with NewsML nar:profile or not.)",
       "type": "string"
     },
     "version": {
-      "title": "Version",
+      "title": "version",
       "description": "The version of the news object which is identified by the uri property. nar:newsItem@version",
       "type": "string"
     },
     "firstcreated": {
-      "title": "First created",
+      "title": "first created",
       "description": "Indicates when the first version of the item was created. (Added in version 1.2 from issue #5). nar:firstCreated",
       "type": "string",
       "format": "date-time"
     },
     "versioncreated": {
-      "title": "Version created",
+      "title": "version created",
       "description": "The date and time when this version of the news object was created. nar:versionCreated",
       "type": "string",
       "format": "date-time"
     },
     "embargoed": {
-      "title": "Embargoed",
+      "title": "embargoed",
       "description": "The date and time before which all versions of the news object are embargoed. If absent, this object is not embargoed. nar:embargoed",
       "type": "string",
       "format": "date-time"
     },
     "pubstatus": {
-      "title": "Publication status",
+      "title": "publication status",
       "description": "The publishing status of the news object, its value is *usable* by default. nar:pubStatus",
       "type": "string",
       "enum": ["usable", "withheld", "canceled"]
     },
     "urgency": {
-      "title": "Urgency",
+      "title": "urgency",
       "description": "The editorial urgency of the content from 1 to 9. 1 represents the highest urgency, 9 the lowest. nar:urgency",
       "type": "number"
     },
     "copyrightholder": {
-      "title": "Copyright holder",
+      "title": "copyright holder",
       "description": "The person or organisation claiming the intellectual property for the content. nar:copyrightHolder",
       "type": "string"
     },
     "copyrightnotice": {
-      "title": "Copyright notice",
+      "title": "copyright notice",
       "description": "Any necessary copyright notice for claiming the intellectual property for the content. nar:copyrightNotice",
       "type": "string"
     },
     "usageterms": {
-      "title": "Usage terms",
+      "title": "usage terms",
       "description": "A natural-language statement about the usage terms pertaining to the content. nar:usageTerms",
       "type": "string"
     },
     "ednote": {
-      "title": "Editorial note",
+      "title": "editorial note",
       "description": "A note that is intended to be read by internal staff at the receiving organisation, but not published to the end-user. (Added in version 1.2 from issue #6.) . ednote: nar:edNote",
       "type": "string"
     },
     "language": {
-      "title": "Language",
+      "title": "language",
       "description": "The human language used by the content. The value should follow IETF BCP47. nar:language",
       "type": "string"
     },
     "person": {
-      "title": "Person",
+      "title": "person",
       "description": "An individual human being. nar:subject",
       "type": "array",
       "items": {
@@ -120,23 +120,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of a person",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the person",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the person",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the person in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -144,7 +144,7 @@
       }
     },
     "organisation": {
-      "title": "Organisation",
+      "title": "organisation",
       "description": "An administrative and functional structure which may act as as a business, as a political party or not-for-profit party. nar:subject",
       "type": "array",
       "items": {
@@ -152,28 +152,28 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the organisation",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the organisation",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the organisation",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the organisation in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           },
           "symbols": {
-            "title": "Symbols",
+            "title": "symbols",
             "description": "Symbols used for a financial instrument linked to the organisation at a specific market place",
             "type": "array",
             "items": {
@@ -181,12 +181,12 @@
               "additionalProperties": false,
               "properties": {
                 "ticker": {
-                  "title": "Ticker",
+                  "title": "ticker",
                   "description": "Ticker symbol used for the financial instrument",
                   "type": "string"
                 },
                 "exchange": {
-                  "title": "Exchange",
+                  "title": "exchange",
                   "description": "Identifier for the marketplace which uses the ticker symbols of the ticker property",
                   "type": "string"
                 }
@@ -197,7 +197,7 @@
       }
     },
     "place": {
-      "title": "Place",
+      "title": "place",
       "description": "A named location. nar:subject",
       "type": "array",
       "items": {
@@ -211,23 +211,23 @@
         },
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the place",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the place",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the place",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the place in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -235,7 +235,7 @@
       }
     },
     "subject": {
-      "title": "Subject",
+      "title": "subject",
       "description": "A concept with a relationship to the content. nar:subject",
       "type": "array",
       "items": {
@@ -243,23 +243,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the subject",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the subject",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the subject",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the subject in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -267,7 +267,7 @@
       }
     },
     "event": {
-      "title": "Event",
+      "title": "event",
       "description": "Something which happens in a planned or unplanned manner. nar:?",
       "type": "array",
       "items": {
@@ -275,23 +275,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the event",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the event",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the event",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the event in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -299,7 +299,7 @@
       }
     },
     "object": {
-      "title": "Object",
+      "title": "object",
       "description": "Something material, excluding persons. nar:subject",
       "type": "array",
       "items": {
@@ -307,23 +307,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the object",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the object",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the object",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the object in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -331,7 +331,7 @@
       }
     },
     "infosource": {
-      "title": "Info source",
+      "title": "info source",
       "description": "A party (person or organisation) which originated, modified, enhanced, distributed, aggregated or supplied the content or provided some information used to create or enhance the content. (Added in version 1.2 according to issue #15.) .    infosource:  nar:infoSource",
       "type": "array",
       "items": {
@@ -339,23 +339,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the infosource",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the infosource",
             "type": "string"
           },
           "scheme": {
-            "title": "Schema",
+            "title": "schema",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the infosource",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the infosource in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -363,42 +363,42 @@
       }
     },
     "title": {
-      "title": "Title",
+      "title": "title",
       "description": "A short natural-language name for the item. (Added in version 1.2 according to issue #9). nar:itemMeta/title",
       "type": "string"
     },
     "byline": {
-      "title": "Byline",
+      "title": "byline",
       "description": "The name(s) of the creator(s) of the content. nar:by",
       "type": "string"
     },
     "headline": {
-      "title": "Headline",
+      "title": "headline",
       "description": "A brief and snappy introduction to the content, designed to catch the reader's attention. nar:headline",
       "type": "string"
     },
     "slugline": {
-      "title": "Slugline",
+      "title": "slugline",
       "description": "A human-readable identifier for the item. (Added in version 1.2 from issue #4.). nar:slugline",
       "type": "string"
     },
     "located": {
-      "title": "Located",
+      "title": "located",
       "description": "The name of the location from which the content originates. nar:located",
       "type": "string"
     },
     "charcount": {
-      "title": "Character count",
+      "title": "character count",
       "description": "The total character count in the article excluding figure captions. (Added in version 1.2 according to issue #27.). nar:charcount",
       "type": "number"
     },
     "wordcount": {
-      "title": "Word count",
+      "title": "word count",
       "description": "The total number of words in the article excluding figure captions. (Added in version 1.2 according to issue #27.). nar:wordcount",
       "type": "number"
     },
     "renditions": {
-      "title": "Renditions",
+      "title": "renditions",
       "description": "Wrapper for different renditions of the news object. nar:remoteContent",
       "type": "object",
       "additionalProperties": false,
@@ -420,32 +420,32 @@
               "type": "string"
             },
             "title": {
-              "title": "Title",
+              "title": "title",
               "description": "A title for the link to the rendition resource",
               "type": "string"
             },
             "height": {
-              "title": "Height",
+              "title": "height",
               "description": "For still and moving images: the height of the display area measured in pixels. nar:remoteContent@height",
               "type": "number"
             },
             "width": {
-              "title": "Width",
+              "title": "width",
               "description": "For still and moving images: the width of the display area measured in pixels. nar:remoteContent@width",
               "type": "number"
             },
             "sizeinbytes": {
-              "title": "Size in bytes",
+              "title": "size in bytes",
               "description": "The size of the rendition resource in bytes",
               "type": "number"
             },
             "duration": {
-              "title": "Duration",
+              "title": "duration",
               "description": "The total time duration of the content in seconds. (Added in version 1.2. Issue #18). nar:remoteContent@duration",
               "type": "number"
             },
             "format": {
-              "title": "Format",
+              "title": "format",
               "description": "Binary format name. (Added in version 1.2. Issue #18). nar:remoteContent@format",
               "type": "string"
             }
@@ -465,6 +465,6 @@
     }
   },
   "required": ["uri"],
-  "title": "IPTC ninjs - News in JSON - version 1.2 (approved, 2019-10-16)",
+  "title": "iptc ninjs - news in json - version 1.2 (approved, 2019-10-16)",
   "type": "object"
 }

--- a/src/schemas/json/ninjs-1.3.json
+++ b/src/schemas/json/ninjs-1.3.json
@@ -5,30 +5,30 @@
   "id": "http://www.iptc.org/std/ninjs/ninjs-schema_1.3.json#",
   "patternProperties": {
     "^description_[a-zA-Z0-9_]+": {
-      "title": "Description",
+      "title": "description",
       "description": "A free-form textual description of the content of the item. (The string appended to description_ in the property name should reflect the format and/or the purpose of the text, separating the parts with _). nar:description",
       "type": "string"
     },
     "^body_[a-zA-Z0-9_]+": {
-      "title": "Body",
+      "title": "body",
       "description": "The textual content of the news object. (The string appended to body_ in the property name should reflect the format and/or the purpose of the text, separating the parts with _). nar:inlineData or nar:inlineXML",
       "type": "string"
     },
     "^headline_[a-zA-Z0-9_]+": {
-      "title": "Extra headlines",
+      "title": "extra headlines",
       "description": "Additional headlines or strings of that type can be handled here. This is not replacing the main headline-property in ninjs. (The string appended to headline_ in the property name should reflect the format and/or the purpose of the text, separating the parts with _) nar:headline with roles issue #13. (Added in 1.3)",
       "type": "string"
     }
   },
   "properties": {
     "uri": {
-      "title": "Uniform Resource Identifier",
+      "title": "uniform resource identifier",
       "description": "The identifier for this news object. nar:newsItem@guid",
       "type": "string",
       "format": "uri"
     },
     "type": {
-      "title": "Type",
+      "title": "type",
       "description": "The generic news type of this news object. (Value 'component' added in version 1.2 as issue #21.). nar:itemClass",
       "type": "string",
       "enum": [
@@ -42,82 +42,82 @@
       ]
     },
     "mimetype": {
-      "title": "MIME type",
+      "title": "mime type",
       "description": "A MIME type which applies to this news object. nar:contentType",
       "type": "string"
     },
     "representationtype": {
-      "title": "Representation type",
+      "title": "representation type",
       "description": "Indicates how complete this representation of a news item is. No mapping to nar. Specific for ninjs.",
       "type": "string",
       "enum": ["complete", "incomplete"]
     },
     "profile": {
-      "title": "Profile",
+      "title": "profile",
       "description": "An identifier for the structure of the news object. This can be any string but we suggest something identifying the structure of the content such as 'text-only' or 'text-photo'. Profiles are typically provider-specific. nar:profile",
       "type": "string"
     },
     "version": {
-      "title": "Version",
+      "title": "version",
       "description": "The version of the news object which is identified by the uri property. nar:newsItem@version",
       "type": "string"
     },
     "firstcreated": {
-      "title": "First created",
+      "title": "first created",
       "description": "Indicates when the first version of the item was created. (Added in version 1.2 from issue #5). nar:firstCreated",
       "type": "string",
       "format": "date-time"
     },
     "versioncreated": {
-      "title": "Version created",
+      "title": "version created",
       "description": "The date and time when this version of the news object was created. nar:versionCreated",
       "type": "string",
       "format": "date-time"
     },
     "embargoed": {
-      "title": "Embargoed",
+      "title": "embargoed",
       "description": "The date and time before which all versions of the news object are embargoed. If absent, this object is not embargoed. nar:embargoed",
       "type": "string",
       "format": "date-time"
     },
     "pubstatus": {
-      "title": "Publication status",
+      "title": "publication status",
       "description": "The publishing status of the news object, its value is *usable* by default. nar:pubStatus",
       "type": "string",
       "enum": ["usable", "withheld", "canceled"]
     },
     "urgency": {
-      "title": "Urgency",
+      "title": "urgency",
       "description": "The editorial urgency of the content from 1 to 9. 1 represents the highest urgency, 9 the lowest. nar:urgency",
       "type": "number"
     },
     "copyrightholder": {
-      "title": "Copyright holder",
+      "title": "copyright holder",
       "description": "The person or organisation claiming the intellectual property for the content. nar:copyrightHolder",
       "type": "string"
     },
     "copyrightnotice": {
-      "title": "Copyright notice",
+      "title": "copyright notice",
       "description": "Any necessary copyright notice for claiming the intellectual property for the content. nar:copyrightNotice",
       "type": "string"
     },
     "usageterms": {
-      "title": "Usage terms",
+      "title": "usage terms",
       "description": "A natural-language statement about the usage terms pertaining to the content. nar:usageTerms",
       "type": "string"
     },
     "ednote": {
-      "title": "Editorial note",
+      "title": "editorial note",
       "description": "A note that is intended to be read by internal staff at the receiving organisation, but not published to the end-user. (Added in version 1.2 from issue #6.) . ednote: nar:edNote",
       "type": "string"
     },
     "language": {
-      "title": "Language",
+      "title": "language",
       "description": "The human language used by the content. The value should follow IETF BCP47. nar:language",
       "type": "string"
     },
     "person": {
-      "title": "Person",
+      "title": "person",
       "description": "An individual human being. nar:subject",
       "type": "array",
       "items": {
@@ -125,23 +125,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of a person",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the person",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the person",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the person in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -149,7 +149,7 @@
       }
     },
     "organisation": {
-      "title": "Organisation",
+      "title": "organisation",
       "description": "An administrative and functional structure which may act as as a business, as a political party or not-for-profit party. nar:subject",
       "type": "array",
       "items": {
@@ -157,28 +157,28 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the organisation",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the organisation",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the organisation",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the organisation in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           },
           "symbols": {
-            "title": "Symbols",
+            "title": "symbols",
             "description": "Symbols used for a financial instrument linked to the organisation at a specific market place",
             "type": "array",
             "items": {
@@ -186,12 +186,12 @@
               "additionalProperties": false,
               "properties": {
                 "ticker": {
-                  "title": "Ticker",
+                  "title": "ticker",
                   "description": "Ticker symbol used for the financial instrument",
                   "type": "string"
                 },
                 "exchange": {
-                  "title": "Exchange",
+                  "title": "exchange",
                   "description": "Identifier for the marketplace which uses the ticker symbols of the ticker property",
                   "type": "string"
                 }
@@ -202,7 +202,7 @@
       }
     },
     "place": {
-      "title": "Place",
+      "title": "place",
       "description": "A named location. nar:subject",
       "type": "array",
       "items": {
@@ -216,23 +216,23 @@
         },
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the place",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the place",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the place",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the place in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -240,7 +240,7 @@
       }
     },
     "subject": {
-      "title": "Subject",
+      "title": "subject",
       "description": "A concept with a relationship to the content. nar:subject",
       "type": "array",
       "items": {
@@ -248,23 +248,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the subject",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the subject",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the subject",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the subject in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -272,7 +272,7 @@
       }
     },
     "event": {
-      "title": "Event",
+      "title": "event",
       "description": "Something which happens in a planned or unplanned manner. nar:?",
       "type": "array",
       "items": {
@@ -280,23 +280,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the event",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the event",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the event",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the event in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -304,7 +304,7 @@
       }
     },
     "object": {
-      "title": "Object",
+      "title": "object",
       "description": "Something material, excluding persons. nar:subject",
       "type": "array",
       "items": {
@@ -312,23 +312,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the object",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the object",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the object",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the object in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -336,7 +336,7 @@
       }
     },
     "infosource": {
-      "title": "Info source",
+      "title": "info source",
       "description": "A party (person or organisation) which originated, modified, enhanced, distributed, aggregated or supplied the content or provided some information used to create or enhance the content. (Added in version 1.2 according to issue #15.) .    infosource:  nar:infoSource",
       "type": "array",
       "items": {
@@ -344,23 +344,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the infosource",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the infosource",
             "type": "string"
           },
           "scheme": {
-            "title": "Schema",
+            "title": "schema",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the infosource",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the infosource in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -368,42 +368,42 @@
       }
     },
     "title": {
-      "title": "Title",
+      "title": "title",
       "description": "A short natural-language name for the item. (Added in version 1.2 according to issue #9). nar:itemMeta/title",
       "type": "string"
     },
     "byline": {
-      "title": "Byline",
+      "title": "byline",
       "description": "The name(s) of the creator(s) of the content. nar:by",
       "type": "string"
     },
     "headline": {
-      "title": "Headline",
+      "title": "headline",
       "description": "A brief and snappy introduction to the content, designed to catch the reader's attention. nar:headline",
       "type": "string"
     },
     "slugline": {
-      "title": "Slugline",
+      "title": "slugline",
       "description": "A human-readable identifier for the item. (Added in version 1.2 from issue #4.). nar:slugline",
       "type": "string"
     },
     "located": {
-      "title": "Located",
+      "title": "located",
       "description": "The name of the location from which the content originates. nar:located",
       "type": "string"
     },
     "charcount": {
-      "title": "Character count",
+      "title": "character count",
       "description": "The total character count in the article excluding figure captions. (Added in version 1.2 according to issue #27.). nar:charcount",
       "type": "number"
     },
     "wordcount": {
-      "title": "Word count",
+      "title": "word count",
       "description": "The total number of words in the article excluding figure captions. (Added in version 1.2 according to issue #27.). nar:wordcount",
       "type": "number"
     },
     "renditions": {
-      "title": "Renditions",
+      "title": "renditions",
       "description": "Wrapper for different renditions of the news object. nar:remoteContent",
       "type": "object",
       "additionalProperties": false,
@@ -425,32 +425,32 @@
               "type": "string"
             },
             "title": {
-              "title": "Title",
+              "title": "title",
               "description": "A title for the link to the rendition resource",
               "type": "string"
             },
             "height": {
-              "title": "Height",
+              "title": "height",
               "description": "For still and moving images: the height of the display area measured in pixels. nar:remoteContent@height",
               "type": "number"
             },
             "width": {
-              "title": "Width",
+              "title": "width",
               "description": "For still and moving images: the width of the display area measured in pixels. nar:remoteContent@width",
               "type": "number"
             },
             "sizeinbytes": {
-              "title": "Size in bytes",
+              "title": "size in bytes",
               "description": "The size of the rendition resource in bytes",
               "type": "number"
             },
             "duration": {
-              "title": "Duration",
+              "title": "duration",
               "description": "The total time duration of the content in seconds. (Added in version 1.2. Issue #18). nar:remoteContent@duration",
               "type": "number"
             },
             "format": {
-              "title": "Format",
+              "title": "format",
               "description": "Binary format name. (Added in version 1.2. Issue #18). nar:remoteContent@format",
               "type": "string"
             }
@@ -469,13 +469,13 @@
       }
     },
     "altids": {
-      "title": "Alternative id",
+      "title": "alternative id",
       "description": "Alternative identifiers of the item. It is up to the individual provider to name and set type on the alternative identifiers they like to use. nar:altId issue #3. (Added in version 1.3)",
       "type": "object",
       "additionalProperties": true
     },
     "trustindicator": {
-      "title": "Trust indicator",
+      "title": "trust indicator",
       "description": "An array of objects to allow links to documents about trust indicators. (nar:link) issue #44. (Added in version 1.3)",
       "type": "array",
       "items": {
@@ -483,18 +483,18 @@
         "additionalProperties": false,
         "properties": {
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the trust indicator",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the trust indicator in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           },
           "title": {
-            "title": "Title",
+            "title": "title",
             "description": "The title of the resource being referenced.",
             "type": "string"
           },
@@ -508,31 +508,31 @@
       }
     },
     "$standard": {
-      "title": "Standard",
+      "title": "standard",
       "type": "object",
       "description": "An object with information about standard, version and schema this instance is valid against. nar:standard, nar:standardversion and xml:schema issue #43. (Added in version 1.3)",
       "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
-          "title": "Name of standard.",
+          "title": "name of standard.",
           "description": "For example ninjs. nar:standard"
         },
         "version": {
           "type": "string",
-          "title": "Version of standard.",
+          "title": "version of standard.",
           "description": "For example 1.3. nar:standardversion"
         },
         "schema": {
           "type": "string",
           "format": "uri",
-          "title": "Schema",
+          "title": "schema",
           "description": "The uri of the json schema to use for validation."
         }
       }
     },
     "genre": {
-      "title": "Genre",
+      "title": "genre",
       "description": "A nature, intellectual or journalistic form of the content. nar:genre. (Added in version 1.3)",
       "type": "array",
       "items": {
@@ -540,18 +540,18 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the genre",
             "type": "string"
           },
           "scheme": {
-            "title": "Scheme",
+            "title": "scheme",
             "description": "The identifier of a scheme (= controlled vocabulary) which includes a code for the genre. Normally  http://cv.iptc.org/newscodes/genre/",
             "type": "string",
             "format": "uri"
           },
           "code": {
-            "title": "Code",
+            "title": "code",
             "description": "The code for the genre in a scheme (= controlled vocabulary) which is identified by the scheme property",
             "type": "string"
           }
@@ -560,6 +560,6 @@
     }
   },
   "required": ["uri"],
-  "title": "IPTC ninjs - News in JSON - 1.3 (approved, 13 May 2020)",
+  "title": "iptc ninjs - news in json - 1.3 (approved, 13 may 2020)",
   "type": "object"
 }

--- a/src/schemas/json/ninjs-2.0.json
+++ b/src/schemas/json/ninjs-2.0.json
@@ -6,13 +6,13 @@
   "name": "ninjs",
   "properties": {
     "uri": {
-      "title": "Uniform Resource Identifier",
+      "title": "uniform resource identifier",
       "description": "The global unique identifier for this news object. This is the only required property and should identify the ninjs object, not be used for links to external resources etc.  nar:newsItem@guid",
       "type": "string",
       "format": "uri"
     },
     "type": {
-      "title": "Type",
+      "title": "type",
       "description": "The generic news type of this news object. (Value 'component' added in version 1.2 as issue #21.). See: http://cv.iptc.org/newscodes/ninature/ nar:itemClass",
       "type": "string",
       "enum": [
@@ -26,83 +26,83 @@
       ]
     },
     "representationtype": {
-      "title": "Representation type",
+      "title": "representation type",
       "description": "Indicates how complete this representation of a news item is. No mapping to nar. Specific for ninjs.",
       "type": "string",
       "enum": ["full", "partial"]
     },
     "profile": {
-      "title": "Profile",
+      "title": "profile",
       "description": "An identifier for the structure of the news object. This can be any string but we suggest something identifying the structure of the content such as 'text-only' or 'text-photo'. Profiles are typically provider-specific. nar:profile",
       "type": "string"
     },
     "version": {
-      "title": "Version",
+      "title": "version",
       "description": "The version of the news object which is identified by the uri property. nar:newsItem@version",
       "type": "string"
     },
     "firstcreated": {
-      "title": "First created",
+      "title": "first created",
       "description": "Indicates when the first version of this ninjs object was created. (Added in version 1.2 from issue #5). nar:firstCreated",
       "type": "string",
       "format": "date-time"
     },
     "versioncreated": {
-      "title": "Version created",
+      "title": "version created",
       "description": "The date and time when this version of this ninjs object was created. nar:versionCreated",
       "type": "string",
       "format": "date-time"
     },
     "contentcreated": {
-      "title": "Content created",
+      "title": "content created",
       "description": "The date and time when the content of this ninjs object was originally created. For example and old photo that is now handled as a ninjs object. nar:contentCreated",
       "type": "string",
       "format": "date-time"
     },
     "embargoed": {
-      "title": "Embargoed",
+      "title": "embargoed",
       "description": "The date and time before which all versions of the news object are embargoed. If absent, this object is not embargoed. nar:embargoed",
       "type": "string",
       "format": "date-time"
     },
     "pubstatus": {
-      "title": "Publication status",
+      "title": "publication status",
       "description": "The publishing status of the news object, its value is *usable* by default. nar:pubStatus",
       "type": "string",
       "enum": ["usable", "withheld", "canceled"]
     },
     "urgency": {
-      "title": "Urgency",
+      "title": "urgency",
       "description": "The editorial urgency of the content. Values from 1 to 9. 1 represents the highest urgency, 9 the lowest. nar:urgency",
       "type": "number"
     },
     "copyrightholder": {
-      "title": "Copyright holder",
+      "title": "copyright holder",
       "description": "The person or organisation claiming the intellectual property for the content. nar:copyrightHolder",
       "type": "string"
     },
     "copyrightnotice": {
-      "title": "Copyright notice",
+      "title": "copyright notice",
       "description": "Any necessary copyright notice for claiming the intellectual property for the content. nar:copyrightNotice",
       "type": "string"
     },
     "usageterms": {
-      "title": "Usage terms",
+      "title": "usage terms",
       "description": "A natural-language statement about the usage terms pertaining to the content. nar:usageTerms",
       "type": "string"
     },
     "ednote": {
-      "title": "Editorial note",
+      "title": "editorial note",
       "description": "A note that is intended to be read by internal staff at the receiving organisation, but not intended to be published. (Added in version 1.2 from issue #6.). (Consider using this before using the descriptions array.) ednote: nar:edNote",
       "type": "string"
     },
     "language": {
-      "title": "Language",
+      "title": "language",
       "description": "The human language used by the content. The value should follow IETF BCP47. nar:language",
       "type": "string"
     },
     "descriptions": {
-      "title": "Descriptions",
+      "title": "descriptions",
       "description": "An array of one or more descriptions of the ninjs object. See also ednote for information from provider to reciever. Descriptions are seen as metadata. For a simple description use an array with one object only containing the value property. Role and contenttype are then undefined and it is up to the provider.",
       "type": "array",
       "items": {
@@ -111,17 +111,17 @@
         "additionalProperties": false,
         "properties": {
           "role": {
-            "title": "Role",
+            "title": "role",
             "description": "The role of this description",
             "type": "string"
           },
           "contenttype": {
-            "title": "Content Type",
+            "title": "content type",
             "description": "The IANA (Internet Assigned Numbers Authority) MIME type of the content of this description.",
             "type": "string"
           },
           "value": {
-            "title": "Value",
+            "title": "value",
             "description": "The descriptive text identified with the above role (and contenttype).",
             "type": "string"
           }
@@ -129,7 +129,7 @@
       }
     },
     "bodies": {
-      "title": "Bodies",
+      "title": "bodies",
       "description": "An array of body objects with the content as text or with markup. For a simple body use an array with one object only containing the value property. Role and contenttype are then undefined and it is up to the provider.",
       "type": "array",
       "items": {
@@ -138,27 +138,27 @@
         "additionalProperties": false,
         "properties": {
           "role": {
-            "title": "Role",
+            "title": "role",
             "description": "The role of this body",
             "type": "string"
           },
           "contenttype": {
-            "title": "Content Type",
+            "title": "content type",
             "description": "The IANA (Internet Assigned Numbers Authority) MIME type of the content of this body.",
             "type": "string"
           },
           "charcount": {
-            "title": "Character count",
+            "title": "character count",
             "description": "The total character count in this body excluding figure captions. (Added in version 1.2 according to issue #27.). nar:charcount",
             "type": "number"
           },
           "wordcount": {
-            "title": "Word count",
+            "title": "word count",
             "description": "The total number of words in this body excluding figure captions. (Added in version 1.2 according to issue #27.). nar:wordcount",
             "type": "number"
           },
           "value": {
-            "title": "Value",
+            "title": "value",
             "description": "The body text identified with the above role and contenttype.",
             "type": "string"
           }
@@ -166,7 +166,7 @@
       }
     },
     "headlines": {
-      "title": "Headlines",
+      "title": "headlines",
       "description": "An array of objects containing various types of headlines. For a simple headline use an array with one object only containing the value property. Role and contenttype are then undefined and it is up to the provider.",
       "type": "array",
       "items": {
@@ -175,17 +175,17 @@
         "additionalProperties": false,
         "properties": {
           "role": {
-            "title": "Role",
+            "title": "role",
             "description": "The role of this headline",
             "type": "string"
           },
           "contenttype": {
-            "title": "Content Type",
+            "title": "content type",
             "description": "The IANA (Internet Assigned Numbers Authority) MIME type of the content of this headline.",
             "type": "string"
           },
           "value": {
-            "title": "Value",
+            "title": "value",
             "description": "The headline identified with the above role and contenttype.",
             "type": "string"
           }
@@ -193,7 +193,7 @@
       }
     },
     "people": {
-      "title": "People",
+      "title": "people",
       "description": "An array of objects describing individual human beings. nar:subject",
       "type": "array",
       "items": {
@@ -201,23 +201,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of a person",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the person",
             "type": "string"
           },
           "uri": {
-            "title": "URI",
+            "title": "uri",
             "description": "The identifier for the person as a complete uri with the code.",
             "type": "string",
             "format": "uri"
           },
           "literal": {
-            "title": "Literal",
+            "title": "literal",
             "description": "The code for the person as a literal value.",
             "type": "string"
           }
@@ -225,7 +225,7 @@
       }
     },
     "organisations": {
-      "title": "Organisations",
+      "title": "organisations",
       "description": "An array of objects describing administrative and functional structures which may, for example, act as as a business, as a political party or not-for-profit party. nar:subject",
       "type": "array",
       "items": {
@@ -233,28 +233,28 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the organisation",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the organisation",
             "type": "string"
           },
           "uri": {
-            "title": "URI",
+            "title": "uri",
             "description": "The identifier of the organisation as a complete uri",
             "type": "string",
             "format": "uri"
           },
           "literal": {
-            "title": "Literal",
+            "title": "literal",
             "description": "The code for the organisation as a literal",
             "type": "string"
           },
           "symbols": {
-            "title": "Symbols",
+            "title": "symbols",
             "description": "Symbols used for a financial instrument linked to the organisation at a specific market place",
             "type": "array",
             "items": {
@@ -262,12 +262,12 @@
               "additionalProperties": false,
               "properties": {
                 "ticker": {
-                  "title": "Ticker",
+                  "title": "ticker",
                   "description": "Ticker symbol used for the financial instrument",
                   "type": "string"
                 },
                 "exchange": {
-                  "title": "Exchange",
+                  "title": "exchange",
                   "description": "Identifier for the marketplace which uses the ticker symbols of the ticker property",
                   "type": "string"
                 }
@@ -278,7 +278,7 @@
       }
     },
     "places": {
-      "title": "Places",
+      "title": "places",
       "description": "An array of named locations. nar:subject",
       "additionalProperties": false,
       "type": "array",
@@ -288,23 +288,23 @@
           {
             "properties": {
               "name": {
-                "title": "Name",
+                "title": "name",
                 "description": "The name of the place",
                 "type": "string"
               },
               "rel": {
-                "title": "Relationship",
+                "title": "relationship",
                 "description": "The relationship of the content of the news object to the place",
                 "type": "string"
               },
               "uri": {
-                "title": "URI",
+                "title": "uri",
                 "description": "The identifier for the place as a complete uri",
                 "type": "string",
                 "format": "uri"
               },
               "literal": {
-                "title": "Literal",
+                "title": "literal",
                 "description": "The code for the place as a literal",
                 "type": "string"
               }
@@ -317,7 +317,7 @@
       }
     },
     "subjects": {
-      "title": "Subjects",
+      "title": "subjects",
       "description": "An array of objects holding concepts with a relationship to the content. nar:subject",
       "type": "array",
       "items": {
@@ -325,23 +325,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the subject",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the subject",
             "type": "string"
           },
           "uri": {
-            "title": "URI",
+            "title": "uri",
             "description": "The identifier of the subject as a complete uri",
             "type": "string",
             "format": "uri"
           },
           "literal": {
-            "title": "Literal",
+            "title": "literal",
             "description": "The code for the subject as a string literal",
             "type": "string"
           }
@@ -349,7 +349,7 @@
       }
     },
     "events": {
-      "title": "Events",
+      "title": "events",
       "description": "An array of objects describing something which happens in a planned or unplanned manner. nar:?",
       "type": "array",
       "items": {
@@ -357,23 +357,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the event",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the event",
             "type": "string"
           },
           "uri": {
-            "title": "URI",
+            "title": "uri",
             "description": "The identifier for the event as a complete uri",
             "type": "string",
             "format": "uri"
           },
           "literal": {
-            "title": "Literal",
+            "title": "literal",
             "description": "The code for the event as a string literal",
             "type": "string"
           }
@@ -381,7 +381,7 @@
       }
     },
     "objects": {
-      "title": "Objects",
+      "title": "objects",
       "description": "An array of objects describing something material, excluding persons. nar:subject",
       "type": "array",
       "items": {
@@ -389,23 +389,23 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the object",
             "type": "string"
           },
           "rel": {
-            "title": "Relationship",
+            "title": "relationship",
             "description": "The relationship of the content of the news object to the object",
             "type": "string"
           },
           "uri": {
-            "title": "URI",
+            "title": "uri",
             "description": "The identifier for the object as a complete uri",
             "type": "string",
             "format": "uri"
           },
           "literal": {
-            "title": "Literal",
+            "title": "literal",
             "description": "The code for the object as a string literal",
             "type": "string"
           }
@@ -413,7 +413,7 @@
       }
     },
     "infosources": {
-      "title": "Info sources",
+      "title": "info sources",
       "description": "An array of parties (person or organisation) which originated, modified, enhanced, distributed, aggregated or supplied the content or provided some information used to create or enhance the content. (Added in version 1.2 according to issue #15.) .  infosource:  nar:infoSource",
       "type": "array",
       "items": {
@@ -421,24 +421,24 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the infosource",
             "type": "string"
           },
           "role": {
-            "title": "Role",
+            "title": "role",
             "description": "The role the infosource in relationship to the content as a uri.",
             "type": "string",
             "format": "uri"
           },
           "uri": {
-            "title": "URI",
+            "title": "uri",
             "description": "The identifier of the infosource as a complete uri",
             "type": "string",
             "format": "uri"
           },
           "literal": {
-            "title": "Literal",
+            "title": "literal",
             "description": "The code for the infosource as a string literal",
             "type": "string"
           }
@@ -446,27 +446,27 @@
       }
     },
     "title": {
-      "title": "Title",
+      "title": "title",
       "description": "A short natural-language name for the item. Title is metadata, use headlines for publishable headlines. (Added in version 1.2 according to issue #9). nar:itemMeta/title",
       "type": "string"
     },
     "by": {
-      "title": "By",
+      "title": "by",
       "description": "A natural-language statement about the creator (author, photographer etc.) of the content. nar:by",
       "type": "string"
     },
     "slugline": {
-      "title": "Slugline",
+      "title": "slugline",
       "description": "A human-readable identifier for the item. (Added in version 1.2 from issue #4.). nar:slugline",
       "type": "string"
     },
     "located": {
-      "title": "Located",
+      "title": "located",
       "description": "The name of the location from which the content originates. nar:located",
       "type": "string"
     },
     "renditions": {
-      "title": "Renditions",
+      "title": "renditions",
       "description": "An array of objects with different renditions of the news object. nar:remoteContent",
       "type": "array",
       "additionalProperties": false,
@@ -477,7 +477,7 @@
         "required": ["name"],
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of this object in the array of renditions. For example 'thumbnail'",
             "type": "string"
           },
@@ -488,37 +488,37 @@
             "format": "uri"
           },
           "contenttype": {
-            "title": "Content Type",
+            "title": "content type",
             "description": "A MIME type which applies to this rendition. nar:remoteContent@contenttype",
             "type": "string"
           },
           "title": {
-            "title": "Title",
+            "title": "title",
             "description": "A title for the link to the rendition resource",
             "type": "string"
           },
           "height": {
-            "title": "Height",
+            "title": "height",
             "description": "For still and moving images: the height of the display area measured in pixels. nar:remoteContent@height",
             "type": "number"
           },
           "width": {
-            "title": "Width",
+            "title": "width",
             "description": "For still and moving images: the width of the display area measured in pixels. nar:remoteContent@width",
             "type": "number"
           },
           "sizeinbytes": {
-            "title": "Size in bytes",
+            "title": "size in bytes",
             "description": "The size of the rendition resource in bytes",
             "type": "number"
           },
           "duration": {
-            "title": "Duration",
+            "title": "duration",
             "description": "The total time duration of the content in seconds. (Added in version 1.2. Issue #18). nar:remoteContent@duration",
             "type": "number"
           },
           "format": {
-            "title": "Format",
+            "title": "format",
             "description": "Binary format name. (Added in version 1.2. Issue #18). nar:remoteContent@format",
             "type": "string"
           }
@@ -526,7 +526,7 @@
       }
     },
     "associations": {
-      "title": "Associations",
+      "title": "associations",
       "description": "An array of objects with content of news objects which are associated with this news object.",
       "type": "array",
       "additionalProperties": false,
@@ -550,7 +550,7 @@
       }
     },
     "altids": {
-      "title": "Alternative ids",
+      "title": "alternative ids",
       "description": "Alternative identifiers assigned to the content. Each alternative id can have a role and a value. nar:altId issue #3.",
       "type": "array",
       "items": {
@@ -558,12 +558,12 @@
         "additionalProperties": false,
         "properties": {
           "role": {
-            "title": "Role",
+            "title": "role",
             "description": "The role of the alternative id",
             "type": "string"
           },
           "value": {
-            "title": "Value",
+            "title": "value",
             "description": "The alternative id value",
             "type": "string"
           }
@@ -571,7 +571,7 @@
       }
     },
     "trustindicators": {
-      "title": "Trust indicators",
+      "title": "trust indicators",
       "description": "An array of objects to allow links to documents about trust indicators. issue #44. (Added in version 1.3)",
       "type": "array",
       "items": {
@@ -579,13 +579,13 @@
         "additionalProperties": false,
         "properties": {
           "role": {
-            "title": "Role",
+            "title": "role",
             "description": "The role of the trust indicator as a complete uri",
             "type": "string",
             "format": "uri"
           },
           "title": {
-            "title": "Title",
+            "title": "title",
             "description": "The title of the resource being referenced.",
             "type": "string"
           },
@@ -599,23 +599,23 @@
       }
     },
     "standard": {
-      "title": "Standard",
+      "title": "standard",
       "type": "object",
       "description": "An object with information about standard, version and schema this instance is valid against. nar:standard, nar:standardversion and xml:schema issue #43. (Added in version 1.3)",
       "additionalProperties": false,
       "properties": {
         "name": {
-          "title": "Name of standard.",
+          "title": "name of standard.",
           "description": "For example ninjs. nar:standard",
           "type": "string"
         },
         "version": {
-          "title": "Version of standard.",
+          "title": "version of standard.",
           "description": "For example 1.3. nar:standardversion",
           "type": "string"
         },
         "schema": {
-          "title": "Schema",
+          "title": "schema",
           "description": "The uri of the json schema to use for validation.",
           "type": "string",
           "format": "uri"
@@ -623,7 +623,7 @@
       }
     },
     "genres": {
-      "title": "Genres",
+      "title": "genres",
       "description": "A nature, intellectual or journalistic form of the content. nar:genre. (Added in version 1.3)",
       "type": "array",
       "items": {
@@ -631,18 +631,18 @@
         "additionalProperties": false,
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "description": "The name of the genre",
             "type": "string"
           },
           "uri": {
-            "title": "URI",
+            "title": "uri",
             "description": "The identifier of  the genre as a complete uri",
             "type": "string",
             "format": "uri"
           },
           "literal": {
-            "title": "Literal",
+            "title": "literal",
             "description": "The code for the genre as a string literal",
             "type": "string"
           }
@@ -650,24 +650,24 @@
       }
     },
     "rightsinfo": {
-      "title": "Rights information",
+      "title": "rights information",
       "type": "object",
       "description": "Expression of rights to be applied to content. nar:rightsInfo",
       "properties": {
         "langid": {
           "type": "string",
-          "title": "Language id",
+          "title": "language id",
           "description": "Identifier for the Rights Expression language used. nar:@langid",
           "format": "uri"
         },
         "linkedrights": {
-          "title": "Linked rights",
+          "title": "linked rights",
           "description": "A link from the current Item to Web resource with rights related information. nar:link",
           "type": "string",
           "format": "uri"
         },
         "encodedrights": {
-          "title": "Encoded Rights",
+          "title": "encoded rights",
           "additionalProperties": false,
           "type": "string",
           "description": "Contains a rights expression as defined by a Rights Expression Language. nar:rightsExpressionXML or nar:rightsExpressionData"
@@ -684,6 +684,6 @@
     }
   },
   "required": ["uri"],
-  "title": "IPTC ninjs - News in JSON - version 2.0 (approved at IPTC Standards Committee October 2021)",
+  "title": "iptc ninjs - news in json - version 2.0 (approved at iptc standards committee october 2021)",
   "type": "object"
 }

--- a/src/schemas/json/nodehawkrc.json
+++ b/src/schemas/json/nodehawkrc.json
@@ -115,6 +115,6 @@
     }
   },
   "required": ["exec"],
-  "title": "Nodehawk configuration schema.",
+  "title": "nodehawk configuration schema.",
   "type": "object"
 }

--- a/src/schemas/json/nodemon.json
+++ b/src/schemas/json/nodemon.json
@@ -183,6 +183,6 @@
       "type": "array"
     }
   },
-  "title": "JSON Schema for Nodemon Config",
+  "title": "json schema for nodemon config",
   "type": "object"
 }

--- a/src/schemas/json/npm-badges.json
+++ b/src/schemas/json/npm-badges.json
@@ -206,6 +206,6 @@
       }
     }
   },
-  "title": "Configuration for the NPM package badges.",
+  "title": "configuration for the npm package badges.",
   "type": "object"
 }

--- a/src/schemas/json/npm-link-up.json
+++ b/src/schemas/json/npm-link-up.json
@@ -63,6 +63,6 @@
     }
   },
   "required": ["list", "packages", "deps"],
-  "title": "JSON schema for NLU (npm-link-up) library.",
+  "title": "json schema for nlu (npm-link-up) library.",
   "type": "object"
 }

--- a/src/schemas/json/npmpackagejsonlintrc.json
+++ b/src/schemas/json/npmpackagejsonlintrc.json
@@ -426,6 +426,6 @@
       ]
     }
   },
-  "title": "JSON schema for npm-package-json-lint configuration files",
+  "title": "json schema for npm-package-json-lint configuration files",
   "type": "object"
 }

--- a/src/schemas/json/nuget-project-3.3.0.json
+++ b/src/schemas/json/nuget-project-3.3.0.json
@@ -73,6 +73,6 @@
       }
     }
   },
-  "title": "JSON schema for NuGet project.json files",
+  "title": "json schema for nuget project.json files",
   "type": "object"
 }

--- a/src/schemas/json/nuget-project.json
+++ b/src/schemas/json/nuget-project.json
@@ -194,6 +194,6 @@
       }
     }
   },
-  "title": "JSON schema for NuGet project.json files",
+  "title": "json schema for nuget project.json files",
   "type": "object"
 }

--- a/src/schemas/json/ocelot.json
+++ b/src/schemas/json/ocelot.json
@@ -4,32 +4,32 @@
     "Routes": {
       "$id": "#/properties/Routes",
       "type": "array",
-      "title": "The Routes Schema",
+      "title": "the routes schema",
       "items": {
         "$id": "#/properties/Routes/items",
         "type": "object",
-        "title": "The Items Schema",
+        "title": "the items schema",
         "properties": {
           "DownstreamPathTemplate": {
             "$id": "#/properties/Routes/items/properties/DownstreamPathTemplate",
             "type": "string",
-            "title": "The Downstreampathtemplate Schema",
+            "title": "the downstreampathtemplate schema",
             "pattern": "^(.*)$"
           },
           "UpstreamPathTemplate": {
             "$id": "#/properties/Routes/items/properties/UpstreamPathTemplate",
             "type": "string",
-            "title": "The Upstreampathtemplate Schema",
+            "title": "the upstreampathtemplate schema",
             "pattern": "^(.*)$"
           },
           "UpstreamHttpMethod": {
             "$id": "#/properties/Routes/items/properties/UpstreamHttpMethod",
             "type": "array",
-            "title": "The Upstreamhttpmethod Schema",
+            "title": "the upstreamhttpmethod schema",
             "items": {
               "$id": "#/properties/Routes/items/properties/UpstreamHttpMethod/items",
               "type": "string",
-              "title": "The Items Schema",
+              "title": "the items schema",
               "examples": ["Get"],
               "pattern": "^(.*)$"
             }
@@ -37,43 +37,43 @@
           "AddHeadersToRequest": {
             "$id": "#/properties/Routes/items/properties/AddHeadersToRequest",
             "type": "object",
-            "title": "The AddHeadersToRequest Schema"
+            "title": "the addheaderstorequest schema"
           },
           "AddClaimsToRequest": {
             "$id": "#/properties/Routes/items/properties/AddClaimsToRequest",
             "type": "object",
-            "title": "The AddClaimsToRequest Schema"
+            "title": "the addclaimstorequest schema"
           },
           "RouteClaimsRequirement": {
             "$id": "#/properties/Routes/items/properties/RouteClaimsRequirement",
             "type": "object",
-            "title": "The Routeclaimsrequirement Schema"
+            "title": "the routeclaimsrequirement schema"
           },
           "AddQueriesToRequest": {
             "$id": "#/properties/Routes/items/properties/AddQueriesToRequest",
             "type": "object",
-            "title": "The AddQueriesToRequest Schema"
+            "title": "the addqueriestorequest schema"
           },
           "RequestIdKey": {
             "$id": "#/properties/Routes/items/properties/RequestIdKey",
             "type": "string",
-            "title": "The Requestidkey Schema",
+            "title": "the requestidkey schema",
             "pattern": "^(.*)$"
           },
           "FileCacheOptions": {
             "$id": "#/properties/Routes/items/properties/FileCacheOptions",
             "type": "object",
-            "title": "The Filecacheoptions Schema",
+            "title": "the filecacheoptions schema",
             "properties": {
               "TtlSeconds": {
                 "$id": "#/properties/Routes/items/properties/FileCacheOptions/properties/TtlSeconds",
                 "type": "integer",
-                "title": "The Ttlseconds Schema"
+                "title": "the ttlseconds schema"
               },
               "Region": {
                 "$id": "#/properties/Routes/items/properties/FileCacheOptions/properties/Region",
                 "type": "string",
-                "title": "The Region Schema",
+                "title": "the region schema",
                 "pattern": "^(.*)$"
               }
             }
@@ -81,33 +81,33 @@
           "RouteIsCaseSensitive": {
             "$id": "#/properties/Routes/items/properties/RouteIsCaseSensitive",
             "type": "boolean",
-            "title": "The Routeiscasesensitive Schema"
+            "title": "the routeiscasesensitive schema"
           },
           "ServiceName": {
             "$id": "#/properties/Routes/items/properties/ServiceName",
             "type": "string",
-            "title": "The Servicename Schema",
+            "title": "the servicename schema",
             "pattern": "^(.*)$"
           },
           "DownstreamScheme": {
             "$id": "#/properties/Routes/items/properties/DownstreamScheme",
             "type": "string",
-            "title": "The Downstreamscheme Schema",
+            "title": "the downstreamscheme schema",
             "pattern": "^(.*)$"
           },
           "DownstreamHostAndPorts": {
             "$id": "#/properties/Routes/items/properties/DownstreamHostAndPorts",
             "type": "array",
-            "title": "The Downstreamhostandports Schema",
+            "title": "the downstreamhostandports schema",
             "items": {
               "$id": "#/properties/Routes/items/properties/DownstreamHostAndPorts/items",
               "type": "object",
-              "title": "The Items Schema",
+              "title": "the items schema",
               "properties": {
                 "Host": {
                   "$id": "#/properties/Routes/items/properties/DownstreamHostAndPorts/items/properties/Host",
                   "type": "string",
-                  "title": "The Host Schema",
+                  "title": "the host schema",
                   "default": "",
                   "examples": ["localhost"],
                   "pattern": "^(.*)$"
@@ -115,7 +115,7 @@
                 "Port": {
                   "$id": "#/properties/Routes/items/properties/DownstreamHostAndPorts/items/properties/Port",
                   "type": "integer",
-                  "title": "The Port Schema"
+                  "title": "the port schema"
                 }
               }
             }
@@ -123,108 +123,108 @@
           "QoSOptions": {
             "$id": "#/properties/Routes/items/properties/QoSOptions",
             "type": "object",
-            "title": "The Qosoptions Schema",
+            "title": "the qosoptions schema",
             "properties": {
               "ExceptionsAllowedBeforeBreaking": {
                 "$id": "#/properties/Routes/items/properties/QoSOptions/properties/ExceptionsAllowedBeforeBreaking",
                 "type": "integer",
-                "title": "The Exceptionsallowedbeforebreaking Schema"
+                "title": "the exceptionsallowedbeforebreaking schema"
               },
               "DurationOfBreak": {
                 "$id": "#/properties/Routes/items/properties/QoSOptions/properties/DurationOfBreak",
                 "type": "integer",
-                "title": "The Durationofbreak Schema"
+                "title": "the durationofbreak schema"
               },
               "TimeoutValue": {
                 "$id": "#/properties/Routes/items/properties/QoSOptions/properties/TimeoutValue",
                 "type": "integer",
-                "title": "The Timeoutvalue Schema"
+                "title": "the timeoutvalue schema"
               }
             }
           },
           "LoadBalancer": {
             "$id": "#/properties/Routes/items/properties/LoadBalancer",
             "type": "string",
-            "title": "The Loadbalancer Schema",
+            "title": "the loadbalancer schema",
             "pattern": "^(.*)$"
           },
           "RateLimitOptions": {
             "$id": "#/properties/Routes/items/properties/RateLimitOptions",
             "type": "object",
-            "title": "The Ratelimitoptions Schema",
+            "title": "the ratelimitoptions schema",
             "properties": {
               "ClientWhitelist": {
                 "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/ClientWhitelist",
                 "type": "array",
-                "title": "The Clientwhitelist Schema"
+                "title": "the clientwhitelist schema"
               },
               "EnableRateLimiting": {
                 "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/EnableRateLimiting",
                 "type": "boolean",
-                "title": "The Enableratelimiting Schema"
+                "title": "the enableratelimiting schema"
               },
               "Period": {
                 "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/Period",
                 "type": "string",
-                "title": "The Period Schema",
+                "title": "the period schema",
                 "pattern": "^(.*)$"
               },
               "PeriodTimespan": {
                 "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/PeriodTimespan",
                 "type": "integer",
-                "title": "The Periodtimespan Schema"
+                "title": "the periodtimespan schema"
               },
               "Limit": {
                 "$id": "#/properties/Routes/items/properties/RateLimitOptions/properties/Limit",
                 "type": "integer",
-                "title": "The Limit Schema"
+                "title": "the limit schema"
               }
             }
           },
           "AuthenticationOptions": {
             "$id": "#/properties/Routes/items/properties/AuthenticationOptions",
             "type": "object",
-            "title": "The Authenticationoptions Schema",
+            "title": "the authenticationoptions schema",
             "properties": {
               "AuthenticationProviderKey": {
                 "$id": "#/properties/Routes/items/properties/AuthenticationOptions/properties/AuthenticationProviderKey",
                 "type": "string",
-                "title": "The Authenticationproviderkey Schema",
+                "title": "the authenticationproviderkey schema",
                 "pattern": "^(.*)$"
               },
               "AllowedScopes": {
                 "$id": "#/properties/Routes/items/properties/AuthenticationOptions/properties/AllowedScopes",
                 "type": "array",
-                "title": "The Allowedscopes Schema"
+                "title": "the allowedscopes schema"
               }
             }
           },
           "HttpHandlerOptions": {
             "$id": "#/properties/Routes/items/properties/HttpHandlerOptions",
             "type": "object",
-            "title": "The Httphandleroptions Schema",
+            "title": "the httphandleroptions schema",
             "properties": {
               "AllowAutoRedirect": {
                 "$id": "#/properties/Routes/items/properties/HttpHandlerOptions/properties/AllowAutoRedirect",
                 "type": "boolean",
-                "title": "The Allowautoredirect Schema"
+                "title": "the allowautoredirect schema"
               },
               "UseCookieContainer": {
                 "$id": "#/properties/Routes/items/properties/HttpHandlerOptions/properties/UseCookieContainer",
                 "type": "boolean",
-                "title": "The Usecookiecontainer Schema"
+                "title": "the usecookiecontainer schema"
               },
               "UseTracing": {
                 "$id": "#/properties/Routes/items/properties/HttpHandlerOptions/properties/UseTracing",
                 "type": "boolean",
-                "title": "The Usetracing Schema"
+                "title": "the usetracing schema"
               }
             }
           },
           "DangerousAcceptAnyServerCertificateValidator": {
             "$id": "#/properties/Routes/items/properties/DangerousAcceptAnyServerCertificateValidator",
             "type": "boolean",
-            "title": "The Dangerousacceptanyservercertificatevalidator Schema"
+            "title": "the dangerousacceptanyservercertificatevalidator schema"
           }
         }
       }
@@ -232,18 +232,18 @@
     "GlobalConfiguration": {
       "$id": "#/properties/GlobalConfiguration",
       "type": "object",
-      "title": "The Globalconfiguration Schema",
+      "title": "the globalconfiguration schema",
       "properties": {
         "RequestIdKey": {
           "$id": "#/properties/GlobalConfiguration/properties/RequestIdKey",
           "type": "string",
-          "title": "The Requestidkey Schema",
+          "title": "the requestidkey schema",
           "pattern": "^(.*)$"
         }
       }
     }
   },
   "required": ["Routes"],
-  "title": "JSON Schema for Ocelot.json",
+  "title": "json schema for ocelot.json",
   "type": "object"
 }

--- a/src/schemas/json/openfin.json
+++ b/src/schemas/json/openfin.json
@@ -439,5 +439,5 @@
     }
   },
   "required": ["runtime", "shortcut", "startup_app"],
-  "title": "JSON schema for OpenFin application configuration files"
+  "title": "json schema for openfin application configuration files"
 }

--- a/src/schemas/json/openweather.current.json
+++ b/src/schemas/json/openweather.current.json
@@ -155,6 +155,6 @@
     "name",
     "cod"
   ],
-  "title": "OpenWeather Current Weather Data API",
+  "title": "openweather current weather data api",
   "type": "object"
 }

--- a/src/schemas/json/openweather.roadrisk.json
+++ b/src/schemas/json/openweather.roadrisk.json
@@ -58,6 +58,6 @@
       }
     }
   },
-  "title": "OpenWeather Road Risk API",
+  "title": "openweather road risk api",
   "type": "array"
 }

--- a/src/schemas/json/opspec-io-0.1.7.json
+++ b/src/schemas/json/opspec-io-0.1.7.json
@@ -46,7 +46,7 @@
           "properties": {
             "array": {
               "additionalProperties": false,
-              "title": "arrayParam",
+              "title": "arrayparam",
               "description": "Array parameter of an op",
               "properties": {
                 "description": {
@@ -60,7 +60,7 @@
                   "type": "boolean"
                 },
                 "constraints": {
-                  "title": "arrayConstraints",
+                  "title": "arrayconstraints",
                   "type": "object",
                   "properties": {
                     "additionalItems": {
@@ -102,7 +102,7 @@
             },
             "boolean": {
               "additionalProperties": false,
-              "title": "booleanParam",
+              "title": "booleanparam",
               "description": "Boolean parameter of an op",
               "properties": {
                 "description": {
@@ -117,7 +117,7 @@
             },
             "dir": {
               "additionalProperties": false,
-              "title": "dirParam",
+              "title": "dirparam",
               "description": "Directory parameter of an op",
               "properties": {
                 "description": {
@@ -138,7 +138,7 @@
             },
             "file": {
               "additionalProperties": false,
-              "title": "fileParam",
+              "title": "fileparam",
               "description": "File parameter of an op",
               "properties": {
                 "description": {
@@ -157,7 +157,7 @@
             },
             "number": {
               "additionalProperties": false,
-              "title": "numberParam",
+              "title": "numberparam",
               "description": "Number parameter of an op",
               "properties": {
                 "description": {
@@ -171,7 +171,7 @@
                   "type": "boolean"
                 },
                 "constraints": {
-                  "title": "numberConstraints",
+                  "title": "numberconstraints",
                   "type": "object",
                   "properties": {
                     "allOf": {
@@ -236,7 +236,7 @@
             },
             "object": {
               "additionalProperties": false,
-              "title": "objectParam",
+              "title": "objectparam",
               "description": "Object parameter of an op",
               "properties": {
                 "description": {
@@ -250,7 +250,7 @@
                   "type": "boolean"
                 },
                 "constraints": {
-                  "title": "objectConstraints",
+                  "title": "objectconstraints",
                   "type": "object",
                   "properties": {
                     "additionalProperties": {
@@ -323,7 +323,7 @@
                       "description": "JSON Schema [properties keyword](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.16)",
                       "type": "object",
                       "additionalProperties": {
-                        "title": "typeConstraints",
+                        "title": "typeconstraints",
                         "description": "Parameter constraints",
                         "anyOf": [
                           {
@@ -383,7 +383,7 @@
             },
             "socket": {
               "additionalProperties": false,
-              "title": "socketParam",
+              "title": "socketparam",
               "description": "Socket parameter of an op",
               "properties": {
                 "description": {
@@ -398,7 +398,7 @@
             },
             "string": {
               "additionalProperties": false,
-              "title": "stringParam",
+              "title": "stringparam",
               "description": "String parameter of an op",
               "properties": {
                 "description": {
@@ -412,7 +412,7 @@
                   "type": "boolean"
                 },
                 "constraints": {
-                  "title": "stringConstraints",
+                  "title": "stringconstraints",
                   "type": "object",
                   "properties": {
                     "allOf": {
@@ -556,7 +556,7 @@
       ],
       "properties": {
         "container": {
-          "title": "containerCall",
+          "title": "containercall",
           "type": "object",
           "properties": {
             "cmd": {
@@ -795,7 +795,7 @@
           "additionalProperties": false
         },
         "parallel": {
-          "title": "parallelCall",
+          "title": "parallelcall",
           "type": "array",
           "items": {
             "$ref": "#/properties/run"
@@ -820,7 +820,7 @@
           "type": "object"
         },
         "serial": {
-          "title": "serialCall",
+          "title": "serialcall",
           "type": "array",
           "items": {
             "$ref": "#/properties/run"
@@ -885,11 +885,11 @@
     },
     "opspec": {
       "description": "Version of [opspec](https://opspec.io) used by the op",
-      "title": "semVer",
+      "title": "semver",
       "type": "string",
       "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:(-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-\\-\\.]+)?$"
     }
   },
   "required": ["name"],
-  "title": "Op File"
+  "title": "op file"
 }

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "JSON schema for NPM package.json files",
+  "title": "json schema for npm package.json files",
   "definitions": {
     "person": {
       "description": "A person who has been involved in creating or maintaining this package.",

--- a/src/schemas/json/package.manifest-7.0.0.json
+++ b/src/schemas/json/package.manifest-7.0.0.json
@@ -223,6 +223,6 @@
       }
     }
   },
-  "title": "A schema for Umbraco's package.manifest files.",
+  "title": "a schema for umbraco's package.manifest files.",
   "type": "object"
 }

--- a/src/schemas/json/package.manifest-8.0.0.json
+++ b/src/schemas/json/package.manifest-8.0.0.json
@@ -366,6 +366,6 @@
       }
     }
   },
-  "title": "A schema for Umbraco's package.manifest files.",
+  "title": "a schema for umbraco's package.manifest files.",
   "type": "object"
 }

--- a/src/schemas/json/package.manifest.json
+++ b/src/schemas/json/package.manifest.json
@@ -396,6 +396,6 @@
       }
     }
   },
-  "title": "A schema for Umbraco's package.manifest files.",
+  "title": "a schema for umbraco's package.manifest files.",
   "type": "object"
 }

--- a/src/schemas/json/petstore-v1.0.json
+++ b/src/schemas/json/petstore-v1.0.json
@@ -16,7 +16,7 @@
           }
         }
       },
-      "title": "Welcome9"
+      "title": "welcome9"
     },
     "Config": {
       "type": "object",
@@ -56,7 +56,7 @@
         "target",
         "tls"
       ],
-      "title": "Config"
+      "title": "config"
     },
     "Environments": {
       "type": "object",
@@ -70,7 +70,7 @@
         }
       },
       "required": ["dev", "qa"],
-      "title": "Environments"
+      "title": "environments"
     },
     "Dev": {
       "type": "object",
@@ -87,7 +87,7 @@
         }
       },
       "required": ["phases", "target"],
-      "title": "Dev"
+      "title": "dev"
     },
     "DevPhase": {
       "type": "object",
@@ -101,7 +101,7 @@
         }
       },
       "required": ["arrivalRate", "duration"],
-      "title": "DevPhase"
+      "title": "devphase"
     },
     "HTTP": {
       "type": "object",
@@ -112,7 +112,7 @@
         }
       },
       "required": ["timeout"],
-      "title": "HTTP"
+      "title": "http"
     },
     "ConfigPhase": {
       "type": "object",
@@ -129,7 +129,7 @@
         }
       },
       "required": ["arrivalRate", "duration", "name"],
-      "title": "ConfigPhase"
+      "title": "configphase"
     },
     "Plugins": {
       "type": "object",
@@ -149,7 +149,7 @@
         }
       },
       "required": ["expect", "metrics-by-endpoint", "publish-metrics"],
-      "title": "Plugins"
+      "title": "plugins"
     },
     "PluginsExpect": {
       "type": "object",
@@ -160,7 +160,7 @@
         }
       },
       "required": ["outputFormat"],
-      "title": "PluginsExpect"
+      "title": "pluginsexpect"
     },
     "MetricsByEndpoint": {
       "type": "object",
@@ -171,7 +171,7 @@
         }
       },
       "required": ["useOnlyRequestNames"],
-      "title": "MetricsByEndpoint"
+      "title": "metricsbyendpoint"
     },
     "PublishMetric": {
       "type": "object",
@@ -200,7 +200,7 @@
         }
       },
       "required": ["event", "host", "port", "prefix", "tags", "type"],
-      "title": "PublishMetric"
+      "title": "publishmetric"
     },
     "Event": {
       "type": "object",
@@ -226,7 +226,7 @@
         }
       },
       "required": ["priority", "send", "status", "tags", "title"],
-      "title": "Event"
+      "title": "event"
     },
     "TLS": {
       "type": "object",
@@ -237,7 +237,7 @@
         }
       },
       "required": ["rejectUnauthorized"],
-      "title": "TLS"
+      "title": "tls"
     },
     "Scenario": {
       "type": "object",
@@ -251,7 +251,7 @@
         }
       },
       "required": ["flow"],
-      "title": "Scenario"
+      "title": "scenario"
     },
     "Flow": {
       "type": "object",
@@ -271,7 +271,7 @@
         }
       },
       "required": [],
-      "title": "Flow"
+      "title": "flow"
     },
     "Delete": {
       "type": "object",
@@ -294,7 +294,7 @@
         }
       },
       "required": ["expect", "headers", "name", "url"],
-      "title": "Delete"
+      "title": "delete"
     },
     "ExpectElement": {
       "type": "object",
@@ -305,7 +305,7 @@
         }
       },
       "required": ["statusCode"],
-      "title": "ExpectElement"
+      "title": "expectelement"
     },
     "DeleteHeaders": {
       "type": "object",
@@ -322,7 +322,7 @@
         }
       },
       "required": ["accept", "api_key", "contentType"],
-      "title": "DeleteHeaders"
+      "title": "deleteheaders"
     },
     "Get": {
       "type": "object",
@@ -348,7 +348,7 @@
         }
       },
       "required": ["expect", "headers", "name", "url"],
-      "title": "Get"
+      "title": "get"
     },
     "GetHeaders": {
       "type": "object",
@@ -362,7 +362,7 @@
         }
       },
       "required": ["accept"],
-      "title": "GetHeaders"
+      "title": "getheaders"
     },
     "Qs": {
       "type": "object",
@@ -376,7 +376,7 @@
         }
       },
       "required": ["password", "username"],
-      "title": "Qs"
+      "title": "qs"
     },
     "Post": {
       "type": "object",
@@ -408,7 +408,7 @@
         }
       },
       "required": ["expect", "headers", "json", "name", "url"],
-      "title": "Post"
+      "title": "post"
     },
     "Capture": {
       "type": "object",
@@ -422,7 +422,7 @@
         }
       },
       "required": ["as", "json"],
-      "title": "Capture"
+      "title": "capture"
     },
     "PostHeaders": {
       "type": "object",
@@ -436,7 +436,7 @@
         }
       },
       "required": ["Content-Type", "accept"],
-      "title": "PostHeaders"
+      "title": "postheaders"
     },
     "JSON": {
       "type": "object",
@@ -489,7 +489,7 @@
         }
       },
       "required": ["id"],
-      "title": "JSON"
+      "title": "json"
     },
     "Category": {
       "type": "object",
@@ -503,7 +503,7 @@
         }
       },
       "required": ["id", "name"],
-      "title": "Category"
+      "title": "category"
     }
   }
 }

--- a/src/schemas/json/pgap_yaml_input_reader.json
+++ b/src/schemas/json/pgap_yaml_input_reader.json
@@ -8,7 +8,7 @@
     "$schema": {
       "$id": "/$schema",
       "type": "string",
-      "title": "Schema",
+      "title": "schema",
       "description": "The value of this keyword MUST be a URI (containing a scheme) and this URI MUST be normalized. ",
       "default": "",
       "examples": ["https://json.schemastore.org/pgap_yaml_input_reader"]
@@ -16,7 +16,7 @@
     "consortium": {
       "$id": "/properties/consortium",
       "type": "string",
-      "title": "Consortium",
+      "title": "consortium",
       "description": "Name of the project that generated the genome assembly",
       "default": "",
       "examples": ["SkyNet"]
@@ -24,7 +24,7 @@
     "comment": {
       "$id": "/properties/comment",
       "type": "string",
-      "title": "Free text comment about the genome assembly",
+      "title": "free text comment about the genome assembly",
       "description": "Appears in the COMMENT section of each GenBank sequence record.",
       "default": "",
       "examples": [
@@ -34,7 +34,7 @@
     "tp_assembly": {
       "$id": "/properties/tp_assembly",
       "type": "boolean",
-      "title": "Reserved",
+      "title": "reserved",
       "description": "NCBI internal flag used for testing.",
       "default": false,
       "examples": [false]
@@ -42,7 +42,7 @@
     "sra": {
       "$id": "/properties/sra",
       "type": "array",
-      "title": "SRA assembly data",
+      "title": "sra assembly data",
       "description": "Sequence reads used to build the assembly",
       "items": {
         "$id": "/properties/sra/items",
@@ -53,7 +53,7 @@
           "accession": {
             "$id": "/properties/sra/items/properties/accession",
             "type": "string",
-            "title": "SRA Accession",
+            "title": "sra accession",
             "description": "Sequence Read Archive (SRA) accession for the run (with SRR, ERR or DRR prefix)",
             "default": "",
             "examples": ["SRR8796989"]
@@ -64,7 +64,7 @@
     "authors": {
       "$id": "/properties/authors",
       "type": "array",
-      "title": "Author(s) of the genome assembly",
+      "title": "author(s) of the genome assembly",
       "description": "Optional, but include if intending to submit to GenBank. Authors can be different from the contact.",
       "items": {
         "$id": "/properties/authors/items",
@@ -81,21 +81,21 @@
               "first_name": {
                 "$id": "/properties/authors/items/properties/author/properties/first_name",
                 "type": "string",
-                "title": "First name",
+                "title": "first name",
                 "default": "",
                 "examples": ["Arnold"]
               },
               "last_name": {
                 "$id": "/properties/authors/items/properties/author/properties/last_name",
                 "type": "string",
-                "title": "Last name",
+                "title": "last name",
                 "default": "",
                 "examples": ["Schwarzenegger"]
               },
               "middle_initial": {
                 "$id": "/properties/authors/items/properties/author/properties/middle_initial",
                 "type": "string",
-                "title": "First letter of middle name",
+                "title": "first letter of middle name",
                 "default": "",
                 "examples": ["T800"]
               }
@@ -107,21 +107,21 @@
     "bioproject": {
       "$id": "/properties/bioproject",
       "type": "string",
-      "title": "BioProject ID (PRJXX) for the project, if available",
+      "title": "bioproject id (prjxx) for the project, if available",
       "default": "",
       "examples": ["PRJ9999999"]
     },
     "biosample": {
       "$id": "/properties/biosample",
       "type": "string",
-      "title": "BioSample ID (SAMXXX) for the sequenced sample, if available",
+      "title": "biosample id (samxxx) for the sequenced sample, if available",
       "default": "",
       "examples": ["SAMN99999999"]
     },
     "contact_info": {
       "$id": "/properties/contact_info",
       "type": "object",
-      "title": "Submitter contact information",
+      "title": "submitter contact information",
       "description": "Optional, but include if intending to submit to GenBank. The main contact for this genome assembly.",
       "additionalProperties": false,
       "required": [
@@ -139,91 +139,91 @@
         "state": {
           "$id": "/properties/contact_info/properties/state",
           "type": "string",
-          "title": "State or region",
+          "title": "state or region",
           "default": "",
           "examples": ["MD", "Florida"]
         },
         "fax": {
           "$id": "/properties/contact_info/properties/fax",
           "type": "string",
-          "title": "Fax number",
+          "title": "fax number",
           "default": "",
           "examples": ["301-555-1234", "+7 095 555 1234"]
         },
         "city": {
           "$id": "/properties/contact_info/properties/city",
           "type": "string",
-          "title": "City",
+          "title": "city",
           "default": "",
           "examples": ["Docker"]
         },
         "country": {
           "$id": "/properties/contact_info/properties/country",
           "type": "string",
-          "title": "Country",
+          "title": "country",
           "default": "",
           "examples": ["Lappland"]
         },
         "department": {
           "$id": "/properties/contact_info/properties/department",
           "type": "string",
-          "title": "Department or division submitting the genome assembly",
+          "title": "department or division submitting the genome assembly",
           "default": "",
           "examples": ["Department of Using NCBI"]
         },
         "email": {
           "$id": "/properties/contact_info/properties/email",
           "type": "string",
-          "title": "Email address",
+          "title": "email address",
           "default": "",
           "examples": ["jane_doe@gmail.com"]
         },
         "first_name": {
           "$id": "/properties/contact_info/properties/first_name",
           "type": "string",
-          "title": "First name",
+          "title": "first name",
           "default": "",
           "examples": ["Jane"]
         },
         "middle_initial": {
           "$id": "/properties/contact_info/properties/middle_initial",
           "type": "string",
-          "title": "First letter of middle name",
+          "title": "first letter of middle name",
           "default": "",
           "examples": ["N"]
         },
         "last_name": {
           "$id": "/properties/contact_info/properties/last_name",
           "type": "string",
-          "title": "Last name",
+          "title": "last name",
           "default": "",
           "examples": ["Doe"]
         },
         "organization": {
           "$id": "/properties/contact_info/properties/organization",
           "type": "string",
-          "title": "Organization or consortium submitting the genome assembly",
+          "title": "organization or consortium submitting the genome assembly",
           "default": "",
           "examples": ["Institute of Klebsiella foobarensis research"]
         },
         "phone": {
           "$id": "/properties/contact_info/properties/phone",
           "type": "string",
-          "title": "Phone number",
+          "title": "phone number",
           "default": "",
           "examples": ["301-555-0245"]
         },
         "postal_code": {
           "$id": "/properties/contact_info/properties/postal_code",
           "type": "string",
-          "title": "Postal code",
+          "title": "postal code",
           "default": "",
           "examples": ["12345"]
         },
         "street": {
           "$id": "/properties/contact_info/properties/street",
           "type": "string",
-          "title": "Street address",
+          "title": "street address",
           "default": "",
           "examples": ["1234 Main St"]
         }
@@ -237,14 +237,14 @@
         "class": {
           "$id": "/properties/fasta/properties/class",
           "type": "string",
-          "title": "Class of input type",
+          "title": "class of input type",
           "default": "",
           "examples": ["File"]
         },
         "location": {
           "$id": "/properties/fasta/properties/location",
           "type": "string",
-          "title": "Location of input file",
+          "title": "location of input file",
           "default": "",
           "examples": ["sample_fasta_input.fasta"]
         }
@@ -253,7 +253,7 @@
     "locus_tag_prefix": {
       "$id": "/properties/locus_tag_prefix",
       "type": "string",
-      "title": "Locus tag prefix",
+      "title": "locus tag prefix",
       "description": "One to 9-letter prefix to use for naming genes on this genome assembly. If an official locus tag prefix was already reserved from an INSDC organization (GenBank, ENA or DDBJ) for the given BioSample and BioProject pair, provide here. Otherwise, provide a string of your choice. If no value is provided, the prefix 'pgaptmp' will be used. See more details in this Note about locus tags at: https://github.com/ncbi/pgap/wiki/Input-Files#Note-about-locus-tags",
       "default": "",
       "examples": ["tmp"]
@@ -266,7 +266,7 @@
         "strain": {
           "$id": "/properties/organism/properties/strain",
           "type": "string",
-          "title": "Strain",
+          "title": "strain",
           "description": "Strain of the sequenced organism",
           "default": "",
           "examples": ["my_strain"]
@@ -274,7 +274,7 @@
         "genus_species": {
           "$id": "/properties/organism/properties/genus_species",
           "type": "string",
-          "title": "Genus and species",
+          "title": "genus and species",
           "description": "Binomial name or, if the species is unknown, genus for the sequenced organism. This identifier must be valid in NCBI Taxonomy. See Taxonomy information for how to find out if the name is valid: https://github.com/ncbi/pgap/wiki/Input-Files#Taxonomy-information",
           "default": "",
           "examples": ["Escherichia coli"]
@@ -284,7 +284,7 @@
     "publications": {
       "$id": "/properties/publications",
       "type": "array",
-      "title": "Publication describing the genome assembly",
+      "title": "publication describing the genome assembly",
       "items": {
         "$id": "/properties/publications/items",
         "type": "object",
@@ -298,7 +298,7 @@
             "properties": {
               "authors": {
                 "$id": "/properties/publications/items/properties/publication/properties/authors",
-                "title": "Author(s)",
+                "title": "author(s)",
                 "type": "array",
                 "items": {
                   "$id": "/properties/publications/items/properties/publication/properties/authors/items",
@@ -314,21 +314,21 @@
                         "first_name": {
                           "$id": "/properties/publications/items/properties/publication/properties/authors/items/properties/author/properties/first_name",
                           "type": "string",
-                          "title": "First name",
+                          "title": "first name",
                           "default": "",
                           "examples": ["Arnold"]
                         },
                         "last_name": {
                           "$id": "/properties/publications/items/properties/publication/properties/authors/items/properties/author/properties/last_name",
                           "type": "string",
-                          "title": "Last name",
+                          "title": "last name",
                           "default": "",
                           "examples": ["Schwarzenegger"]
                         },
                         "middle_initial": {
                           "$id": "/properties/publications/items/properties/publication/properties/authors/items/properties/author/properties/middle_initial",
                           "type": "string",
-                          "title": "First letter of middle name",
+                          "title": "first letter of middle name",
                           "default": "",
                           "examples": ["T800"]
                         }
@@ -340,7 +340,7 @@
               "status": {
                 "$id": "/properties/publications/items/properties/publication/properties/status",
                 "type": "string",
-                "title": "Publication status",
+                "title": "publication status",
                 "description": "Can be only one of: published, in-press, unpublished",
                 "default": "",
                 "enum": ["published", "in-press", "unpublished"]
@@ -348,13 +348,13 @@
               "pmid": {
                 "$id": "/properties/publications/items/properties/publication/properties/pmid",
                 "type": "integer",
-                "title": "PubMed ID for the publication",
+                "title": "pubmed id for the publication",
                 "default": ""
               },
               "title": {
                 "$id": "/properties/publications/items/properties/publication/properties/title",
                 "type": "string",
-                "title": "Title",
+                "title": "title",
                 "default": "",
                 "examples": [
                   "Discrete CHARMm of Klebsiella foobarensis. Journal of Improbable Results, vol. 34, issue 13, pages: 10001-100005, 2018"
@@ -368,7 +368,7 @@
     "topology": {
       "$id": "/properties/topology",
       "type": "string",
-      "title": "Topology of the sequences included in the fasta file",
+      "title": "topology of the sequences included in the fasta file",
       "description": "Possible values are linear or circular. Circular means that the first base in the sequence is adjacent to the last base. Please provide the topology in the metadata YAML file only if it is applicable to ALL sequences in the fasta file. If some sequences in the assembled genome are circular and others linear, include the topology in the definition line of each sequence in the fasta file with the tag value pair [topology=circular] or [topology=linear], after the SeqID and a space (e.g. >seq1 [topology=circular]). If the topology is provided in neither the metadata YAML nor the fasta file, the sequences will be presumed to be linear.",
       "default": "",
       "examples": ["circular", "linear"]
@@ -376,13 +376,13 @@
     "location": {
       "$id": "/properties/location",
       "type": "string",
-      "title": "Location of the sequences included in the fasta file",
+      "title": "location of the sequences included in the fasta file",
       "description": "Possible values are chromosome or plasmid. Please provide the location in the metadata YAML file only if it is applicable to ALL sequences in the fasta file. If some sequences in the assembled genome are chromosomes and others plasmids, include the location in the definition line of each sequence in the fasta file with the tag value pair [location=chromosome] or [location=plasmid], after the SeqID and a space (e.g. >seq1 [location=plasmid]). In plasmid case add [plasmid-name=<plasmidname>]. If the location is provided in neither the metadata YAML nor the fasta file, the sequences will be presumed to be chromosome. Note: since 2021 releases of PGAPx this will affect noticeably the annotation on the molecule",
       "default": "",
       "examples": ["chromosome", "plasmid"]
     }
   },
   "required": ["authors", "contact_info"],
-  "title": "NCBI PGAP submol YAML",
+  "title": "ncbi pgap submol yaml",
   "type": "object"
 }

--- a/src/schemas/json/phraseapp.json
+++ b/src/schemas/json/phraseapp.json
@@ -211,5 +211,5 @@
       }
     }
   },
-  "title": "JSON schema for PhraseApp configuration files"
+  "title": "json schema for phraseapp configuration files"
 }

--- a/src/schemas/json/plagiarize-0.0.json
+++ b/src/schemas/json/plagiarize-0.0.json
@@ -40,6 +40,6 @@
     }
   },
   "required": ["repo", "strings"],
-  "title": "Plagiarize configuration",
+  "title": "plagiarize configuration",
   "type": "object"
 }

--- a/src/schemas/json/plagiarize-me-0.0.json
+++ b/src/schemas/json/plagiarize-me-0.0.json
@@ -620,6 +620,6 @@
     }
   },
   "required": ["replace"],
-  "title": "Plagiarize Me Configuration",
+  "title": "plagiarize me configuration",
   "type": "object"
 }

--- a/src/schemas/json/plagiarize-me.json
+++ b/src/schemas/json/plagiarize-me.json
@@ -620,6 +620,6 @@
     }
   },
   "required": ["replace"],
-  "title": "Plagiarize Me Configuration",
+  "title": "plagiarize me configuration",
   "type": "object"
 }

--- a/src/schemas/json/plagiarize.json
+++ b/src/schemas/json/plagiarize.json
@@ -40,6 +40,6 @@
     }
   },
   "required": ["repo", "strings"],
-  "title": "Plagiarize configuration",
+  "title": "plagiarize configuration",
   "type": "object"
 }

--- a/src/schemas/json/pm2-ecosystem.json
+++ b/src/schemas/json/pm2-ecosystem.json
@@ -361,6 +361,6 @@
       }
     }
   },
-  "title": "PM2 ecosystem config file",
+  "title": "pm2 ecosystem config file",
   "type": "object"
 }

--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -249,6 +249,6 @@
     }
   },
   "required": ["repos"],
-  "title": "JSON schema for .pre-commit-config.yaml",
+  "title": "json schema for .pre-commit-config.yaml",
   "type": "object"
 }

--- a/src/schemas/json/prettierrc-1.8.2.json
+++ b/src/schemas/json/prettierrc-1.8.2.json
@@ -139,6 +139,6 @@
       }
     }
   },
-  "title": "Schema for .prettierrc",
+  "title": "schema for .prettierrc",
   "type": "object"
 }

--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -404,5 +404,5 @@
       "type": "string"
     }
   ],
-  "title": "Schema for .prettierrc"
+  "title": "schema for .prettierrc"
 }

--- a/src/schemas/json/prisma.json
+++ b/src/schemas/json/prisma.json
@@ -119,5 +119,5 @@
     }
   },
   "required": ["datamodel"],
-  "title": "JSON schema for Prisma prisma.yml files"
+  "title": "json schema for prisma prisma.yml files"
 }

--- a/src/schemas/json/project-1.0.0-beta3.json
+++ b/src/schemas/json/project-1.0.0-beta3.json
@@ -198,6 +198,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for ASP.NET project.json files",
+  "title": "json schema for asp.net project.json files",
   "type": "object"
 }

--- a/src/schemas/json/project-1.0.0-beta4.json
+++ b/src/schemas/json/project-1.0.0-beta4.json
@@ -347,6 +347,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for ASP.NET project.json files",
+  "title": "json schema for asp.net project.json files",
   "type": "object"
 }

--- a/src/schemas/json/project-1.0.0-beta5.json
+++ b/src/schemas/json/project-1.0.0-beta5.json
@@ -256,6 +256,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for ASP.NET project.json files",
+  "title": "json schema for asp.net project.json files",
   "type": "object"
 }

--- a/src/schemas/json/project-1.0.0-beta6.json
+++ b/src/schemas/json/project-1.0.0-beta6.json
@@ -281,6 +281,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for ASP.NET project.json files",
+  "title": "json schema for asp.net project.json files",
   "type": "object"
 }

--- a/src/schemas/json/project-1.0.0-beta8.json
+++ b/src/schemas/json/project-1.0.0-beta8.json
@@ -389,6 +389,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for DNX project.json files",
+  "title": "json schema for dnx project.json files",
   "type": "object"
 }

--- a/src/schemas/json/project-1.0.0-rc1.json
+++ b/src/schemas/json/project-1.0.0-rc1.json
@@ -389,6 +389,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for DNX project.json files",
+  "title": "json schema for dnx project.json files",
   "type": "object"
 }

--- a/src/schemas/json/project-1.0.0-rc2.json
+++ b/src/schemas/json/project-1.0.0-rc2.json
@@ -829,6 +829,6 @@
       "type": "object"
     }
   },
-  "title": "JSON schema for .NET Core project.json files",
+  "title": "json schema for .net core project.json files",
   "type": "object"
 }

--- a/src/schemas/json/project.json
+++ b/src/schemas/json/project.json
@@ -869,6 +869,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for .NET Core project.json files",
+  "title": "json schema for .net core project.json files",
   "type": "object"
 }

--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -1454,6 +1454,6 @@
       }
     }
   },
-  "title": "Prometheus",
+  "title": "prometheus",
   "type": ["object", "null"]
 }

--- a/src/schemas/json/prometheus.rules.json
+++ b/src/schemas/json/prometheus.rules.json
@@ -123,6 +123,6 @@
       }
     }
   },
-  "title": "Prometheus Rules",
+  "title": "prometheus rules",
   "type": ["object", "null"]
 }

--- a/src/schemas/json/proxies.json
+++ b/src/schemas/json/proxies.json
@@ -244,6 +244,6 @@
     }
   },
   "required": ["proxies"],
-  "title": "JSON schema for Azure Functions Proxies proxies.json files",
+  "title": "json schema for azure functions proxies proxies.json files",
   "type": "object"
 }

--- a/src/schemas/json/publiccode.json
+++ b/src/schemas/json/publiccode.json
@@ -622,6 +622,6 @@
     "maintenance",
     "localisation"
   ],
-  "title": "JSON schema for publiccode.yml",
+  "title": "json schema for publiccode.yml",
   "type": "object"
 }

--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -41,7 +41,7 @@
           "$comment": "Syntax in yaml: `foo:` or `foo: null`"
         },
         {
-          "title": "SDK dependency",
+          "title": "sdk dependency",
           "type": "object",
           "properties": {
             "sdk": {
@@ -56,7 +56,7 @@
           "additionalProperties": false
         },
         {
-          "title": "Hosted dependency",
+          "title": "hosted dependency",
           "type": "object",
           "properties": {
             "hosted": {
@@ -206,6 +206,6 @@
     }
   },
   "required": ["name"],
-  "title": "Pubspec",
+  "title": "pubspec",
   "type": "object"
 }

--- a/src/schemas/json/pull-request-labeler.json
+++ b/src/schemas/json/pull-request-labeler.json
@@ -2,7 +2,7 @@
   "$comment": "https://github.com/actions/labeler",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": {
-    "title": "Label",
+    "title": "label",
     "type": ["string", "array"],
     "items": {
       "anyOf": [
@@ -12,14 +12,14 @@
         {
           "properties": {
             "any": {
-              "title": "Any",
+              "title": "any",
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
             "all": {
-              "title": "All",
+              "title": "all",
               "type": "array",
               "items": {
                 "type": "string"
@@ -31,6 +31,6 @@
     }
   },
   "description": "A GitHub Action for automatically labelling pull requests.",
-  "title": "Pull Request Labeler",
+  "title": "pull request labeler",
   "type": "object"
 }

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -23,11 +23,11 @@
       ],
       "properties": {
         "name": {
-          "title": "Author name",
+          "title": "author name",
           "type": "string"
         },
         "email": {
-          "title": "Author email",
+          "title": "author email",
           "type": "string",
           "format": "email"
         }
@@ -434,7 +434,7 @@
       ]
     },
     "BuildSystem": {
-      "title": "Project build system configuration",
+      "title": "project build system configuration",
       "$comment": "see PEP 517 (https://peps.python.org/pep-0517/) and PEP 518 (https://peps.python.org/pep-0518/)",
       "type": "object",
       "x-taplo": {
@@ -447,7 +447,7 @@
       "required": ["requires"],
       "properties": {
         "requires": {
-          "title": "Build system dependencies",
+          "title": "build system dependencies",
           "description": "A list of strings representing [PEP 508](https://www.python.org/dev/peps/pep-0508) dependencies required to execute the build system.\n",
           "type": "array",
           "items": {
@@ -461,7 +461,7 @@
           "examples": ["setuptools >= 64.0"]
         },
         "build-backend": {
-          "title": "Build backend",
+          "title": "build backend",
           "description": "Python path to project's build backend",
           "type": "string",
           "x-taplo": {
@@ -472,7 +472,7 @@
           "examples": ["setuptools.build_meta", "my_build_backend:backend"]
         },
         "backend-path": {
-          "title": "Build backend directories",
+          "title": "build backend directories",
           "description": "paths to prepend to 'sys.path' when loading the build backend, relative to project root",
           "type": "array",
           "items": {
@@ -487,7 +487,7 @@
       "$ref": "#/definitions/BuildSystem"
     },
     "tool": {
-      "title": "Tool-specific configuration",
+      "title": "tool-specific configuration",
       "type": "object",
       "description": "A table for tool configurations.\n\nEvery tool that is used by the project can have its own sub-table for its configuration.\n",
       "additionalProperties": {
@@ -742,33 +742,33 @@
       ]
     },
     "project": {
-      "title": "Project metadata",
+      "title": "project metadata",
       "$comment": "see PEP 621 (https://peps.python.org/pep-0621/)",
       "type": "object",
       "additionalProperties": false,
       "required": ["name"],
       "properties": {
         "name": {
-          "title": "Project name",
+          "title": "project name",
           "type": "string",
           "pattern": "^([a-zA-Z\\d]|[a-zA-Z\\d][\\w.-]*[a-zA-Z\\d])$"
         },
         "version": {
-          "title": "Project version",
+          "title": "project version",
           "type": "string",
           "pattern": "^([1-9]\\d*!)?(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))*((a|b|rc)(0|[1-9]\\d*))?(\\.post(0|[1-9]\\d*))?(\\.dev(0|[1-9]\\d*))?$",
           "examples": ["42.0.1", "0.3.9rc7.post0.dev5"]
         },
         "description": {
-          "title": "Project summary description",
+          "title": "project summary description",
           "type": "string"
         },
         "readme": {
-          "title": "Project full description",
+          "title": "project full description",
           "description": "AKA the README",
           "oneOf": [
             {
-              "title": "README file path",
+              "title": "readme file path",
               "type": "string"
             },
             {
@@ -776,7 +776,7 @@
               "required": ["content-type"],
               "properties": {
                 "content-type": {
-                  "title": "README text content-type",
+                  "title": "readme text content-type",
                   "description": "RFC 1341 compliant content-type (with optional charset, defaulting to UTF-8)",
                   "type": "string"
                 }
@@ -788,7 +788,7 @@
                   "properties": {
                     "content-type": true,
                     "file": {
-                      "title": "README file path",
+                      "title": "readme file path",
                       "type": "string"
                     }
                   }
@@ -799,7 +799,7 @@
                   "properties": {
                     "content-type": true,
                     "text": {
-                      "title": "README text",
+                      "title": "readme text",
                       "type": "string"
                     }
                   }
@@ -820,12 +820,12 @@
           ]
         },
         "requires-python": {
-          "title": "Python version compatibility",
+          "title": "python version compatibility",
           "type": "string",
           "examples": [">= 3.7"]
         },
         "license": {
-          "title": "Project license",
+          "title": "project license",
           "oneOf": [
             {
               "type": "object",
@@ -833,7 +833,7 @@
               "required": ["file"],
               "properties": {
                 "file": {
-                  "title": "License file path",
+                  "title": "license file path",
                   "type": "string"
                 }
               }
@@ -844,7 +844,7 @@
               "required": ["text"],
               "properties": {
                 "text": {
-                  "title": "License text",
+                  "title": "license text",
                   "type": "string"
                 }
               }
@@ -866,35 +866,35 @@
           ]
         },
         "authors": {
-          "title": "Project authors",
+          "title": "project authors",
           "type": "array",
           "items": {
             "$ref": "#/definitions/projectAuthor"
           }
         },
         "maintainers": {
-          "title": "Project maintainers",
+          "title": "project maintainers",
           "type": "array",
           "items": {
             "$ref": "#/definitions/projectAuthor"
           }
         },
         "keywords": {
-          "title": "Project keywords",
+          "title": "project keywords",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "classifiers": {
-          "title": "Applicable Trove classifiers",
+          "title": "applicable trove classifiers",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "urls": {
-          "title": "Project URLs",
+          "title": "project urls",
           "type": "object",
           "additionalProperties": {
             "type": "string",
@@ -907,7 +907,7 @@
           ]
         },
         "scripts": {
-          "title": "Console scripts",
+          "title": "console scripts",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -919,7 +919,7 @@
           ]
         },
         "gui-scripts": {
-          "title": "GUI scripts",
+          "title": "gui scripts",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -931,7 +931,7 @@
           ]
         },
         "entry-points": {
-          "title": "Other entry-point groups",
+          "title": "other entry-point groups",
           "type": "object",
           "additionalProperties": false,
           "patternProperties": {
@@ -963,7 +963,7 @@
           ]
         },
         "dependencies": {
-          "title": "Project dependency requirements",
+          "title": "project dependency requirements",
           "type": "array",
           "items": {
             "type": "string"
@@ -971,7 +971,7 @@
           "examples": [["attrs", "requests ~= 2.28"]]
         },
         "optional-dependencies": {
-          "title": "Project extra dependency requirements",
+          "title": "project extra dependency requirements",
           "description": "keys are extra names",
           "type": "object",
           "additionalProperties": false,
@@ -990,7 +990,7 @@
           ]
         },
         "dynamic": {
-          "title": "Dynamic metadata values",
+          "title": "dynamic metadata values",
           "type": "array",
           "items": {
             "type": "string",
@@ -1233,7 +1233,7 @@
       }
     }
   },
-  "title": "JSON schema for Python project metadata and configuration",
+  "title": "json schema for python project metadata and configuration",
   "type": "object",
   "x-taplo-info": {
     "authors": ["zevisert (https://github.com/zevisert)"],

--- a/src/schemas/json/pyrseas-0.8.json
+++ b/src/schemas/json/pyrseas-0.8.json
@@ -1041,5 +1041,5 @@
       "$ref": "#/definitions/schema"
     }
   ],
-  "title": "JSON schema for Pyrseas yaml files"
+  "title": "json schema for pyrseas yaml files"
 }

--- a/src/schemas/json/qodana-1.0.json
+++ b/src/schemas/json/qodana-1.0.json
@@ -307,6 +307,6 @@
     }
   },
   "required": ["version"],
-  "title": "Qodana",
+  "title": "qodana",
   "type": "object"
 }

--- a/src/schemas/json/rehyperc.json
+++ b/src/schemas/json/rehyperc.json
@@ -156,6 +156,6 @@
       }
     }
   },
-  "title": "JSON schema for .rehyperc",
+  "title": "json schema for .rehyperc",
   "type": "object"
 }

--- a/src/schemas/json/remarkrc.json
+++ b/src/schemas/json/remarkrc.json
@@ -112,6 +112,6 @@
       }
     }
   },
-  "title": "JSON schema for .remarkrc",
+  "title": "json schema for .remarkrc",
   "type": "object"
 }

--- a/src/schemas/json/renovate.json
+++ b/src/schemas/json/renovate.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://docs.renovatebot.com/renovate-schema.json",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Deprecated JSON schema for Renovate, please use https://docs.renovatebot.com/renovate-schema.json"
+  "title": "deprecated json schema for renovate, please use https://docs.renovatebot.com/renovate-schema.json"
 }

--- a/src/schemas/json/replit.json
+++ b/src/schemas/json/replit.json
@@ -215,7 +215,7 @@
       "additionalProperties": false
     }
   },
-  "title": "Repl.it config schema (.replit)",
+  "title": "repl.it config schema (.replit)",
   "type": "object",
   "x-taplo-info": {
     "authors": ["Emily Grace Seville (https://github.com/EmilySeville7cfg)"],

--- a/src/schemas/json/resjson.json
+++ b/src/schemas/json/resjson.json
@@ -27,6 +27,6 @@
       }
     }
   },
-  "title": "JSON schema for Windows resource files (.resjson)",
+  "title": "json schema for windows resource files (.resjson)",
   "type": "object"
 }

--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -1126,6 +1126,6 @@
       }
     }
   },
-  "title": "Options",
+  "title": "options",
   "type": "object"
 }

--- a/src/schemas/json/rust-project.json
+++ b/src/schemas/json/rust-project.json
@@ -6,23 +6,23 @@
       "properties": {
         "display_name": {
           "description": "Crate name used for display purposes, without affecting semantics.",
-          "title": "Display name",
+          "title": "display name",
           "type": "string"
         },
         "root_module": {
           "description": "Path to the root module of the crate.",
-          "title": "Root module",
+          "title": "root module",
           "type": "string"
         },
         "edition": {
           "description": "Edition of the crate.",
-          "title": "Edition",
+          "title": "edition",
           "type": "string",
           "enum": ["2015", "2018", "2021"]
         },
         "deps": {
           "description": "Crate dependencies.",
-          "title": "Dependencies",
+          "title": "dependencies",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -31,22 +31,22 @@
         },
         "version": {
           "description": "The crate's version",
-          "title": "Version",
+          "title": "version",
           "type": "string",
           "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$"
         },
         "is_workspace_member": {
           "description": "Whether this crate should be treated as a member of the current \"workspace\".",
-          "title": "Is workspace member?",
+          "title": "is workspace member?",
           "type": "boolean"
         },
         "source": {
           "description": "(Super)set of `.rs` files comprising this crate.",
-          "title": "Source",
+          "title": "source",
           "type": "object",
           "properties": {
             "include_dirs": {
-              "title": "Included directories",
+              "title": "included directories",
               "type": "array",
               "uniqueItems": true,
               "items": {
@@ -54,7 +54,7 @@
               }
             },
             "exclude_dirs": {
-              "title": "Excluded directories",
+              "title": "excluded directories",
               "type": "array",
               "uniqueItems": true,
               "items": {
@@ -66,7 +66,7 @@
         },
         "cfg": {
           "description": "The set of cfgs activated for a given crate.",
-          "title": "Configurations",
+          "title": "configurations",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -75,12 +75,12 @@
         },
         "target": {
           "description": "Target triple for this crate.",
-          "title": "Target",
+          "title": "target",
           "type": "string"
         },
         "env": {
           "description": "Environment variables, used for the `env!` macro",
-          "title": "Environment variables",
+          "title": "environment variables",
           "type": "object",
           "patternProperties": {
             "^.*$": {
@@ -91,34 +91,34 @@
         },
         "is_proc_macro": {
           "description": "Whether the crate is a proc-macro crate.",
-          "title": "Is proc-macro?",
+          "title": "is proc-macro?",
           "type": "boolean"
         },
         "proc_macro_dylib_path": {
           "description": "For proc-macro crates, path to compiled proc-macro (.so file).",
-          "title": "Path to compiled proc-macro",
+          "title": "path to compiled proc-macro",
           "type": "string"
         },
         "repository": {
           "description": "URL to the source repository of the crate.",
-          "title": "Repository",
+          "title": "repository",
           "type": "string"
         }
       },
       "required": ["root_module", "edition", "deps"]
     },
     "dep": {
-      "title": "Dependencies",
+      "title": "dependencies",
       "type": "object",
       "properties": {
         "crate": {
           "description": "Index of a crate in the `crates` array.",
-          "title": "Crate index",
+          "title": "crate index",
           "type": "integer"
         },
         "name": {
           "description": "Name as should appear in the (implicit) `extern crate name` declaration.",
-          "title": "Name",
+          "title": "name",
           "type": "string"
         }
       },
@@ -128,17 +128,17 @@
   "properties": {
     "sysroot": {
       "description": "Path to sysroot.",
-      "title": "Sysroot",
+      "title": "sysroot",
       "type": "string"
     },
     "sysroot_src": {
       "description": "Path to the directory with source code of sysroot crates.",
-      "title": "Sysroot source",
+      "title": "sysroot source",
       "type": "string"
     },
     "crates": {
       "description": "The set of crates comprising the current project.",
-      "title": "Crates",
+      "title": "crates",
       "type": "array",
       "uniqueItems": true,
       "items": {
@@ -147,6 +147,6 @@
     }
   },
   "required": ["crates"],
-  "title": "JSON schema for non-Cargo based Rust projects",
+  "title": "json schema for non-cargo based rust projects",
   "type": "object"
 }

--- a/src/schemas/json/rust-toolchain.json
+++ b/src/schemas/json/rust-toolchain.json
@@ -363,7 +363,7 @@
     }
   },
   "required": ["toolchain"],
-  "title": "Schema for rust-toolchain.toml",
+  "title": "schema for rust-toolchain.toml",
   "type": "object",
   "x-taplo-info": {
     "authors": ["ian-h-chamberlain (https://github.com/ian-h-chamberlain)"],

--- a/src/schemas/json/sarif-1.0.0.json
+++ b/src/schemas/json/sarif-1.0.0.json
@@ -1092,6 +1092,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 1.0.0 JSON Schema",
+  "title": "static analysis results format (sarif) version 1.0.0 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.0.0-csd.2.beta.2018-10-10.json
+++ b/src/schemas/json/sarif-2.0.0-csd.2.beta.2018-10-10.json
@@ -1566,6 +1566,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.0.0-csd.2.beta.2018-10-10 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.0.0-csd.2.beta.2018-10-10 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.0.0-csd.2.beta.2019-01-09.json
+++ b/src/schemas/json/sarif-2.0.0-csd.2.beta.2019-01-09.json
@@ -1781,6 +1781,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.0.0-csd.2.beta.2019-01-09 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.0.0-csd.2.beta.2019-01-09 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.0.0-csd.2.beta.2019-01-24.json
+++ b/src/schemas/json/sarif-2.0.0-csd.2.beta.2019-01-24.json
@@ -1878,6 +1878,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.0.0-csd.2.beta.2019-01-24 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.0.0-csd.2.beta.2019-01-24 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.0.0.json
+++ b/src/schemas/json/sarif-2.0.0.json
@@ -1719,6 +1719,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.0.0 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.0.0 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.1.0-rtm.0.json
+++ b/src/schemas/json/sarif-2.1.0-rtm.0.json
@@ -2858,6 +2858,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.0 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.1.0-rtm.0 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.1.0-rtm.1.json
+++ b/src/schemas/json/sarif-2.1.0-rtm.1.json
@@ -2864,6 +2864,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.1 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.1.0-rtm.1 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.1.0-rtm.2.json
+++ b/src/schemas/json/sarif-2.1.0-rtm.2.json
@@ -2864,6 +2864,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.2 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.1.0-rtm.2 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.1.0-rtm.3.json
+++ b/src/schemas/json/sarif-2.1.0-rtm.3.json
@@ -2864,6 +2864,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.3 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.1.0-rtm.3 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.1.0-rtm.4.json
+++ b/src/schemas/json/sarif-2.1.0-rtm.4.json
@@ -2877,6 +2877,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.4 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.1.0-rtm.4 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.1.0-rtm.5.json
+++ b/src/schemas/json/sarif-2.1.0-rtm.5.json
@@ -2877,6 +2877,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.5 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.1.0-rtm.5 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.1.0.json
+++ b/src/schemas/json/sarif-2.1.0.json
@@ -2877,6 +2877,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.1.0 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.0.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.0.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["version"],
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.0 JSON Schema",
+  "title": "sarif external property file schema version 2.1.0-rtm.0 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.1.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.1.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["version"],
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.1 JSON Schema",
+  "title": "sarif external property file schema version 2.1.0-rtm.1 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.2.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.2.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["version"],
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.2 JSON Schema",
+  "title": "sarif external property file schema version 2.1.0-rtm.2 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.3.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.3.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["version"],
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.3 JSON Schema",
+  "title": "sarif external property file schema version 2.1.0-rtm.3 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.4.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.4.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["version"],
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.4 JSON Schema",
+  "title": "sarif external property file schema version 2.1.0-rtm.4 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-external-property-file-2.1.0-rtm.5.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0-rtm.5.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["version"],
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.5 JSON Schema",
+  "title": "sarif external property file schema version 2.1.0-rtm.5 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-external-property-file-2.1.0.json
+++ b/src/schemas/json/sarif-external-property-file-2.1.0.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["version"],
-  "title": "SARIF External Property File Schema Version 2.1.0 JSON Schema",
+  "title": "sarif external property file schema version 2.1.0 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif-external-property-file.json
+++ b/src/schemas/json/sarif-external-property-file.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["version"],
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.5 JSON Schema",
+  "title": "sarif external property file schema version 2.1.0-rtm.5 json schema",
   "type": "object"
 }

--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -2877,6 +2877,6 @@
     }
   },
   "required": ["version", "runs"],
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.5 JSON Schema",
+  "title": "static analysis results format (sarif) version 2.1.0-rtm.5 json schema",
   "type": "object"
 }

--- a/src/schemas/json/schema-catalog.json
+++ b/src/schemas/json/schema-catalog.json
@@ -56,6 +56,6 @@
     }
   },
   "required": ["schemas", "version", "$schema"],
-  "title": "JSON schema for SchemaStore.org catalog files",
+  "title": "json schema for schemastore.org catalog files",
   "type": "object"
 }

--- a/src/schemas/json/schema-org-action.json
+++ b/src/schemas/json/schema-org-action.json
@@ -110,6 +110,6 @@
     }
   },
   "required": ["@type"],
-  "title": "JSON schema for schema.org / Action",
+  "title": "json schema for schema.org / action",
   "type": "object"
 }

--- a/src/schemas/json/schema-org-contact-point.json
+++ b/src/schemas/json/schema-org-contact-point.json
@@ -166,6 +166,6 @@
     }
   },
   "required": ["@type"],
-  "title": "JSON schema for schema.org / ContactPoint",
+  "title": "json schema for schema.org / contactpoint",
   "type": "object"
 }

--- a/src/schemas/json/schema-org-place.json
+++ b/src/schemas/json/schema-org-place.json
@@ -169,6 +169,6 @@
     }
   },
   "required": ["@type"],
-  "title": "JSON schema for schema.org / Place",
+  "title": "json schema for schema.org / place",
   "type": "object"
 }

--- a/src/schemas/json/schema-org-thing.json
+++ b/src/schemas/json/schema-org-thing.json
@@ -74,7 +74,7 @@
     }
   },
   "required": ["@type"],
-  "title": "JSON schema for schema.org / Thing",
+  "title": "json schema for schema.org / thing",
   "type": "object",
   "version": "1.1"
 }

--- a/src/schemas/json/semantic-release.json
+++ b/src/schemas/json/semantic-release.json
@@ -121,6 +121,6 @@
       "default": true
     }
   },
-  "title": "semantic-release Schema",
+  "title": "semantic-release schema",
   "type": "object"
 }

--- a/src/schemas/json/semgrep.json
+++ b/src/schemas/json/semgrep.json
@@ -2,7 +2,7 @@
   "$defs": {
     "patterns-content": {
       "type": "array",
-      "title": "Return finding where all of the nested conditions are true",
+      "title": "return finding where all of the nested conditions are true",
       "items": {
         "anyOf": [
           {
@@ -52,7 +52,7 @@
     },
     "pattern-either-content": {
       "type": "array",
-      "title": "Return finding where any of the nested conditions are true",
+      "title": "return finding where any of the nested conditions are true",
       "items": {
         "anyOf": [
           {
@@ -81,11 +81,11 @@
             "type": "object",
             "properties": {
               "pattern": {
-                "title": "Return finding where Semgrep pattern matches exactly",
+                "title": "return finding where semgrep pattern matches exactly",
                 "type": "string"
               },
               "pattern-regex": {
-                "title": "Return finding where regular expression matches exactly",
+                "title": "return finding where regular expression matches exactly",
                 "type": "string"
               },
               "patterns": {
@@ -167,7 +167,7 @@
     },
     "r2c-internal-project-depends-on-content": {
       "type": "object",
-      "title": "One or more dependencies that the project contains in a lock file",
+      "title": "one or more dependencies that the project contains in a lock file",
       "properties": {
         "namespace": {
           "type": "string"
@@ -222,7 +222,7 @@
     },
     "join-content": {
       "type": "object",
-      "title": "Join one or more rules together based on metavariable contents",
+      "title": "join one or more rules together based on metavariable contents",
       "properties": {
         "refs": {
           "type": "array",
@@ -373,11 +373,11 @@
               "type": "string"
             },
             "pattern": {
-              "title": "Return finding where Semgrep pattern matches exactly",
+              "title": "return finding where semgrep pattern matches exactly",
               "type": "string"
             },
             "pattern-regex": {
-              "title": "Return finding where regular expression matches exactly",
+              "title": "return finding where regular expression matches exactly",
               "type": "string"
             },
             "patterns": {
@@ -490,7 +490,7 @@
       "type": "object",
       "properties": {
         "pattern": {
-          "title": "Return finding where Semgrep pattern matches exactly",
+          "title": "return finding where semgrep pattern matches exactly",
           "type": "string"
         }
       },
@@ -501,7 +501,7 @@
       "type": "object",
       "properties": {
         "pattern-regex": {
-          "title": "Return finding where regular expression matches",
+          "title": "return finding where regular expression matches",
           "type": "string"
         }
       },
@@ -512,7 +512,7 @@
       "type": "object",
       "properties": {
         "pattern-not-regex": {
-          "title": "Do not return finding where regular expression matches",
+          "title": "do not return finding where regular expression matches",
           "type": "string"
         }
       },
@@ -523,7 +523,7 @@
       "type": "object",
       "properties": {
         "patterns": {
-          "title": "Return finding where all of the nested conditions are true",
+          "title": "return finding where all of the nested conditions are true",
           "$ref": "#/$defs/patterns-content"
         }
       },
@@ -534,7 +534,7 @@
       "type": "object",
       "properties": {
         "pattern-either": {
-          "title": "Return finding where any of the nested conditions are true",
+          "title": "return finding where any of the nested conditions are true",
           "$ref": "#/$defs/pattern-either-content"
         }
       },
@@ -545,7 +545,7 @@
       "type": "object",
       "properties": {
         "focus-metavariable": {
-          "title": "Focus on what a given metavariable is matching",
+          "title": "focus on what a given metavariable is matching",
           "type": "string"
         }
       },
@@ -556,7 +556,7 @@
       "type": "object",
       "properties": {
         "pattern-inside": {
-          "title": "Return findings only from within snippets Semgrep pattern matches",
+          "title": "return findings only from within snippets semgrep pattern matches",
           "type": "string"
         }
       },
@@ -567,7 +567,7 @@
       "type": "object",
       "properties": {
         "pattern-not-inside": {
-          "title": "Do not return findings from within snippets Semgrep pattern matches",
+          "title": "do not return findings from within snippets semgrep pattern matches",
           "type": "string"
         }
       },
@@ -578,7 +578,7 @@
       "type": "object",
       "properties": {
         "pattern-not": {
-          "title": "Do not return finding where Semgrep pattern matches exactly",
+          "title": "do not return finding where semgrep pattern matches exactly",
           "type": "string"
         }
       },
@@ -589,7 +589,7 @@
       "type": "object",
       "properties": {
         "pattern-where-python": {
-          "title": "Return finding where Python expression returns true",
+          "title": "return finding where python expression returns true",
           "type": "string"
         }
       },
@@ -603,7 +603,7 @@
       }
     },
     "id": {
-      "title": "Rule ID to attach to findings",
+      "title": "rule id to attach to findings",
       "type": "string"
     }
   },
@@ -619,11 +619,11 @@
             "$ref": "#/$defs/id"
           },
           "version": {
-            "title": "Version of rule",
+            "title": "version of rule",
             "type": "string"
           },
           "message": {
-            "title": "Description to attach to findings",
+            "title": "description to attach to findings",
             "type": "string"
           },
           "mode": {
@@ -631,14 +631,14 @@
             "enum": ["search", "taint", "join", "extract"]
           },
           "languages": {
-            "title": "Languages this pattern should run on",
+            "title": "languages this pattern should run on",
             "type": "array",
             "items": {
               "type": "string"
             }
           },
           "paths": {
-            "title": "Path globs this pattern should run on",
+            "title": "path globs this pattern should run on",
             "type": "object",
             "properties": {
               "include": {
@@ -651,7 +651,7 @@
             "additionalProperties": false
           },
           "severity": {
-            "title": "Severity to report alongside this finding",
+            "title": "severity to report alongside this finding",
             "enum": ["ERROR", "WARNING", "INFO", "INVENTORY", "EXPERIMENT"]
           },
           "pattern-sinks": {
@@ -670,23 +670,23 @@
             "$ref": "#/$defs/join-content"
           },
           "fix": {
-            "title": "Replacement text to fix matched code. Can use matched metavariables.",
+            "title": "replacement text to fix matched code. can use matched metavariables.",
             "type": "string"
           },
           "fix-regex": {
             "type": "object",
-            "title": "Replacement regex to fix matched code.",
+            "title": "replacement regex to fix matched code.",
             "properties": {
               "count": {
-                "title": "Replace up to this many regex matches",
+                "title": "replace up to this many regex matches",
                 "type": "integer"
               },
               "regex": {
-                "title": "Regular expression to find in matched code",
+                "title": "regular expression to find in matched code",
                 "type": "string"
               },
               "replacement": {
-                "title": "Code to replace the regular expression match with. Can use capture groups.",
+                "title": "code to replace the regular expression match with. can use capture groups.",
                 "type": "string"
               }
             },
@@ -694,19 +694,19 @@
             "additionalProperties": false
           },
           "metadata": {
-            "title": "Arbitrary structured data for your own reference",
+            "title": "arbitrary structured data for your own reference",
             "type": "object"
           },
           "options": {
-            "title": "Options object to enable/disable certain matching features in semgrep-core",
+            "title": "options object to enable/disable certain matching features in semgrep-core",
             "type": "object"
           },
           "pattern": {
-            "title": "Return finding where Semgrep pattern matches exactly",
+            "title": "return finding where semgrep pattern matches exactly",
             "type": "string"
           },
           "pattern-regex": {
-            "title": "Return finding where regular expression matches exactly",
+            "title": "return finding where regular expression matches exactly",
             "type": "string"
           },
           "patterns": {
@@ -719,15 +719,15 @@
             "$ref": "#/$defs/r2c-internal-project-depends-on-content"
           },
           "extract": {
-            "title": "Metavariable whose content to use as the extracted result for subsequent rules",
+            "title": "metavariable whose content to use as the extracted result for subsequent rules",
             "type": "string"
           },
           "dest-language": {
-            "title": "Language to process the extracted result of this rule as",
+            "title": "language to process the extracted result of this rule as",
             "type": "string"
           },
           "reduce": {
-            "title": "Method of intrafile match reduction",
+            "title": "method of intrafile match reduction",
             "enum": ["concat", "separate"],
             "default": "separate"
           }

--- a/src/schemas/json/servicehub.config.schema.json
+++ b/src/schemas/json/servicehub.config.schema.json
@@ -65,6 +65,6 @@
     }
   },
   "required": ["controller", "hosts", "services"],
-  "title": "Microsoft ServiceHub Configuration",
+  "title": "microsoft servicehub configuration",
   "type": "object"
 }

--- a/src/schemas/json/servicehub.service.schema.json
+++ b/src/schemas/json/servicehub.service.schema.json
@@ -64,6 +64,6 @@
     }
   },
   "required": ["host", "entryPoint"],
-  "title": "Microsoft ServiceHub Service",
+  "title": "microsoft servicehub service",
   "type": "object"
 }

--- a/src/schemas/json/settings.job.json
+++ b/src/schemas/json/settings.job.json
@@ -11,6 +11,6 @@
       "type": "boolean"
     }
   },
-  "title": "JSON schema for Azure Webjob settings.job files",
+  "title": "json schema for azure webjob settings.job files",
   "type": "object"
 }

--- a/src/schemas/json/size-limit.json
+++ b/src/schemas/json/size-limit.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "default": [],
   "items": {
-    "title": "Configuration Section",
+    "title": "configuration section",
     "allOf": [
       {
         "type": "object",
@@ -19,7 +19,7 @@
                 "title": "relative paths to files",
                 "type": "array",
                 "items": {
-                  "title": "Path or Glob Pattern",
+                  "title": "path or glob pattern",
                   "type": "string",
                   "pattern": "^/?([^/]+/)*[^/]+/?$",
                   "default": ""
@@ -50,18 +50,18 @@
             "default": ""
           },
           "limit": {
-            "title": "size or time limit for files from the path option. It should be a string with a number and unit, separated by a space.",
+            "title": "size or time limit for files from the path option. it should be a string with a number and unit, separated by a space.",
             "type": "string",
             "pattern": "\\d+( ?(ms|s)|\\s*(B|kB|[MGTPEZY]i?B|KiB))",
             "default": ""
           },
           "name": {
-            "title": "the name of the current section. It will only be useful if you have multiple sections.",
+            "title": "the name of the current section. it will only be useful if you have multiple sections.",
             "type": "string",
             "default": ""
           },
           "entry": {
-            "title": "when using a custom webpack config, a webpack entry could be given. It could be a string or an array of strings. By default, the total size of all entry points will be checked.",
+            "title": "when using a custom webpack config, a webpack entry could be given. it could be a string or an array of strings. by default, the total size of all entry points will be checked.",
             "oneOf": [
               {
                 "type": "string",
@@ -136,7 +136,7 @@
       }
     ]
   },
-  "title": "JSON Schema for configuration for size-limit",
+  "title": "json schema for configuration for size-limit",
   "type": "array",
   "uniqueItems": true
 }

--- a/src/schemas/json/solidaritySchema.json
+++ b/src/schemas/json/solidaritySchema.json
@@ -240,6 +240,6 @@
     }
   },
   "required": ["requirements"],
-  "title": "Solidarity",
+  "title": "solidarity",
   "type": "object"
 }

--- a/src/schemas/json/solution-filter.json
+++ b/src/schemas/json/solution-filter.json
@@ -19,6 +19,6 @@
       }
     }
   },
-  "title": "JSON Schema for MSBuild solution filters",
+  "title": "json schema for msbuild solution filters",
   "type": "object"
 }

--- a/src/schemas/json/sourcehut-build-0.41.2.json
+++ b/src/schemas/json/sourcehut-build-0.41.2.json
@@ -59,6 +59,6 @@
     }
   },
   "required": ["image"],
-  "title": "Sourcehut Build Manifest",
+  "title": "sourcehut build manifest",
   "type": "object"
 }

--- a/src/schemas/json/sourcehut-build-0.65.0.json
+++ b/src/schemas/json/sourcehut-build-0.65.0.json
@@ -119,6 +119,6 @@
     }
   },
   "required": ["image", "tasks"],
-  "title": "Sourcehut Build Manifest",
+  "title": "sourcehut build manifest",
   "type": "object"
 }

--- a/src/schemas/json/sourcemap-v3.json
+++ b/src/schemas/json/sourcemap-v3.json
@@ -95,6 +95,6 @@
     }
   },
   "required": ["version"],
-  "title": "JSON schema for the Source Maps v3",
+  "title": "json schema for the source maps v3",
   "type": "object"
 }

--- a/src/schemas/json/specif-1.0.json
+++ b/src/schemas/json/specif-1.0.json
@@ -301,7 +301,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "title": "Data-type 'Boolean' or 'dateTime'",
+                "title": "data-type 'boolean' or 'datetime'",
                 "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
                 "enum": ["xs:boolean", "xs:dateTime"]
               },
@@ -335,7 +335,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "title": "Data-type 'Integer'",
+                "title": "data-type 'integer'",
                 "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
                 "enum": ["xs:integer"]
               },
@@ -350,12 +350,12 @@
               },
               "minInclusive": {
                 "type": "number",
-                "title": "Minimum Value of a Number",
+                "title": "minimum value of a number",
                 "description": "Optional use by dataTypes 'xs:integer' and 'xs:double'."
               },
               "maxInclusive": {
                 "type": "number",
-                "title": "Maximum Value of a Number",
+                "title": "maximum value of a number",
                 "description": "Optional use by dataTypes 'xs:integer' and 'xs:double'."
               },
               "revision": {
@@ -379,7 +379,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "title": "Data-type 'Double'",
+                "title": "data-type 'double'",
                 "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
                 "enum": ["xs:double"]
               },
@@ -394,18 +394,18 @@
               },
               "fractionDigits": {
                 "type": "integer",
-                "title": "Number of fraction digits of a Decimal Number",
+                "title": "number of fraction digits of a decimal number",
                 "description": "Optional use by dataType 'xs:double', indicates the number of decimals.",
                 "minimum": 1
               },
               "minInclusive": {
                 "type": "number",
-                "title": "Minimum Value of a Number",
+                "title": "minimum value of a number",
                 "description": "Optional use by dataTypes 'xs:integer' and 'xs:double'."
               },
               "maxInclusive": {
                 "type": "number",
-                "title": "Maximum Value of a Number",
+                "title": "maximum value of a number",
                 "description": "Optional use by dataTypes 'xs:integer' and 'xs:double'."
               },
               "revision": {
@@ -429,7 +429,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "title": "Data-type 'String' or 'Formatted Text'",
+                "title": "data-type 'string' or 'formatted text'",
                 "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ resp. https://www.w3.org/TR/xhtml1/ applies.",
                 "enum": ["xs:string", "xhtml"]
               },
@@ -444,7 +444,7 @@
               },
               "maxLength": {
                 "type": "integer",
-                "title": "Maximum String Length",
+                "title": "maximum string length",
                 "description": "Optional use by dataTypes 'xs:string' and 'xhtml'.",
                 "minimum": 0
               },
@@ -469,7 +469,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "title": "Data-type 'Enumeration'",
+                "title": "data-type 'enumeration'",
                 "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
                 "enum": ["xs:enumeration"]
               },
@@ -484,7 +484,7 @@
               },
               "values": {
                 "type": "array",
-                "title": "Enumerated Values",
+                "title": "enumerated values",
                 "description": "Mandatory use by dataType 'xs:enumeration'. If 'multiple' is true 0..n options may be selected, otherwise exactly one must be selected.",
                 "uniqueItems": true,
                 "items": {
@@ -664,7 +664,7 @@
           },
           "subjectClasses": {
             "type": "array",
-            "title": "Resource and statement classes eligible as subject",
+            "title": "resource and statement classes eligible as subject",
             "description": "A collection of id's of eligible resource and statement classes; if 'subjectClasses' is missing, all resource or statement classes are eligible.",
             "minItems": 1,
             "uniqueItems": true,
@@ -675,7 +675,7 @@
           },
           "objectClasses": {
             "type": "array",
-            "title": "Resource and statement classes eligible as object",
+            "title": "resource and statement classes eligible as object",
             "description": "A collection of id's of eligible resource and statement classes; if 'objectClasses' is missing, all resource or statement classes are eligible.",
             "minItems": 1,
             "uniqueItems": true,
@@ -853,6 +853,6 @@
     "statements",
     "hierarchies"
   ],
-  "title": "JSON-Schema for SpecIF v1.0",
+  "title": "json-schema for specif v1.0",
   "type": "object"
 }

--- a/src/schemas/json/specif-1.1.json
+++ b/src/schemas/json/specif-1.1.json
@@ -181,7 +181,7 @@
     },
     "SpecifEnumeratedValues": {
       "type": "array",
-      "title": "Enumerated Values",
+      "title": "enumerated values",
       "description": "Enumerated values for the given dataType. If 'multiple' is true 0..n options may be selected, otherwise exactly one must be selected.",
       "uniqueItems": true,
       "items": {
@@ -214,7 +214,7 @@
             "type": {
               "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
               "type": "string",
-              "title": "Data-type 'Boolean'",
+              "title": "data-type 'boolean'",
               "enum": ["xs:boolean"]
             },
             "id": {
@@ -248,7 +248,7 @@
             "type": {
               "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
               "type": "string",
-              "title": "Data-type 'dateTime', 'duration' or 'URI'",
+              "title": "data-type 'datetime', 'duration' or 'uri'",
               "enum": ["xs:dateTime", "xs:duration", "xs:anyURI"]
             },
             "id": {
@@ -290,7 +290,7 @@
             "type": {
               "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
               "type": "string",
-              "title": "Data-type 'Integer'",
+              "title": "data-type 'integer'",
               "enum": ["xs:integer"]
             },
             "id": {
@@ -304,12 +304,12 @@
             },
             "minInclusive": {
               "type": "number",
-              "title": "Minimum Value of a Number",
+              "title": "minimum value of a number",
               "description": "Optional use by dataTypes 'xs:integer' and 'xs:double'."
             },
             "maxInclusive": {
               "type": "number",
-              "title": "Maximum Value of a Number",
+              "title": "maximum value of a number",
               "description": "Optional use by dataTypes 'xs:integer' and 'xs:double'."
             },
             "enumeration": {
@@ -342,7 +342,7 @@
             "type": {
               "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
               "type": "string",
-              "title": "Data-type 'Double'",
+              "title": "data-type 'double'",
               "enum": ["xs:double"]
             },
             "id": {
@@ -357,18 +357,18 @@
             "fractionDigits": {
               "description": "Optional use by dataType 'xs:double', indicates the number of decimals.",
               "type": "integer",
-              "title": "Number of fraction digits of a Decimal Number",
+              "title": "number of fraction digits of a decimal number",
               "minimum": 1
             },
             "minInclusive": {
               "description": "Optional use by dataTypes 'xs:integer' and 'xs:double'.",
               "type": "number",
-              "title": "Minimum Value of a Number"
+              "title": "minimum value of a number"
             },
             "maxInclusive": {
               "description": "Optional use by dataTypes 'xs:integer' and 'xs:double'.",
               "type": "number",
-              "title": "Maximum Value of a Number"
+              "title": "maximum value of a number"
             },
             "enumeration": {
               "description": "An optional list of values to choose from for a specific instance; multiple values are allowed, if 'multiple' is set to 'true'.",
@@ -400,7 +400,7 @@
             "type": {
               "description": "The corresponding definition in https://www.w3.org/TR/xmlschema-2/ applies.",
               "type": "string",
-              "title": "Data-type 'String' with plain or formatted text. The property's text object MAY specify the format and language.",
+              "title": "data-type 'string' with plain or formatted text. the property's text object may specify the format and language.",
               "enum": ["xs:string"]
             },
             "id": {
@@ -415,7 +415,7 @@
             "maxLength": {
               "description": "Optional use by dataType 'xs:string'.",
               "type": "integer",
-              "title": "Maximum String Length",
+              "title": "maximum string length",
               "minimum": 0
             },
             "enumeration": {
@@ -889,6 +889,6 @@
     "statements",
     "hierarchies"
   ],
-  "title": "JSON-Schema for SpecIF v1.1",
+  "title": "json-schema for specif v1.1",
   "type": "object"
 }

--- a/src/schemas/json/stale.json
+++ b/src/schemas/json/stale.json
@@ -6,73 +6,73 @@
     "configuration": {
       "properties": {
         "daysUntilStale": {
-          "title": "Days Until Stale",
+          "title": "days until stale",
           "description": "Number of days of inactivity before an Issue or Pull Request becomes stale.",
           "type": "number",
           "default": 60
         },
         "daysUntilClose": {
-          "title": "Days Until Close",
+          "title": "days until close",
           "description": "Number of days of inactivity before an Issue or Pull Request with the stale label is closed.",
           "type": ["integer", "boolean"],
           "default": 7
         },
         "onlyLabels": {
-          "title": "Only Labels",
+          "title": "only labels",
           "description": "Only issues or pull requests with all of these labels are check if stale.",
           "type": "array",
           "items": {
-            "title": "Label",
+            "title": "label",
             "type": "string"
           },
           "default": []
         },
         "exemptLabels": {
-          "title": "Exempt Labels",
+          "title": "exempt labels",
           "description": "Issues or Pull Requests with these labels will never be considered stale.",
           "type": "array",
           "items": {
-            "title": "Label",
+            "title": "label",
             "type": "string"
           },
           "default": []
         },
         "exemptProjects": {
-          "title": "Exempt Projects",
+          "title": "exempt projects",
           "description": "Set to true to ignore issues in a milestone.",
           "type": "boolean",
           "default": false
         },
         "exemptAssignees": {
-          "title": "Exempt Assignees",
+          "title": "exempt assignees",
           "description": "Set to true to ignore issues with an assignee.",
           "type": "boolean",
           "default": false
         },
         "staleLabel": {
-          "title": "Stale Label",
+          "title": "stale label",
           "description": "Label to use when marking as stale.",
           "type": "string",
           "default": "wontfix"
         },
         "markComment": {
-          "title": "Mark Comment",
+          "title": "mark comment",
           "description": "Comment to post when marking as stale.",
           "type": ["string", "boolean"],
           "default": "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         },
         "unmarkComment": {
-          "title": "Unmark Comment",
+          "title": "unmark comment",
           "description": "Comment to post when removing the stale label.",
           "type": ["string", "boolean"]
         },
         "closeComment": {
-          "title": "Closed Comment",
+          "title": "closed comment",
           "description": "Comment to post when closing a stale issue or pull request.",
           "type": ["string", "boolean"]
         },
         "limitPerRun": {
-          "title": "Limit Per Run",
+          "title": "limit per run",
           "description": "Limit the number of actions per hour.",
           "type": "number",
           "minimum": 1,
@@ -80,7 +80,7 @@
           "default": 30
         },
         "only": {
-          "title": "Only",
+          "title": "only",
           "description": "Limit to only issues or pulls requests.",
           "enum": ["issues", "pulls"]
         }
@@ -90,12 +90,12 @@
   "description": "A GitHub app that closes abandoned issues and pull requests",
   "properties": {
     "pulls": {
-      "title": "Pulls",
+      "title": "pulls",
       "description": "Specify configuration settings that are specific to pull requests.",
       "$ref": "#/definitions/configuration"
     },
     "issues": {
-      "title": "Issues",
+      "title": "issues",
       "description": "Specify configuration settings that are specific to issues.",
       "$ref": "#/definitions/configuration"
     }

--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -621,6 +621,6 @@
       "description": "JSON schema"
     }
   },
-  "title": "Azure Static Web Apps configuration file",
+  "title": "azure static web apps configuration file",
   "type": "object"
 }

--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -3223,6 +3223,6 @@
       "$ref": "#/definitions/allRules"
     }
   },
-  "title": "JSON schema for the Stylelint configuration files",
+  "title": "json schema for the stylelint configuration files",
   "type": "object"
 }

--- a/src/schemas/json/stylintrc.json
+++ b/src/schemas/json/stylintrc.json
@@ -10,136 +10,136 @@
     },
     "brackets": {
       "type": ["string", "boolean"],
-      "title": "Brackets preference",
+      "title": "brackets preference",
       "description": "Expect {} when declaring a selector.",
       "default": "never",
       "enum": [false, "never", "always"]
     },
     "colons": {
       "type": ["string", "boolean"],
-      "title": "Colon preference",
+      "title": "colon preference",
       "description": "Expect : when declaring a property.",
       "default": "always",
       "enum": [false, "never", "always"]
     },
     "colors": {
       "type": ["string", "boolean"],
-      "title": "Colors preference",
+      "title": "colors preference",
       "description": "Enforce variables when defining hex values",
       "default": "always",
       "enum": [false, "always"]
     },
     "commaSpace": {
       "type": ["string", "boolean"],
-      "title": "CommaSpace preference",
+      "title": "commaspace preference",
       "description": "Enforce or disallow spaces after commas.",
       "default": "always",
       "enum": [false, "never", "always"]
     },
     "commentSpace": {
       "type": ["string", "boolean"],
-      "title": "CommentSpace preference",
+      "title": "commentspace preference",
       "description": "Enforce or disallow spaces after line comments ('// comment' vs '//comment').",
       "default": "always",
       "enum": [false, "never", "always"]
     },
     "cssLiteral": {
       "type": ["string", "boolean"],
-      "title": "CssLiteral preference",
+      "title": "cssliteral preference",
       "description": "By default Stylint ignores @css blocks. If set to true however, it will throw a warning if @css is used.",
       "default": "never",
       "enum": [false, "never"]
     },
     "customProperties": {
       "type": "array",
-      "title": "Custom Properties array.",
+      "title": "custom properties array.",
       "description": "In Stylus you have the option of using mixins transparently, like css properties. Because of how Stylus' syntax works, this rule also allows you to add adhoc support for custom properties as needed by just added the name of the property to this array.",
       "items": {}
     },
     "depthLimit": {
       "type": ["boolean", "integer"],
-      "title": "Max selector depth preference",
+      "title": "max selector depth preference",
       "description": "Sets the max selector depth. If set to 4, max selector depth will be 4 indents. Pseudo selectors like &:first-child or &:hover won't count towards the limit. Set to false if you don't want to check for this",
       "default": false
     },
     "duplicates": {
       "type": "boolean",
-      "title": "Duplicates preference",
+      "title": "duplicates preference",
       "description": "Checks if selector or property duplicated unnecessarily.",
       "default": true
     },
     "efficient": {
       "type": ["string", "boolean"],
-      "title": "Property efficiency preference",
+      "title": "property efficiency preference",
       "description": "Check for places where properties can be written more efficiently. (Example: prefer margin 0 over margin 0 0)",
       "default": "always",
       "enum": [false, "never", "always"]
     },
     "exclude": {
       "type": "array",
-      "title": "Exclude files preference",
+      "title": "exclude files preference",
       "description": "Exclude certain file patterns from linting. (Example: ['vendor/**/*', 'node_modules/**/*'])",
       "items": {}
     },
     "extendPref": {
       "type": ["string", "boolean"],
-      "title": "Extend(s) preference",
+      "title": "extend(s) preference",
       "description": "Pass in either @extend or @extends to enforce one, or false to enforce neither.",
       "default": false,
       "enum": [false, "@extend", "@extends"]
     },
     "globalDupe": {
       "type": "boolean",
-      "title": "Global Duplicate rules preference",
+      "title": "global duplicate rules preference",
       "description": "Works in conjunction with duplicates. Does nothing on its own. If false, duplicates will check for dupes within individual files only. If true, duplicates will check for dupes across all files.",
       "default": false
     },
     "groupOutputByFile": {
       "type": "boolean",
-      "title": "GroupOutputByFile schema.",
+      "title": "groupoutputbyfile schema.",
       "description": "Stylint's default setting groups errors and warnings by file when outputting. You can disable this if you want.",
       "default": true
     },
     "indentPref": {
       "type": ["boolean", "integer"],
-      "title": "IndentPref preference.",
+      "title": "indentpref preference.",
       "description": "Number of spaces to indent.",
       "default": false
     },
     "leadingZero": {
       "type": ["string", "boolean"],
-      "title": "LeadingZero preference",
+      "title": "leadingzero preference",
       "description": "Enforce or disallow unnecessary leading zeroes on decimal points.",
       "default": "never",
       "enum": [false, "never", "always"]
     },
     "maxErrors": {
       "type": ["boolean", "integer"],
-      "title": "Max number of errors preference",
+      "title": "max number of errors preference",
       "description": "Set 'max' number of Errors.",
       "default": false
     },
     "maxWarnings": {
       "type": ["boolean", "integer"],
-      "title": "Max number of warnings preference",
+      "title": "max number of warnings preference",
       "description": "Set 'max' number of Warnings.",
       "default": false
     },
     "mixed": {
       "type": "boolean",
-      "title": "Allow mixed hard & soft tabs",
+      "title": "allow mixed hard & soft tabs",
       "description": "Returns true if mixed spaces and tabs are found. If a number is passed to indentPref, it assumes soft tabs (ie, spaces), and if false is passed to indentPref it assumes hard tabs. If soft tabs, outputs warning/error if hard tabs used. If hard tabs, outputs warning/error if unnecessary extra spaces found.",
       "default": false
     },
     "mixins": {
       "type": "array",
-      "title": "Mixins",
+      "title": "mixins",
       "description": "In Stylus you have the option of using mixins transparently, like css properties. Because of how Stylus' syntax works, this rule also allows you to add adhoc support for custom mixins as needed by just added the name of the mixin to this array.",
       "items": {}
     },
     "namingConvention": {
       "type": ["boolean", "string"],
-      "title": "Naming Convention",
+      "title": "naming convention",
       "description": "Enforce a particular naming convention when declaring classes, ids, and variables. Throws a warning if you don't follow the convention.",
       "default": false,
       "enum": [
@@ -152,59 +152,59 @@
     },
     "namingConventionStrict": {
       "type": "boolean",
-      "title": "NamingConventionStrict schema.",
+      "title": "namingconventionstrict schema.",
       "description": "By default, namingConvention only looks at variable names. If namingConventionStrict is set to true, namingConvention will also look at class and id names. If you have a lot of 3rd party css you can't change you might want to leave this off.",
       "default": false
     },
     "none": {
       "type": ["boolean", "string"],
-      "title": "None preference.",
+      "title": "none preference.",
       "description": "If 'always' check for places where none used instead of 0. If 'never' check for places where 0 could be used instead of none.",
       "default": "never",
       "enum": [false, "always", "never"]
     },
     "noImportant": {
       "type": "boolean",
-      "title": "NoImportant preference.",
+      "title": "noimportant preference.",
       "description": "If true, show warning when !important is found.",
       "default": true
     },
     "parenSpace": {
       "type": ["boolean", "string"],
-      "title": "ParenSpace preference.",
+      "title": "parenspace preference.",
       "description": "Enforce or disallow use of extra spaces inside parens.",
       "default": false,
       "enum": [false, "always", "never"]
     },
     "placeholders": {
       "type": ["boolean", "string"],
-      "title": "Placeholders preference",
+      "title": "placeholders preference",
       "description": "Enforce extending placeholder vars when using @extend(s) (prefer @extends $placeholder over $extends .some-class)",
       "default": "always",
       "enum": [false, "always", "never"]
     },
     "prefixVarsWithDollar": {
       "type": ["boolean", "string"],
-      "title": "PrefixVarsWithDollar preference",
+      "title": "prefixvarswithdollar preference",
       "description": "Enforce use of $ when defining a variable. In Stylus using a $ when defining a variable is optional, but is a good idea if you want to prevent ambiguity. Not including the $ sets up situations where you wonder: 'Is this a variable or a value?' For instance: padding $default is easier to understand than padding default.",
       "default": "always",
       "enum": [false, "always", "never"]
     },
     "quotePref": {
       "type": ["boolean", "string"],
-      "title": "Quote style preference",
+      "title": "quote style preference",
       "description": "Enforce consistent quotation style.",
       "default": false,
       "enum": [false, "single", "double"]
     },
     "reporterOptions": {
       "type": "object",
-      "title": "ReporterOptions schema.",
+      "title": "reporteroptions schema.",
       "description": "Customize reporter output.",
       "properties": {
         "columns": {
           "type": "array",
-          "title": "Columns schema.",
+          "title": "columns schema.",
           "items": {
             "type": "string",
             "title": "3 schema.",
@@ -213,73 +213,73 @@
         },
         "columnSplitter": {
           "type": ["boolean", "string"],
-          "title": "ColumnSplitter schema.",
+          "title": "columnsplitter schema.",
           "default": "  "
         },
         "showHeaders": {
-          "title": "ShowHeaders schema.",
+          "title": "showheaders schema.",
           "default": false
         },
         "truncate": {
           "type": "boolean",
-          "title": "Truncate schema.",
+          "title": "truncate schema.",
           "default": true
         }
       }
     },
     "semicolons": {
       "type": ["boolean", "string"],
-      "title": "Semicolon preference",
+      "title": "semicolon preference",
       "description": "Enforce or disallow semicolons",
       "default": "never",
       "enum": [false, "always", "never"]
     },
     "sortOrder": {
       "type": ["boolean", "string", "array"],
-      "title": "Property sorting order preference",
+      "title": "property sorting order preference",
       "description": "Enforce a particular sort order when declaring properties. Throws a warning if you don't follow the order.",
       "default": "alphabetical"
     },
     "stackedProperties": {
       "type": ["boolean", "string"],
-      "title": "One-liners preference",
+      "title": "one-liners preference",
       "description": "Enforce putting properties on new lines.",
       "enum": [false, "always", "never"]
     },
     "trailingWhitespace": {
       "type": ["string", "boolean"],
-      "title": "TrailingWhitespace preference",
+      "title": "trailingwhitespace preference",
       "description": "An explanation about the purpose of this instance.",
       "default": "never",
       "enum": [false, "never"]
     },
     "universal": {
       "type": ["boolean", "string"],
-      "title": "Universal preference",
+      "title": "universal preference",
       "description": "Looks for instances of the inefficient * selector. Lots of resets use this, for good reason (resetting box model), but past that you really don't need this selector, and you should avoid it if possible.",
       "default": false,
       "enum": [false, "never"]
     },
     "valid": {
       "type": "boolean",
-      "title": "Valid preference",
+      "title": "valid preference",
       "description": "Check that a property is valid CSS or HTML.",
       "default": true
     },
     "zeroUnits": {
       "type": ["boolean", "string"],
-      "title": "ZeroUnits preference",
+      "title": "zerounits preference",
       "description": "Looks for instances of 0px. You don't need the px. Checks all units, not just px.",
       "default": "never",
       "enum": [false, "never"]
     },
     "zIndexNormalize": {
       "type": ["boolean", "integer"],
-      "title": "ZIndexNormalize preference",
+      "title": "zindexnormalize preference",
       "description": "Enforce some (very) basic z-index sanity. Any number passed in will be used as the base for your z-index values. Throws an error if your value is not normalized.",
       "default": false
     }
   },
-  "title": "JSON schema for Stylint configuration files",
+  "title": "json schema for stylint configuration files",
   "type": "object"
 }

--- a/src/schemas/json/swagger-2.0.json
+++ b/src/schemas/json/swagger-2.0.json
@@ -1454,6 +1454,6 @@
     }
   },
   "required": ["swagger", "info", "paths"],
-  "title": "A JSON Schema for Swagger 2.0 API.",
+  "title": "a json schema for swagger 2.0 api.",
   "type": "object"
 }

--- a/src/schemas/json/taskfile.json
+++ b/src/schemas/json/taskfile.json
@@ -1,4 +1,4 @@
 {
   "$ref": "https://taskfile.dev/schema.json",
-  "title": "Taskfile YAML Schema"
+  "title": "taskfile yaml schema"
 }

--- a/src/schemas/json/template.json
+++ b/src/schemas/json/template.json
@@ -1511,6 +1511,6 @@
     "shortName",
     "tags"
   ],
-  "title": "JSON schema .NET template configuration (template.json).",
+  "title": "json schema .net template configuration (template.json).",
   "type": "object"
 }

--- a/src/schemas/json/templatesources.json
+++ b/src/schemas/json/templatesources.json
@@ -33,5 +33,5 @@
       "enum": ["Always", "OnceADay", "OnceAWeek", "OnceAMonth", "Never"]
     }
   },
-  "title": "JSON schema for SideWaffle template sources"
+  "title": "json schema for sidewaffle template sources"
 }

--- a/src/schemas/json/testenvironments.json
+++ b/src/schemas/json/testenvironments.json
@@ -104,6 +104,6 @@
       }
     }
   },
-  "title": "Schema for Visual Studio's test environment config",
+  "title": "schema for visual studio's test environment config",
   "type": "object"
 }

--- a/src/schemas/json/theme-v1.json
+++ b/src/schemas/json/theme-v1.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://raw.githubusercontent.com/WordPress/gutenberg/b40b61fabf13a6229c616527689d9a7024f81535/schemas/json/theme.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "JSON schema for WordPress block theme global settings and styles"
+  "title": "json schema for wordpress block theme global settings and styles"
 }

--- a/src/schemas/json/toolinfo.1.1.0.json
+++ b/src/schemas/json/toolinfo.1.1.0.json
@@ -258,6 +258,6 @@
       "$ref": "#/definitions/tool"
     }
   ],
-  "title": "Wikimedia Tool",
+  "title": "wikimedia tool",
   "version": "1.1.0"
 }

--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -2256,5 +2256,5 @@
       ]
     }
   },
-  "title": "JSON schema for Travis CI configuration files"
+  "title": "json schema for travis ci configuration files"
 }

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1221,6 +1221,6 @@
     }
   },
   "id": "https://json.schemastore.org/tsconfig",
-  "title": "JSON schema for the TypeScript compiler's configuration file",
+  "title": "json schema for the typescript compiler's configuration file",
   "type": "object"
 }

--- a/src/schemas/json/tsd.json
+++ b/src/schemas/json/tsd.json
@@ -37,6 +37,6 @@
     }
   },
   "required": ["path", "ref", "repo", "version"],
-  "title": "JSON schema for DefinitelyTyped TypeScript definitions manager (TSD)",
+  "title": "json schema for definitelytyped typescript definitions manager (tsd)",
   "type": "object"
 }

--- a/src/schemas/json/tsdrc.json
+++ b/src/schemas/json/tsdrc.json
@@ -17,6 +17,6 @@
       "description": "The OAuth token can be used to boost the GitHub API rate-limit from 60 to 5000 (non-cached) requests per hour. The is token needs just 'read-only access to public information' so no additional OAuth scopes are necessary."
     }
   },
-  "title": "JSON schema for .tsdrc files",
+  "title": "json schema for .tsdrc files",
   "type": "object"
 }

--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -5552,6 +5552,6 @@
       }
     }
   },
-  "title": "JSON schema for the TSLint configuration files.",
+  "title": "json schema for the tslint configuration files.",
   "type": "object"
 }

--- a/src/schemas/json/typewiz.json
+++ b/src/schemas/json/typewiz.json
@@ -45,6 +45,6 @@
       }
     }
   },
-  "title": "Typewiz configuration schema",
+  "title": "typewiz configuration schema",
   "type": "object"
 }

--- a/src/schemas/json/typings.json
+++ b/src/schemas/json/typings.json
@@ -77,6 +77,6 @@
       }
     }
   },
-  "title": "JSON schema for Typings TypeScript definitions manager",
+  "title": "json schema for typings typescript definitions manager",
   "type": "object"
 }

--- a/src/schemas/json/typingsrc.json
+++ b/src/schemas/json/typingsrc.json
@@ -57,6 +57,6 @@
       "description": "Set the User-Agent for HTTP requests"
     }
   },
-  "title": "JSON schema for .typingsrc files",
+  "title": "json schema for .typingsrc files",
   "type": "object"
 }

--- a/src/schemas/json/typo3.json
+++ b/src/schemas/json/typo3.json
@@ -911,7 +911,7 @@
               "required": ["type"],
               "properties": {
                 "type": {
-                  "title": "Type of aspect",
+                  "title": "type of aspect",
                   "type": "string",
                   "anyOf": [
                     {

--- a/src/schemas/json/ubuntu-server-autoinstall.json
+++ b/src/schemas/json/ubuntu-server-autoinstall.json
@@ -313,6 +313,6 @@
       "additionalProperties": true
     }
   },
-  "title": "Ubuntu Server Autoinstall",
+  "title": "ubuntu server autoinstall",
   "type": "object"
 }

--- a/src/schemas/json/unist.json
+++ b/src/schemas/json/unist.json
@@ -72,6 +72,6 @@
     }
   },
   "required": ["type"],
-  "title": "JSON schema for unist syntax trees",
+  "title": "json schema for unist syntax trees",
   "type": "object"
 }

--- a/src/schemas/json/up.json
+++ b/src/schemas/json/up.json
@@ -3,19 +3,19 @@
   "properties": {
     "name": {
       "type": "string",
-      "title": "Name of the project.",
+      "title": "name of the project.",
       "description": "A machine-friendly project name.",
       "examples": ["apex-site", "apex-api", "ping-app"]
     },
     "description": {
       "type": "string",
-      "title": "Description of the project.",
+      "title": "description of the project.",
       "description": "An optional project description.",
       "examples": ["Marketing site", "Public API"]
     },
     "type": {
       "type": "string",
-      "title": "Type of project.",
+      "title": "type of project.",
       "description": "The type of project.",
       "default": "server",
       "enum": ["static", "server"],
@@ -23,7 +23,7 @@
     },
     "profile": {
       "type": "string",
-      "title": "AWS profile.",
+      "title": "aws profile.",
       "description": "AWS credentials profile name, these are stored in ~/.aws/credentials.",
       "examples": ["apex-prod", "apex-dev", "personal"]
     },
@@ -33,7 +33,7 @@
       "minItems": 1,
       "items": {
         "type": "string",
-        "title": "AWS Region.",
+        "title": "aws region.",
         "description": "AWS region.",
         "enum": [
           "us-east-2",
@@ -60,32 +60,32 @@
       "properties": {
         "accelerate": {
           "type": "boolean",
-          "title": "Enables S3 acceleration.",
+          "title": "enables s3 acceleration.",
           "description": "Enable S3 acceleration for faster uploads via the CloudFront CDN.",
           "default": false
         },
         "warm": {
           "type": "boolean",
-          "title": "Enables active warming.",
+          "title": "enables active warming.",
           "description": "Active warming mitigates cold starts when enabled.",
           "default": false
         },
         "warm_rate": {
           "type": "string",
-          "title": "Active warming rate.",
+          "title": "active warming rate.",
           "description": "Active warming sends requests to your application at this interval.",
           "default": "15m",
           "examples": ["5m", "30m"]
         },
         "warm_count": {
           "type": "integer",
-          "title": "Active warming container count.",
+          "title": "active warming container count.",
           "description": "Number of concurrent containers to warm.",
           "default": "15"
         },
         "memory": {
           "type": "integer",
-          "title": "Memory.",
+          "title": "memory.",
           "description": "Lambda memory size.",
           "default": 512,
           "enum": [
@@ -105,7 +105,7 @@
           "properties": {
             "domain": {
               "type": "string",
-              "title": "Domain name.",
+              "title": "domain name.",
               "description": "Domain hostname for the stage.",
               "default": "",
               "examples": ["gh-polls.com", "api.gh-polls.com"]
@@ -117,7 +117,7 @@
           "properties": {
             "domain": {
               "type": "string",
-              "title": "Domain name.",
+              "title": "domain name.",
               "description": "Domain hostname for the stage.",
               "default": "",
               "examples": ["stage.gh-polls.com", "gh-polls-staging.com"]
@@ -129,7 +129,7 @@
           "properties": {
             "domain": {
               "type": "string",
-              "title": "Domain name.",
+              "title": "domain name.",
               "description": "Domain hostname for the stage.",
               "default": "",
               "examples": ["dev.gh-polls.com"]
@@ -143,32 +143,32 @@
       "properties": {
         "build": {
           "type": "string",
-          "title": "Build hook.",
+          "title": "build hook.",
           "description": "Hook command(s) to run."
         },
         "clean": {
           "type": "string",
-          "title": "Clean hook.",
+          "title": "clean hook.",
           "description": "Hook command(s) to run."
         },
         "prebuild": {
           "type": "string",
-          "title": "Prebuild hook.",
+          "title": "prebuild hook.",
           "description": "Hook command(s) to run."
         },
         "postbuild": {
           "type": "string",
-          "title": "Postbuild hook.",
+          "title": "postbuild hook.",
           "description": "Hook command(s) to run."
         },
         "predeploy": {
           "type": "string",
-          "title": "Predeploy hook.",
+          "title": "predeploy hook.",
           "description": "Hook command(s) to run."
         },
         "postdeploy": {
           "type": "string",
-          "title": "Postdeploy hook.",
+          "title": "postdeploy hook.",
           "description": "Hook command(s) to run."
         }
       }
@@ -178,14 +178,14 @@
       "properties": {
         "dir": {
           "type": "string",
-          "title": "Directory path.",
+          "title": "directory path.",
           "description": "Path to directory from which assets are served.",
           "default": ".",
           "examples": ["public", "./dist"]
         },
         "prefix": {
           "type": "string",
-          "title": "URL prefix.",
+          "title": "url prefix.",
           "description": "Optional URL path prefix.",
           "examples": ["/public/", "/static/"]
         }
@@ -196,26 +196,26 @@
       "properties": {
         "command": {
           "type": "string",
-          "title": "Command.",
+          "title": "command.",
           "description": "Command run to start your application.",
           "default": "./server",
           "examples": ["node app.js"]
         },
         "timeout": {
           "type": "integer",
-          "title": "Request timeout.",
+          "title": "request timeout.",
           "description": "Timeout in seconds per request.",
           "default": 15
         },
         "listen_timeout": {
           "type": "integer",
-          "title": "Listen timeout.",
+          "title": "listen timeout.",
           "description": "Timeout in seconds Up will wait for your app to boot and listen on `PORT`.",
           "default": 15
         },
         "shutdown_timeout": {
           "type": "integer",
-          "title": "Shutdown timeout.",
+          "title": "shutdown timeout.",
           "description": "Timeout in seconds Up will wait after sending a SIGINT to your server, before sending a SIGKILL.",
           "default": 15
         },
@@ -224,31 +224,31 @@
           "properties": {
             "min": {
               "type": "integer",
-              "title": "Minimum delay.",
+              "title": "minimum delay.",
               "description": "Minimum time in milliseconds before retrying.",
               "default": 500
             },
             "max": {
               "type": "integer",
-              "title": "Max delay.",
+              "title": "max delay.",
               "description": "Maximum time in milliseconds before retrying.",
               "default": 1500
             },
             "factor": {
               "type": "number",
-              "title": "Factor.",
+              "title": "factor.",
               "description": "Factor applied to each attempt.",
               "default": 1.5
             },
             "attempts": {
               "type": "integer",
-              "title": "Retry attempts.",
+              "title": "retry attempts.",
               "description": "Attempts made before failing.",
               "default": 5
             },
             "jitter": {
               "type": "boolean",
-              "title": "Jitter.",
+              "title": "jitter.",
               "description": "Apply jitter.",
               "default": false
             }
@@ -270,13 +270,13 @@
       "properties": {
         "disable": {
           "type": "boolean",
-          "title": "Disable error pages.",
+          "title": "disable error pages.",
           "description": "Disable default error pages.",
           "default": false
         },
         "dir": {
           "type": "string",
-          "title": "Directory path.",
+          "title": "directory path.",
           "description": "Path to directory from which error pages are served.",
           "default": ".",
           "examples": ["public", "./dist"]
@@ -286,13 +286,13 @@
           "properties": {
             "support_email": {
               "type": "string",
-              "title": "Support email.",
+              "title": "support email.",
               "description": "Support email for contact link.",
               "examples": ["support@apex.sh"]
             },
             "color": {
               "type": "string",
-              "title": "Color.",
+              "title": "color.",
               "description": "Theme color.",
               "examples": ["#228ae6"]
             }
@@ -305,7 +305,7 @@
       "properties": {
         "enable": {
           "type": "boolean",
-          "title": "Enable CORS.",
+          "title": "enable cors.",
           "description": "Enable Cross-Origin Resource Sharing.",
           "default": false
         },
@@ -313,7 +313,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "title": "Allowed Origins.",
+            "title": "allowed origins.",
             "description": "A list of origins a cross-domain request can be executed from. Use `*` to allow any origin, or a wildcard such as `http://*.domain.com`.",
             "default": "*",
             "examples": ["https://*.myapp.com", "https://myapp.com"]
@@ -323,7 +323,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "title": "Allowed Methods.",
+            "title": "allowed methods.",
             "description": "A list of methods the client is allowed to use with cross-domain requests.",
             "examples": ["GET", "HEAD"]
           }
@@ -332,7 +332,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "title": "Allowed Headers.",
+            "title": "allowed headers.",
             "description": "A list of headers the client is allowed to use with cross-domain requests. If the special `*` value is present in the list, all headers will be allowed.",
             "examples": ["Content-Type"]
           }
@@ -341,20 +341,20 @@
           "type": "array",
           "items": {
             "type": "string",
-            "title": "Exposed Headers.",
+            "title": "exposed headers.",
             "description": "A list of headers which are safe to expose to the API of a CORS response.",
             "examples": ["Content-Type"]
           }
         },
         "max_age": {
           "type": "integer",
-          "title": "Max Age.",
+          "title": "max age.",
           "description": "A number indicating how long (in seconds) the results of a preflight request can be cached.",
           "default": 0
         },
         "allowed_credentials": {
           "type": "boolean",
-          "title": "Allow Credentials.",
+          "title": "allow credentials.",
           "description": "A boolean indicating whether the request can include user credentials such as cookies, HTTP authentication or client side SSL certificates. Defaults to true.",
           "default": true
         }
@@ -374,7 +374,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "title": "Action Name.",
+            "title": "action name.",
             "description": "Name of the action for reference from alert definitions.",
             "examples": [
               "slack",
@@ -388,7 +388,7 @@
           },
           "type": {
             "type": "string",
-            "title": "Action Type.",
+            "title": "action type.",
             "description": "Type of action to perform.",
             "examples": ["email", "sms"]
           },
@@ -396,7 +396,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "title": "Email addresses.",
+              "title": "email addresses.",
               "description": "Email addresses when using the email action.",
               "examples": ["tj@apex.sh"]
             }
@@ -405,7 +405,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "title": "Phone numbers.",
+              "title": "phone numbers.",
               "description": "Phone numbers when using the sms action.",
               "examples": ["+12508004123"]
             }
@@ -421,63 +421,63 @@
         "properties": {
           "metric": {
             "type": "string",
-            "title": "Metric name.",
+            "title": "metric name.",
             "description": "Name of the metric.",
             "examples": ["http.count", "http.latency", "http.4xx", "http.5xx"]
           },
           "statistic": {
             "type": "string",
-            "title": "Statistics name.",
+            "title": "statistics name.",
             "description": "Name of statistic to perform.",
             "enum": ["min", "max", "avg", "sum", "count"],
             "examples": ["avg", "sum"]
           },
           "threshold": {
             "type": "integer",
-            "title": "Value Threshold.",
+            "title": "value threshold.",
             "description": "Threshold which is compared to the operator.",
             "default": 0
           },
           "action": {
             "type": "string",
-            "title": "Action Name.",
+            "title": "action name.",
             "description": "Name of the action to perform.",
             "examples": ["email.backend", "sms backend team"]
           },
           "period": {
             "type": ["integer", "string"],
-            "title": "Period.",
+            "title": "period.",
             "description": "Period is the alert query time-span.",
             "default": "1m"
           },
           "evaluation_periods": {
             "type": "integer",
-            "title": "Evaluation Periods.",
+            "title": "evaluation periods.",
             "description": "Number of periods to evaluate over.",
             "default": 1
           },
           "operator": {
             "type": "string",
-            "title": "Operator.",
+            "title": "operator.",
             "description": "Operator is the comparison operator.",
             "default": ">",
             "enum": [">", "<", ">=", "<="]
           },
           "namespace": {
             "type": "string",
-            "title": "Namespace.",
+            "title": "namespace.",
             "description": "Metric namespace.",
             "examples": ["AWS/ApiGateway"]
           },
           "description": {
             "type": "string",
-            "title": "Description.",
+            "title": "description.",
             "description": "Informative alert description, displayed in the email, sms, or slack.",
             "examples": ["Huge traffic spike"]
           },
           "disable": {
             "type": "boolean",
-            "title": "Disable.",
+            "title": "disable.",
             "description": "Disable the alert.",
             "default": false
           }
@@ -486,6 +486,6 @@
     }
   },
   "required": ["name"],
-  "title": "JSON schema for Apex Up configuration files",
+  "title": "json schema for apex up configuration files",
   "type": "object"
 }

--- a/src/schemas/json/uplugin.json
+++ b/src/schemas/json/uplugin.json
@@ -416,6 +416,6 @@
     }
   },
   "required": ["FileVersion"],
-  "title": "JSON schema for Unreal Engine uplugin",
+  "title": "json schema for unreal engine uplugin",
   "type": "object"
 }

--- a/src/schemas/json/uproject.json
+++ b/src/schemas/json/uproject.json
@@ -303,6 +303,6 @@
     }
   },
   "required": ["EngineAssociation", "FileVersion"],
-  "title": "JSON schema for Unreal Engine uproject",
+  "title": "json schema for unreal engine uproject",
   "type": "object"
 }

--- a/src/schemas/json/utam-page-object.json
+++ b/src/schemas/json/utam-page-object.json
@@ -32,7 +32,7 @@
     "pageObject": {
       "type": "object",
       "additionalProperties": false,
-      "title": "Page Object",
+      "title": "page object",
       "description": "An object representing a page or a UI element in a web page",
       "properties": {
         "description": {
@@ -55,7 +55,7 @@
           "type": "string"
         },
         "profile": {
-          "title": "Page Object Profile",
+          "title": "page object profile",
           "description": "list of profiles that can use this page object implementation.",
           "type": "array",
           "items": {
@@ -69,13 +69,13 @@
           }
         },
         "platform": {
-          "title": "Page Object Platform",
+          "title": "page object platform",
           "description": "Declares the page context type (WebView or native).",
           "enum": ["web", "native"],
           "default": "web"
         },
         "beforeLoad": {
-          "title": "Preload Criteria",
+          "title": "preload criteria",
           "description": "The beforeLoad array sets the criteria to be satisfied before the load method completes. If you don't specify a beforeLoad array, the load method finds a root element for a regular page object, or waits for the root element to be present for a root page object), by default.",
           "type": ["array"],
           "items": {
@@ -98,7 +98,7 @@
           "$ref": "#/definitions/elementsArray"
         },
         "methods": {
-          "title": "Methods",
+          "title": "methods",
           "description": "An array of methods performing actions on this page object's elements.",
           "type": "array",
           "items": {
@@ -106,7 +106,7 @@
           }
         },
         "shadow": {
-          "title": "Shadow Boundary",
+          "title": "shadow boundary",
           "description": "A shadow boundary at the root of the page object.",
           "type": "object",
           "properties": {
@@ -128,7 +128,7 @@
     "pageObjectInterface": {
       "type": "object",
       "additionalProperties": false,
-      "title": "Page Object Inferface",
+      "title": "page object inferface",
       "description": "An interace to abstract page object APIs for page objects with similar structure and function.",
       "properties": {
         "interface": {
@@ -146,7 +146,7 @@
           "$ref": "#/definitions/type"
         },
         "methods": {
-          "title": "Interface Methods",
+          "title": "interface methods",
           "description": "An array of method declarations that page objects implementing this interface must define.",
           "type": "array",
           "items": {
@@ -159,7 +159,7 @@
       }
     },
     "element": {
-      "title": "Element",
+      "title": "element",
       "description": "An interace to abstract page object APIs for page objects with similar structure and function.",
       "type": "object",
       "properties": {
@@ -211,7 +211,7 @@
       "additionalProperties": false
     },
     "elementsArray": {
-      "title": "Elements",
+      "title": "elements",
       "description": "A nested tree of element objects.",
       "type": "array",
       "items": {
@@ -219,7 +219,7 @@
       }
     },
     "selector": {
-      "title": "Selector",
+      "title": "selector",
       "description": "An object that locates an element or a list of elements at run time.",
       "type": "object",
       "$defs": {
@@ -364,7 +364,7 @@
       "additionalProperties": false
     },
     "interfaceMethod": {
-      "title": "Interface Method",
+      "title": "interface method",
       "description": "A declarative, interface method definition.",
       "type": "object",
       "properties": {
@@ -406,7 +406,7 @@
       "additionalProperties": false
     },
     "composeMethod": {
-      "title": "Method",
+      "title": "method",
       "description": "A method definition, composed of element actions.",
       "type": "object",
       "properties": {
@@ -435,7 +435,7 @@
     },
     "action": {
       "type": "object",
-      "title": "Element Action",
+      "title": "element action",
       "description": "An action to be performed on an element.",
       "additionalProperties": false,
       "properties": {
@@ -654,7 +654,7 @@
     },
     "shadow": {
       "type": "object",
-      "title": "Shadow Root",
+      "title": "shadow root",
       "description": "A shadow boundary at the root of the page object.",
       "properties": {
         "elements": {
@@ -678,7 +678,7 @@
       "type": "array"
     },
     "rootDescription": {
-      "title": "Root element description",
+      "title": "root element description",
       "description": "summary of the functionality and use cases",
       "type": ["object", "string"],
       "properties": {
@@ -699,7 +699,7 @@
       "additionalProperties": false
     },
     "methodDescription": {
-      "title": "Method description",
+      "title": "method description",
       "description": "summary at the method or element level",
       "type": ["object", "string"],
       "properties": {
@@ -728,6 +728,6 @@
       "type": "boolean"
     }
   },
-  "title": "UI Test Automation Model Page Object",
+  "title": "ui test automation model page object",
   "type": "object"
 }

--- a/src/schemas/json/vega.json
+++ b/src/schemas/json/vega.json
@@ -307,7 +307,7 @@
       ]
     },
     "data": {
-      "title": "Input data set definition",
+      "title": "input data set definition",
       "type": "object",
       "allOf": [
         {
@@ -517,7 +517,7 @@
       }
     },
     "encodeEntry": {
-      "title": "Mark encode property set",
+      "title": "mark encode property set",
       "type": "object",
       "properties": {
         "x": {
@@ -1799,7 +1799,7 @@
       "required": ["name", "type"]
     },
     "scale": {
-      "title": "Scale mapping",
+      "title": "scale mapping",
       "type": "object",
       "allOf": [
         {
@@ -3001,7 +3001,7 @@
       "required": ["type"]
     },
     "stream": {
-      "title": "Input event stream definition",
+      "title": "input event stream definition",
       "type": "object",
       "allOf": [
         {
@@ -6977,7 +6977,7 @@
       "required": ["field"]
     },
     "field": {
-      "title": "FieldRef",
+      "title": "fieldref",
       "oneOf": [
         {
           "type": "string"
@@ -7881,7 +7881,7 @@
       "required": ["h", "c", "l"]
     },
     "colorValue": {
-      "title": "ColorRef",
+      "title": "colorref",
       "oneOf": [
         {
           "$ref": "#/refs/nullableStringValue"
@@ -7922,7 +7922,7 @@
       ]
     },
     "expr": {
-      "title": "ExpressionRef",
+      "title": "expressionref",
       "type": "object",
       "properties": {
         "expr": {
@@ -7932,7 +7932,7 @@
       "required": ["expr"]
     },
     "exprString": {
-      "title": "Expression String",
+      "title": "expression string",
       "type": "string"
     },
     "compare": {
@@ -8086,7 +8086,7 @@
       ]
     },
     "marktype": {
-      "title": "Mark Type definition",
+      "title": "mark type definition",
       "type": "string"
     },
     "sortOrder": {
@@ -8266,11 +8266,11 @@
       ]
     },
     "selector": {
-      "title": "Event Selector String",
+      "title": "event selector string",
       "type": "string"
     },
     "signal": {
-      "title": "SignalRef",
+      "title": "signalref",
       "type": "object",
       "properties": {
         "signal": {
@@ -8310,6 +8310,6 @@
       ]
     }
   },
-  "title": "Vega 3.0 Visualization Specification Language",
+  "title": "vega 3.0 visualization specification language",
   "type": "object"
 }

--- a/src/schemas/json/venvironment-basic-schema.json
+++ b/src/schemas/json/venvironment-basic-schema.json
@@ -65,7 +65,7 @@
       },
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Functional mockup unit",
+        "title": "functional mockup unit",
         "description": "Represents a functional mockup unit used in a scenario",
         "type": "object",
         "anyOf": [
@@ -134,7 +134,7 @@
     "8431": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Version",
+        "title": "version",
         "description": "Json schema version for the vEnvironment-Basic configuration file. Acceptance criteria: equal major version, less/equal minor and patch version.",
         "const": "1.0.0",
         "type": "string",
@@ -243,7 +243,7 @@
       },
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Include files",
+        "title": "include files",
         "description": "Include a different file (similar to #include of the c preprocessor). The order of includes does not matter. Circular / multiple includes are resolved correctly.",
         "oneOf": [
           {
@@ -265,7 +265,7 @@
     "9ff3": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Datasources",
+        "title": "datasources",
         "description": "The definition of datasources used by application models.",
         "type": "object",
         "additionalProperties": false,
@@ -298,7 +298,7 @@
     "91ad": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "System Variables",
+        "title": "system variables",
         "description": "A lists of system variables to be used by the simulation.",
         "type": "array",
         "items": {
@@ -316,7 +316,7 @@
     "770b": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Version",
+        "title": "version",
         "description": "Json schema version for the vEnvironment-Basic configuration file. Acceptance criteria: equal major version, less/equal minor and patch version.",
         "const": "1.1.0",
         "type": "string",
@@ -332,7 +332,7 @@
       },
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Include files",
+        "title": "include files",
         "description": "Include a different file (similar to #include of the c preprocessor). The order of includes does not matter. Circular / multiple includes are resolved correctly.",
         "oneOf": [
           {
@@ -354,7 +354,7 @@
     "f504": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Functional mockup units",
+        "title": "functional mockup units",
         "description": "List of functional mockup units.",
         "type": "array",
         "items": {
@@ -396,7 +396,7 @@
     "a6c2": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "SIL Kit",
+        "title": "sil kit",
         "description": "SIL Kit settings.",
         "type": "object",
         "additionalProperties": false,
@@ -437,7 +437,7 @@
     "0643": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Logging Block",
+        "title": "logging block",
         "description": "Configuration of the standalone logging block.",
         "type": "object",
         "additionalProperties": false,
@@ -500,7 +500,7 @@
     "e1ba": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "System variables",
+        "title": "system variables",
         "description": "Absolute or relative path to an external file containing system variables. Relative path specifications are resolved relative to the defining configuration file.",
         "type": "object",
         "additionalProperties": false,

--- a/src/schemas/json/venvironment-schema.json
+++ b/src/schemas/json/venvironment-schema.json
@@ -176,7 +176,7 @@
     "8711": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CANFD network",
+        "title": "canfd network",
         "description": "A Network using the CANFD protocol taking part in a simulation.",
         "type": "object",
         "additionalProperties": false,
@@ -269,7 +269,7 @@
     "9738": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Global settings for Ethernet",
+        "title": "global settings for ethernet",
         "type": "object",
         "properties": {
           "access-mode": {
@@ -500,7 +500,7 @@
     "f46b": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Version",
+        "title": "version",
         "description": "Json schema version for the vEnvironment configuration file. Acceptance criteria: equal major version, less/equal minor and patch version.",
         "const": "1.0.0",
         "type": "string",
@@ -516,7 +516,7 @@
       },
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Include files",
+        "title": "include files",
         "description": "Include a different file (similar to #include of the c preprocessor). The order of includes does not matter. Circular / multiple includes are resolved correctly.",
         "oneOf": [
           {
@@ -538,7 +538,7 @@
     "910e": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Variables",
+        "title": "variables",
         "description": "List of variables to be used in this configuration file.",
         "type": "array",
         "items": {
@@ -579,7 +579,7 @@
     "7b8b": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Application Models",
+        "title": "application models",
         "description": "List of application models representing some program. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -598,7 +598,7 @@
     "3cec": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Datasources",
+        "title": "datasources",
         "description": "The definition of datasources used by application models. Input files can be deactivated with when.",
         "type": "object",
         "additionalProperties": false,
@@ -653,7 +653,7 @@
     "d219": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Defines",
+        "title": "defines",
         "description": "List of defines to be passed to capl / vcdl. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -686,7 +686,7 @@
     "dec4": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "System Variables",
+        "title": "system variables",
         "description": "A lists of system variables to be used by the simulation. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -713,7 +713,7 @@
     "62bc": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Simulation Nodes",
+        "title": "simulation nodes",
         "description": "A list of simulation nodes used in a simulation. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -765,7 +765,7 @@
     "c9ff": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Databases",
+        "title": "databases",
         "description": "List of databases. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -800,7 +800,7 @@
     "6d72": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CAN Networks",
+        "title": "can networks",
         "description": "List of CAN networks. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -830,7 +830,7 @@
     "aefd": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CANFD Networks",
+        "title": "canfd networks",
         "description": "List of CANFD networks. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -862,7 +862,7 @@
     "9fce": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Scenarios",
+        "title": "scenarios",
         "description": "List of scenarios with the option to define / override variables or defines.",
         "type": "array",
         "items": {
@@ -898,7 +898,7 @@
     "cf43": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Version",
+        "title": "version",
         "description": "Json schema version for the vEnvironment configuration file. Acceptance criteria: equal major version, less/equal minor and patch version.",
         "const": "1.1.0",
         "type": "string",
@@ -908,7 +908,7 @@
     "a18a": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Global Settings",
+        "title": "global settings",
         "description": "Global settings for all scenarios.",
         "type": "object",
         "additionalProperties": false,
@@ -1022,7 +1022,7 @@
       },
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Include files",
+        "title": "include files",
         "description": "Include a different file (similar to #include of the c preprocessor). The order of includes does not matter. Circular / multiple includes are resolved correctly.",
         "oneOf": [
           {
@@ -1044,7 +1044,7 @@
     "0e5c": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Functional mockup units",
+        "title": "functional mockup units",
         "description": "List of functional mockup units. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -1086,7 +1086,7 @@
     "7c33": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "SIL Kit",
+        "title": "sil kit",
         "description": "SIL Kit settings. Entry can be deactivated with when.",
         "type": "object",
         "additionalProperties": false,
@@ -1177,7 +1177,7 @@
     "7d21": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "XCP files",
+        "title": "xcp files",
         "description": "List of XCP configuration files (entries can be deactivated with when)",
         "type": "array",
         "items": {
@@ -1204,7 +1204,7 @@
     "37da": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Logging Block",
+        "title": "logging block",
         "description": "Configuration of the standalone logging block.",
         "type": "object",
         "additionalProperties": false,
@@ -1266,7 +1266,7 @@
     "9f91": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Simulation Nodes",
+        "title": "simulation nodes",
         "description": "A list of simulation nodes used in a simulation. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -1320,7 +1320,7 @@
     "c683": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CAN Networks",
+        "title": "can networks",
         "description": "List of CAN networks. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -1352,7 +1352,7 @@
     "762b": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CANFD Networks",
+        "title": "canfd networks",
         "description": "List of CANFD networks. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -1385,7 +1385,7 @@
     "ea31": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CAN Networks",
+        "title": "can networks",
         "description": "List of Ethernet networks. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -1445,7 +1445,7 @@
     "37e0": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CAN Replay Blocks",
+        "title": "can replay blocks",
         "description": "List of CAN replay blocks. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -1476,7 +1476,7 @@
     "58db": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Ethernet Replay Blocks",
+        "title": "ethernet replay blocks",
         "description": "List of ethernet replay blocks. Entries can be deactivated with when.",
         "type": "array",
         "items": {
@@ -1760,7 +1760,7 @@
       },
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Variable",
+        "title": "variable",
         "description": "This variable can be used in any other node and overwritten by a scenario.",
         "type": "object",
         "required": ["name"],
@@ -1961,7 +1961,7 @@
     "aaae": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Application Model",
+        "title": "application model",
         "description": "Represents an application used in a scenario",
         "type": "object",
         "additionalProperties": false,
@@ -2050,7 +2050,7 @@
     "28a4": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Define",
+        "title": "define",
         "description": "Defines to be passed to capl / vcdl.",
         "type": "object",
         "additionalProperties": false,
@@ -2093,7 +2093,7 @@
     "a3db": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "System variables",
+        "title": "system variables",
         "description": "Absolute or relative path to an external file containing system variables. Relative path specifications are resolved relative to the defining configuration file.",
         "type": "object",
         "additionalProperties": false,
@@ -2133,7 +2133,7 @@
     "5a68": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Simulation Node",
+        "title": "simulation node",
         "description": "Represents a simulation node used in a simulation",
         "additionalProperties": false,
         "type": "object",
@@ -2196,7 +2196,7 @@
     "2cf5": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Database",
+        "title": "database",
         "description": "Absolute or relative path to an external database file (.dbc / .ldf / ...). Relative path specifications are resolved relative to the defining configuration file.",
         "type": "object",
         "additionalProperties": false,
@@ -2261,7 +2261,7 @@
     "d7ad": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CAN network",
+        "title": "can network",
         "description": "A Network using the CAN protocol taking part in a simulation.",
         "type": "object",
         "additionalProperties": false,
@@ -2325,7 +2325,7 @@
     "d46a": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Scenario",
+        "title": "scenario",
         "description": "A scenario with the option to define / override variables or defines",
         "type": "object",
         "additionalProperties": false,
@@ -2435,7 +2435,7 @@
       },
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Functional mockup unit",
+        "title": "functional mockup unit",
         "description": "Represents a functional mockup unit used in a scenario",
         "type": "object",
         "anyOf": [
@@ -2537,7 +2537,7 @@
     "d186": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "XCP files",
+        "title": "xcp files",
         "description": "Absolute or relative path to an external xcpcfg file. Relative path specifications are resolved relative to the defining configuration file.",
         "type": "object",
         "additionalProperties": false,
@@ -2643,7 +2643,7 @@
     "1e1a": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Simulation Node",
+        "title": "simulation node",
         "description": "Represents a simulation node used in a simulation",
         "type": "object",
         "additionalProperties": false,
@@ -2708,7 +2708,7 @@
     "da7f": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CAN network",
+        "title": "can network",
         "description": "A Network using the CAN protocol taking part in a simulation.",
         "type": "object",
         "additionalProperties": false,
@@ -2776,7 +2776,7 @@
     "d18f": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CANFD network",
+        "title": "canfd network",
         "description": "A Network using the CANFD protocol taking part in a simulation.",
         "type": "object",
         "additionalProperties": false,
@@ -2873,7 +2873,7 @@
     "888c": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Ethernet network",
+        "title": "ethernet network",
         "description": "A Network using the Ethernet protocol taking part in a simulation.",
         "type": "object",
         "additionalProperties": false,
@@ -2958,7 +2958,7 @@
     "a9f3": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "CAN replay block",
+        "title": "can replay block",
         "description": "A replay block for the CAN protocol.",
         "type": "object",
         "additionalProperties": false,
@@ -3062,7 +3062,7 @@
     "780d": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Ethernet replay block",
+        "title": "ethernet replay block",
         "description": "A replay block for the ethernet protocol.",
         "type": "object",
         "additionalProperties": false,
@@ -3583,7 +3583,7 @@
     "0e34": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Timing conditions",
+        "title": "timing conditions",
         "description": "Timing conditions for a replay block.",
         "type": "object",
         "additionalProperties": false,
@@ -3644,7 +3644,7 @@
     "6e1c": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "Channel mapping",
+        "title": "channel mapping",
         "description": "The channel mapping for a replay block.",
         "type": "object",
         "additionalProperties": false,
@@ -3667,13 +3667,13 @@
             ]
           },
           "mappings": {
-            "title": "Explicit mappings",
+            "title": "explicit mappings",
             "description": "The explicitly mapped channels. Overwrites the default mapping for the source.",
             "type": "array",
             "items": {
               "anyOf": [
                 {
-                  "title": "Map source channel",
+                  "title": "map source channel",
                   "type": "object",
                   "description": "Mapping from application channel of the replay file to a target network.",
                   "additionalProperties": false,
@@ -3707,7 +3707,7 @@
                   }
                 },
                 {
-                  "title": "Map source network",
+                  "title": "map source network",
                   "type": "object",
                   "description": "Mapping from a named source network of the replay file to a named target network.",
                   "additionalProperties": false,
@@ -3731,7 +3731,7 @@
                   }
                 },
                 {
-                  "title": "Ignore source channel",
+                  "title": "ignore source channel",
                   "type": "object",
                   "description": "Ignores an application channel of the replay file.",
                   "additionalProperties": false,
@@ -3754,7 +3754,7 @@
                   }
                 },
                 {
-                  "title": "Ignore source network",
+                  "title": "ignore source network",
                   "type": "object",
                   "description": "Ignores a named source network of the replay file.",
                   "additionalProperties": false,

--- a/src/schemas/json/vim-addon-info.json
+++ b/src/schemas/json/vim-addon-info.json
@@ -133,6 +133,6 @@
       }
     }
   },
-  "title": "JSON schema for vim plugin addon-info.json metadata files",
+  "title": "json schema for vim plugin addon-info.json metadata files",
   "type": "object"
 }

--- a/src/schemas/json/vs-2017.3.host.json
+++ b/src/schemas/json/vs-2017.3.host.json
@@ -5,5 +5,5 @@
       "$ref": "https://json.schemastore.org/ide.host.json"
     }
   ],
-  "title": "JSON schema for IDE template host files"
+  "title": "json schema for ide template host files"
 }

--- a/src/schemas/json/vs-nesting.json
+++ b/src/schemas/json/vs-nesting.json
@@ -240,6 +240,6 @@
       }
     }
   },
-  "title": "JSON schema for Visual Studio's file nesting feature",
+  "title": "json schema for visual studio's file nesting feature",
   "type": "object"
 }

--- a/src/schemas/json/vsconfig.json
+++ b/src/schemas/json/vsconfig.json
@@ -16,6 +16,6 @@
     }
   },
   "required": ["components"],
-  "title": "JSON schema for Visual Studio component configuration files",
+  "title": "json schema for visual studio component configuration files",
   "type": "object"
 }

--- a/src/schemas/json/vsext.json
+++ b/src/schemas/json/vsext.json
@@ -42,6 +42,6 @@
     }
   },
   "required": ["version"],
-  "title": "JSON schema for Visual Studio extension pack manifests",
+  "title": "json schema for visual studio extension pack manifests",
   "type": "object"
 }

--- a/src/schemas/json/vsix-manifestinjection.json
+++ b/src/schemas/json/vsix-manifestinjection.json
@@ -152,6 +152,6 @@
       }
     }
   },
-  "title": "JSON schema for Visual Studio manifest extensions",
+  "title": "json schema for visual studio manifest extensions",
   "type": "object"
 }

--- a/src/schemas/json/vsix-publish.json
+++ b/src/schemas/json/vsix-publish.json
@@ -7,39 +7,39 @@
       "properties": {
         "description": {
           "type": "string",
-          "title": "Description",
+          "title": "description",
           "description": "A description for the extension. Required if the extension is not a VSIX.",
           "minLength": 1,
           "maxLength": 280
         },
         "displayName": {
           "type": "string",
-          "title": "DisplayName",
+          "title": "displayname",
           "description": "A display name for the extension. Required if the extension is not a VSIX.",
           "minLength": 1,
           "maxLength": 80
         },
         "icon": {
           "type": "string",
-          "title": "Icon",
+          "title": "icon",
           "description": "An icon for the extension. Required if the extension is not a VSIX. Can be relative to the current json file's directory.",
           "minLength": 1
         },
         "installTargets": {
           "type": "array",
-          "title": "InstallTargets",
+          "title": "installtargets",
           "description": "A list of install targets for the extension. At least one is required if the extension is not a VSIX.",
           "minItems": 1,
           "uniqueItems": true,
           "items": {
-            "title": "InstallTarget",
+            "title": "installtarget",
             "description": "An installation target for the extension.",
             "type": "object",
             "required": ["sku", "version"],
             "properties": {
               "sku": {
                 "type": "string",
-                "title": "Install target SKU",
+                "title": "install target sku",
                 "description": "The SKU name of the installation target.",
                 "enum": [
                   "Microsoft.VisualStudio.Community",
@@ -62,7 +62,7 @@
               },
               "version": {
                 "type": "string",
-                "title": "Install target version range",
+                "title": "install target version range",
                 "description": "The version range of the install target that the extension can be installed to.",
                 "pattern": "^[0-9\\[\\(,. \\)\\]]+$"
               }
@@ -71,7 +71,7 @@
         },
         "internalName": {
           "type": "string",
-          "title": "Internal name",
+          "title": "internal name",
           "description": "The internal name of the extension. A marketplace extension is identified as 'publisherName'.'internalName'. Cannot contain spaces.",
           "minLength": 1,
           "maxLength": 63,
@@ -79,17 +79,17 @@
         },
         "language": {
           "type": ["string", "number"],
-          "title": "Language",
+          "title": "language",
           "description": "The default language the extension applies to. Must be a CLR locale code or an lcid code.",
           "pattern": "^(\\d{4})$|^([a-zA-Z]{2}(-[A-Za-z]{2})?)$|^neutral$"
         },
         "tags": {
           "type": "array",
-          "title": "Tags",
+          "title": "tags",
           "description": "A list of tags for the extension.",
           "items": {
             "type": "string",
-            "title": "Tag",
+            "title": "tag",
             "description": "A tag for the extension.",
             "minLength": 1,
             "maxLength": 50
@@ -97,13 +97,13 @@
         },
         "version": {
           "type": "string",
-          "title": "Version",
+          "title": "version",
           "description": "The version of the extension. Required if the extension is not a VSIX.",
           "pattern": "^([0-9]+\\.){1,3}([0-9]+)$"
         },
         "vsixId": {
           "type": "string",
-          "title": "VsixId",
+          "title": "vsixid",
           "description": "The vsix identifier of the extension.",
           "minLength": 1
         }
@@ -111,7 +111,7 @@
     },
     "assetFiles": {
       "type": "array",
-      "title": "AssetFiles",
+      "title": "assetfiles",
       "description": "A list of assets to include in the package sent to the marketplace.",
       "items": {
         "type": "object",
@@ -119,13 +119,13 @@
         "properties": {
           "pathOnDisk": {
             "type": "string",
-            "title": "PathOnDisk",
+            "title": "pathondisk",
             "description": "A path to the file to include in the package. Can be relative to the current json file's directory.",
             "minLength": 1
           },
           "targetPath": {
             "type": "string",
-            "title": "TargetPath",
+            "title": "targetpath",
             "description": "The path to embed the file in the package. This can be referenced from your overview file via an image link, for example",
             "default": ""
           }
@@ -134,7 +134,7 @@
     },
     "categories": {
       "type": "array",
-      "title": "Categories",
+      "title": "categories",
       "description": "A list of categories that the extension applies to.",
       "minItems": 1,
       "maxItems": 3,
@@ -143,7 +143,7 @@
         "anyOf": [
           {
             "type": "string",
-            "title": "Category",
+            "title": "category",
             "description": "A valid category on the marketplace that the extension applies to.",
             "minLength": 1
           },
@@ -197,38 +197,38 @@
     },
     "overview": {
       "type": "string",
-      "title": "Overview",
+      "title": "overview",
       "description": "A path to a markdown file that will be displayed on the extension's page in the marketplace. The path can be relative to the current json file's path.",
       "minLength": 1
     },
     "priceCategory": {
       "type": "string",
-      "title": "PriceCategory",
+      "title": "pricecategory",
       "description": "The pricing model for the extension.",
       "default": "free",
       "enum": ["free", "trial", "paid"]
     },
     "publisher": {
       "type": "string",
-      "title": "Publisher",
+      "title": "publisher",
       "description": "The publisher of the extension. Must not be a display name of the publisher.",
       "minLength": 1
     },
     "private": {
       "type": "boolean",
-      "title": "Private",
+      "title": "private",
       "description": "If true, the extension will be uploaded as a private extension.",
       "default": false
     },
     "qna": {
       "type": "boolean",
-      "title": "Q&A",
+      "title": "q&a",
       "description": "If true, the extension will have a Q&A page on the marketplace.",
       "default": true
     },
     "repo": {
       "type": "string",
-      "title": "Repo",
+      "title": "repo",
       "description": "A URL that points to the GitHub repo for the extension.",
       "format": "uri"
     }

--- a/src/schemas/json/vsls.json
+++ b/src/schemas/json/vsls.json
@@ -22,6 +22,6 @@
       }
     }
   },
-  "title": "JSON schema for Visual Studio Live Share config files",
+  "title": "json schema for visual studio live share config files",
   "type": "object"
 }

--- a/src/schemas/json/vss-extension.json
+++ b/src/schemas/json/vss-extension.json
@@ -25,7 +25,7 @@
       "properties": {
         "path": {
           "type": "string",
-          "title": "Valid file path in the extension",
+          "title": "valid file path in the extension",
           "format": "uri-reference"
         }
       }
@@ -36,7 +36,7 @@
       "required": ["id", "type", "targets"],
       "properties": {
         "id": {
-          "title": "Referencing contributions and types => https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#contributionIds",
+          "title": "referencing contributions and types => https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#contributionids",
           "description": "A reference ID (string) for the contribution. Each contribution's ID must be unique within an extension.",
           "type": "string"
         },
@@ -51,28 +51,28 @@
         "targets": {
           "type": "array",
           "description": "An array of contribution IDs that the contribution is targeting (contributing to).",
-          "title": "Targeting Contributions: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#targeting-contributions",
+          "title": "targeting contributions: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#targeting-contributions",
           "items": {
             "type": "string",
             "description": "Contribution IDs that the contribution is targeting.",
-            "title": "Targeting Contributions: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#targeting-contributions"
+            "title": "targeting contributions: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#targeting-contributions"
           }
         },
         "restrictedTo": {
           "type": "array",
           "description": "Valid Values: https://docs.microsoft.com/en-us/azure/devops/extend/develop/public-project?view=azure-devops#contribution-visibility",
-          "title": "Contribution visibility: By default, contributions are only visible to organization members. To give non-member users visibility to a contribution, set the restrictedTo attribute on that contribution. The value is a string array that lists which types of users should have visibility to the contribution",
+          "title": "contribution visibility: by default, contributions are only visible to organization members. to give non-member users visibility to a contribution, set the restrictedto attribute on that contribution. the value is a string array that lists which types of users should have visibility to the contribution",
           "items": {
             "type": "string",
             "description": "Valid Values: https://docs.microsoft.com/en-us/azure/devops/extend/develop/public-project?view=azure-devops#contribution-visibility",
-            "title": "Contribution visibility: By default, contributions are only visible to organization members. To give non-member users visibility to a contribution, set the restrictedTo attribute on that contribution. The value is a string array that lists which types of users should have visibility to the contribution",
+            "title": "contribution visibility: by default, contributions are only visible to organization members. to give non-member users visibility to a contribution, set the restrictedto attribute on that contribution. the value is a string array that lists which types of users should have visibility to the contribution",
             "enum": ["member", "public", "anonymous"]
           }
         },
         "properties": {
           "type": "object",
           "description": "(Optional) An object that includes properties for the contribution as defined in the contribution type.",
-          "title": "For more information, see the contribution model overview => https://docs.microsoft.com/en-us/azure/devops/extend/develop/contributions-overview?view=azure-devops"
+          "title": "for more information, see the contribution model overview => https://docs.microsoft.com/en-us/azure/devops/extend/develop/contributions-overview?view=azure-devops"
         }
       }
     },
@@ -82,7 +82,7 @@
       "required": ["id", "name"],
       "properties": {
         "id": {
-          "title": "Referencing contributions and types => https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#contributionIds",
+          "title": "referencing contributions and types => https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#contributionids",
           "description": "A reference ID (string) for the contribution type. Each contribution type's ID must be unique within an extension.",
           "type": "string"
         },
@@ -135,14 +135,14 @@
   "properties": {
     "manifestVersion": {
       "type": "integer",
-      "title": "A number corresponding to the version of the manifest format.",
+      "title": "a number corresponding to the version of the manifest format.",
       "default": 1,
       "description": "This should be 1.",
       "enum": [1]
     },
     "id": {
       "type": "string",
-      "title": "The extension's identifier",
+      "title": "the extension's identifier",
       "description": "This is a string that must be unique among extensions from the same publisher.",
       "allOf": [
         {
@@ -152,14 +152,14 @@
     },
     "version": {
       "type": "string",
-      "title": "A string specifying the version of an extension.",
+      "title": "a string specifying the version of an extension.",
       "description": "Should be in the format major.minor.patch, for example 0.1.2 or 1.0.0. You can also add a fourth number for the following format: 0.1.2.3",
       "examples": ["1.0.0", "1.0.0.0"],
       "pattern": "^\\d+\\.\\d+\\.\\d+(\\.\\d+)?$"
     },
     "name": {
       "type": "string",
-      "title": "A short, human-readable name of the extension. Limited to 200 characters.",
+      "title": "a short, human-readable name of the extension. limited to 200 characters.",
       "maxLength": 200,
       "examples": [
         "Azure DevOps Extension Tasks",
@@ -168,7 +168,7 @@
     },
     "publisher": {
       "type": "string",
-      "title": "The identifier of the publisher.",
+      "title": "the identifier of the publisher.",
       "description": "This identifier must match the identifier the extension is published under.",
       "$comment": "This identifier must match the identifier the extension is published under.",
       "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]+$"
@@ -176,7 +176,7 @@
     "categories": {
       "type": "array",
       "uniqueItems": true,
-      "title": "Array of strings representing the categories your extension belongs to.",
+      "title": "array of strings representing the categories your extension belongs to.",
       "description": "At least one category must be provided and there is no limit to how many categories you may include.",
       "items": {
         "type": "string",
@@ -191,14 +191,14 @@
     },
     "targets": {
       "type": "array",
-      "title": "The products and services supported by your integration or extension.",
+      "title": "the products and services supported by your integration or extension.",
       "items": {
         "type": "object",
         "required": ["id"],
         "properties": {
           "id": {
             "type": "string",
-            "title": "Installation targets: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#installation-targets",
+            "title": "installation targets: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#installation-targets",
             "description": "Id of the product or service which your integration/extension should support",
             "enum": [
               "Microsoft.VisualStudio.Services",
@@ -211,7 +211,7 @@
           },
           "version": {
             "type": "string",
-            "title": "Installation target versions: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#installation-targets",
+            "title": "installation target versions: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#installation-targets",
             "description": "Some installation target identifiers, like and , support an optional version range. This further clarifies the supported releases the extension or integration is supported on.Microsoft.TeamFoundation.ServerMicrosoft.TeamFoundation.Server.Integration",
             "examples": [
               "[17.0,)",
@@ -231,12 +231,12 @@
     },
     "scopes": {
       "type": "array",
-      "title": "Authorization scopes required by your extension.",
+      "title": "authorization scopes required by your extension.",
       "description": "An array of authorization scopes (strings) listing permissions required by your extension.",
       "items": {
         "type": "string",
         "description": "Authorization Scope.",
-        "title": "Valid Values: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#scopes",
+        "title": "valid values: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#scopes",
         "enum": [
           "vso.acquisition_write",
           "vso.agentpools",
@@ -330,12 +330,12 @@
     },
     "demands": {
       "type": "array",
-      "title": "Capabilities required by your extension.",
+      "title": "capabilities required by your extension.",
       "description": "An array of demands (strings) listing the capabilities required by your extension.",
       "items": {
         "type": "string",
         "description": "Demand Scope.",
-        "title": "Valid Values: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#demands",
+        "title": "valid values: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#demands",
         "allOf": [
           {
             "$ref": "#/definitions/demand_pattern"
@@ -346,12 +346,12 @@
     "baseUri": {
       "type": "string",
       "description": "(Optional) base URL for all relative URLs specified by the extension's contributions.",
-      "title": "This property should be left empty if your extension's contents are packaged with your extension.",
+      "title": "this property should be left empty if your extension's contents are packaged with your extension.",
       "format": "uri"
     },
     "description": {
       "type": "string",
-      "title": "A few sentences describing the extension.",
+      "title": "a few sentences describing the extension.",
       "maxLength": 200
     },
     "icons": {
@@ -361,7 +361,7 @@
       "properties": {
         "default": {
           "type": "string",
-          "title": "(128x128 pixels) of type BMP, GIF, EXIF, JPG, PNG and TIFF.",
+          "title": "(128x128 pixels) of type bmp, gif, exif, jpg, png and tiff.",
           "description": "The value must be the path to the icon file in the extension",
           "format": "uri-reference"
         }
@@ -412,17 +412,17 @@
     },
     "screenshots": {
       "type": "array",
-      "title": "Screenshots are more valuable when featured in your content, and should be used there to help make a quality market details page for your extension. Use screenshots for less important images not featured in your content.",
+      "title": "screenshots are more valuable when featured in your content, and should be used there to help make a quality market details page for your extension. use screenshots for less important images not featured in your content.",
       "description": "Array of images that could not be included in your **content*.",
       "items": {
         "type": "object",
-        "title": "An image that could not be included in your **content*.",
+        "title": "an image that could not be included in your **content*.",
         "description": "Each image should be 1366x768 pixels.",
         "required": ["path"],
         "properties": {
           "path": {
             "type": "string",
-            "title": "Each image should be 1366x768 pixels.",
+            "title": "each image should be 1366x768 pixels.",
             "description": "The path of each item is the path to the file in the extension.",
             "format": "uri-reference"
           }
@@ -431,11 +431,11 @@
     },
     "content": {
       "type": "object",
-      "title": "Dictionary of content files that describe your extension to users.",
+      "title": "dictionary of content files that describe your extension to users.",
       "required": ["details"],
       "properties": {
         "details": {
-          "title": "Extension Details (GitHub Flavored Markdown File)",
+          "title": "extension details (github flavored markdown file)",
           "description": "GitHub Flavored Markdown file which describes the details of the Extension",
           "allOf": [
             {
@@ -444,7 +444,7 @@
           ]
         },
         "license": {
-          "title": "Extension License Information (GitHub Flavored Markdown File)",
+          "title": "extension license information (github flavored markdown file)",
           "description": "GitHub Flavored Markdown file which describes the license information of the Extension",
           "allOf": [
             {
@@ -453,7 +453,7 @@
           ]
         },
         "pricing": {
-          "title": "Extension Pricing Information (GitHub Flavored Markdown File)",
+          "title": "extension pricing information (github flavored markdown file)",
           "description": "GitHub Flavored Markdown file which describes the pricing information of the Extension",
           "allOf": [
             {
@@ -465,11 +465,11 @@
     },
     "links": {
       "type": "object",
-      "title": "Dictionary of links that help users learn more about your extension, get support, and move.",
+      "title": "dictionary of links that help users learn more about your extension, get support, and move.",
       "minProperties": 1,
       "properties": {
         "getstarted": {
-          "title": "Get Started Documentation (GitHub Flavored Markdown File)",
+          "title": "get started documentation (github flavored markdown file)",
           "description": "First steps, how to setup or use.",
           "allOf": [
             {
@@ -478,7 +478,7 @@
           ]
         },
         "learn": {
-          "title": "Learning Documentation (GitHub Flavored Markdown File)",
+          "title": "learning documentation (github flavored markdown file)",
           "description": "Deeper content to help users better understand your extension or service.",
           "allOf": [
             {
@@ -487,7 +487,7 @@
           ]
         },
         "license": {
-          "title": "License Documentation (GitHub Flavored Markdown File)",
+          "title": "license documentation (github flavored markdown file)",
           "description": "End user license agreement.",
           "allOf": [
             {
@@ -496,7 +496,7 @@
           ]
         },
         "privacypolicy": {
-          "title": "Privacy Policy (GitHub Flavored Markdown File)",
+          "title": "privacy policy (github flavored markdown file)",
           "description": "Privacy policy for an extension.",
           "allOf": [
             {
@@ -505,7 +505,7 @@
           ]
         },
         "support": {
-          "title": "Support Information (GitHub Flavored Markdown File)",
+          "title": "support information (github flavored markdown file)",
           "description": "Get help and support for an extension.",
           "allOf": [
             {
@@ -517,17 +517,17 @@
     },
     "repository": {
       "type": "object",
-      "title": "The source code repository for the extension",
+      "title": "the source code repository for the extension",
       "required": ["type", "uri"],
       "properties": {
         "type": {
           "type": "string",
-          "title": "Type of the repository",
+          "title": "type of the repository",
           "enum": ["git", "mercurial", "svn", "cvs"]
         },
         "uri": {
           "type": "string",
-          "title": "Absolute URI of the repository",
+          "title": "absolute uri of the repository",
           "format": "uri"
         }
       }
@@ -535,10 +535,10 @@
     "badges": {
       "type": "array",
       "description": "Array of links to external metadata badges like TravisCI, Appveyor etc from the approved badges sites.",
-      "title": "Approved Badge Sites: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest.#approvedbadges",
+      "title": "approved badge sites: https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest.#approvedbadges",
       "items": {
         "type": "object",
-        "title": "Badge Information",
+        "title": "badge information",
         "required": ["href", "uri"],
         "properties": {
           "href": {
@@ -553,7 +553,7 @@
           },
           "description": {
             "type": "string",
-            "title": "Description of the badge, to be displayed on hover."
+            "title": "description of the badge, to be displayed on hover."
           }
         }
       }
@@ -581,7 +581,7 @@
     },
     "files": {
       "type": "array",
-      "title": "The files section is where you reference any files you wish to include in your extension. You can add both folders and individual files.",
+      "title": "the files section is where you reference any files you wish to include in your extension. you can add both folders and individual files.",
       "items": {
         "type": "object",
         "description": "A file you wish to include in your extension. Both folders and individual files are acceptable",
@@ -607,7 +607,7 @@
     },
     "contributions": {
       "type": "array",
-      "title": "An array of contributions to the system.",
+      "title": "an array of contributions to the system.",
       "items": {
         "allOf": [
           {
@@ -618,7 +618,7 @@
     },
     "contributionTypes": {
       "type": "array",
-      "title": "An array of contribution types defined by the extension",
+      "title": "an array of contribution types defined by the extension",
       "items": {
         "allOf": [
           {
@@ -637,6 +637,6 @@
     "categories",
     "targets"
   ],
-  "title": "JSON Schema for Azure DevOps Extensions",
+  "title": "json schema for azure devops extensions",
   "type": "object"
 }

--- a/src/schemas/json/web-manifest-app-info.json
+++ b/src/schemas/json/web-manifest-app-info.json
@@ -25,6 +25,6 @@
       }
     }
   },
-  "title": "JSON schema for Web Application manifest files with app information extensions",
+  "title": "json schema for web application manifest files with app information extensions",
   "type": "object"
 }

--- a/src/schemas/json/web-manifest-combined.json
+++ b/src/schemas/json/web-manifest-combined.json
@@ -11,5 +11,5 @@
       "$ref": "https://json.schemastore.org/web-manifest-share-target.json"
     }
   ],
-  "title": "JSON schema for Web Application manifest files"
+  "title": "json schema for web application manifest files"
 }

--- a/src/schemas/json/web-manifest-share-target.json
+++ b/src/schemas/json/web-manifest-share-target.json
@@ -100,6 +100,6 @@
       "$ref": "#/definitions/share_target"
     }
   },
-  "title": "JSON schema for Web Application manifest files with Web Share Target and Web Share Target Level 2 extensions",
+  "title": "json schema for web application manifest files with web share target and web share target level 2 extensions",
   "type": "object"
 }

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -201,6 +201,6 @@
       "type": "string"
     }
   },
-  "title": "JSON schema for Web Application manifest files",
+  "title": "json schema for web application manifest files",
   "type": "object"
 }

--- a/src/schemas/json/web-types.json
+++ b/src/schemas/json/web-types.json
@@ -1051,6 +1051,6 @@
     }
   },
   "required": ["name", "version"],
-  "title": "JSON schema for Web-Types",
+  "title": "json schema for web-types",
   "type": "object"
 }

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -635,6 +635,6 @@
     }
   },
   "required": ["manifest_version", "name", "version"],
-  "title": "JSON schema for WebExtensions manifest files",
+  "title": "json schema for webextensions manifest files",
   "type": "object"
 }

--- a/src/schemas/json/webjob-publish-settings.json
+++ b/src/schemas/json/webjob-publish-settings.json
@@ -74,6 +74,6 @@
     }
   ],
   "required": ["runMode"],
-  "title": "JSON schema for Azure Webjobs configuration files",
+  "title": "json schema for azure webjobs configuration files",
   "type": "object"
 }

--- a/src/schemas/json/webjobs-list.json
+++ b/src/schemas/json/webjobs-list.json
@@ -16,6 +16,6 @@
     }
   },
   "required": ["WebJobs"],
-  "title": "JSON schema for Azure Webjobs collection files",
+  "title": "json schema for azure webjobs collection files",
   "type": "object"
 }

--- a/src/schemas/json/winget-pkgs-installer-1.0.0.json
+++ b/src/schemas/json/winget-pkgs-installer-1.0.0.json
@@ -29,7 +29,7 @@
     "Platform": {
       "type": ["array", "null"],
       "items": {
-        "title": "Platform",
+        "title": "platform",
         "type": "string",
         "enum": ["Windows.Desktop", "Windows.Universal"]
       },
@@ -66,7 +66,7 @@
     "InstallModes": {
       "type": ["array", "null"],
       "items": {
-        "title": "InstallModes",
+        "title": "installmodes",
         "type": "string",
         "enum": ["interactive", "silent", "silentWithProgress"]
       },

--- a/src/schemas/json/winget-pkgs-singleton-1.0.0.json
+++ b/src/schemas/json/winget-pkgs-singleton-1.0.0.json
@@ -41,7 +41,7 @@
     "Platform": {
       "type": ["array", "null"],
       "items": {
-        "title": "Platform",
+        "title": "platform",
         "type": "string",
         "enum": ["Windows.Desktop", "Windows.Universal"]
       },
@@ -78,7 +78,7 @@
     "InstallModes": {
       "type": ["array", "null"],
       "items": {
-        "title": "InstallModes",
+        "title": "installmodes",
         "type": "string",
         "enum": ["interactive", "silent", "silentWithProgress"]
       },

--- a/src/schemas/json/workflows.json
+++ b/src/schemas/json/workflows.json
@@ -352,5 +352,5 @@
     }
   },
   "description": "Orchestrate Workflows consisting of Google Cloud APIs, SaaS APIs or private API endpoints.",
-  "title": "Google Cloud Workflows config file"
+  "title": "google cloud workflows config file"
 }

--- a/src/schemas/json/xunit-2.2.json
+++ b/src/schemas/json/xunit-2.2.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "xUnit.net Runner Configuration"
+  "title": "xunit.net runner configuration"
 }

--- a/src/schemas/json/xunit-2.3.json
+++ b/src/schemas/json/xunit-2.3.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://xunit.net/schema/v2.3/xunit.runner.schema.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "xUnit.net Runner Configuration"
+  "title": "xunit.net runner configuration"
 }

--- a/src/schemas/json/xunit.runner.schema.json
+++ b/src/schemas/json/xunit.runner.schema.json
@@ -1,5 +1,5 @@
 {
   "$ref": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "xUnit.net Runner Configuration"
+  "title": "xunit.net runner configuration"
 }

--- a/src/schemas/json/yamllint.json
+++ b/src/schemas/json/yamllint.json
@@ -10,7 +10,7 @@
     "ignore": {
       "properties": {
         "ignore": {
-          "title": "Ignore",
+          "title": "ignore",
           "description": "Ignore files, so that the linter doesn't process them.",
           "type": "string"
         }
@@ -20,7 +20,7 @@
       "$ref": "#/definitions/ignore",
       "properties": {
         "level": {
-          "title": "Level",
+          "title": "level",
           "type": "string",
           "default": "warning"
         }
@@ -30,27 +30,27 @@
   "description": "yamllint uses a set of rules to check source files for problems.",
   "properties": {
     "extends": {
-      "title": "Extends",
+      "title": "extends",
       "type": "string"
     },
     "yaml-files": {
-      "title": "YAML Files",
+      "title": "yaml files",
       "type": "array",
       "items": {
-        "title": "YAML File",
+        "title": "yaml file",
         "type": "string"
       },
       "default": ["*.yaml", "*.yml", ".yamllint"]
     },
     "locale": {
-      "title": "Locale",
+      "title": "locale",
       "description": "This is passed to Python's locale.setlocale.",
       "type": "string"
     },
     "rules": {
       "properties": {
         "braces": {
-          "title": "Braces",
+          "title": "braces",
           "description": "Use this rule to control the use of flow mappings or number of spaces inside braces ({ and }).",
           "anyOf": [
             {
@@ -64,7 +64,7 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "forbid": {
-                  "title": "Forbid",
+                  "title": "forbid",
                   "description": "Used to forbid the use of flow mappings which are denoted by surrounding braces ({ and }).",
                   "anyOf": [
                     {
@@ -78,25 +78,25 @@
                   "default": false
                 },
                 "min-spaces-inside": {
-                  "title": "Minimum Spaces Inside",
+                  "title": "minimum spaces inside",
                   "description": "Defines the minimal number of spaces required inside braces.",
                   "type": "number",
                   "default": 0
                 },
                 "max-spaces-inside": {
-                  "title": "Max Spaces Inside",
+                  "title": "max spaces inside",
                   "description": "Defines the maximal number of spaces allowed inside braces.",
                   "type": "number",
                   "default": 0
                 },
                 "min-spaces-inside-empty": {
-                  "title": "Minimum Spaces Inside Empty",
+                  "title": "minimum spaces inside empty",
                   "description": "Defines the minimal number of spaces required inside empty braces.",
                   "type": "number",
                   "default": -1
                 },
                 "max-spaces-inside-empty": {
-                  "title": "Max Spaces Inside Empty",
+                  "title": "max spaces inside empty",
                   "description": "Defines the maximal number of spaces allowed inside empty braces.",
                   "type": "number",
                   "default": -1
@@ -107,7 +107,7 @@
           "default": "enable"
         },
         "brackets": {
-          "title": "Brackets",
+          "title": "brackets",
           "description": "Use this rule to control the use of flow sequences or the number of spaces inside brackets ([ and ]).",
           "anyOf": [
             {
@@ -121,7 +121,7 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "forbid": {
-                  "title": "Forbid",
+                  "title": "forbid",
                   "description": "Used to forbid the use of flow sequences which are denoted by surrounding brackets ([ and ]).",
                   "anyOf": [
                     {
@@ -135,25 +135,25 @@
                   "default": false
                 },
                 "min-spaces-inside": {
-                  "title": "Minimum Spaces Inside",
+                  "title": "minimum spaces inside",
                   "description": "Defines the minimal number of spaces required inside brackets.",
                   "type": "number",
                   "default": 0
                 },
                 "max-spaces-inside": {
-                  "title": "Max Spaces Inside",
+                  "title": "max spaces inside",
                   "description": "Defines the maximal number of spaces allowed inside brackets.",
                   "type": "number",
                   "default": 0
                 },
                 "min-spaces-inside-empty": {
-                  "title": "Minimum Spaces Inside Empty",
+                  "title": "minimum spaces inside empty",
                   "description": "Defines the minimal number of spaces required inside empty brackets.",
                   "type": "number",
                   "default": -1
                 },
                 "max-spaces-inside-empty": {
-                  "title": "Max Spaces Inside Empty",
+                  "title": "max spaces inside empty",
                   "description": "Defines the maximal number of spaces allowed inside empty brackets.",
                   "type": "number",
                   "default": -1
@@ -164,7 +164,7 @@
           "default": "enable"
         },
         "colons": {
-          "title": "Colons",
+          "title": "colons",
           "description": "Use this rule to control the number of spaces before and after colons (:).",
           "anyOf": [
             {
@@ -178,13 +178,13 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "max-spaces-before": {
-                  "title": "Max Spaces Before",
+                  "title": "max spaces before",
                   "description": "Defines the maximal number of spaces allowed before colons (use -1 to disable).",
                   "type": "number",
                   "default": 0
                 },
                 "max-spaces-after": {
-                  "title": "Max Spaces After",
+                  "title": "max spaces after",
                   "description": "Defines the maximal number of spaces allowed after colons (use -1 to disable).",
                   "type": "number",
                   "default": 1
@@ -195,7 +195,7 @@
           "default": "enable"
         },
         "commas": {
-          "title": "Commas",
+          "title": "commas",
           "description": "Use this rule to control the number of spaces before and after commas (,).",
           "anyOf": [
             {
@@ -209,19 +209,19 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "max-spaces-before": {
-                  "title": "Max Spaces Before",
+                  "title": "max spaces before",
                   "description": "Defines the maximal number of spaces allowed before commas (use -1 to disable).",
                   "type": "number",
                   "default": 0
                 },
                 "min-spaces-after": {
-                  "title": "Minimum Spaces After",
+                  "title": "minimum spaces after",
                   "description": "Defines the minimal number of spaces required after commas.",
                   "type": "number",
                   "default": 1
                 },
                 "max-spaces-after": {
-                  "title": "Max Spaces After",
+                  "title": "max spaces after",
                   "description": "Defines the maximal number of spaces allowed after commas (use -1 to disable).",
                   "type": "number",
                   "default": 1
@@ -232,7 +232,7 @@
           "default": "enable"
         },
         "comments": {
-          "title": "Comments",
+          "title": "comments",
           "description": "Use this rule to control the position and formatting of comments.",
           "anyOf": [
             {
@@ -246,19 +246,19 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "require-starting-space": {
-                  "title": "Require Starting Space",
+                  "title": "require starting space",
                   "description": "Require a space character right after the #.",
                   "type": "boolean",
                   "default": true
                 },
                 "ignore-shebangs": {
-                  "title": "Ignore Shebangs",
+                  "title": "ignore shebangs",
                   "description": "Ignore a shebang at the beginning of the file when require-starting-space is set.",
                   "type": "boolean",
                   "default": true
                 },
                 "min-spaces-from-content": {
-                  "title": "Minimum Spaces from Content",
+                  "title": "minimum spaces from content",
                   "description": "Used to visually separate inline comments from content.",
                   "type": "number",
                   "default": 2
@@ -271,7 +271,7 @@
           }
         },
         "comments-indentation": {
-          "title": "Comments Indentation",
+          "title": "comments indentation",
           "description": "Use this rule to force comments to be indented like content.",
           "anyOf": [
             {
@@ -290,7 +290,7 @@
           }
         },
         "document-end": {
-          "title": "Document End",
+          "title": "document end",
           "description": "Use this rule to require or forbid the use of document end marker (...).",
           "anyOf": [
             {
@@ -304,7 +304,7 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "present": {
-                  "title": "Present",
+                  "title": "present",
                   "description": "True when the document end marker is required, or to false when it is forbidden.",
                   "type": "boolean",
                   "default": true
@@ -315,7 +315,7 @@
           "default": "disable"
         },
         "document-start": {
-          "title": "Document Start",
+          "title": "document start",
           "description": "Use this rule to require or forbid the use of document start marker (---).",
           "anyOf": [
             {
@@ -329,7 +329,7 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "present": {
-                  "title": "Present",
+                  "title": "present",
                   "description": "True when the document start marker is required, or to false when it is forbidden.",
                   "type": "boolean",
                   "default": true
@@ -342,7 +342,7 @@
           }
         },
         "empty-lines": {
-          "title": "Empty Lines",
+          "title": "empty lines",
           "description": "Use this rule to set a maximal number of allowed consecutive blank lines.",
           "anyOf": [
             {
@@ -356,19 +356,19 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "max": {
-                  "title": "Max",
+                  "title": "max",
                   "description": "Defines the maximal number of empty lines allowed in the document.",
                   "type": "number",
                   "default": 2
                 },
                 "max-start": {
-                  "title": "Max Start",
+                  "title": "max start",
                   "description": "Defines the maximal number of empty lines allowed at the beginning of the file.",
                   "type": "number",
                   "default": 0
                 },
                 "max-end": {
-                  "title": "Max End",
+                  "title": "max end",
                   "description": "",
                   "type": "number",
                   "default": 0
@@ -379,7 +379,7 @@
           "default": "enable"
         },
         "empty-values": {
-          "title": "Empty Values",
+          "title": "empty values",
           "description": "Use this rule to prevent nodes with empty content, that implicitly result in null values.",
           "anyOf": [
             {
@@ -393,13 +393,13 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "forbid-in-block-mappings": {
-                  "title": "Forbid in Block Mappings",
+                  "title": "forbid in block mappings",
                   "description": "Prevent empty values in block mappings.",
                   "type": "boolean",
                   "default": true
                 },
                 "forbid-in-flow-mappings": {
-                  "title": "Forbid in Flow Mappings",
+                  "title": "forbid in flow mappings",
                   "description": "Prevent empty values in flow mappings.",
                   "type": "boolean",
                   "default": true
@@ -410,7 +410,7 @@
           "default": "disable"
         },
         "hyphens": {
-          "title": "Hyphens",
+          "title": "hyphens",
           "description": "Use this rule to control the number of spaces after hyphens (-).",
           "anyOf": [
             {
@@ -424,7 +424,7 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "max-spaces-after": {
-                  "title": "Max Spaces After",
+                  "title": "max spaces after",
                   "description": "Defines the maximal number of spaces allowed after hyphens.",
                   "type": "number",
                   "default": 1
@@ -435,7 +435,7 @@
           "default": "enable"
         },
         "indentation": {
-          "title": "Indentation",
+          "title": "indentation",
           "description": "Use this rule to control the indentation.",
           "anyOf": [
             {
@@ -449,7 +449,7 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "spaces": {
-                  "title": "Spaces",
+                  "title": "spaces",
                   "description": "Defines the indentation width, in spaces.",
                   "anyOf": [
                     {
@@ -463,7 +463,7 @@
                   "default": "consistent"
                 },
                 "indent-sequences": {
-                  "title": "Indent Sequences",
+                  "title": "indent sequences",
                   "description": "Defines whether block sequences should be indented or not (when in a mapping, this indentation is not mandatory – some people perceive the - as part of the indentation).",
                   "anyOf": [
                     {
@@ -477,7 +477,7 @@
                   "default": true
                 },
                 "check-multi-line-strings": {
-                  "title": "Check Multi Line Strings",
+                  "title": "check multi line strings",
                   "description": "Defines whether to lint indentation in multi-line strings.",
                   "type": "boolean",
                   "default": false
@@ -488,7 +488,7 @@
           "default": "enable"
         },
         "key-duplicates": {
-          "title": "Key Duplicates",
+          "title": "key duplicates",
           "description": "Use this rule to prevent multiple entries with the same key in mappings.",
           "anyOf": [
             {
@@ -505,7 +505,7 @@
           "default": "enable"
         },
         "key-ordering": {
-          "title": "Key Ordering",
+          "title": "key ordering",
           "description": "Use this rule to enforce alphabetical ordering of keys in mappings.",
           "anyOf": [
             {
@@ -522,7 +522,7 @@
           "default": "disable"
         },
         "line-length": {
-          "title": "Line Length",
+          "title": "line length",
           "description": "Use this rule to set a limit to lines length.",
           "anyOf": [
             {
@@ -536,19 +536,19 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "max": {
-                  "title": "Max",
+                  "title": "max",
                   "description": "Defines the maximal (inclusive) length of lines.",
                   "type": "number",
                   "default": 80
                 },
                 "allow-non-breakable-words": {
-                  "title": "Allow Non-Breakable Words",
+                  "title": "allow non-breakable words",
                   "description": "Used to allow non breakable words (without spaces inside) to overflow the limit.",
                   "type": "boolean",
                   "default": true
                 },
                 "allow-non-breakable-inline-mappings": {
-                  "title": "Allow Non-Breakable Inline Mappings",
+                  "title": "allow non-breakable inline mappings",
                   "description": "Implies allow-non-breakable-words and extends it to also allow non-breakable words in inline mappings.",
                   "type": "boolean",
                   "default": true
@@ -559,7 +559,7 @@
           "default": "enable"
         },
         "new-line-at-end-of-file": {
-          "title": "New Line at End of File",
+          "title": "new line at end of file",
           "description": "Use this rule to require a new line character (\n) at the end of files.",
           "anyOf": [
             {
@@ -576,7 +576,7 @@
           "default": "enable"
         },
         "new-lines": {
-          "title": "New Lines",
+          "title": "new lines",
           "description": "Use this rule to force the type of new line characters.",
           "anyOf": [
             {
@@ -590,7 +590,7 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "type": {
-                  "title": "Type",
+                  "title": "type",
                   "description": "Unix to use UNIX-typed new line characters (\n), or dos to use DOS-typed new line characters (\r\n).",
                   "type": "string",
                   "enum": ["unix", "dos"],
@@ -602,7 +602,7 @@
           "default": "enable"
         },
         "octal-values": {
-          "title": "Octal Values",
+          "title": "octal values",
           "description": "Use this rule to prevent values with octal numbers.",
           "anyOf": [
             {
@@ -616,13 +616,13 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "forbid-implicit-octal": {
-                  "title": "Forbid Implicit Octal",
+                  "title": "forbid implicit octal",
                   "description": "Prevent numbers starting with 0.",
                   "type": "boolean",
                   "default": true
                 },
                 "forbid-explicit-octal": {
-                  "title": "Forbid Explicit Octal",
+                  "title": "forbid explicit octal",
                   "description": "Prevent numbers starting with 0o.",
                   "type": "boolean",
                   "default": true
@@ -633,7 +633,7 @@
           "default": "disable"
         },
         "quoted-strings": {
-          "title": "Quoted Strings",
+          "title": "quoted strings",
           "description": "Use this rule to forbid any string values that are not quoted, or to prevent quoted strings without needing it.",
           "anyOf": [
             {
@@ -647,14 +647,14 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "quote-type": {
-                  "title": "Quote Type",
+                  "title": "quote type",
                   "description": "Defines allowed quotes.",
                   "type": "string",
                   "enum": ["single", "double", "any"],
                   "default": "any"
                 },
                 "required": {
-                  "title": "Required",
+                  "title": "required",
                   "description": "Defines whether using quotes in string values is required.",
                   "anyOf": [
                     {
@@ -668,21 +668,21 @@
                   "default": true
                 },
                 "extra-required": {
-                  "title": "Extra Required",
+                  "title": "extra required",
                   "description": "List of PCRE regexes to force string values to be quoted, if they match any regex.",
                   "type": "array",
                   "items": {
-                    "title": "Pattern",
+                    "title": "pattern",
                     "type": "string"
                   },
                   "default": []
                 },
                 "extra-allowed": {
-                  "title": "Extra Allowed",
+                  "title": "extra allowed",
                   "description": "List of PCRE regexes to allow quoted string values, even if required: only-when-needed is set.",
                   "type": "array",
                   "items": {
-                    "title": "Pattern",
+                    "title": "pattern",
                     "type": "string"
                   },
                   "default": []
@@ -693,7 +693,7 @@
           "default": "disable"
         },
         "trailing-spaces": {
-          "title": "Tailing Spaces",
+          "title": "tailing spaces",
           "description": "Use this rule to forbid trailing spaces at the end of lines.",
           "anyOf": [
             {
@@ -710,7 +710,7 @@
           "default": "enable"
         },
         "truthy": {
-          "title": "Truthy",
+          "title": "truthy",
           "description": "Use this rule to forbid non-explictly typed truthy values other than allowed ones (by default: true and false), for example YES or off.",
           "anyOf": [
             {
@@ -724,7 +724,7 @@
               "$ref": "#/definitions/allRules",
               "properties": {
                 "allowed-values": {
-                  "title": "Allowed Values",
+                  "title": "allowed values",
                   "description": "Defines the list of truthy values which will be ignored during linting.",
                   "type": "array",
                   "items": {
@@ -753,7 +753,7 @@
                   "default": ["true", "false"]
                 },
                 "check-keys": {
-                  "title": "Check Keys",
+                  "title": "check keys",
                   "description": "Disables verification for keys in mappings.",
                   "type": "boolean",
                   "default": true

--- a/src/schemas/json/zuul.json
+++ b/src/schemas/json/zuul.json
@@ -9,7 +9,7 @@
         }
       },
       "required": ["job"],
-      "title": "JobEntry",
+      "title": "jobentry",
       "type": "object"
     },
     "JobModel": {
@@ -17,11 +17,11 @@
       "properties": {
         "abstract": {
           "default": false,
-          "title": "Abstract",
+          "title": "abstract",
           "type": "boolean"
         },
         "allowed-projects": {
-          "title": "Allowed-Projects",
+          "title": "allowed-projects",
           "type": "string"
         },
         "ansible-version": {
@@ -34,18 +34,18 @@
               "type": "string"
             }
           ],
-          "title": "Ansible-Version"
+          "title": "ansible-version"
         },
         "attempts": {
-          "title": "Attempts",
+          "title": "attempts",
           "type": "integer"
         },
         "branches": {
-          "title": "Branches",
+          "title": "branches",
           "type": "string"
         },
         "description": {
-          "title": "Description",
+          "title": "description",
           "type": "string"
         },
         "dependencies": {
@@ -63,10 +63,10 @@
               "type": "array"
             }
           ],
-          "title": "Files"
+          "title": "files"
         },
         "failure-url": {
-          "title": "Failure-Url",
+          "title": "failure-url",
           "type": "string"
         },
         "files": {
@@ -81,18 +81,18 @@
               "type": "array"
             }
           ],
-          "title": "Files"
+          "title": "files"
         },
         "final": {
           "default": false,
-          "title": "Final",
+          "title": "final",
           "type": "boolean"
         },
         "host-vars": {
           "additionalProperties": {
             "type": "object"
           },
-          "title": "Host-Vars",
+          "title": "host-vars",
           "type": "object"
         },
         "irrelevant-files": {
@@ -107,21 +107,21 @@
               "type": "array"
             }
           ],
-          "title": "Irrelevant-Files"
+          "title": "irrelevant-files"
         },
         "name": {
-          "title": "Name",
+          "title": "name",
           "type": "string"
         },
         "nodeset": {
-          "title": "Nodeset"
+          "title": "nodeset"
         },
         "override-checkout": {
-          "title": "Override-Checkout",
+          "title": "override-checkout",
           "type": "string"
         },
         "parent": {
-          "title": "Parent",
+          "title": "parent",
           "type": "string"
         },
         "post-run": {
@@ -136,10 +136,10 @@
               "type": "array"
             }
           ],
-          "title": "Post-Run"
+          "title": "post-run"
         },
         "post-timeout": {
-          "title": "Post-Timeout",
+          "title": "post-timeout",
           "type": "integer"
         },
         "pre-run": {
@@ -154,13 +154,13 @@
               "type": "array"
             }
           ],
-          "title": "Pre-Run"
+          "title": "pre-run"
         },
         "provides": {
           "items": {
             "type": "string"
           },
-          "title": "Provides",
+          "title": "provides",
           "type": "array"
         },
         "required-projects": {
@@ -174,21 +174,21 @@
               }
             ]
           },
-          "title": "Required-Projects",
+          "title": "required-projects",
           "type": "array"
         },
         "requires": {
           "items": {
             "type": "string"
           },
-          "title": "Requires",
+          "title": "requires",
           "type": "array"
         },
         "roles": {
           "items": {
             "$ref": "#/definitions/ZuulRoleModel"
           },
-          "title": "Roles",
+          "title": "roles",
           "type": "array"
         },
         "run": {
@@ -203,7 +203,7 @@
               "type": "array"
             }
           ],
-          "title": "Run"
+          "title": "run"
         },
         "secrets": {
           "anyOf": [
@@ -224,10 +224,10 @@
               "type": "array"
             }
           ],
-          "title": "Secrets"
+          "title": "secrets"
         },
         "success-url": {
-          "title": "Success-Url",
+          "title": "success-url",
           "type": "string"
         },
         "tags": {
@@ -242,62 +242,62 @@
               "type": "array"
             }
           ],
-          "title": "Tags"
+          "title": "tags"
         },
         "timeout": {
-          "title": "Timeout",
+          "title": "timeout",
           "type": "integer"
         },
         "vars": {
-          "title": "Vars",
+          "title": "vars",
           "type": "object"
         },
         "voting": {
           "default": true,
-          "title": "Voting",
+          "title": "voting",
           "type": "boolean"
         }
       },
       "required": ["name"],
-      "title": "JobModel",
+      "title": "jobmodel",
       "type": "object"
     },
     "JobDependencyModel": {
       "additionalProperties": false,
       "properties": {
         "name": {
-          "title": "Name",
+          "title": "name",
           "type": "string"
         },
         "soft": {
           "default": false,
-          "title": "Soft",
+          "title": "soft",
           "type": "boolean"
         }
       },
       "required": ["name"],
-      "title": "JobDependencyModel",
+      "title": "jobdependencymodel",
       "type": "object"
     },
     "JobSecretModel": {
       "additionalProperties": false,
       "properties": {
         "name": {
-          "title": "Name",
+          "title": "name",
           "type": "string"
         },
         "pass-to-parent": {
           "default": false,
-          "title": "Pass-To-Parent",
+          "title": "pass-to-parent",
           "type": "boolean"
         },
         "secret": {
-          "title": "Secret",
+          "title": "secret",
           "type": "string"
         }
       },
       "required": ["name", "secret"],
-      "title": "JobSecretModel",
+      "title": "jobsecretmodel",
       "type": "object"
     },
     "PipelineModel": {
@@ -305,15 +305,15 @@
       "properties": {
         "jobs": {
           "items": {},
-          "title": "Jobs",
+          "title": "jobs",
           "type": "array"
         },
         "queue": {
-          "title": "Queue",
+          "title": "queue",
           "type": "string"
         }
       },
-      "title": "PipelineModel",
+      "title": "pipelinemodel",
       "type": "object"
     },
     "ProjectEntry": {
@@ -324,7 +324,7 @@
         }
       },
       "required": ["project"],
-      "title": "ProjectEntry",
+      "title": "projectentry",
       "type": "object"
     },
     "ProjectModel": {
@@ -334,18 +334,18 @@
           "$ref": "#/definitions/PipelineModel"
         },
         "default-branch": {
-          "title": "Default-Branch",
+          "title": "default-branch",
           "type": "string"
         },
         "description": {
-          "title": "Description",
+          "title": "description",
           "type": "string"
         },
         "gate": {
           "$ref": "#/definitions/PipelineModel"
         },
         "name": {
-          "title": "Name",
+          "title": "name",
           "type": "string"
         },
         "periodic-weekly": {
@@ -364,18 +364,18 @@
           "items": {
             "type": "string"
           },
-          "title": "Templates",
+          "title": "templates",
           "type": "array"
         },
         "third-party-check": {
           "$ref": "#/definitions/PipelineModel"
         },
         "vars": {
-          "title": "Vars",
+          "title": "vars",
           "type": "object"
         }
       },
-      "title": "ProjectModel",
+      "title": "projectmodel",
       "type": "object"
     },
     "ProjectTemplateEntry": {
@@ -386,7 +386,7 @@
         }
       },
       "required": ["project-template"],
-      "title": "ProjectTemplateEntry",
+      "title": "projecttemplateentry",
       "type": "object"
     },
     "ProjectTemplateModel": {
@@ -396,18 +396,18 @@
           "$ref": "#/definitions/PipelineModel"
         },
         "default-branch": {
-          "title": "Default-Branch",
+          "title": "default-branch",
           "type": "string"
         },
         "description": {
-          "title": "Description",
+          "title": "description",
           "type": "string"
         },
         "gate": {
           "$ref": "#/definitions/PipelineModel"
         },
         "name": {
-          "title": "Name",
+          "title": "name",
           "type": "string"
         },
         "periodic-weekly": {
@@ -426,27 +426,27 @@
           "$ref": "#/definitions/PipelineModel"
         },
         "vars": {
-          "title": "Vars",
+          "title": "vars",
           "type": "object"
         }
       },
       "required": ["name"],
-      "title": "ProjectTemplateModel",
+      "title": "projecttemplatemodel",
       "type": "object"
     },
     "RequiredProjectModel": {
       "properties": {
         "name": {
-          "title": "Name",
+          "title": "name",
           "type": "string"
         },
         "override-checkout": {
-          "title": "Override-Checkout",
+          "title": "override-checkout",
           "type": "string"
         }
       },
       "required": ["name"],
-      "title": "RequiredProjectModel",
+      "title": "requiredprojectmodel",
       "type": "object"
     },
     "SecretEntry": {
@@ -457,35 +457,35 @@
         }
       },
       "required": ["secret"],
-      "title": "SecretEntry",
+      "title": "secretentry",
       "type": "object"
     },
     "SecretModel": {
       "additionalProperties": false,
       "properties": {
         "data": {
-          "title": "Data",
+          "title": "data",
           "type": "object"
         },
         "name": {
-          "title": "Name",
+          "title": "name",
           "type": "string"
         }
       },
       "required": ["name", "data"],
-      "title": "SecretModel",
+      "title": "secretmodel",
       "type": "object"
     },
     "ZuulRoleModel": {
       "additionalProperties": false,
       "properties": {
         "zuul": {
-          "title": "Zuul",
+          "title": "zuul",
           "type": "string"
         }
       },
       "required": ["zuul"],
-      "title": "ZuulRoleModel",
+      "title": "zuulrolemodel",
       "type": "object"
     }
   },
@@ -506,6 +506,6 @@
       }
     ]
   },
-  "title": "Zuul Config Schema",
+  "title": "zuul config schema",
   "type": "array"
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

One-liner used (in JSON schemas directory): `for schema in *.json; do sed -i -E 's/"title": "(.*)"/"title": "\L\1"/' $schema; done`.
