### PR TITLE
Update ruff.json

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -818,7 +818,7 @@
       "type": "object",
       "properties": {
         "convention": {
-          "description": "Whether to use Google-style, Numpy-style or PEP257-style conventions when detecting docstring sections. By default, conventions will be inferred from the available sections.",
+          "description": "Whether to use Google-style, Numpy-style or PEP257-style conventions when detecting docstring sections. By default, conventions will be inferred from the available sections.\nhttps://github.com/charliermarsh/ruff#does-ruff-support-numpy--or-google-style-docstrings",
           "anyOf": [
             {
               "$ref": "#/definitions/Convention"

--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -578,7 +578,7 @@
     },
     "Convention": {
       "type": "string",
-      "enum": ["google", "numpy"]
+      "enum": ["google", "numpy", "pep257"]
     },
     "Flake8AnnotationsOptions": {
       "type": "object",
@@ -818,7 +818,7 @@
       "type": "object",
       "properties": {
         "convention": {
-          "description": "Whether to use Google-style or Numpy-style conventions when detecting docstring sections. By default, conventions will be inferred from the available sections.",
+          "description": "Whether to use Google-style, Numpy-style or PEP257-style conventions when detecting docstring sections. By default, conventions will be inferred from the available sections.",
           "anyOf": [
             {
               "$ref": "#/definitions/Convention"


### PR DESCRIPTION
Add missing pep257 convention to the list of pre-set docstring conventions. See this ruff commit to verify: https://github.com/charliermarsh/ruff/commit/0c05488740ef391de5495ae72ee944f2fa89541b

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
