### PR TITLE
Added Apple Silicon to resource_class enum

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -459,7 +459,8 @@
               "gpu.nvidia.medium",
               "windows.gpu.nvidia.medium",
               "macos.x86.medium.gen2",
-              "macos.x86.metal.gen1"
+              "macos.x86.metal.gen1",
+              "macos.m1.large.gen1"
             ]
           },
           "shell": {


### PR DESCRIPTION
CircleCi [recently added Apple Silicon](https://circleci.com/blog/m1-mac-resource-class/) to their VM offerings. This PR adds this option to the `resource_class` enum so that VS Code will not underline it as an error. The enum should now match [Available resource classes](https://circleci.com/docs/using-macos/#available-resource-classes).

Before:
![image](https://user-images.githubusercontent.com/121245612/230152132-626edc6b-cbf8-4d59-9118-e52ae421b9b0.png)


After:
![image](https://user-images.githubusercontent.com/121245612/230151972-d12b3a4d-20be-4ade-ad76-b4547ba7da1a.png)


