### PR TITLE
Added IBM zapp and zcodeformat to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1885,6 +1885,18 @@
       "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
     },
     {
+      "name": "IBM Zapp document",
+      "description": "IBM Z APPlication configuration file for IBM zDevOps development tools such as Z Open Editor.",
+      "fileMatch": ["zapp.yaml", "zapp.json"],
+      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.0.0.json"
+    },
+    {
+      "name": "IBM zCodeFormatSettings",
+      "description": "IBM Enterprise languages code formatter settings file for IBM zDevOps development tools such as Z Open Editor.",
+      "fileMatch": ["zcodeformat.yaml", "zcodeformat.json"],
+      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zcodeformat/zcodeformat-schema-0.0.1.json"
+    },
+    {
       "name": "ide.host.json",
       "description": "JSON schema for IDE template host file",
       "fileMatch": ["ide.host.json"],


### PR DESCRIPTION
Adding two schemas used by free development tools provided by IBM.

- <https://ibm.github.io/zopeneditor-about/Docs/zapp.html>
- <https://ibm.github.io/zopeneditor-about/Docs/zcodeformatting.html>
