### PR TITLE
Add JMeter DSL cli tool jmdsl configuration file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1930,6 +1930,12 @@
       "url": "https://raw.githubusercontent.com/jfrog/jfrog-cli/v2/schema/filespec-schema.json"
     },
     {
+      "name": "JMeter DSL cli config schema",
+      "description": "jmdsl JMeter DSL command line configuration file schema definition",
+      "fileMatch": ["*.jmdsl.yml", "*.jmdsl.yaml", "*.jmdsl.json"],
+      "url": "https://github.com/abstracta/jmeter-java-dsl/releases/latest/download/jmdsl-config-schema.json"
+    },
+    {
       "name": "Jovo Language Models",
       "description": "JSON Schema for Jovo language Models (https://www.jovo.tech/docs/model)",
       "url": "https://json.schemastore.org/jovo-language-model.json"


### PR DESCRIPTION
You can find some intro to the tool here: https://abstracta.github.io/jmeter-java-dsl/guide/#dsl-recorder.

Having the schema would greatly improve user experience.

Thank you! 
