### PR TITLE
Add schema for OpenRewrite resource descriptors

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2413,6 +2413,12 @@
       "url": "https://json.schemastore.org/openfin.json"
     },
     {
+      "name": "OpenRewrite Resource",
+      "description": "JSON schema for OpenRewrite resource descriptors",
+      "fileMatch": ["**/META-INF/rewrite/*.yml"],
+      "url": "https://raw.githubusercontent.com/openrewrite/rewrite/main/rewrite-core/openrewrite.json"
+    },
+    {
       "name": "Outblocks project configuration",
       "description": "JSON schema for Outblocks project configuration files",
       "fileMatch": ["project.outblocks.yaml", "project.outblocks.yml"],


### PR DESCRIPTION
This schema is for OpenRewrite, which is a mass source code refactoring ecosystem. See https://docs.openrewrite.org/ and https://github.com/openrewrite/rewrite for details.

The code migrations can largely be authored using YAML files, which this PR registers the schema for.
