### PR TITLE
Fix clangd schema UnusedIncludes

### DIFF
--- a/src/schemas/json/clangd.json
+++ b/src/schemas/json/clangd.json
@@ -566,15 +566,15 @@
                   "readability-identifier-naming.VariableCase": "CamelCase"
                 }
               ]
-            },
-            "UnusedIncludes": {
-              "description": "Whether to enable Include Cleaner's unused includes diagnostics\nhttps://clangd.llvm.org/config.html#unusedincludes",
-              "type": "string",
-              "enum": ["None", "Strict"],
-              "default": "None"
             }
           },
           "additionalProperties": false
+        },
+        "UnusedIncludes": {
+          "description": "Whether to enable Include Cleaner's unused includes diagnostics\nhttps://clangd.llvm.org/config.html#unusedincludes",
+          "type": "string",
+          "enum": ["None", "Strict"],
+          "default": "None"
         }
       },
       "additionalProperties": false

--- a/src/test/clangd/clangd-3.yml
+++ b/src/test/clangd/clangd-3.yml
@@ -15,7 +15,7 @@ Diagnostics:
     Remove: modernize-use-trailing-return-type
     CheckOptions:
       readability-identifier-naming.VariableCase: CamelCase
-    UnusedIncludes: Strict
+  UnusedIncludes: Strict
 InlayHints:
   Enabled: true
   ParameterNames: true


### PR DESCRIPTION
Unused includes is part of the Diagnostics property, not nested in Diagnostics:ClangTidy