### PR TITLE
apple-app-site-association.json: refresh schema

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -279,9 +279,7 @@
     },
     {
       "apple-app-site-association.json": {
-        "externalSchema": [
-          "base-04.json"
-        ]
+        "externalSchema": ["base-04.json"]
       }
     },
     {

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -278,6 +278,13 @@
       }
     },
     {
+      "apple-app-site-association.json": {
+        "externalSchema": [
+          "base-04.json"
+        ]
+      }
+    },
+    {
       "azure-deviceupdate-import-manifest-5.0.json": {
         "externalSchema": ["azure-deviceupdate-manifest-definitions-5.0.json"]
       }

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -1,39 +1,51 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Apple Universal Link config",
+  "description": "An Apple Universal Link config schema",
+  "type": "object",
+  "required": [
+    "applinks"
+  ],
   "properties": {
     "applinks": {
       "title": "application links",
+      "description": "Application links",
       "type": "object",
+      "required": [
+        "apps",
+        "details"
+      ],
       "properties": {
         "apps": {
-          "enum": [[]],
-          "description": "Must be an empty array"
+          "description": "Applications",
+          "type": "array",
+          "enum": [[]]
         },
         "details": {
+          "description": "Details",
           "type": "array",
           "items": {
             "title": "detail",
+            "description": "A detail",
             "type": "object",
             "properties": {
               "appID": {
-                "type": "string",
-                "description": "The value of the appID key is the team ID or app ID prefix, followed by the bundle ID"
+                "description": "An appID key or app ID prefix, followed by the bundle ID",
+                "type": "string"
               },
               "paths": {
+                "description": "Paths",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
-                  "type": "string",
-                  "description": "Ordered list of paths to open in the mobile app. Prefix with 'NOT ' to remove a path"
+                  "description": "Path to open in the mobile app",
+                  "type": "string"
                 }
               }
             }
           }
         }
-      },
-      "required": ["apps", "details"]
+      }
     }
-  },
-  "required": ["applinks"],
-  "title": "Apple Universal Link, App Site Association",
-  "type": "object"
+  }
 }

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -1,20 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Apple Universal Link config",
   "description": "An Apple Universal Link config schema",
-  "type": "object",
-  "required": [
-    "applinks"
-  ],
   "properties": {
     "applinks": {
       "title": "application links",
       "description": "Application links",
       "type": "object",
-      "required": [
-        "apps",
-        "details"
-      ],
+      "required": ["apps", "details"],
       "properties": {
         "apps": {
           "description": "Applications",
@@ -47,5 +39,8 @@
         }
       }
     }
-  }
+  },
+  "required": ["applinks"],
+  "title": "Apple Universal Link config",
+  "type": "object"
 }

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -31,7 +31,7 @@
                 "uniqueItems": true,
                 "items": {
                   "description": "Path to open in the mobile app",
-                  "$ref": "https://json.schemastore.org/base.json#/definitions/path"
+                  "$ref": "https://json.schemastore.org/base-04.json#/definitions/path"
                 }
               }
             }

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -39,7 +39,7 @@
                 "uniqueItems": true,
                 "items": {
                   "description": "Path to open in the mobile app",
-                  "type": "string"
+                  "$ref": "https://json.schemastore.org/base.json#/definitions/path"
                 }
               }
             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

- reorder properties
- add missing `title`-s and `description`-s
- use `base-04.json` for paths
