### PR TITLE
Add lower/uppercase, keep/dropequal actions to prometheus

### DIFF
--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -391,8 +391,12 @@
             "type": "string",
             "enum": [
               "replace",
+              "lowercase",
+              "uppercase",
               "keep",
               "drop",
+              "keepequal",
+              "dropequal",
               "hashmod",
               "labelmap",
               "labeldrop",


### PR DESCRIPTION
Add `lowercase`, `uppercase`, `keepequal` and `dropequal` [relabel actions](https://prometheus.io/docs/prometheus/2.37/configuration/configuration/#relabel_config) available since Prometheus 2.36 and 2.41 (respectively).