### PR TITLE
Add docs for targetUnprocessedEventThreshold

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -1182,6 +1182,11 @@
                 {
                   "type": "object",
                   "properties": {
+                    "targetUnprocessedEventThreshold": {
+                      "description": "The target number of unprocessed events per worker for Event Hub-triggered functions. This is used in target-based scaling to override the default scaling threshold inferred from maxEventBatchSize.",
+                      "type": "integer",
+                      "minimum": 1
+                    },
                     "maxEventBatchSize": {
                       "description": "The maximum number of events that will be included in a batch for a single invocation.",
                       "type": "integer",


### PR DESCRIPTION
Adding schema for `targetUnprocessedEventThreshold`, a new parameter introduced in the EventHubs SDK to support Target Based Scaling.

See PR [here](https://github.com/Azure/azure-sdk-for-net/pull/33675)
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
