### PR TITLE
schema(geojson): Refresh

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1559,6 +1559,11 @@
       "url": "https://json.schemastore.org/geojson.json"
     },
     {
+      "name": "GeoJSON.json latest",
+      "description": "GeoJSON format for representing geographic data. Newest version from GeoJSON org.",
+      "url": "https://geojson.org/schema/GeoJSON.json"
+    },
+    {
       "name": "GitVersion",
       "description": "The output from the GitVersion tool",
       "fileMatch": ["gitversion.json"],
@@ -2197,6 +2202,12 @@
       "description": "Configuration file defining what sounds play when sound event is triggered for a resourcepack for Minecraft.",
       "fileMatch": ["**/assets/*/sounds.json"],
       "url": "https://raw.githubusercontent.com/AxoCode/json-schema/master/minecraft/sounds.json"
+    },
+    {
+      "name": "MkDocs Configuration 1.0",
+      "description": "JSON schema for MkDocs configuration file",
+      "fileMatch": ["mkdocs.yml"],
+      "url": "https://json.schemastore.org/mkdocs-1.0.json"
     },
     {
       "name": ".mocharc",
@@ -4223,11 +4234,6 @@
         "updatecli.yaml"
       ],
       "url": "https://www.updatecli.io/schema/latest/config.json"
-    },
-    {
-      "name": "GeoJSON.json latest",
-      "description": "GeoJSON format for representing geographic data. Newest version from GeoJSON org.",
-      "url": "https://geojson.org/schema/GeoJSON.json"
     },
     {
       "name": ".clang-format",

--- a/src/schemas/json/geojson.json
+++ b/src/schemas/json/geojson.json
@@ -1,412 +1,1278 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "additionalProperties": true,
-  "definitions": {
-    "coordinates": {
-      "title": "Coordinates",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          {
-            "type": "array"
-          },
-          {
-            "type": "number"
-          }
-        ]
-      }
-    },
-    "geometry": {
-      "title": "Geometry",
-      "description": "A geometry is a GeoJSON object where the type member's value is one of the following strings: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, or `GeometryCollection`.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "oneOf": [
+    {
+      "title": "GeoJSON Point",
+      "type": "object",
+      "required": ["type", "coordinates"],
       "properties": {
         "type": {
-          "enum": [
-            "Point",
-            "MultiPoint",
-            "LineString",
-            "MultiLineString",
-            "Polygon",
-            "MultiPolygon",
-            "GeometryCollection"
-          ]
+          "type": "string",
+          "enum": ["Point"]
+        },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "number"
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
         }
       }
     },
-    "feature": {
-      "title": "Feature",
-      "description": "A GeoJSON object with the type `Feature` is a feature object.\n\n* A feature object must have a member with the name `geometry`. The value of the geometry member is a geometry object as defined above or a JSON null value.\n\n* A feature object must have a member with the name `properties`. The value of the properties member is an object (any JSON object or a JSON null value).\n\n* If a feature has a commonly used identifier, that identifier should be included as a member of the feature object with the name `id`.",
-      "required": ["geometry", "properties"],
+    {
+      "title": "GeoJSON LineString",
+      "type": "object",
+      "required": ["type", "coordinates"],
       "properties": {
         "type": {
+          "type": "string",
+          "enum": ["LineString"]
+        },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    {
+      "title": "GeoJSON Polygon",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["Polygon"]
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    {
+      "title": "GeoJSON MultiPoint",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["MultiPoint"]
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    {
+      "title": "GeoJSON MultiLineString",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["MultiLineString"]
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    {
+      "title": "GeoJSON MultiPolygon",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["MultiPolygon"]
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    {
+      "title": "GeoJSON GeometryCollection",
+      "type": "object",
+      "required": ["type", "geometries"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["GeometryCollection"]
+        },
+        "geometries": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "title": "GeoJSON Point",
+                "type": "object",
+                "required": ["type", "coordinates"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["Point"]
+                  },
+                  "coordinates": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "bbox": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "GeoJSON LineString",
+                "type": "object",
+                "required": ["type", "coordinates"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["LineString"]
+                  },
+                  "coordinates": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "bbox": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "GeoJSON Polygon",
+                "type": "object",
+                "required": ["type", "coordinates"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["Polygon"]
+                  },
+                  "coordinates": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 4,
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  "bbox": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "GeoJSON MultiPoint",
+                "type": "object",
+                "required": ["type", "coordinates"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["MultiPoint"]
+                  },
+                  "coordinates": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "bbox": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "GeoJSON MultiLineString",
+                "type": "object",
+                "required": ["type", "coordinates"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["MultiLineString"]
+                  },
+                  "coordinates": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  "bbox": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "GeoJSON MultiPolygon",
+                "type": "object",
+                "required": ["type", "coordinates"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["MultiPolygon"]
+                  },
+                  "coordinates": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "bbox": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    {
+      "title": "GeoJSON Feature",
+      "type": "object",
+      "required": ["type", "properties", "geometry"],
+      "properties": {
+        "type": {
+          "type": "string",
           "enum": ["Feature"]
         },
-        "geometry": {
-          "title": "Geometry",
+        "id": {
           "oneOf": [
             {
-              "$ref": "#/definitions/geometry"
+              "type": "number"
             },
             {
-              "type": "null"
+              "type": "string"
             }
           ]
         },
         "properties": {
-          "title": "Properties",
           "oneOf": [
             {
-              "type": "object"
+              "type": "null"
             },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "geometry": {
+          "oneOf": [
             {
               "type": "null"
-            }
-          ]
-        },
-        "id": {}
-      }
-    },
-    "linearRingCoordinates": {
-      "title": "Linear Ring Coordinates",
-      "description": "A LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/lineStringCoordinates"
-        },
-        {
-          "minItems": 4
-        }
-      ]
-    },
-    "lineStringCoordinates": {
-      "title": "Line String Coordinates",
-      "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/coordinates"
-        },
-        {
-          "minLength": 2,
-          "items": {
-            "$ref": "#/definitions/position"
-          }
-        }
-      ]
-    },
-    "polygonCoordinates": {
-      "title": "Polygon Coordinates",
-      "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/coordinates"
-        },
-        {
-          "items": {
-            "$ref": "#/definitions/linearRingCoordinates"
-          }
-        }
-      ]
-    },
-    "position": {
-      "title": "Position",
-      "type": "array",
-      "description": "A position is the fundamental geometry construct. The `coordinates` member of a geometry object is composed of one position (in the case of a Point geometry), an array of positions (LineString or MultiPoint geometries), an array of arrays of positions (Polygons, MultiLineStrings), or a multidimensional array of positions (MultiPolygon).\n\nA position is represented by an array of numbers. There must be at least two elements, and may be more. The order of elements must follow x, y, z order (easting, northing, altitude for coordinates in a projected coordinate reference system, or longitude, latitude, altitude for coordinates in a geographic coordinate reference system). Any number of additional elements are allowed -- interpretation and meaning of additional elements is beyond the scope of this specification.",
-      "minItems": 2,
-      "items": {
-        "type": "number"
-      }
-    }
-  },
-  "description": "This object represents a geometry, feature, or collection of features.",
-  "id": "https://json.schemastore.org/geojson",
-  "oneOf": [
-    {
-      "title": "Point",
-      "description": "For type `Point`, the `coordinates` member must be a single position.",
-      "required": ["coordinates"],
-      "properties": {
-        "type": {
-          "enum": ["Point"]
-        },
-        "coordinates": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/coordinates"
             },
             {
-              "$ref": "#/definitions/position"
-            }
-          ]
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/geometry"
-        }
-      ]
-    },
-    {
-      "title": "Multi Point Geometry",
-      "description": "For type `MultiPoint`, the `coordinates` member must be an array of positions.",
-      "required": ["coordinates"],
-      "properties": {
-        "type": {
-          "enum": ["MultiPoint"]
-        },
-        "coordinates": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/coordinates"
+              "title": "GeoJSON Point",
+              "type": "object",
+              "required": ["type", "coordinates"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["Point"]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
             },
             {
-              "items": {
-                "$ref": "#/definitions/position"
+              "title": "GeoJSON LineString",
+              "type": "object",
+              "required": ["type", "coordinates"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["LineString"]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON Polygon",
+              "type": "object",
+              "required": ["type", "coordinates"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["Polygon"]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 4,
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiPoint",
+              "type": "object",
+              "required": ["type", "coordinates"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["MultiPoint"]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiLineString",
+              "type": "object",
+              "required": ["type", "coordinates"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["MultiLineString"]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                      "type": "array",
+                      "minItems": 2,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON MultiPolygon",
+              "type": "object",
+              "required": ["type", "coordinates"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["MultiPolygon"]
+                },
+                "coordinates": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 4,
+                      "items": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "title": "GeoJSON GeometryCollection",
+              "type": "object",
+              "required": ["type", "geometries"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["GeometryCollection"]
+                },
+                "geometries": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "title": "GeoJSON Point",
+                        "type": "object",
+                        "required": ["type", "coordinates"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["Point"]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "number"
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON LineString",
+                        "type": "object",
+                        "required": ["type", "coordinates"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["LineString"]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON Polygon",
+                        "type": "object",
+                        "required": ["type", "coordinates"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["Polygon"]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 4,
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiPoint",
+                        "type": "object",
+                        "required": ["type", "coordinates"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["MultiPoint"]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiLineString",
+                        "type": "object",
+                        "required": ["type", "coordinates"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["MultiLineString"]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "title": "GeoJSON MultiPolygon",
+                        "type": "object",
+                        "required": ["type", "coordinates"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["MultiPolygon"]
+                          },
+                          "coordinates": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "minItems": 4,
+                                "items": {
+                                  "type": "array",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "bbox": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "bbox": {
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "number"
+                  }
+                }
               }
             }
           ]
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/geometry"
-        }
-      ]
-    },
-    {
-      "title": "Line String",
-      "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.\n\nA LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
-      "required": ["coordinates"],
-      "properties": {
-        "type": {
-          "enum": ["LineString"]
         },
-        "coordinates": {
-          "$ref": "#/definitions/lineStringCoordinates"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/geometry"
-        }
-      ]
-    },
-    {
-      "title": "MultiLineString",
-      "description": "For type `MultiLineString`, the `coordinates` member must be an array of LineString coordinate arrays.",
-      "required": ["coordinates"],
-      "properties": {
-        "type": {
-          "enum": ["MultiLineString"]
-        },
-        "coordinates": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/coordinates"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/lineStringCoordinates"
-              }
-            }
-          ]
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/geometry"
-        }
-      ]
-    },
-    {
-      "title": "Polygon",
-      "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
-      "required": ["coordinates"],
-      "properties": {
-        "type": {
-          "enum": ["Polygon"]
-        },
-        "coordinates": {
-          "$ref": "#/definitions/polygonCoordinates"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/geometry"
-        }
-      ]
-    },
-    {
-      "title": "Multi-Polygon Geometry",
-      "description": "For type `MultiPolygon`, the `coordinates` member must be an array of Polygon coordinate arrays.",
-      "required": ["coordinates"],
-      "properties": {
-        "type": {
-          "enum": ["MultiPolygon"]
-        },
-        "coordinates": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/coordinates"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/polygonCoordinates"
-              }
-            }
-          ]
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/geometry"
-        }
-      ]
-    },
-    {
-      "title": "Geometry Collection",
-      "description": "A GeoJSON object with type `GeometryCollection` is a geometry object which represents a collection of geometry objects.\n\nA geometry collection must have a member with the name `geometries`. The value corresponding to `geometries` is an array. Each element in this array is a GeoJSON geometry object.",
-      "required": ["geometries"],
-      "properties": {
-        "type": {
-          "enum": ["GeometryCollection"]
-        },
-        "geometries": {
-          "title": "Geometries",
+        "bbox": {
           "type": "array",
+          "minItems": 4,
           "items": {
-            "$ref": "#/definitions/geometry"
+            "type": "number"
           }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/geometry"
-        }
-      ]
+      }
     },
     {
-      "$ref": "#/definitions/feature"
-    },
-    {
-      "title": "Feature Collection",
-      "description": "A GeoJSON object with the type `FeatureCollection` is a feature collection object.\n\nAn object of type `FeatureCollection` must have a member with the name `features`. The value corresponding to `features` is an array. Each element in the array is a feature object as defined above.",
-      "required": ["features"],
+      "title": "GeoJSON FeatureCollection",
+      "type": "object",
+      "required": ["type", "features"],
       "properties": {
         "type": {
+          "type": "string",
           "enum": ["FeatureCollection"]
         },
         "features": {
-          "title": "Features",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/feature"
+            "title": "GeoJSON Feature",
+            "type": "object",
+            "required": ["type", "properties", "geometry"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["Feature"]
+              },
+              "id": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "properties": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
+              },
+              "geometry": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "title": "GeoJSON Point",
+                    "type": "object",
+                    "required": ["type", "coordinates"],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["Point"]
+                      },
+                      "coordinates": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                          "type": "number"
+                        }
+                      },
+                      "bbox": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "GeoJSON LineString",
+                    "type": "object",
+                    "required": ["type", "coordinates"],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["LineString"]
+                      },
+                      "coordinates": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "bbox": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "GeoJSON Polygon",
+                    "type": "object",
+                    "required": ["type", "coordinates"],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["Polygon"]
+                      },
+                      "coordinates": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "minItems": 4,
+                          "items": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      "bbox": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "GeoJSON MultiPoint",
+                    "type": "object",
+                    "required": ["type", "coordinates"],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["MultiPoint"]
+                      },
+                      "coordinates": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "bbox": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "GeoJSON MultiLineString",
+                    "type": "object",
+                    "required": ["type", "coordinates"],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["MultiLineString"]
+                      },
+                      "coordinates": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "minItems": 2,
+                          "items": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      },
+                      "bbox": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "GeoJSON MultiPolygon",
+                    "type": "object",
+                    "required": ["type", "coordinates"],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["MultiPolygon"]
+                      },
+                      "coordinates": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "array",
+                            "minItems": 4,
+                            "items": {
+                              "type": "array",
+                              "minItems": 2,
+                              "items": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "bbox": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "GeoJSON GeometryCollection",
+                    "type": "object",
+                    "required": ["type", "geometries"],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["GeometryCollection"]
+                      },
+                      "geometries": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "title": "GeoJSON Point",
+                              "type": "object",
+                              "required": ["type", "coordinates"],
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["Point"]
+                                },
+                                "coordinates": {
+                                  "type": "array",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                },
+                                "bbox": {
+                                  "type": "array",
+                                  "minItems": 4,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "title": "GeoJSON LineString",
+                              "type": "object",
+                              "required": ["type", "coordinates"],
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["LineString"]
+                                },
+                                "coordinates": {
+                                  "type": "array",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                },
+                                "bbox": {
+                                  "type": "array",
+                                  "minItems": 4,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "title": "GeoJSON Polygon",
+                              "type": "object",
+                              "required": ["type", "coordinates"],
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["Polygon"]
+                                },
+                                "coordinates": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "minItems": 4,
+                                    "items": {
+                                      "type": "array",
+                                      "minItems": 2,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                "bbox": {
+                                  "type": "array",
+                                  "minItems": 4,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "title": "GeoJSON MultiPoint",
+                              "type": "object",
+                              "required": ["type", "coordinates"],
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["MultiPoint"]
+                                },
+                                "coordinates": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "items": {
+                                      "type": "number"
+                                    }
+                                  }
+                                },
+                                "bbox": {
+                                  "type": "array",
+                                  "minItems": 4,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "title": "GeoJSON MultiLineString",
+                              "type": "object",
+                              "required": ["type", "coordinates"],
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["MultiLineString"]
+                                },
+                                "coordinates": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "items": {
+                                      "type": "array",
+                                      "minItems": 2,
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                "bbox": {
+                                  "type": "array",
+                                  "minItems": 4,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "title": "GeoJSON MultiPolygon",
+                              "type": "object",
+                              "required": ["type", "coordinates"],
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": ["MultiPolygon"]
+                                },
+                                "coordinates": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "array",
+                                      "minItems": 4,
+                                      "items": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "items": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "bbox": {
+                                  "type": "array",
+                                  "minItems": 4,
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "bbox": {
+                        "type": "array",
+                        "minItems": 4,
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "bbox": {
+                "type": "array",
+                "minItems": 4,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
           }
         }
       }
     }
   ],
-  "properties": {
-    "type": {
-      "title": "Type",
-      "type": "string",
-      "description": "The type of GeoJSON object.",
-      "enum": [
-        "Point",
-        "MultiPoint",
-        "LineString",
-        "MultiLineString",
-        "Polygon",
-        "MultiPolygon",
-        "GeometryCollection",
-        "Feature",
-        "FeatureCollection"
-      ]
-    },
-    "crs": {
-      "title": "Coordinate Reference System (CRS)",
-      "description": "The coordinate reference system (CRS) of a GeoJSON object is determined by its `crs` member (referred to as the CRS object below). If an object has no crs member, then its parent or grandparent object's crs member may be acquired. If no crs member can be so acquired, the default CRS shall apply to the GeoJSON object.\n\n* The default CRS is a geographic coordinate reference system, using the WGS84 datum, and with longitude and latitude units of decimal degrees.\n\n* The value of a member named `crs` must be a JSON object (referred to as the CRS object below) or JSON null. If the value of CRS is null, no CRS can be assumed.\n\n* The crs member should be on the top-level GeoJSON object in a hierarchy (in feature collection, feature, geometry order) and should not be repeated or overridden on children or grandchildren of the object.\n\n* A non-null CRS object has two mandatory members: `type` and `properties`.\n\n* The value of the type member must be a string, indicating the type of CRS object.\n\n* The value of the properties member must be an object.\n\n* CRS shall not change coordinate ordering.",
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "required": ["type", "properties"],
-          "properties": {
-            "type": {
-              "title": "CRS Type",
-              "type": "string",
-              "description": "The value of the type member must be a string, indicating the type of CRS object.",
-              "minLength": 1
-            },
-            "properties": {
-              "title": "CRS Properties",
-              "type": "object"
-            }
-          }
-        }
-      ],
-      "not": {
-        "anyOf": [
-          {
-            "properties": {
-              "type": {
-                "enum": ["name"]
-              },
-              "properties": {
-                "not": {
-                  "required": ["name"],
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  }
-                }
-              }
-            }
-          },
-          {
-            "properties": {
-              "type": {
-                "enum": ["link"]
-              },
-              "properties": {
-                "not": {
-                  "title": "Link Object",
-                  "type": "object",
-                  "required": ["href"],
-                  "properties": {
-                    "href": {
-                      "title": "href",
-                      "type": "string",
-                      "description": "The value of the required `href` member must be a dereferenceable URI.",
-                      "format": "uri"
-                    },
-                    "type": {
-                      "title": "Link Object Type",
-                      "type": "string",
-                      "description": "The value of the optional `type` member must be a string that hints at the format used to represent CRS parameters at the provided URI. Suggested values are: `proj4`, `ogcwkt`, `esriwkt`, but others can be used."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        ]
-      }
-    },
-    "bbox": {
-      "title": "Bounding Box",
-      "type": "array",
-      "description": "To include information on the coordinate range for geometries, features, or feature collections, a GeoJSON object may have a member named `bbox`. The value of the bbox member must be a 2*n array where n is the number of dimensions represented in the contained geometries, with the lowest values for all axes followed by the highest values. The axes order of a bbox follows the axes order of geometries. In addition, the coordinate reference system for the bbox is assumed to match the coordinate reference system of the GeoJSON object of which it is a member.",
-      "minItems": 4,
-      "items": {
-        "type": "number"
-      }
-    }
-  },
-  "required": ["type"],
-  "title": "GeoJSON Object",
-  "type": "object"
+  "title": "GeoJSON"
 }

--- a/src/schemas/json/mkdocs-1.0.json
+++ b/src/schemas/json/mkdocs-1.0.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [
+    {
+      "$ref": "#/definitions/coreProperties"
+    },
+    {
+      "required": ["site_name"]
+    }
+  ],
+  "definitions": {
+    "coreProperties": {
+      "type": "object",
+      "properties": {
+        "site_name": {
+          "description": "The main title for the project documentation.\nhttps://www.mkdocs.org/user-guide/configuration/#site_name",
+          "type": "string"
+        },
+        "site_url": {
+          "description": "Set the canonical URL of the site. This will add a link tag with the canonical URL to the head section of each HTML page. If the 'root' of the MkDocs site will be within a subdirectory of a domain, be sure to include that subdirectory in the setting (https://example.com/foo/).\nhttps://www.mkdocs.org/user-guide/configuration/#site_url",
+          "type": "string"
+        },
+        "repo_url": {
+          "description": "When set, provides a link to your repository (GitHub, Bitbucket, GitLab, ...) on each page.\nhttps://www.mkdocs.org/user-guide/configuration/#repo_url",
+          "type": "string"
+        },
+        "repo_name": {
+          "description": "When set, provides the name for the link to your repository on each page.\nhttps://www.mkdocs.org/user-guide/configuration/#repo_name",
+          "type": "string"
+        },
+        "edit_uri": {
+          "description": "The path from the base repo_url to the docs directory when directly viewing a page, accounting for specifics of the repository host (e.g. GitHub, Bitbucket, etc), the branch, and the docs directory itself.\nhttps://www.mkdocs.org/user-guide/configuration/#edit_uri",
+          "type": "string"
+        },
+        "edit_uri_template": {
+          "description": "The more flexible variant of edit_uri.\nhttps://www.mkdocs.org/user-guide/configuration/#edit_uri_template",
+          "type": "string"
+        },
+        "site_description": {
+          "description": "Set the site description. This will add a meta tag to the generated HTML header.\nhttps://www.mkdocs.org/user-guide/configuration/#site_description",
+          "type": "string"
+        },
+        "site_author": {
+          "description": "Set the name of the author. This will add a meta tag to the generated HTML header.\nhttps://www.mkdocs.org/user-guide/configuration/#site_author",
+          "type": "string"
+        },
+        "copyright": {
+          "description": "Set the copyright information to be included in the documentation by the theme.\nhttps://www.mkdocs.org/user-guide/configuration/#copyright",
+          "type": "string"
+        },
+        "remote_branch": {
+          "default": "gh-pages",
+          "description": "Set the remote branch to commit to when using gh-deploy to deploy to GitHub Pages. This option can be overridden by a command line option in gh-deploy.\nhttps://www.mkdocs.org/user-guide/configuration/#remote_branch",
+          "type": "string"
+        },
+        "remote_name": {
+          "default": "origin",
+          "description": "Set the remote name to push to when using gh-deploy to deploy to GitHub Pages. This option can be overridden by a command line option in gh-deploy.\nhttps://www.mkdocs.org/user-guide/configuration/#remote_name",
+          "type": "string"
+        },
+        "nav": {
+          "description": "This setting is used to determine the format and layout of the global navigation for the site.\nhttps://www.mkdocs.org/user-guide/configuration/#nav",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "theme": {
+          "description": "Sets the theme and theme specific configuration of your documentation site.\nhttps://www.mkdocs.org/user-guide/configuration/#theme",
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "default": "mkdocs",
+                  "description": "The string name of a known installed theme.",
+                  "type": "string"
+                },
+                "locale": {
+                  "default": "en",
+                  "description": "A code representing the language of your site.",
+                  "type": "string"
+                },
+                "custom_dir": {
+                  "description": "A directory containing a custom theme. This can either be a relative directory, in which case it is resolved relative to the directory containing your configuration file or it can be an absolute directory path from the root of your local file system.",
+                  "type": "string"
+                },
+                "static_templates": {
+                  "description": "A list of templates to render as static pages. The templates must be located in either the theme's template directory or in the custom_dir defined in the theme configuration.",
+                  "type": "array"
+                }
+              }
+            },
+            {
+              "default": "mkdocs",
+              "type": "string"
+            }
+          ]
+        },
+        "docs_dir": {
+          "default": "docs",
+          "description": "The directory containing the documentation source markdown files. This can either be a relative directory, in which case it is resolved relative to the directory containing your configuration file, or it can be an absolute directory path from the root of your local file system.\nhttps://www.mkdocs.org/user-guide/configuration/#docs_dir",
+          "type": "string"
+        },
+        "site_dir": {
+          "default": "site",
+          "description": "The directory where the output HTML and other files are created. This can either be a relative directory, in which case it is resolved relative to the directory containing your configuration file, or it can be an absolute directory path from the root of your local file system.\nhttps://www.mkdocs.org/user-guide/configuration/#site_dir",
+          "type": "string"
+        },
+        "extra_css": {
+          "default": [],
+          "description": "Set a list of CSS files in your docs_dir to be included by the theme. For example, the following example will include the extra.css file within the css subdirectory in your docs_dir.\nhttps://www.mkdocs.org/user-guide/configuration/#extra_css",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra_javascript": {
+          "default": [],
+          "description": "Set a list of JavaScript files in your docs_dir to be included by the theme. See the example in extra_css for usage.\nhttps://www.mkdocs.org/user-guide/configuration/#extra_javascript",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra_templates": {
+          "default": [],
+          "description": "Set a list of templates in your docs_dir to be built by MkDocs. To see more about writing templates for MkDocs read the documentation about [custom themes] and specifically the section about the [available variables] to templates. See the example in extra_css for usage.\nhttps://www.mkdocs.org/user-guide/configuration/#extra_templates",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra": {
+          "default": {},
+          "description": "A set of key-value pairs, where the values can be any valid YAML construct, that will be passed to the template. This allows for great flexibility when creating custom themes.\nhttps://www.mkdocs.org/user-guide/configuration/#extra",
+          "type": "object"
+        },
+        "watch": {
+          "description": "Determines additional directories to watch when running mkdocs serve.\nhttps://www.mkdocs.org/user-guide/configuration/#watch",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "use_directory_urls": {
+          "default": true,
+          "description": "This setting controls the style used for linking to pages within the documentation.\nhttps://www.mkdocs.org/user-guide/configuration/#use_directory_urls",
+          "type": "boolean"
+        },
+        "strict": {
+          "default": false,
+          "description": "Determines how warnings are handled. Set to true to halt processing when a warning is raised. Set to false to print a warning and continue processing.\nhttps://www.mkdocs.org/user-guide/configuration/#strict",
+          "type": "boolean"
+        },
+        "dev_addr": {
+          "default": "127.0.0.1:8000",
+          "description": "Determines the address used when running mkdocs serve. Must be of the format IP:PORT.\nhttps://www.mkdocs.org/user-guide/configuration/#dev_addr",
+          "type": "string"
+        },
+        "markdown_extensions": {
+          "default": [],
+          "description": "This setting lets you enable a list of extensions beyond the ones that MkDocs uses by default (meta, toc, tables, and fenced_code).\nhttps://www.mkdocs.org/user-guide/configuration/#markdown_extensions",
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "hooks": {
+          "description": "A list of paths to Python scripts (relative to mkdocs.yml) that are loaded and used as plugin instances.\nhttps://www.mkdocs.org/user-guide/configuration/#hooks",
+          "type": "array"
+        },
+        "plugins": {
+          "default": ["search"],
+          "description": "A list of plugins (with optional configuration settings) to use when building the site. See the Plugins documentation for full details.\nhttps://www.mkdocs.org/user-guide/configuration/#plugins",
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "INHERIT": {
+          "description": "Define the parent for a configuration file. The path must be relative to the location of the primary file.\nhttps://www.mkdocs.org/user-guide/configuration/#configuration-inheritance",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "description": "JSON schema for MkDocs configuration file",
+  "title": "MkDocs Configuration",
+  "type": "object"
+}

--- a/src/test/mkdocs-1.0/mkdocs-test.yml
+++ b/src/test/mkdocs-1.0/mkdocs-test.yml
@@ -1,0 +1,55 @@
+INHERIT: ../base.yml
+site_name: My Docs
+site_url: https://example.com/foo/
+repo_url: https://github.com/example/repository/
+repo_name: 'GitHub'
+edit_uri: '?query=root/path/docs/'
+edit_uri_template: 'blob/main/docs/{path}'
+site_description: This is my doc
+site_author: Me
+copyright: Copyright (c) present, me
+remote_branch: gh-pages
+remote_name: origin
+nav:
+  - Home: '../'
+  - 'index.md'
+  - 'about.md'
+  - 'Issue Tracker': 'https://example.com/'
+  - 'User Guide': 'user-guide.md'
+  - 'Bug Tracker': '/bugs/'
+theme:
+  name: mkdocs
+  locale: en
+  custom_dir: my_theme_customizations/
+  static_templates:
+    - sitemap.html
+  include_sidebar: false
+extra_css:
+  - css/extra.css
+  - css/second_extra.css
+extra_javascript:
+  - js/extra.js
+  - js/second_extra.js
+extra_templates:
+  - template.extra
+  - template.second_extra
+extra:
+  version: 1.0
+watch:
+  - directory_a
+  - directory_b
+use_directory_urls: true
+strict: false
+dev_addr: 127.0.0.1:8000
+markdown_extensions:
+  - smarty
+  - toc:
+      permalink: true
+  - sane_lists
+hooks:
+  - my_hooks.py
+plugins:
+  - search:
+  - your_other_plugin:
+      option1: value
+      option2: other value


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This partially addresses #2751 by updating the GeoJSON schema and moving the two GeoJSON entries close to each other in `catalog.json` to make it clear that there is a duplicate.

More work needs to be done, related to #2731, to completely solve this issue. In `schema-validation.json`, there is an entry:

```json
{
      "ninjs-2.0.json": {
        "unknownKeywords": ["name"],
        "externalSchema": ["geojson.json"]
      }
    }
```

So we cannot just remove the `geojson.json` external schema completely. To fix this issue, there needs to be some way of referencing external schemas without breaking the tests.

Closes #1371 (that issue has been resolved an is not an issue with schemastore)
