### PR TITLE
Add Docker command name to the launchsetting schema

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -77,7 +77,8 @@
             "Project",
             "IIS",
             "IISExpress",
-            "DebugRoslynComponent"
+            "DebugRoslynComponent",
+            "Docker"
           ],
           "default": "",
           "minLength": 1


### PR DESCRIPTION
According to [this documentation](https://learn.microsoft.com/en-us/visualstudio/containers/container-launch-settings?view=vs-2022), there should also be a `Docker` command name.
