### PR TITLE
Update minecraft-pack-mcmeta.json

### DIFF
--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -17,7 +17,7 @@
           "description": "A version for the current pack\nhttps://minecraft.fandom.com/wiki/Data_pack#Contents",
           "type": "integer",
           "minimum": 4,
-          "maximum": 11,
+          "maximum": 12,
           "default": 4
         }
       },


### PR DESCRIPTION
Updated to include Pack Format version 12, as added by Minecraft version [1.19.4](https://minecraft.fandom.com/wiki/Data_pack#Pack_format)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
