### PR TITLE
minecraft-advancement.json: refresh schema (part 1)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3277,6 +3277,19 @@
       "url": "https://sap.github.io/ui5-tooling/schema/ui5.yaml.json"
     },
     {
+      "name": "ui5-workspace.yaml",
+      "description": "UI5 Tooling Workspace Configuration File (ui5-workspace.yaml)",
+      "fileMatch": [
+        "ui5-workspace.yaml",
+        "*-ui5-workspace.yaml",
+        "*.ui5-workspace.yaml",
+        "ui5-workspace-deploy.yaml",
+        "ui5-workspace-dist.yaml",
+        "ui5-workspace-local.yaml"
+      ],
+      "url": "https://sap.github.io/ui5-tooling/schema/ui5-workspace.yaml.json"
+    },
+    {
       "name": "UTAM Page Object",
       "description": "UI Test Automation Model page object - https://utam.dev/",
       "fileMatch": ["*.utam.json", ".utam.json"],

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -724,6 +724,13 @@
       "jekyll.json": {
         "externalSchema": ["base.json"]
       }
+    },
+    {
+      "minecraft-advancement.json": {
+        "externalSchema": [
+          "base.json"
+        ]
+      }
     }
   ],
   "skiptest": [

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -727,9 +727,7 @@
     },
     {
       "minecraft-advancement.json": {
-        "externalSchema": [
-          "base.json"
-        ]
+        "externalSchema": ["base.json"]
       }
     }
   ],

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -196,8 +196,8 @@
       }
     },
     "parent": {
-      "description": "The parent advancement directory of this advancement. If this field is absent, this advancement is a root advancement. Circular references cause a loading failure.",
-      "type": "string"
+      "description": "A parent directory for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+      "$ref": "https://json.schemastore.org/base.json#/definitions/path"
     },
     "criteria": {
       "title": "criterias",

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -240,7 +240,8 @@
           "uniqueItems": true,
           "items": {
             "description": "A namespaced identifier for a recipe for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         },
         "loot": {
@@ -249,7 +250,8 @@
           "uniqueItems": true,
           "items": {
             "description": "A namespaced identifier for a loot table for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         },
         "experience": {

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -220,12 +220,17 @@
       }
     },
     "requirements": {
-      "description": "A list of requirements (all the <criteriaNames>). If all criteria are required, this may be omitted. With multiple criteria: requirements contains a list of lists with criteria (all criteria need to be mentioned). If all of the lists each have any criteria met, the advancement is complete. (basically AND grouping of OR groups)",
+      "description": "Requirements for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
       "type": "array",
+      "uniqueItems": true,
       "items": {
-        "type": ["string", "array"],
+        "description": "Criterions for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+        "type": "array",
+        "uniqueItems": true,
         "items": {
-          "type": "string"
+          "description": "Criterion name for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -140,56 +140,58 @@
   "properties": {
     "display": {
       "title": "display",
-      "description": "The display data.",
+      "description": "Display options for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
       "type": "object",
       "properties": {
         "icon": {
           "title": "icon",
-          "description": "The data for the icon.",
+          "description": "Icon options for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "type": "object",
           "properties": {
             "item": {
-              "description": "The item ID.",
-              "type": "string"
+              "description": "An item identifier for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+              "type": "string",
+              "minLength": 1
             },
             "nbt": {
-              "description": "The Named Binary Tag (NBT) data of the item.",
-              "type": "string"
+              "description": "A named binary tag of an item for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+              "type": "string",
+              "minLength": 1
             }
           }
         },
         "title": {
           "title": "title",
-          "description": "The title for this advancement.",
+          "description": "A title for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "$ref": "#/definitions/jsonTextComponent"
         },
         "frame": {
-          "description": "The type of frame for the icon.",
+          "description": "A frame type for the icon for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "type": "string",
           "enum": ["challenge", "goal", "task"],
           "default": "task"
         },
         "background": {
-          "description": "The directory for the background to use in this advancement tab (used only for the root advancement).",
-          "type": "string"
+          "description": "A background directory for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "$ref": "https://json.schemastore.org/base.json#/definitions/path"
         },
         "description": {
           "title": "description",
-          "description": "The description of the advancement.",
+          "description": "A description for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "$ref": "#/definitions/jsonTextComponent"
         },
         "show_toast": {
-          "description": "Whether or not to show the toast pop up after completing this advancement.",
+          "description": "Whether or not to show the toast pop up after completing the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "type": "boolean",
           "default": true
         },
         "annouce_to_chat": {
-          "description": "Whether or not to announce in the chat when this advancement has been completed.",
+          "description": "Whether or not to announce in the chat when the current advancement has been completed\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "type": "boolean",
           "default": true
         },
         "hidden": {
-          "description": "Whether or not to hide this advancement and all its children from the advancement screen until this advancement have been completed. Has no effect on root advancements themselves, but still affects all their children.",
+          "description": "Whether or not to hide this advancement and all its children from the advancement screen until the current advancement have been completed\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "type": "boolean",
           "default": false
         }

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -152,7 +152,7 @@
       }
     }
   },
-  "description": "Configuration file defining an advancement for a data pack for Minecraft.",
+  "description": "A data pack advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
   "properties": {
     "display": {
       "title": "Display",
@@ -290,6 +290,6 @@
       }
     }
   },
-  "title": "Minecraft Data Pack Advancement",
+  "title": "data pack advancement",
   "type": "object"
 }

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -200,21 +200,28 @@
       "type": "string"
     },
     "criteria": {
-      "title": "criteria",
-      "description": "The required criteria that have to be met.",
+      "title": "criterias",
+      "description": "Required criterias have to be met for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
       "type": "object",
       "additionalProperties": {
+        "title": "criteria",
+      "description": "Required criteria have to be met for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
         "type": "object",
         "properties": {
           "trigger": {
-            "title": "Trigger",
-            "description": "The trigger for this advancement; specifies what the game should check for the advancement.",
+            "description": "A trigger for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Criteria",
             "type": "string"
           },
           "conditions": {
-            "title": "Conditions",
-            "description": "All the conditions that need to be met when the trigger gets activated.",
-            "type": "object"
+            "description": "Conditions need to be met when the trigger gets activated for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Criteria",
+            "type": "object",
+            "properties": {
+              "player": {
+                "title": "player options",
+                "description": "Check properties of the player for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Criteria",
+                "type": ["array", "object"]
+              }
+            }
           }
         }
       }

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -7,7 +7,6 @@
       "type": ["string", "boolean", "number", "array", "object"],
       "properties": {
         "extra": {
-          "title": "Extra",
           "description": "A list of additional raw JSON text components to be displayed after this one.",
           "type": "array",
           "items": {
@@ -16,7 +15,6 @@
           }
         },
         "color": {
-          "title": "Color",
           "description": "The color to render the content in.",
           "type": "string",
           "anyOf": [
@@ -47,48 +45,40 @@
           ]
         },
         "font": {
-          "title": "Font",
           "description": "The resource location of the font for this component in the resource pack within assets/<namespace>/font.",
           "type": "string",
           "default": "minecraft:default"
         },
         "bold": {
-          "title": "Bold",
           "description": "Whether to render the content in bold.",
           "type": "boolean"
         },
         "italic": {
-          "title": "Italic",
           "description": "Whether to render the content in italics. Note that text that is italicized by default, such as custom item names, can be unitalicized by setting this to false.",
           "type": "boolean"
         },
         "underlined": {
-          "title": "Underlined",
           "description": "Whether to underline the content.",
           "type": "boolean"
         },
         "strikethrough": {
-          "title": "Strikethrough",
           "description": "Whether to strikethrough the content.",
           "type": "boolean"
         },
         "obfuscated": {
-          "title": "Obfuscated",
           "description": "Whether to render the content obfuscated.",
           "type": "boolean"
         },
         "insertion": {
-          "title": "Insertions",
           "description": "When the text is shift-clicked by a player, this string is inserted in their chat input. It does not overwrite any existing text the player was writing. This only works in chat messages.",
           "type": "string"
         },
         "clickEvent": {
-          "title": "Click Event",
+          "title": "click event",
           "description": "Allows for events to occur when the player clicks on text. Only work in chat messages and written books, unless specified otherwise.",
           "type": "object",
           "properties": {
             "action": {
-              "title": "Action",
               "description": "The action to perform when clicked.",
               "type": "string",
               "enum": [
@@ -101,47 +91,41 @@
               ]
             },
             "value": {
-              "title": "Value",
               "description": "The URL, file path, chat, command or book page used by the specified action.",
               "type": "string"
             }
           }
         },
         "hoverEvent": {
-          "title": "Hover Event",
+          "title": "hover event",
           "description": "Allows for a tooltip to be displayed when the player hovers their mouse over text.",
           "type": "object",
           "properties": {
             "action": {
-              "title": "Action",
               "description": "The type of tooltip to show.",
               "type": "string",
               "enum": ["show_text", "show_item", "show_entity"]
             },
             "value": {
-              "title": "Value",
               "description": "The formatting and type of this tag varies depending on the action.",
               "type": "string"
             },
             "contents": {
-              "title": "Contents",
+              "title": "contents",
               "description": "The formatting of this tag varies depending on the action.",
               "type": "object"
             }
           }
         },
         "text": {
-          "title": "Text",
           "description": "A string containing plain text to display directly. Can also be a number or boolean that is displayed directly.",
           "type": ["string", "number", "boolean"]
         },
         "translate": {
-          "title": "Translate",
           "description": "A translation identifier, corresponding to the identifiers found in loaded language files. Displayed as the corresponding text in the player's selected language. If no corresponding translation can be found, the identifier itself is used as the translated text.",
           "type": "string"
         },
         "with": {
-          "title": "With",
           "description": "A list of raw JSON text components to be inserted into slots in the translation text.",
           "type": "array",
           "items": {
@@ -155,63 +139,56 @@
   "description": "A data pack advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
   "properties": {
     "display": {
-      "title": "Display",
+      "title": "display",
       "description": "The display data.",
       "type": "object",
       "properties": {
         "icon": {
-          "title": "Icon",
+          "title": "icon",
           "description": "The data for the icon.",
           "type": "object",
           "properties": {
             "item": {
-              "title": "Item",
               "description": "The item ID.",
               "type": "string"
             },
             "nbt": {
-              "title": "Named Binary Tag",
               "description": "The Named Binary Tag (NBT) data of the item.",
               "type": "string"
             }
           }
         },
         "title": {
-          "title": "Title",
+          "title": "title",
           "description": "The title for this advancement.",
           "$ref": "#/definitions/jsonTextComponent"
         },
         "frame": {
-          "title": "Frame",
           "description": "The type of frame for the icon.",
           "type": "string",
           "enum": ["challenge", "goal", "task"],
           "default": "task"
         },
         "background": {
-          "title": "Background",
           "description": "The directory for the background to use in this advancement tab (used only for the root advancement).",
           "type": "string"
         },
         "description": {
-          "title": "Description",
+          "title": "description",
           "description": "The description of the advancement.",
           "$ref": "#/definitions/jsonTextComponent"
         },
         "show_toast": {
-          "title": "Show Toast",
           "description": "Whether or not to show the toast pop up after completing this advancement.",
           "type": "boolean",
           "default": true
         },
         "annouce_to_chat": {
-          "title": "Annouce to Chat",
           "description": "Whether or not to announce in the chat when this advancement has been completed.",
           "type": "boolean",
           "default": true
         },
         "hidden": {
-          "title": "Hidden",
           "description": "Whether or not to hide this advancement and all its children from the advancement screen until this advancement have been completed. Has no effect on root advancements themselves, but still affects all their children.",
           "type": "boolean",
           "default": false
@@ -219,12 +196,11 @@
       }
     },
     "parent": {
-      "title": "Parent",
       "description": "The parent advancement directory of this advancement. If this field is absent, this advancement is a root advancement. Circular references cause a loading failure.",
       "type": "string"
     },
     "criteria": {
-      "title": "Criteria",
+      "title": "criteria",
       "description": "The required criteria that have to be met.",
       "type": "object",
       "additionalProperties": {
@@ -244,7 +220,6 @@
       }
     },
     "requirements": {
-      "title": "Requirements",
       "description": "A list of requirements (all the <criteriaNames>). If all criteria are required, this may be omitted. With multiple criteria: requirements contains a list of lists with criteria (all criteria need to be mentioned). If all of the lists each have any criteria met, the advancement is complete. (basically AND grouping of OR groups)",
       "type": "array",
       "items": {
@@ -255,12 +230,11 @@
       }
     },
     "rewards": {
-      "title": "Rewards",
+      "title": "rewards",
       "description": "The rewards provided when this advancement is obtained.",
       "type": "object",
       "properties": {
         "recipes": {
-          "title": "Recipes",
           "description": "A list of recipes to unlock.",
           "type": "array",
           "items": {
@@ -269,7 +243,6 @@
           }
         },
         "loot": {
-          "title": "Loot",
           "description": "A list of loot tables to give to the player.",
           "type": "array",
           "items": {
@@ -278,12 +251,10 @@
           }
         },
         "experience": {
-          "title": "Experience",
           "description": "An amount of experience.",
           "type": "integer"
         },
         "function": {
-          "title": "Function",
           "description": "A function to run. Function tags are not allowed.",
           "type": "string"
         }

--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -231,34 +231,39 @@
     },
     "rewards": {
       "title": "rewards",
-      "description": "The rewards provided when this advancement is obtained.",
+      "description": "Rewards for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
       "type": "object",
       "properties": {
         "recipes": {
-          "description": "A list of recipes to unlock.",
+          "description": "Recipes to unlock for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "type": "array",
+          "uniqueItems": true,
           "items": {
-            "description": "A namespaced ID for a recipe.",
+            "description": "A namespaced identifier for a recipe for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
             "type": "string"
           }
         },
         "loot": {
-          "description": "A list of loot tables to give to the player.",
+          "description": "Loot tables to give to the player for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
           "type": "array",
+          "uniqueItems": true,
           "items": {
-            "description": "A namespaced ID for a loot table.",
+            "description": "A namespaced identifier for a loot table for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
             "type": "string"
           }
         },
         "experience": {
-          "description": "An amount of experience.",
-          "type": "integer"
+          "description": "An experience amount for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "type": "integer",
+          "minimum": 0
         },
         "function": {
-          "description": "A function to run. Function tags are not allowed.",
-          "type": "string"
+          "description": "A function to run for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "type": "string",
+          "minLength": 1
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "title": "data pack advancement",


### PR DESCRIPTION
## ToDo

- [x] refresh all properties under top-level `properties` key

Some properties are not completely refreshed, for instance `criteria` is not as there are too many content to be created in one PR.

## Next PR

Add base schema for [resource locations](https://minecraft.fandom.com/wiki/Resource_location) and use it. All common Minecraft config types should be moved to this new base schema and be reused.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
