### PR TITLE
fix: add missing type (boolean) for on.workflow_call.secrets.required property

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1576,7 +1576,8 @@
                         },
                         "required": {
                           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callsecretssecret_idrequired",
-                          "description": "A boolean specifying whether the secret must be supplied."
+                          "description": "A boolean specifying whether the secret must be supplied.",
+                          "type": "boolean"
                         }
                       },
                       "required": ["required"],


### PR DESCRIPTION
Fixes #2826 

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
