### PR TITLE
Add schema for Frogbot config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -417,6 +417,12 @@
       "url": "https://raw.githubusercontent.com/freifunk/api.freifunk.net/master/specs/0.1.json"
     },
     {
+      "name": "Frogbot Config",
+      "description": "The Frogbot configuration required to scan Git repositories",
+      "fileMatch": ["frogbot-config.yml"],
+      "url": "https://raw.githubusercontent.com/jfrog/frogbot/master/schema/frogbot-schema.json"
+    },
+    {
       "name": ".asmdef",
       "description": "Unity 3D assembly definition file",
       "fileMatch": ["*.asmdef"],


### PR DESCRIPTION
**What is Frogbot?**
Frogbot is a Git bot that scans your pull requests and repositories for security vulnerabilities. You can scan pull requests when they are opened, and Git repositories following new commits.
Read more about Frogbot here - https://github.com/jfrog/frogbot#frogbot

**The Frogbot Config**
The frogbot-config.yml file includes the configuration required for Frogbot to scan your Git repositories.
Read more about it here - https://github.com/jfrog/frogbot/blob/master/docs/frogbot-config.md

**Frogbot Config Schema**
The [Frogbot config schema](https://github.com/jfrog/frogbot/blob/master/schema/frogbot-schema.json) is located in the Frogbot repository.

**Tests**
Some [schema unit tests](https://github.com/jfrog/frogbot/blob/master/schema/frogbotschema_test.go) are available in the Frogbot repository.