### PR TITLE
Add the Freifunk.de Community API JSON Schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -395,6 +395,12 @@
       "url": "https://json.schemastore.org/fly.json"
     },
     {
+      "name": "Freifunk.de Community API",
+      "description": "Schema for Freifunk.de Community API. See more details https://github.com/freifunk/directory.api.freifunk.net",
+      "fileMatch": ["*.freifunk-api.json"],
+      "url": "https://raw.githubusercontent.com/freifunk/api.freifunk.net/master/specs/0.1.json"
+    },
+    {
       "name": ".asmdef",
       "description": "Unity 3D assembly definition file",
       "fileMatch": ["*.asmdef"],


### PR DESCRIPTION
Public hosted on https://github.com/freifunk/directory.api.freifunk.net

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
