### PR TITLE
Add Helm Unittest test suite schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -841,6 +841,12 @@
       "url": "https://json.schemastore.org/chart-lock.json"
     },
     {
+      "name": "Helm Unittest Test Suite",
+      "description": "A Helm Unittest Test Suite file",
+      "fileMatch": ["**/charts/*/tests/*.yaml"],
+      "url": "https://raw.githubusercontent.com/helm-unittest/helm-unittest/v0.3.0/schema/helm-testsuite.json"
+    },
+    {
       "name": "CircleCI config.yml",
       "description": "Schema for CircleCI config files",
       "fileMatch": ["**/.circleci/config.yml"],


### PR DESCRIPTION
This pull request aims for adding a JSON schema for Helm's Unittest plug-in. The [helm-unittest](https://github.com/helm-unittest/helm-unittest) plug-in is growing more and more in popularity because it enables BDD styled unit tests for Kubernetes Helm charts.