### PR TITLE
Update AWS SAM JSON URL to newer version

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1021,7 +1021,7 @@
         "sam.yml",
         "sam.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/awslabs/goformation/master/schema/sam.schema.json"
+      "url": "https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json"
     },
     {
       "name": "Citation File Format",


### PR DESCRIPTION
The SAM team has their github repo. This PR updates the AWS SAM json url to the updated one by the SAM team (so it's currently maintained).

https://github.com/aws/serverless-application-model/discussions/2645


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
