### PR TITLE
Add DockerCompose to launchsetting schema

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -78,7 +78,8 @@
             "IIS",
             "IISExpress",
             "DebugRoslynComponent",
-            "Docker"
+            "Docker",
+            "DockerCompose"
           ],
           "default": "",
           "minLength": 1


### PR DESCRIPTION
According to [Microsoft's documentation](https://learn.microsoft.com/en-us/visualstudio/containers/launch-profiles?view=vs-2022#properties), the `DockerCompose` command should be valid. 

