### PR TITLE
schema(fly): Allow numbers and strings for timing measurements

### DIFF
--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -108,11 +108,25 @@
             "properties": {
               "grace_period": {
                 "description": "The time to wait after a VM starts before checking its health. Units are milliseconds unless you specify them like `10s` or `1m`.",
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "interval": {
                 "description": "Length of the pause between connectivity checks. Units are milliseconds unless you specify them like `10s` or `1m`.",
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "restart_limit": {
                 "default": 0,
@@ -121,7 +135,14 @@
               },
               "timeout": {
                 "description": "The maximum time a connection can take before being reported as failing its healthcheck. Units are milliseconds unless you specify them like `10s` or `1m`.",
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               }
             }
           }
@@ -139,11 +160,25 @@
             "properties": {
               "grace_period": {
                 "description": "The time to wait after a VM starts before checking its health. Units are milliseconds unless you specify them like `10s` or `1m`.",
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "interval": {
                 "description": "Length of the pause between connectivity checks. Units are milliseconds unless you specify them like `10s` or `1m`.",
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "restart_limit": {
                 "default": 0,
@@ -152,7 +187,14 @@
               },
               "timeout": {
                 "description": "The maximum time a connection can take before being reported as failing its healthcheck. Units are milliseconds unless you specify them like `10s` or `1m`.",
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "method": {
                 "description": "The HTTP method to be used for the check.",


### PR DESCRIPTION
This fixes areas in the fly schema in which numbers are strings are supposed to be accepted, but currently only strings are accepted.

Closes #2829