### PR TITLE
Adding support for python 3.10 in Static Web Apps CLI

### DIFF
--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -603,7 +603,8 @@
             "node:16",
             "node:18",
             "python:3.8",
-            "python:3.9"
+            "python:3.9",
+            "python:3.10"
           ],
           "description": "Language runtime for the managed functions API"
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
