### PR TITLE
minecraft-biome: refresh keys following `effects`

### DIFF
--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -663,17 +663,26 @@
       "additionalProperties": false
     },
     "spawn_costs": {
-      "title": "Spawn Costs",
-      "description": "List of entity IDs\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "title": "spawn costs",
+      "description": "Entity identifiers for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "type": "object",
       "additionalProperties": {
+        "title": "entity identifier",
+        "description": "A namespaced entity identifier for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+        "type": "object",
         "properties": {
           "energy_budget": {
-            "type": "integer"
+            "description": "A new mob maximum potential for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "type": "number",
+            "minimum": 0
           },
           "charge": {
-            "type": "integer"
+            "description": "A new mob charge for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "type": "number",
+            "minimum": 0
           }
-        }
+        },
+        "additionalProperties": false
       }
     }
   },

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -579,10 +579,15 @@
       "additionalProperties": false
     },
     "features": {
-      "description": "\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "description": "Features for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
       "type": "array",
+      "uniqueItems": true,
       "items": {
-        "type": "array"
+        "description": "A feature for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+        "type": [
+          "string",
+          "array"
+        ]
       }
     },
     "starts": {

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -570,7 +570,7 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "description": "The namespaced id of a configured carver\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "description": "A namespaced id of a configured carver\nhttps://minecraft.fandom.com/wiki/Custom_biome",
             "type": "string",
             "minLength": 1
           }

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -552,25 +552,25 @@
     },
     "carvers": {
       "title": "carvers",
-      "description": "Carvers to use\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "description": "Carvers to use for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
       "type": "object",
       "properties": {
         "air": {
-          "description": "Carvers used during air generation step\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+          "description": "Carvers used during air generation step for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "description": "A namespaced id of a configured carver\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "description": "A namespaced id of a configured carver for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
             "type": "string",
             "minLength": 1
           }
         },
         "liquid": {
-          "description": "Carvers used during liquid generation step\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+          "description": "Carvers used during liquid generation step for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "description": "A namespaced id of a configured carver\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "description": "A namespaced id of a configured carver for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
             "type": "string",
             "minLength": 1
           }
@@ -579,7 +579,7 @@
       "additionalProperties": false
     },
     "features": {
-      "description": "A list of 10 lists of features. In vanilla, each of the 10 lists corresponds to a different type of feature: the feature lists are applied to each chunk in order from top to bottom. The index of the list which the feature is placed in is also used to generate part of the feature seed, so moving features to a different list definitely has some effect on generation. Each element of each list is a namespaced ID of a configured feature. Can be a empty list\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "description": "\nhttps://minecraft.fandom.com/wiki/Custom_biome",
       "type": "array",
       "items": {
         "type": "array"

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -3,31 +3,36 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "spawner-options": {
-      "title": "swawner options",
       "description": "Spawner options for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-      "type": "object",
-      "properties": {
-        "type": {
-          "description": "A mob namespaced entity for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-          "type": "string"
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "title": "swawner options",
+        "description": "A spawner for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "A mob namespaced entity for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "type": "string"
+          },
+          "weight": {
+            "description": "A mod spawn factor for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "type": "integer",
+            "minimum": 0
+          },
+          "minCount": {
+            "description": "A minimum mob spawn in a pack for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "type": "integer",
+            "minimum": 0
+          },
+          "maxCount": {
+            "description": "A maximum mob spawn in a pack for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "type": "integer",
+            "minimum": 0
+          }
         },
-        "weight": {
-          "description": "A mod spawn factor for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-          "type": "integer",
-          "minimum": 0
-        },
-        "minCount": {
-          "description": "A minimum mob spawn in a pack for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-          "type": "integer",
-          "minimum": 0
-        },
-        "maxCount": {
-          "description": "A maximum mob spawn in a pack for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-          "type": "integer",
-          "minimum": 0
-        }
-      },
-      "additionalProperties": false
+        "additionalProperties": false
+      }
     }
   },
   "description": "Configuration file defining a biome for a data pack for Minecraft",

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -584,10 +584,7 @@
       "uniqueItems": true,
       "items": {
         "description": "A feature for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-        "type": [
-          "string",
-          "array"
-        ]
+        "type": ["string", "array"]
       }
     },
     "creature_spawn_probability": {

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -551,27 +551,32 @@
       "type": "string"
     },
     "carvers": {
-      "title": "Carvers",
-      "description": "The carvers to use\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "title": "carvers",
+      "description": "Carvers to use\nhttps://minecraft.fandom.com/wiki/Custom_biome",
       "type": "object",
       "properties": {
         "air": {
-          "description": "List of carvers used during the air generation step\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+          "description": "Carvers used during air generation step\nhttps://minecraft.fandom.com/wiki/Custom_biome",
           "type": "array",
+          "uniqueItems": true,
           "items": {
-            "description": "The namespaced id of a configured carver\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-            "type": "string"
+            "description": "A namespaced id of a configured carver\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+            "type": "string",
+            "minLength": 1
           }
         },
         "liquid": {
-          "description": "List of carvers used during the liquid generation step",
+          "description": "Carvers used during liquid generation step\nhttps://minecraft.fandom.com/wiki/Custom_biome",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "description": "The namespaced id of a configured carver\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "features": {
       "description": "A list of 10 lists of features. In vanilla, each of the 10 lists corresponds to a different type of feature: the feature lists are applied to each chunk in order from top to bottom. The index of the list which the feature is placed in is also used to generate part of the feature seed, so moving features to a different list definitely has some effect on generation. Each element of each list is a namespaced ID of a configured feature. Can be a empty list\nhttps://minecraft.fandom.com/wiki/Custom_biome",

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -1,6 +1,35 @@
 {
   "$comment": "https://minecraft.fandom.com/wiki/Biome/JSON_format",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "spawner-options": {
+      "title": "swawner options",
+      "description": "Spawner options for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "A mob namespaced entity for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+          "type": "string"
+        },
+        "weight": {
+          "description": "A mod spawn factor for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+          "type": "integer",
+          "minimum": 0
+        },
+        "minCount": {
+          "description": "A minimum mob spawn in a pack for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxCount": {
+          "description": "A maximum mob spawn in a pack for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    }
+  },
   "description": "Configuration file defining a biome for a data pack for Minecraft",
   "properties": {
     "depth": {
@@ -602,9 +631,36 @@
       }
     },
     "spawners": {
-      "title": "Spawners",
-      "description": "Entity spawning settings\nhttps://minecraft.fandom.com/wiki/Custom_biome",
-      "type": "object"
+      "title": "spawners",
+      "description": "Entity spawning options for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "type": "object",
+      "properties": {
+        "monster": {
+          "$ref": "#/definitions/spawner-options"
+        },
+        "creature": {
+          "$ref": "#/definitions/spawner-options"
+        },
+        "ambient": {
+          "$ref": "#/definitions/spawner-options"
+        },
+        "water_creature": {
+          "$ref": "#/definitions/spawner-options"
+        },
+        "underground_water_creature": {
+          "$ref": "#/definitions/spawner-options"
+        },
+        "water_ambient": {
+          "$ref": "#/definitions/spawner-options"
+        },
+        "misc": {
+          "$ref": "#/definitions/spawner-options"
+        },
+        "axolotls": {
+          "$ref": "#/definitions/spawner-options"
+        }
+      },
+      "additionalProperties": false
     },
     "spawn_costs": {
       "title": "Spawn Costs",

--- a/src/schemas/json/minecraft-biome.json
+++ b/src/schemas/json/minecraft-biome.json
@@ -590,6 +590,12 @@
         ]
       }
     },
+    "creature_spawn_probability": {
+      "description": "A creature spawn probability for the current biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
+      "type": "number",
+      "minimum": 0,
+      "exclusiveMaximum": 1
+    },
     "starts": {
       "description": "The structures to generate in this biome\nhttps://minecraft.fandom.com/wiki/Custom_biome",
       "type": "array",

--- a/src/test/minecraft-biome/dreadlands.json
+++ b/src/test/minecraft-biome/dreadlands.json
@@ -3,7 +3,7 @@
     "air": ["minecraft:cave"]
   },
   "category": "forest",
-  "creature_spawn_probability": 1,
+  "creature_spawn_probability": 0.9999999,
   "depth": 0.125,
   "downfall": 0.5,
   "effects": {


### PR DESCRIPTION
This is the continuation of #2705.

- standardize descriptions
- add missing titles
- refresh remaining properties: add more hints

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
