### PR TITLE
Allow expressions for github workflow job.<job-id>.timeout-minutes and add documented default

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -821,7 +821,15 @@
                   "timeout-minutes": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes",
                     "description": "The maximum number of minutes to run the step before killing the process.",
-                    "type": "number"
+                    "oneOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/expressionSyntax"
+                      }
+                    ],
+                    "default": 360
                   }
                 },
                 "dependencies": {


### PR DESCRIPTION
Fixes #2806 

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
