### PR TITLE
Updating UTAM page object schema for v1.6.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3293,7 +3293,11 @@
       "name": "UTAM Page Object",
       "description": "UI Test Automation Model page object - https://utam.dev/",
       "fileMatch": ["*.utam.json", ".utam.json"],
-      "url": "https://json.schemastore.org/utam-page-object.json"
+      "url": "https://json.schemastore.org/utam-page-object.json",
+      "versions": {
+        "1.5.0": "https://json.schemastore.org/utam-page-object-1.5.0.json",
+        "current": "https://json.schemastore.org/utam-page-object.json"
+      }
     },
     {
       "name": "vega.json",

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -183,6 +183,7 @@
     "ubuntu-server-autoinstall.json",
     "up.json",
     "utam-page-object.json",
+    "utam-page-object-1.5.0.json",
     "vega-lite.json",
     "vs-nesting.json",
     "vsext.json",

--- a/src/schemas/json/utam-page-object-1.5.0.json
+++ b/src/schemas/json/utam-page-object-1.5.0.json
@@ -87,7 +87,7 @@
                 "properties": {
                   "element": {
                     "type": "string",
-                    "enum": ["document", "root", "navigation"]
+                    "enum": ["document", "root"]
                   }
                 }
               }
@@ -117,9 +117,6 @@
           "default": {
             "elements": []
           }
-        },
-        "metadata": {
-          "$ref": "#/definitions/metadata"
         }
       },
       "dependencies": {
@@ -158,9 +155,6 @@
         },
         "description": {
           "$ref": "#/definitions/rootDescription"
-        },
-        "metadata": {
-          "$ref": "#/definitions/metadata"
         }
       }
     },
@@ -702,20 +696,6 @@
         }
       },
       "required": ["text"],
-      "additionalProperties": false
-    },
-    "metadata": {
-      "title": "Page Object Metadata",
-      "description": "track miscellaneous information for the page object",
-      "type": ["object"],
-      "properties": {
-        "status": {
-          "type": "string"
-        },
-        "teamOwner": {
-          "type": "string"
-        }
-      },
       "additionalProperties": false
     },
     "methodDescription": {

--- a/src/test/utam-page-object/valid-page-object.utam.json
+++ b/src/test/utam-page-object/valid-page-object.utam.json
@@ -44,5 +44,8 @@
   "root": true,
   "selector": {
     "css": "body"
+  },
+  "metadata": {
+    "status": "internal"
   }
 }

--- a/src/test/utam-page-object/valid-page-object.utam.json
+++ b/src/test/utam-page-object/valid-page-object.utam.json
@@ -41,11 +41,11 @@
       }
     }
   ],
+  "metadata": {
+    "status": "internal"
+  },
   "root": true,
   "selector": {
     "css": "body"
-  },
-  "metadata": {
-    "status": "internal"
   }
 }


### PR DESCRIPTION
Updating the UTAM page object JSON schema for UI Page Objects using the UI Test Automation Model to version 1.6.

More information on the page object model here - https://utam.dev/
