### PR TITLE
schema: Pantsbuild - use generic default values for certain options and lower case URLs

### DIFF
--- a/src/schemas/json/pantsbuild-2.14.0.json
+++ b/src/schemas/json/pantsbuild-2.14.0.json
@@ -8,453 +8,453 @@
       "properties": {
         "backend_packages": {
           "default": [],
-          "description": "Register functionality from these backends\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#backend_packages",
+          "description": "Register functionality from these backends\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#backend_packages",
           "type": "array"
         },
         "build_file_prelude_globs": {
           "default": [],
-          "description": "Python files to evaluate and whose symbols should be exposed to all BUILD files\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#build_file_prelude_globs",
+          "description": "Python files to evaluate and whose symbols should be exposed to all BUILD files\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#build_file_prelude_globs",
           "type": "array"
         },
         "build_ignore": {
           "default": [],
-          "description": "Path globs or literals to ignore when identifying BUILD files\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#build_ignore",
+          "description": "Path globs or literals to ignore when identifying BUILD files\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#build_ignore",
           "type": "array"
         },
         "build_patterns": {
           "default": ["BUILD", "BUILD.*"],
-          "description": "The naming scheme for BUILD files, i.e. where you define targets\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#build_patterns",
+          "description": "The naming scheme for BUILD files, i.e. where you define targets\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#build_patterns",
           "type": "array"
         },
         "ca_certs_path": {
           "default": null,
-          "description": "Path to a file containing PEM-format CA certificates used for verifying secure connections when downloading files required by a build\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#ca_certs_path",
+          "description": "Path to a file containing PEM-format CA certificates used for verifying secure connections when downloading files required by a build\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#ca_certs_path",
           "type": "string"
         },
         "cache_content_behavior": {
           "default": "fetch",
-          "description": "Controls how the content of cache entries is handled during process execution\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#cache_content_behavior",
+          "description": "Controls how the content of cache entries is handled during process execution\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#cache_content_behavior",
           "enum": ["fetch", "validate", "defer"]
         },
         "colors": {
           "default": false,
-          "description": "Whether Pants should use colors in output or not\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#colors",
+          "description": "Whether Pants should use colors in output or not\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#colors",
           "type": "boolean"
         },
         "concurrent": {
           "default": false,
-          "description": "Enable concurrent runs of Pants\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#concurrent",
+          "description": "Enable concurrent runs of Pants\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#concurrent",
           "type": "boolean"
         },
         "dynamic_ui": {
           "default": true,
-          "description": "Display a dynamically-updating console UI as Pants runs\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#dynamic_ui",
+          "description": "Display a dynamically-updating console UI as Pants runs\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#dynamic_ui",
           "type": "boolean"
         },
         "dynamic_ui_renderer": {
           "default": "indicatif-spinner",
-          "description": "If `--dynamic-ui` is enabled, selects the renderer\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#dynamic_ui_renderer",
+          "description": "If `--dynamic-ui` is enabled, selects the renderer\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#dynamic_ui_renderer",
           "enum": ["indicatif-spinner", "experimental-prodash"]
         },
         "engine_visualize_to": {
           "default": null,
-          "description": "A directory to write execution and rule graphs to as `dot` files\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#engine_visualize_to"
+          "description": "A directory to write execution and rule graphs to as `dot` files\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#engine_visualize_to"
         },
         "ignore_warnings": {
           "default": [],
-          "description": "Ignore logs and warnings matching these strings\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#ignore_warnings",
+          "description": "Ignore logs and warnings matching these strings\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#ignore_warnings",
           "type": "array"
         },
         "keep_sandboxes": {
           "default": "never",
-          "description": "Controls whether Pants will clean up local directories used as chroots for running processes\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#keep_sandboxes",
+          "description": "Controls whether Pants will clean up local directories used as chroots for running processes\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#keep_sandboxes",
           "enum": ["always", "on_failure", "never"]
         },
         "level": {
           "default": "info",
-          "description": "Set the logging level\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#level",
+          "description": "Set the logging level\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#level",
           "enum": ["trace", "debug", "info", "warn", "error"]
         },
         "local_cache": {
           "default": true,
-          "description": "Whether to cache process executions in a local cache persisted to disk at `--local-store-dir`\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#local_cache",
+          "description": "Whether to cache process executions in a local cache persisted to disk at `--local-store-dir`\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#local_cache",
           "type": "boolean"
         },
         "local_execution_root_dir": {
           "default": "<tmp_dir>",
-          "description": "Directory to use for local process execution sandboxing\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#local_execution_root_dir",
+          "description": "Directory to use for local process execution sandboxing\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#local_execution_root_dir",
           "type": "string"
         },
         "local_store_dir": {
-          "default": "/home/alexey.tereshenkov/.cache/pants/lmdb_store",
-          "description": "Directory to use for the local file store, which stores the results of subprocesses run by Pants\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#local_store_dir",
+          "default": "$XDG_CACHE_HOME/lmdb_store",
+          "description": "Directory to use for the local file store, which stores the results of subprocesses run by Pants\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#local_store_dir",
           "type": "string"
         },
         "local_store_directories_max_size_bytes": {
           "default": 16000000000,
-          "description": "The maximum size in bytes of the local store containing directories\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#local_store_directories_max_size_bytes",
+          "description": "The maximum size in bytes of the local store containing directories\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#local_store_directories_max_size_bytes",
           "type": "number"
         },
         "local_store_files_max_size_bytes": {
           "default": 256000000000,
-          "description": "The maximum size in bytes of the local store containing files\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#local_store_files_max_size_bytes",
+          "description": "The maximum size in bytes of the local store containing files\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#local_store_files_max_size_bytes",
           "type": "number"
         },
         "local_store_processes_max_size_bytes": {
           "default": 16000000000,
-          "description": "The maximum size in bytes of the local store containing process cache entries\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#local_store_processes_max_size_bytes",
+          "description": "The maximum size in bytes of the local store containing process cache entries\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#local_store_processes_max_size_bytes",
           "type": "number"
         },
         "local_store_shard_count": {
           "default": 16,
-          "description": "The number of LMDB shards created for the local store\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#local_store_shard_count",
+          "description": "The number of LMDB shards created for the local store\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#local_store_shard_count",
           "type": "number"
         },
         "log_levels_by_target": {
           "default": {},
-          "description": "Set a more specific logging level for one or more logging targets\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#log_levels_by_target",
+          "description": "Set a more specific logging level for one or more logging targets\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#log_levels_by_target",
           "type": "object"
         },
         "log_show_rust_3rdparty": {
           "default": false,
-          "description": "Whether to show/hide logging done by 3rdparty Rust crates used by the Pants engine\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#log_show_rust_3rdparty",
+          "description": "Whether to show/hide logging done by 3rdparty Rust crates used by the Pants engine\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#log_show_rust_3rdparty",
           "type": "boolean"
         },
         "logdir": {
           "default": null,
-          "description": "Write logs to files under this directory\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#logdir",
+          "description": "Write logs to files under this directory\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#logdir",
           "type": "string"
         },
         "loop": {
           "default": false,
-          "description": "Run goals continuously as file changes are detected\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#loop",
+          "description": "Run goals continuously as file changes are detected\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#loop",
           "type": "boolean"
         },
         "loop_max": {
           "default": 4294967296,
-          "description": "The maximum number of times to loop when `--loop` is specified\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#loop_max",
+          "description": "The maximum number of times to loop when `--loop` is specified\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#loop_max",
           "type": "number"
         },
         "named_caches_dir": {
-          "default": "/home/alexey.tereshenkov/.cache/pants/named_caches",
-          "description": "Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#named_caches_dir",
+          "default": "$XDG_CACHE_HOME/named_caches",
+          "description": "Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#named_caches_dir",
           "type": "string"
         },
         "pants_bin_name": {
           "default": "./pants",
-          "description": "The name of the script or binary used to invoke Pants\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_bin_name",
+          "description": "The name of the script or binary used to invoke Pants\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_bin_name",
           "type": "string"
         },
         "pants_config_files": {
-          "default": ["/home/alexey.tereshenkov/code/pants/pants.toml"],
-          "description": "Paths to Pants config files\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_config_files",
+          "default": ["<buildroot>/pants.toml"],
+          "description": "Paths to Pants config files\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_config_files",
           "type": "array"
         },
         "pants_distdir": {
-          "default": "/home/alexey.tereshenkov/code/pants/dist",
-          "description": "Write end products, such as the results of `./pants package`, to this dir\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_distdir",
+          "default": "<buildroot>/dist",
+          "description": "Write end products, such as the results of `./pants package`, to this dir\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_distdir",
           "type": "string"
         },
         "pants_ignore": {
           "default": [".*/", "/dist/", "__pycache__"],
-          "description": "Paths to ignore for all filesystem operations performed by pants (e.g\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_ignore",
+          "description": "Paths to ignore for all filesystem operations performed by pants (e.g\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_ignore",
           "type": "array"
         },
         "pants_ignore_use_gitignore": {
           "default": true,
-          "description": "Make use of a root .gitignore file when determining whether to ignore filesystem operations performed by Pants\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_ignore_use_gitignore",
+          "description": "Make use of a root .gitignore file when determining whether to ignore filesystem operations performed by Pants\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_ignore_use_gitignore",
           "type": "boolean"
         },
         "pants_physical_workdir_base": {
           "default": null,
-          "description": "When set, a base directory in which to store `--pants-workdir` contents\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_physical_workdir_base",
+          "description": "When set, a base directory in which to store `--pants-workdir` contents\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_physical_workdir_base",
           "type": "string"
         },
         "pants_subprocessdir": {
-          "default": "/home/alexey.tereshenkov/code/pants/.pids",
-          "description": "The directory to use for tracking subprocess metadata\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_subprocessdir",
+          "default": "<buildroot>/.pids",
+          "description": "The directory to use for tracking subprocess metadata\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_subprocessdir",
           "type": "string"
         },
         "pants_version": {
           "default": "<pants_version>",
-          "description": "Use this Pants version\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_version",
+          "description": "Use this Pants version\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_version",
           "type": "string"
         },
         "pants_workdir": {
-          "default": "/home/alexey.tereshenkov/code/pants/.pants.d",
-          "description": "Write intermediate logs and output files to this dir\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pants_workdir",
+          "default": "<buildroot>/.pants.d",
+          "description": "Write intermediate logs and output files to this dir\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pants_workdir",
           "type": "string"
         },
         "pantsd": {
           "default": true,
-          "description": "Enables use of the Pants daemon (pantsd). pantsd can significantly improve runtime performance by lowering per-run startup cost, and by memoizing filesystem operations and rule execution\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pantsd",
+          "description": "Enables use of the Pants daemon (pantsd). pantsd can significantly improve runtime performance by lowering per-run startup cost, and by memoizing filesystem operations and rule execution\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pantsd",
           "type": "boolean"
         },
         "pantsd_invalidation_globs": {
           "default": [],
-          "description": "Filesystem events matching any of these globs will trigger a daemon restart\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pantsd_invalidation_globs",
+          "description": "Filesystem events matching any of these globs will trigger a daemon restart\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pantsd_invalidation_globs",
           "type": "array"
         },
         "pantsd_max_memory_usage": {
           "default": "1GiB",
-          "description": "The maximum memory usage of the pantsd process\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pantsd_max_memory_usage"
+          "description": "The maximum memory usage of the pantsd process\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pantsd_max_memory_usage"
         },
         "pantsd_pailgun_port": {
           "default": 0,
-          "description": "The port to bind the Pants nailgun server to\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pantsd_pailgun_port",
+          "description": "The port to bind the Pants nailgun server to\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pantsd_pailgun_port",
           "type": "number"
         },
         "pantsd_timeout_when_multiple_invocations": {
           "default": 60.0,
-          "description": "The maximum amount of time to wait for the invocation to start until raising a timeout exception\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pantsd_timeout_when_multiple_invocations",
+          "description": "The maximum amount of time to wait for the invocation to start until raising a timeout exception\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pantsd_timeout_when_multiple_invocations",
           "type": "number"
         },
         "pantsrc": {
           "default": true,
-          "description": "Use pantsrc files located at the paths specified in the global option `pantsrc_files`\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pantsrc",
+          "description": "Use pantsrc files located at the paths specified in the global option `pantsrc_files`\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pantsrc",
           "type": "boolean"
         },
         "pantsrc_files": {
           "default": ["/etc/pantsrc", "~/.pants.rc", ".pants.rc"],
-          "description": "Override config with values from these files, using syntax matching that of `--pants-config-files`\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pantsrc_files",
+          "description": "Override config with values from these files, using syntax matching that of `--pants-config-files`\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pantsrc_files",
           "type": "array"
         },
         "plugins": {
           "default": [],
-          "description": "Allow backends to be loaded from these plugins (usually released through PyPI). The default backends for each plugin will be loaded automatically\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#plugins",
+          "description": "Allow backends to be loaded from these plugins (usually released through PyPI). The default backends for each plugin will be loaded automatically\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#plugins",
           "type": "array"
         },
         "plugins_force_resolve": {
           "default": false,
-          "description": "Re-resolve plugins, even if previously resolved\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#plugins_force_resolve",
+          "description": "Re-resolve plugins, even if previously resolved\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#plugins_force_resolve",
           "type": "boolean"
         },
         "print_stacktrace": {
           "default": false,
-          "description": "Print the full exception stack trace for any errors\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#print_stacktrace",
+          "description": "Print the full exception stack trace for any errors\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#print_stacktrace",
           "type": "boolean"
         },
         "process_cleanup": {
           "default": true,
-          "description": "If false, Pants will not clean up local directories used as chroots for running processes\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#process_cleanup",
+          "description": "If false, Pants will not clean up local directories used as chroots for running processes\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#process_cleanup",
           "type": "boolean"
         },
         "process_execution_cache_namespace": {
           "default": null,
-          "description": "The cache namespace for process execution\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#process_execution_cache_namespace",
+          "description": "The cache namespace for process execution\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#process_execution_cache_namespace",
           "type": "string"
         },
         "process_execution_graceful_shutdown_timeout": {
           "default": 3,
-          "description": "The time in seconds to wait when gracefully shutting down an interactive process (such as one opened using `./pants run`) before killing it\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#process_execution_graceful_shutdown_timeout",
+          "description": "The time in seconds to wait when gracefully shutting down an interactive process (such as one opened using `./pants run`) before killing it\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#process_execution_graceful_shutdown_timeout",
           "type": "number"
         },
         "process_execution_local_enable_nailgun": {
           "default": true,
-          "description": "Whether or not to use nailgun to run JVM requests that are marked as supporting nailgun\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#process_execution_local_enable_nailgun",
+          "description": "Whether or not to use nailgun to run JVM requests that are marked as supporting nailgun\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#process_execution_local_enable_nailgun",
           "type": "boolean"
         },
         "process_execution_local_parallelism": {
           "default": "#cores",
-          "description": "Number of concurrent processes that may be executed locally\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#process_execution_local_parallelism",
+          "description": "Number of concurrent processes that may be executed locally\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#process_execution_local_parallelism",
           "type": "number"
         },
         "process_execution_remote_parallelism": {
           "default": 128,
-          "description": "Number of concurrent processes that may be executed remotely\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#process_execution_remote_parallelism",
+          "description": "Number of concurrent processes that may be executed remotely\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#process_execution_remote_parallelism",
           "type": "number"
         },
         "process_per_child_memory_usage": {
           "default": "512MiB",
-          "description": "The default memory usage for a single \"pooled\" child process\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#process_per_child_memory_usage"
+          "description": "The default memory usage for a single \"pooled\" child process\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#process_per_child_memory_usage"
         },
         "process_total_child_memory_usage": {
           "default": null,
-          "description": "The maximum memory usage for all \"pooled\" child processes\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#process_total_child_memory_usage"
+          "description": "The maximum memory usage for all \"pooled\" child processes\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#process_total_child_memory_usage"
         },
         "pythonpath": {
           "default": [],
-          "description": "Add these directories to PYTHONPATH to search for plugins\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#pythonpath",
+          "description": "Add these directories to PYTHONPATH to search for plugins\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#pythonpath",
           "type": "array"
         },
         "remote_auth_plugin": {
           "default": null,
-          "description": "Path to a plugin to dynamically configure remote caching and execution options\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_auth_plugin",
+          "description": "Path to a plugin to dynamically configure remote caching and execution options\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_auth_plugin",
           "type": "string"
         },
         "remote_ca_certs_path": {
           "default": null,
-          "description": "Path to a PEM file containing CA certificates used for verifying secure connections to `[GLOBAL].remote_execution_address` and `[GLOBAL].remote_store_address`\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_ca_certs_path",
+          "description": "Path to a PEM file containing CA certificates used for verifying secure connections to `[GLOBAL].remote_execution_address` and `[GLOBAL].remote_store_address`\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_ca_certs_path",
           "type": "string"
         },
         "remote_cache_read": {
           "default": false,
-          "description": "Whether to enable reading from a remote cache\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_cache_read",
+          "description": "Whether to enable reading from a remote cache\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_cache_read",
           "type": "boolean"
         },
         "remote_cache_read_timeout_millis": {
           "default": 1500,
-          "description": "Timeout value for remote cache lookups in milliseconds\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_cache_read_timeout_millis",
+          "description": "Timeout value for remote cache lookups in milliseconds\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_cache_read_timeout_millis",
           "type": "number"
         },
         "remote_cache_rpc_concurrency": {
           "default": 128,
-          "description": "The number of concurrent requests allowed to the remote cache service\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_cache_rpc_concurrency",
+          "description": "The number of concurrent requests allowed to the remote cache service\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_cache_rpc_concurrency",
           "type": "number"
         },
         "remote_cache_warnings": {
           "default": "backoff",
-          "description": "How frequently to log remote cache failures at the `warn` log level\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_cache_warnings",
+          "description": "How frequently to log remote cache failures at the `warn` log level\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_cache_warnings",
           "enum": ["ignore", "first_only", "backoff"]
         },
         "remote_cache_write": {
           "default": false,
-          "description": "Whether to enable writing results to a remote cache\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_cache_write",
+          "description": "Whether to enable writing results to a remote cache\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_cache_write",
           "type": "boolean"
         },
         "remote_execution": {
           "default": false,
-          "description": "Enables remote workers for increased parallelism\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_execution",
+          "description": "Enables remote workers for increased parallelism\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_execution",
           "type": "boolean"
         },
         "remote_execution_address": {
           "default": null,
-          "description": "The URI of a server used as a remote execution scheduler\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_execution_address",
+          "description": "The URI of a server used as a remote execution scheduler\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_execution_address",
           "type": "string"
         },
         "remote_execution_extra_platform_properties": {
           "default": [],
-          "description": "Platform properties to set on remote execution requests\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_execution_extra_platform_properties",
+          "description": "Platform properties to set on remote execution requests\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_execution_extra_platform_properties",
           "type": "array"
         },
         "remote_execution_headers": {
           "default": "{'user-agent': 'pants/<pants_version>'}",
-          "description": "Headers to set on remote execution requests\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_execution_headers",
+          "description": "Headers to set on remote execution requests\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_execution_headers",
           "type": "object"
         },
         "remote_execution_overall_deadline_secs": {
           "default": 3600,
-          "description": "\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_execution_overall_deadline_secs",
+          "description": "\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_execution_overall_deadline_secs",
           "type": "number"
         },
         "remote_execution_rpc_concurrency": {
           "default": 128,
-          "description": "The number of concurrent requests allowed to the remote execution service\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_execution_rpc_concurrency",
+          "description": "The number of concurrent requests allowed to the remote execution service\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_execution_rpc_concurrency",
           "type": "number"
         },
         "remote_instance_name": {
           "default": null,
-          "description": "Name of the remote instance to use by remote caching and remote execution\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_instance_name",
+          "description": "Name of the remote instance to use by remote caching and remote execution\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_instance_name",
           "type": "string"
         },
         "remote_oauth_bearer_token_path": {
           "default": null,
-          "description": "Path to a file containing an oauth token to use for gGRPC connections to `[GLOBAL].remote_execution_address` and `[GLOBAL].remote_store_address`\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_oauth_bearer_token_path",
+          "description": "Path to a file containing an oauth token to use for gGRPC connections to `[GLOBAL].remote_execution_address` and `[GLOBAL].remote_store_address`\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_oauth_bearer_token_path",
           "type": "string"
         },
         "remote_store_address": {
           "default": null,
-          "description": "The URI of a server used for the remote file store\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_store_address",
+          "description": "The URI of a server used for the remote file store\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_store_address",
           "type": "string"
         },
         "remote_store_batch_api_size_limit": {
           "default": 4194304,
-          "description": "The maximum total size of blobs allowed to be sent in a single batch API call to the remote store\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_store_batch_api_size_limit",
+          "description": "The maximum total size of blobs allowed to be sent in a single batch API call to the remote store\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_store_batch_api_size_limit",
           "type": "number"
         },
         "remote_store_chunk_bytes": {
           "default": 1048576,
-          "description": "Size in bytes of chunks transferred to/from the remote file store\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_store_chunk_bytes",
+          "description": "Size in bytes of chunks transferred to/from the remote file store\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_store_chunk_bytes",
           "type": "number"
         },
         "remote_store_chunk_upload_timeout_seconds": {
           "default": 60,
-          "description": "Timeout (in seconds) for uploads of individual chunks to the remote file store\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_store_chunk_upload_timeout_seconds",
+          "description": "Timeout (in seconds) for uploads of individual chunks to the remote file store\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_store_chunk_upload_timeout_seconds",
           "type": "number"
         },
         "remote_store_headers": {
           "default": "{'user-agent': 'pants/<pants_version>'}",
-          "description": "Headers to set on remote store requests\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_store_headers",
+          "description": "Headers to set on remote store requests\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_store_headers",
           "type": "object"
         },
         "remote_store_rpc_concurrency": {
           "default": 128,
-          "description": "The number of concurrent requests allowed to the remote store service\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_store_rpc_concurrency",
+          "description": "The number of concurrent requests allowed to the remote store service\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_store_rpc_concurrency",
           "type": "number"
         },
         "remote_store_rpc_retries": {
           "default": 2,
-          "description": "Number of times to retry any RPC to the remote store before giving up\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#remote_store_rpc_retries",
+          "description": "Number of times to retry any RPC to the remote store before giving up\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#remote_store_rpc_retries",
           "type": "number"
         },
         "rule_threads_core": {
           "default": "max(2, #cores/2)",
-          "description": "The number of threads to keep active and ready to execute `@rule` logic (see also: `--rule-threads-max`)\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#rule_threads_core",
+          "description": "The number of threads to keep active and ready to execute `@rule` logic (see also: `--rule-threads-max`)\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#rule_threads_core",
           "type": "number"
         },
         "rule_threads_max": {
           "default": null,
-          "description": "The maximum number of threads to use to execute `@rule` logic\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#rule_threads_max",
+          "description": "The maximum number of threads to use to execute `@rule` logic\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#rule_threads_max",
           "type": "number"
         },
         "show_log_target": {
           "default": false,
-          "description": "Display the target where a log message originates in that log message's output\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#show_log_target",
+          "description": "Display the target where a log message originates in that log message's output\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#show_log_target",
           "type": "boolean"
         },
         "spec_files": {
           "default": [],
-          "description": "Read additional specs (target addresses, files, and/or globs), one per line, from these files\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#spec_files",
+          "description": "Read additional specs (target addresses, files, and/or globs), one per line, from these files\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#spec_files",
           "type": "array"
         },
         "stats_record_option_scopes": {
           "default": ["*"],
-          "description": "Option scopes to record in stats on run completion\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#stats_record_option_scopes",
+          "description": "Option scopes to record in stats on run completion\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#stats_record_option_scopes",
           "type": "array"
         },
         "streaming_workunits_complete_async": {
           "default": true,
-          "description": "True if stats recording should be allowed to complete asynchronously when `pantsd` is enabled\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#streaming_workunits_complete_async",
+          "description": "True if stats recording should be allowed to complete asynchronously when `pantsd` is enabled\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#streaming_workunits_complete_async",
           "type": "boolean"
         },
         "streaming_workunits_level": {
           "default": "debug",
-          "description": "The level of workunits that will be reported to streaming workunit event receivers\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#streaming_workunits_level",
+          "description": "The level of workunits that will be reported to streaming workunit event receivers\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#streaming_workunits_level",
           "enum": ["trace", "debug", "info", "warn", "error"]
         },
         "streaming_workunits_report_interval": {
           "default": 1.0,
-          "description": "Interval in seconds between when streaming workunit event receivers will be polled\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#streaming_workunits_report_interval",
+          "description": "Interval in seconds between when streaming workunit event receivers will be polled\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#streaming_workunits_report_interval",
           "type": "number"
         },
         "subproject_roots": {
           "default": [],
-          "description": "Paths that correspond with build roots for any subproject that this project depends on\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#subproject_roots",
+          "description": "Paths that correspond with build roots for any subproject that this project depends on\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#subproject_roots",
           "type": "array"
         },
         "tag": {
           "default": [],
-          "description": "Include only targets with these tags (optional '+' prefix) or without these tags ('-' prefix)\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#tag",
+          "description": "Include only targets with these tags (optional '+' prefix) or without these tags ('-' prefix)\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#tag",
           "type": "array"
         },
         "unmatched_build_file_globs": {
           "default": "warn",
-          "description": "What to do when files and globs specified in BUILD files, such as in the `sources` field, cannot be found\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#unmatched_build_file_globs",
+          "description": "What to do when files and globs specified in BUILD files, such as in the `sources` field, cannot be found\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#unmatched_build_file_globs",
           "enum": ["warn", "error"]
         },
         "unmatched_cli_globs": {
           "default": "error",
-          "description": "What to do when command line arguments, e.g. files and globs like `dir::`, cannot be found\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#unmatched_cli_globs",
+          "description": "What to do when command line arguments, e.g. files and globs like `dir::`, cannot be found\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#unmatched_cli_globs",
           "enum": ["ignore", "warn", "error"]
         },
         "verify_config": {
           "default": true,
-          "description": "Verify that all config file values correspond to known options\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#verify_config",
+          "description": "Verify that all config file values correspond to known options\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#verify_config",
           "type": "boolean"
         },
         "watch_filesystem": {
           "default": true,
-          "description": "Set to False if Pants should not watch the filesystem for changes. `pantsd` or `loop` may not be enabled\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#watch_filesystem",
+          "description": "Set to False if Pants should not watch the filesystem for changes. `pantsd` or `loop` may not be enabled\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#watch_filesystem",
           "type": "boolean"
         }
       },


### PR DESCRIPTION
* As schema is machine generated, there were some paths expansion that picks up local environment details; this has been resolved to use a generic value
* Now lower case URLs are used