### PR TITLE
add support for Deta Spacefile

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -788,6 +788,12 @@
       "url": "https://json.schemastore.org/dein.json"
     },
     {
+      "name": "Deta Spacefile Schema",
+      "description": "Configuration file for Space Apps",
+      "fileMatch": ["Spacefile"],
+      "url": "https://deta.space/assets/spacefile.schema.json"
+    },
+    {
       "name": "Drupal Breakpoints Schema",
       "description": "A Drupal schema for breakpoints",
       "fileMatch": ["*.breakpoints.yml"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

The Spacefile is a configuration file for Deta Spaces. It's used to configure and deploy Space apps.

The schema is based on the [Spacefile documentation](https://deta.space/docs/en/reference/spacefile).

I'm a member of the Deta team.
