### PR TITLE
add enable-beta-ecosystems to dependabot-2.0.json

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -328,6 +328,9 @@
         }
       ]
     },
+    "enable-beta-ecosystems": {
+      "type": "boolean"
+    },
     "updates": {
       "type": "array",
       "items": {

--- a/src/test/dependabot-2.0/example.json
+++ b/src/test/dependabot-2.0/example.json
@@ -195,5 +195,6 @@
       "labels": ["pub dependencies"]
     }
   ],
-  "version": 2
+  "version": 2,
+  "enable-beta-ecosystems": true
 }

--- a/src/test/dependabot-2.0/example.json
+++ b/src/test/dependabot-2.0/example.json
@@ -1,4 +1,5 @@
 {
+  "enable-beta-ecosystems": true,
   "registries": {
     "composer": {
       "type": "composer-repository",
@@ -195,6 +196,5 @@
       "labels": ["pub dependencies"]
     }
   ],
-  "version": 2,
-  "enable-beta-ecosystems": true
+  "version": 2
 }


### PR DESCRIPTION
As seen here: https://github.blog/changelog/2022-04-05-pub-beta-support-for-dependabot-version-updates/

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
