### PR TITLE
Allow expressions for github workflow job.<job-id>.timeout-minutes.

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -828,8 +828,7 @@
                       {
                         "$ref": "#/definitions/expressionSyntax"
                       }
-                    ],
-                    "default": 360
+                    ]
                   }
                 },
                 "dependencies": {
@@ -845,7 +844,14 @@
         "timeout-minutes": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes",
           "description": "The maximum number of minutes to let a workflow run before GitHub automatically cancels it. Default: 360",
-          "type": "number",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
+            }
+          ],
           "default": 360
         },
         "strategy": {


### PR DESCRIPTION
Previous patch (https://github.com/SchemaStore/schemastore/pull/2807) accidentally modified job.<job-id>.steps[*].timeout-minutes.  Which was valid to allow expressions didn't solve what I intended, and didn't have a documented default.

Fixes #2806 (properly)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
