### PR TITLE
Add devcontainer.json schema to catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -943,6 +943,12 @@
       "url": "https://wixplosives.github.io/codux-config-schema/codux.config.schema.json"
     },
     {
+      "name": "devcontainer.json",
+      "description": "Schema for dev container configuration files.",
+      "fileMatch": ["devcontainer.json"],
+      "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json"
+    },
+    {
       "name": "JSON schema for Codecov configuration files",
       "description": "Schema for codecov.yml files.",
       "fileMatch": [".codecov.yml", "codecov.yml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -945,7 +945,7 @@
     {
       "name": "devcontainer.json",
       "description": "Schema for dev container configuration files.",
-      "fileMatch": ["devcontainer.json"],
+      "fileMatch": ["devcontainer.json", ".devcontainer.json"],
       "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json"
     },
     {


### PR DESCRIPTION
Adds a new external schema for [devcontainer.json](https://containers.dev/) files to the catalog, enabling typeahead and hinting on the core configuration file for [VS Code Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and [GitHub Codespaces](https://github.com/features/codespaces).

**Note:** There are no tests because it is an externally referenced schema rather than local

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
