### PR TITLE
Add schema for `transcend.yml`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3304,7 +3304,7 @@
       "description": "Traefik v2 Dynamic Configuration File Provider",
       "url": "https://json.schemastore.org/traefik-v2-file-provider.json"
     },
-        {
+    {
       "name": "transcend.yml",
       "description": "Define personal data schema in code using Transcend",
       "fileMatch": ["transcend.yml", "transcend.yaml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3304,6 +3304,12 @@
       "description": "Traefik v2 Dynamic Configuration File Provider",
       "url": "https://json.schemastore.org/traefik-v2-file-provider.json"
     },
+        {
+      "name": "transcend.yml",
+      "description": "Define personal data schema in code using Transcend",
+      "fileMatch": ["transcend.yml", "transcend.yaml"],
+      "url": "https://raw.githubusercontent.com/transcend-io/cli/main/transcend-yml-schema-v4.json"
+    },
     {
       "name": "trunk.yaml schema",
       "description": "Configuration schema for trunk, a powerful linter runner - https://docs.trunk.io",


### PR DESCRIPTION
This adds support for `transcend.yml` for use with the [Transcend CLI](https://github.com/transcend-io/cli#transcendyml).