### PR TITLE
Update travis.json to include linux-ppc64le platform

### DIFF
--- a/src/schemas/json/travis.json
+++ b/src/schemas/json/travis.json
@@ -1002,14 +1002,14 @@
           "description": "The operating system to run the job on",
           "oneOf": [
             {
-              "enum": ["osx", "linux", "windows"]
+              "enum": ["osx", "linux", "linux-ppc64le", "windows"]
             },
             {
               "type": "array",
               "uniqueItems": true,
               "minItems": 1,
               "items": {
-                "enum": ["osx", "linux", "windows"]
+                "enum": ["osx", "linux", "linux-ppc64le", "windows"]
               }
             }
           ]


### PR DESCRIPTION
We are using "linux-ppc64le" as an os here and currently get an error, can this be updated?

![image](https://user-images.githubusercontent.com/5566472/217853463-44725ae0-4ddd-4ad8-843d-6dc7d6c9cd9a.png)


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
