### PR TITLE
[BX CI]: add build args to docker output

### DIFF
--- a/src/negative_test/bxci.schema-2.x/bxci-output-docker-wrong-args.yml
+++ b/src/negative_test/bxci.schema-2.x/bxci-output-docker-wrong-args.yml
@@ -1,0 +1,17 @@
+project:
+  name: any
+
+stages:
+  first:
+    steps:
+      - echo "Hello"
+
+output:
+  docker:
+    dockerfile: Dockerfile
+    image_name: britebill/image-name
+    args:
+      - key: GIT_COMMIT
+
+      - key: VERSION
+        value: some value

--- a/src/schemas/json/bxci.schema-2.x.json
+++ b/src/schemas/json/bxci.schema-2.x.json
@@ -261,6 +261,14 @@
             }
           },
           "additionalProperties": false
+        },
+        "args": {
+          "type": "array",
+          "description": "List of build args (--build-arg) to pass in docker build",
+          "title": "Docker build args",
+          "items": {
+            "$ref": "#/definitions/outputDockerBuildArgs"
+          }
         }
       },
       "required": ["dockerfile", "image_name"],
@@ -271,6 +279,40 @@
       "items": {
         "$ref": "#/definitions/dockerReleaseChannel"
       }
+    },
+    "outputDockerBuildArgs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "ARG name"
+        },
+        "env": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "description": "Environment variable whose value will be used to set the ARG"
+        },
+        "value": {
+          "type": "string",
+          "description": "Value of the ARG"
+        }
+      },
+      "required": ["key"],
+      "oneOf": [
+        {
+          "required": ["env"],
+          "not": {
+            "required": ["value"]
+          }
+        },
+        {
+          "required": ["value"],
+          "not": {
+            "required": ["env"]
+          }
+        }
+      ]
     },
     "dockerReleaseChannel": {
       "type": "object",

--- a/src/test/bxci.schema-2.x/bxci-output-docker.yml
+++ b/src/test/bxci.schema-2.x/bxci-output-docker.yml
@@ -1,0 +1,17 @@
+project:
+  name: any
+
+stages:
+  first:
+    steps:
+      - echo "Hello"
+
+output:
+  docker:
+    dockerfile: Dockerfile
+    image_name: britebill/image-name
+    args:
+      - key: GIT_COMMIT
+        env: GIT_COMMIT
+      - key: VERSION
+        value: some value


### PR DESCRIPTION
Add new property to set build args in Docker image publication.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
