### PR TITLE
Add new Github Actions large runner options

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -572,9 +572,13 @@
                 "ubuntu-20.04",
                 "ubuntu-22.04",
                 "ubuntu-latest",
+                "ubuntu-latest-4-cores",
+                "ubuntu-latest-8-cores",
+                "ubuntu-latest-16-cores",
                 "windows-2019",
                 "windows-2022",
-                "windows-latest"
+                "windows-latest",
+                "windows-latest-8-cores"
               ]
             },
             {

--- a/src/test/github-workflow/runs-on.yaml
+++ b/src/test/github-workflow/runs-on.yaml
@@ -16,6 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo 'Hello from ${{ runner.os }}'
+  ubuntu-large-4:
+    runs-on: ubuntu-latest-4-cores
+    steps:
+      - run: echo 'Hello from ${{ runner.os }}'
+  ubuntu-large-8:
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - run: echo 'Hello from ${{ runner.os }}'
+  ubuntu-large-16:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+      - run: echo 'Hello from ${{ runner.os }}'
   ubuntu-22:
     runs-on: ubuntu-22.04
     steps:
@@ -42,6 +54,10 @@ jobs:
       - run: echo 'Hello from ${{ runner.os }}'
   windows:
     runs-on: windows-latest
+    steps:
+      - run: echo 'Hello from ${{ runner.os }}'
+  windows-large:
+    runs-on: windows-latest-8-cores
     steps:
       - run: echo 'Hello from ${{ runner.os }}'
   windows-2022:


### PR DESCRIPTION
Github Actions recently released support for larger runners (see [the announcement](https://github.blog/changelog/2022-10-20-github-actions-larger-hosted-runners-are-now-automatically-created-for-customers/)), this PR just adds them as possible values for `runs-on`
