### PR TITLE
Allow jekyll permalinks ending in slash

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -2,6 +2,23 @@
   "$comment": "https://jekyllrb.com/docs/configuration/",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "nullable-boolean": {
+      "description": "Copy of definition from https://json.schemastore.org/base.json#/definitions/nullable-boolean",
+      "$id": "nullable-boolean",
+      "type": ["boolean", "null"]
+    },
+    "nullable-timezone": {
+      "description": "Copy of definition from https://json.schemastore.org/base.json#/definitions/nullable-timezone",
+      "$id": "nullable-timezone",
+      "oneOf": [
+        {
+          "$ref": "https://json.schemastore.org/base.json#/definitions/timezone"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "global-permalink": {
       "description": "The global permalink format\nhttps://jekyllrb.com/docs/permalinks/#global",
       "type": "string",
@@ -38,7 +55,7 @@
         "/:categories/:year/:week/:short_day/:title:output_ext",
         "/:categories/:title:output_ext"
       ],
-      "pattern": "^((/(:(year|short_year|month|i_month|short_month|long_month|day|i_day|y_day|w_year|week|w_day|short_day|long_day|hour|minute|second|title|slug|categories|slugified_categories))+)+|date|pretty|ordinal|weekdate|none)$"
+      "pattern": "^((/(:(year|short_year|month|i_month|short_month|long_month|day|i_day|y_day|w_year|week|w_day|short_day|long_day|hour|minute|second|title|slug|categories|slugified_categories))+)+|date|pretty|ordinal|weekdate|none)(/?)$"
     },
     "collection-permalink": {
       "description": "The collection permalink format\nhttps://jekyllrb.com/docs/permalinks/#collections",
@@ -122,7 +139,7 @@
     },
     "timezone": {
       "description": "A time zone for the current site\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
-      "$ref": "https://json.schemastore.org/base.json#/definitions/timezone"
+      "$ref": "#/definitions/nullable-timezone"
     },
     "encoding": {
       "description": "An encoding for the current site\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
@@ -131,6 +148,7 @@
       "enum": [
         "ASCII-8BIT",
         "UTF-8",
+        "utf-8",
         "US-ASCII",
         "UTF-16BE",
         "UTF-16LE",
@@ -346,7 +364,7 @@
     },
     "show_drafts": {
       "description": "Whether to process and render draft posts for the current site\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
-      "type": "boolean",
+      "$ref": "#/definitions/nullable-boolean",
       "default": false
     },
     "future": {
@@ -804,10 +822,17 @@
         },
         "toc_levels": {
           "description": "The levels that are used for the table of contents\nhttps://kramdown.gettalong.org/converter/html.html",
-          "type": "string",
-          "pattern": "^\\d((\\.\\.\\d)?|(,\\d)*)$",
-          "default": "1..6",
-          "examples": ["1", "2", "3", "4", "5", "6"]
+          "anyOf": [
+            {
+              "type": "string",
+              "default": "1..6",
+              "examples": ["1", "2", "3", "4", "5", "6"]
+            },
+            {
+              "type": "array",
+              "examples": [1, 2, 3, 4, 5, 6]
+            }
+          ]
         },
         "transliterated_header_ids": {
           "description": "Enable/disable transliterating header text before generating the ID\nhttps://kramdown.gettalong.org/converter/html.html",
@@ -850,7 +875,7 @@
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "liquid": {
       "title": "liquid options",

--- a/src/test/jekyll/_config.yaml
+++ b/src/test/jekyll/_config.yaml
@@ -1,0 +1,83 @@
+# Default jekyll configuration from
+# https://jekyllrb.com/docs/configuration/default/
+
+# Where things are
+source: .
+destination: ./_site
+collections_dir: .
+plugins_dir: _plugins # takes an array of strings and loads plugins in that order
+layouts_dir: _layouts
+data_dir: _data
+includes_dir: _includes
+sass:
+  sass_dir: _sass
+collections:
+  posts:
+    output: true
+
+# Handling Reading
+safe: false
+include: ['.htaccess']
+exclude:
+  [
+    'Gemfile',
+    'Gemfile.lock',
+    'node_modules',
+    'vendor/bundle/',
+    'vendor/cache/',
+    'vendor/gems/',
+    'vendor/ruby/',
+  ]
+keep_files: ['.git', '.svn']
+encoding: 'utf-8'
+markdown_ext: 'markdown,mkdown,mkdn,mkd,md'
+strict_front_matter: false
+
+# Filtering Content
+show_drafts: null
+limit_posts: 0
+future: false
+unpublished: false
+
+# Plugins
+whitelist: []
+plugins: []
+
+# Conversion
+markdown: kramdown
+highlighter: rouge
+lsi: false
+excerpt_separator: "\n\n"
+incremental: false
+
+# Serving
+detach: false
+port: 4000
+host: 127.0.0.1
+baseurl: '' # does not include hostname
+show_dir_listing: false
+
+# Outputting
+permalink: date
+paginate_path: /page:num
+timezone: null
+
+quiet: false
+verbose: false
+defaults: []
+
+liquid:
+  error_mode: warn
+  strict_filters: false
+  strict_variables: false
+
+# Markdown Processors
+kramdown:
+  auto_ids: true
+  entity_output: as_char
+  toc_levels: [1, 2, 3, 4, 5, 6]
+  smart_quotes: lsquo,rsquo,ldquo,rdquo
+  input: GFM
+  hard_wrap: false
+  footnote_nr: 1
+  show_warnings: false


### PR DESCRIPTION
The jekyll schema file gives as an example a permalink that ends in a slash, but doesn't actually allow such a permalink. This work fixes that.

This work also adds a test example using default jekyll configuration file, and updates the schema to validate this default file.
