### PR TITLE
Update fileMatch in catalog.json for Hugo

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4410,7 +4410,7 @@
     {
       "name": "Hugo",
       "description": "Hugo static site generator config file schema",
-      "fileMatch": [],
+      "fileMatch": ["hugo.toml", "hugo.json", "hugo.yaml"],
       "url": "https://json.schemastore.org/hugo.json"
     },
     {


### PR DESCRIPTION
In Hugo 0.110.0 they changed the default config base filename to hugo, e.g. hugo.toml (from config) so now it's easy to match it.

**Info:**
- https://gohugo.io/getting-started/configuration/#hugotoml-vs-configtoml
- https://github.com/gohugoio/hugo/issues/8979
- https://github.com/gohugoio/hugo/pull/10621

**Related issues:**
https://github.com/SchemaStore/schemastore/issues/2148

PD:
First time in the schemastore world, sorry if I missed something
