### PR TITLE
Fix jsEngine enum in expo-46.0.0.json

### DIFF
--- a/src/schemas/json/expo-46.0.0.json
+++ b/src/schemas/json/expo-46.0.0.json
@@ -1659,7 +1659,7 @@
         "jsEngine": {
           "description": "Sets the JS Engine that will interpret your code",
           "type": "string",
-          "enum": ["hermes"]
+          "enum": ["hermes", "jsc"]
         },
         "_internal": {
           "description": "Internal properties for developer tools",


### PR DESCRIPTION
Fixes https://github.com/SchemaStore/schemastore/issues/2839.