### PR TITLE
feat(golangci-lint): add missing `header` case

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -2253,7 +2253,8 @@
                         "goKebab",
                         "goSnake",
                         "upper",
-                        "lower"
+                        "lower",
+                        "header"
                       ]
                     }
                   }


### PR DESCRIPTION
Added missing `header` case to tagliatelle config. 

See the golangci-lint reference here: https://github.com/golangci/golangci-lint/blob/v1.52.2/.golangci.reference.yml#L1721

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
