### PR TITLE
Support queue attribute in zuul schema

### DIFF
--- a/src/schemas/json/zuul.json
+++ b/src/schemas/json/zuul.json
@@ -357,6 +357,10 @@
         "promote": {
           "$ref": "#/definitions/PipelineModel"
         },
+        "queue": {
+          "title": "Queue",
+          "type": "string"
+        },
         "release": {
           "$ref": "#/definitions/PipelineModel"
         },

--- a/src/test/zuul/jobs.yaml
+++ b/src/test/zuul/jobs.yaml
@@ -83,6 +83,7 @@
 # project maximal
 - project:
     name: Sample project
+    queue: test
     description: Description
     templates:
       - sample-template


### PR DESCRIPTION
The queue attribute on project stanzas is currently not recognized by the schema [1].

[1] https://zuul-ci.org/docs/zuul/latest/config/project.html#attr-project.queue
