### PR TITLE
schema(hugo): PascalCase anchor property

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -665,7 +665,7 @@
         "resampleFilter": "box",
         "quality": 75,
         "hint": "photo",
-        "anchor": "smart",
+        "anchor": "Smart",
         "bgColor": "#ffffff",
         "exif": {
           "includeFields": "",
@@ -713,18 +713,18 @@
         "anchor": {
           "description": "The anchor used when cropping pictures with either .Fill or .Crop\nhttps://gohugo.io/content-management/image-processing/#image-processing-config",
           "type": "string",
-          "default": "smart",
+          "default": "Smart",
           "enum": [
-            "smart",
-            "center",
-            "topLeft",
-            "top",
-            "topRight",
-            "left",
-            "right",
-            "bottomLeft",
-            "bottom",
-            "bottomRight"
+            "Smart",
+            "TopLeft",
+            "Top",
+            "TopRight",
+            "Left",
+            "Center",
+            "Right",
+            "BottomLeft",
+            "Bottom",
+            "BottomRight"
           ]
         },
         "bgColor": {


### PR DESCRIPTION
As per documentation https://gohugo.io/content-management/image-processing/#anchor

Probably a pattern could be used like in https://github.com/andrewbranch/schemastore/blob/master/src/schemas/json/jsconfig.json#L140 and it would be a better solution
