### PR TITLE
a*.json: add missing `title`-s

### DIFF
--- a/src/schemas/json/airlock-microgateway-3.0.json
+++ b/src/schemas/json/airlock-microgateway-3.0.json
@@ -3,6 +3,7 @@
   "additionalProperties": false,
   "definitions": {
     "DefaultActionDto": {
+      "title": "action",
       "type": "object",
       "properties": {
         "enabled": {
@@ -72,6 +73,7 @@
       "additionalProperties": false
     },
     "PatternWithoutInvertDto": {
+      "title": "pattern",
       "type": "object",
       "properties": {
         "ignore_case": {
@@ -182,11 +184,13 @@
     "apps": {
       "type": "array",
       "items": {
+        "title": "application",
         "type": "object",
         "properties": {
           "mappings": {
             "type": "array",
             "items": {
+              "title": "mapping",
               "type": "object",
               "properties": {
                 "access_token": {
@@ -201,6 +205,7 @@
                       "description": "All specified claims are checked and must match the claim's value of the decoded token. If a claim is an array, at least one entry must match the specified regex.",
                       "type": "array",
                       "items": {
+                        "title": "claim",
                         "type": "object",
                         "properties": {
                           "claim": {
@@ -273,6 +278,7 @@
                       "description": "Specifies which roles should be extracted from the claims.",
                       "type": "array",
                       "items": {
+                        "title": "role",
                         "type": "object",
                         "properties": {
                           "claim": {
@@ -318,6 +324,7 @@
                 "allow_rules": {
                   "type": "array",
                   "items": {
+                    "title": "rule",
                     "type": "object",
                     "properties": {
                       "content_type": {
@@ -435,6 +442,7 @@
                       "description": "A list of access restrictions can be created. Each request matching the combination of HTTP method and path of a access restriction must have at least one of the specified roles to access the service. All matching restrictions must be satisfied to gain access.",
                       "type": "array",
                       "items": {
+                        "title": "access restriction",
                         "type": "object",
                         "properties": {
                           "method": {
@@ -520,6 +528,7 @@
                     "hosts": {
                       "type": "array",
                       "items": {
+                        "title": "host",
                         "type": "object",
                         "properties": {
                           "name": {
@@ -607,6 +616,7 @@
                       "description": "All incoming URLs that match one of these patterns are accepted by Airlock Microgateway without a valid CSRF token.",
                       "type": ["array", "null"],
                       "items": {
+                        "title": "exception",
                         "type": "object",
                         "properties": {
                           "path": {
@@ -627,6 +637,7 @@
                 "deny_rule_groups": {
                   "type": "array",
                   "items": {
+                    "title": "rule group",
                     "type": "object",
                     "properties": {
                       "enabled": {
@@ -637,6 +648,7 @@
                       "exceptions": {
                         "type": "array",
                         "items": {
+                          "title": "exception",
                           "type": "object",
                           "properties": {
                             "content_type": {
@@ -829,6 +841,7 @@
                       "description": "A list of request custom actions executed in order of appearance. Only one action type (e.g. add_header or header_redirect) can be specified in each entry. Create multiple list positions if needed.",
                       "type": ["array", "null"],
                       "items": {
+                        "title": "custom action",
                         "type": "object",
                         "properties": {
                           "add_header": {
@@ -975,6 +988,7 @@
                       "description": "A list of request custom actions executed in order of appearance. Only one action type (e.g. add_header or header_redirect) can be specified in each entry. Create multiple list positions if needed.",
                       "type": ["array", "null"],
                       "items": {
+                        "title": "custom action",
                         "type": "object",
                         "properties": {
                           "add_header": {
@@ -1123,6 +1137,7 @@
                       "description": "Replacement rules for error responses returned by backend systems.",
                       "type": ["array", "null"],
                       "items": {
+                        "title": "page replacement",
                         "type": "object",
                         "properties": {
                           "page": {
@@ -1150,6 +1165,7 @@
                           "description": "Rewrite the body of HTTP response.",
                           "type": "array",
                           "items": {
+                            "title": "rewrite",
                             "type": "object",
                             "properties": {
                               "content": {
@@ -1179,6 +1195,7 @@
                           "description": "Rewriting HTML content may be necessary to modify URLs in the HTML content if the application creates absolute or incorrect links because it is not reverse proxy compatible",
                           "type": "array",
                           "items": {
+                            "title": "html",
                             "type": "object",
                             "properties": {
                               "options": {
@@ -1213,6 +1230,7 @@
                           "description": "Rewrite the json body of http responses.",
                           "type": "array",
                           "items": {
+                            "title": "json",
                             "type": "object",
                             "properties": {
                               "content": {
@@ -1241,6 +1259,7 @@
                           "description": "Rewrite option to modify the HTTP redirect location header sent from the back-end server before it is sent to the client.",
                           "type": "array",
                           "items": {
+                            "title": "location header",
                             "type": "object",
                             "properties": {
                               "to": {
@@ -1447,6 +1466,7 @@
               "redirects": {
                 "type": ["array", "null"],
                 "items": {
+                  "title": "redirect",
                   "type": "object",
                   "properties": {
                     "dest": {
@@ -1502,12 +1522,14 @@
       "description": "Custom deny rule groups that can be referenced in mappings on top of the built in Airlock deny rules.",
       "type": "array",
       "items": {
+        "title": "rule group",
         "type": "object",
         "properties": {
           "deny_rules": {
             "description": "Filter rule that blocks requests based on the evaluation of different request attributes.",
             "type": "array",
             "items": {
+              "title": "deny group",
               "type": "object",
               "properties": {
                 "content_type": {
@@ -1570,6 +1592,7 @@
           "default": "[]",
           "type": "array",
           "items": {
+            "title": "provider",
             "type": "object",
             "properties": {
               "issuer": {
@@ -1604,6 +1627,7 @@
           "default": "[]",
           "type": "array",
           "items": {
+            "title": "remote",
             "type": "object",
             "properties": {
               "issuer": {
@@ -1619,6 +1643,7 @@
                 "description": "URL of JWKS service provider."
               },
               "tls": {
+                "title": "tls",
                 "type": "object",
                 "properties": {
                   "cipher_suite": {
@@ -1731,9 +1756,11 @@
       "additionalProperties": false
     },
     "metrics": {
+      "title": "metrics",
       "type": "object",
       "properties": {
         "statsd": {
+          "title": "statsd",
           "type": "object",
           "properties": {
             "enabled": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

Add missing titles for all object keys for all JSON schemas starting with `a` letter.
