### PR TITLE
Allow jekyll permalinks with output_ext

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -55,7 +55,7 @@
         "/:categories/:year/:week/:short_day/:title:output_ext",
         "/:categories/:title:output_ext"
       ],
-      "pattern": "^((/(:(year|short_year|month|i_month|short_month|long_month|day|i_day|y_day|w_year|week|w_day|short_day|long_day|hour|minute|second|title|slug|categories|slugified_categories))+)+|date|pretty|ordinal|weekdate|none)(/?)$"
+      "pattern": "^((/(:(year|short_year|month|i_month|short_month|long_month|day|i_day|y_day|w_year|week|w_day|short_day|long_day|hour|minute|second|title|slug|categories|slugified_categories|output_ext))+)+|date|pretty|ordinal|weekdate|none)(/?)$"
     },
     "collection-permalink": {
       "description": "The collection permalink format\nhttps://jekyllrb.com/docs/permalinks/#collections",

--- a/src/test/jekyll/permalink.yaml
+++ b/src/test/jekyll/permalink.yaml
@@ -1,3 +1,3 @@
 # Test a more complex permalink example
 
-permalink: "/:categories/:year/:week/:short_day/:title:output_ext"
+permalink: '/:categories/:year/:week/:short_day/:title:output_ext'

--- a/src/test/jekyll/permalink.yaml
+++ b/src/test/jekyll/permalink.yaml
@@ -1,0 +1,3 @@
+# Test a more complex permalink example
+
+permalink: "/:categories/:year/:week/:short_day/:title:output_ext"


### PR DESCRIPTION
Examples for permalink property list `:output_ext` as one of the possible variables, as is in line with Jekyll documentation and how its working. However, the regex validation skips this variable.
This contribution adds a test for that case and extends the regex to allow this. 
