### PR TITLE
Add schema for IfState config.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1809,6 +1809,12 @@
       "url": "https://json.schemastore.org/ide.host.json"
     },
     {
+      "name": "ifstate.conf",
+      "description": "Schema for IfState configuration file",
+      "fileMatch": ["**/ifstate/config.yml"],
+      "url": "https://ifstate.net/schema/ifstate.conf.schema.json"
+    },
+    {
       "name": "imageoptimizer.json",
       "description": "Schema for imageoptimizer.json files",
       "fileMatch": ["imageoptimizer.json"],


### PR DESCRIPTION
IfState is a tool to configure (linux) host interfaces in a declarative manner. It is a front end for the kernel netlink protocol (similar to *NMState* but w/o *NetworkManager* backend).

See also https://ifstate.net/

IfState uses a YaML configuration file and checks it against the schema before using it. The schema is published at: https://ifstate.net/schema/ifstate.conf.schema.json