### PR TITLE
Update URL for Airplane task schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -81,7 +81,7 @@
       "name": "Airplane task",
       "description": "Schema for building Airplane tasks",
       "fileMatch": ["*.task.json", "*.task.yaml", "*.task.yml"],
-      "url": "https://raw.githubusercontent.com/airplanedev/lib/main/pkg/deploy/taskdir/definitions/schema_0_3.json"
+      "url": "https://api.airplane.dev/schemas/task.json"
     },
     {
       "name": "angular.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -81,7 +81,7 @@
       "name": "Airplane task",
       "description": "Schema for building Airplane tasks",
       "fileMatch": ["*.task.json", "*.task.yaml", "*.task.yml"],
-      "url": "https://api.airplane.dev/schemas/task.json"
+      "url": "https://api.airplane.dev/v0/schemas/task.json"
     },
     {
       "name": "angular.json",


### PR DESCRIPTION
Updates the URL used by the Airplane task schema since we archived the [repository](https://github.com/airplanedev/lib) that currently hosts this schema in Schema Store.

This schema was previously added to the catalog here: https://github.com/SchemaStore/schemastore/pull/2155

cc @francescaleung 