### PR TITLE
CONTRIBUTING: fix `title` naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,8 @@ After adding a schema file in `src/schemas`, register them in alphabetical order
 - Always use `minLength`/`maxLength`/`pattern`/etc for property values.
 - Don't end `title`/`description` values with colon.
 - Always omit leading articles for `title`-s and trailing punctuation to make
-  expected object values look more like types in programming languages.
+  expected object values look more like types in programming languages. Also
+  start `title`-s with a lowercase letter and try use nouns for titles instead of sentences.
 - Always explicitly state whether some setting is global for some tool or local
   for a project created with this tool. For instance if some settings is local
   then add `for the current <project-type>` at the end of the `description` like

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ After adding a schema file in `src/schemas`, register them in alphabetical order
     can be changed in the future to allow wrong extra properties.
 - Always use `minLength`/`maxLength`/`pattern`/etc for property values.
 - Don't end `title`/`description` values with colon.
-- Always use lower case with spaces between words for `title`-s to make expected object
-  values look more like types in programming languages.
+- Always omit leading articles for `title`-s and trailing punctuation to make
+  expected object values look more like types in programming languages.
 - Always explicitly state whether some setting is global for some tool or local
   for a project created with this tool. For instance if some settings is local
   then add `for the current <project-type>` at the end of the `description` like


### PR DESCRIPTION
Fix `title` naming convention:

- addresses https://github.com/SchemaStore/schemastore/pull/2715#discussion_r1063634310 comment

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
