### PR TITLE
fix(all-contributors): add `"none"` to `commitConventions`

### DIFF
--- a/src/schemas/json/all-contributors.json
+++ b/src/schemas/json/all-contributors.json
@@ -48,7 +48,15 @@
     },
     "commitConvention": {
       "title": "Commit convention",
-      "enum": ["angular", "atom", "ember", "eslint", "jshint", "gitmoji"],
+      "enum": [
+        "angular",
+        "atom",
+        "ember",
+        "eslint",
+        "jshint",
+        "gitmoji",
+        "none"
+      ],
       "default": "angular"
     },
     "contributorsPerLine": {


### PR DESCRIPTION
Hi, I'm pushing a very small fix to the `all-contributors` schema

See https://github.com/all-contributors/all-contributors/issues/685

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
