### PR TITLE
allow number or string for github-workflow max-parallel

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -5,7 +5,11 @@
   "definitions": {
     "architecture": {
       "type": "string",
-      "enum": ["ARM32", "x64", "x86"]
+      "enum": [
+        "ARM32",
+        "x64",
+        "x86"
+      ]
     },
     "branch": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestbranchestags",
@@ -33,7 +37,9 @@
           ]
         }
       },
-      "required": ["group"],
+      "required": [
+        "group"
+      ],
       "additionalProperties": false
     },
     "configuration": {
@@ -119,7 +125,9 @@
           "type": "string"
         }
       },
-      "required": ["image"],
+      "required": [
+        "image"
+      ],
       "additionalProperties": false
     },
     "defaults": {
@@ -148,7 +156,10 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": ["read-all", "write-all"]
+          "enum": [
+            "read-all",
+            "write-all"
+          ]
         },
         {
           "$ref": "#/definitions/permissions-event"
@@ -202,7 +213,11 @@
     },
     "permissions-level": {
       "type": "string",
-      "enum": ["read", "write", "none"]
+      "enum": [
+        "read",
+        "write",
+        "none"
+      ]
     },
     "env": {
       "$comment": "https://docs.github.com/en/actions/learn-github-actions/environment-variables",
@@ -245,7 +260,9 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     },
     "event": {
@@ -319,7 +336,11 @@
     },
     "machine": {
       "type": "string",
-      "enum": ["linux", "macos", "windows"]
+      "enum": [
+        "linux",
+        "macos",
+        "windows"
+      ]
     },
     "name": {
       "type": "string",
@@ -357,17 +378,26 @@
           "allOf": [
             {
               "not": {
-                "required": ["branches", "branches-ignore"]
+                "required": [
+                  "branches",
+                  "branches-ignore"
+                ]
               }
             },
             {
               "not": {
-                "required": ["tags", "tags-ignore"]
+                "required": [
+                  "tags",
+                  "tags-ignore"
+                ]
               }
             },
             {
               "not": {
-                "required": ["paths", "paths-ignore"]
+                "required": [
+                  "paths",
+                  "paths-ignore"
+                ]
               }
             }
           ]
@@ -387,7 +417,14 @@
         {
           "type": "string",
           "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell",
-          "enum": ["bash", "pwsh", "python", "sh", "cmd", "powershell"]
+          "enum": [
+            "bash",
+            "pwsh",
+            "python",
+            "sh",
+            "cmd",
+            "powershell"
+          ]
         }
       ]
     },
@@ -437,7 +474,11 @@
         "if": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif",
           "description": "You can use the if conditional to prevent a job from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-          "type": ["boolean", "number", "string"]
+          "type": [
+            "boolean",
+            "number",
+            "string"
+          ]
         },
         "uses": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses",
@@ -459,7 +500,9 @@
             },
             {
               "type": "string",
-              "enum": ["inherit"]
+              "enum": [
+                "inherit"
+              ]
             }
           ]
         },
@@ -517,10 +560,15 @@
             "max-parallel": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel",
               "description": "The maximum number of jobs that can run simultaneously when using a matrix job strategy. By default, GitHub will maximize the number of jobs run in parallel depending on the available runners on GitHub-hosted virtual machines.",
-              "type": "number"
+              "type": [
+                "number",
+                "string"
+              ]
             }
           },
-          "required": ["matrix"],
+          "required": [
+            "matrix"
+          ],
           "additionalProperties": false
         },
         "concurrency": {
@@ -536,7 +584,9 @@
           ]
         }
       },
-      "required": ["uses"],
+      "required": [
+        "uses"
+      ],
       "additionalProperties": false
     },
     "normalJob": {
@@ -721,7 +771,11 @@
         "if": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif",
           "description": "You can use the if conditional to prevent a job from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-          "type": ["boolean", "number", "string"]
+          "type": [
+            "boolean",
+            "number",
+            "string"
+          ]
         },
         "steps": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idsteps",
@@ -738,7 +792,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["uses"]
+                    "required": [
+                      "uses"
+                    ]
                   },
                   {
                     "type": "object",
@@ -747,7 +803,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["run"]
+                    "required": [
+                      "run"
+                    ]
                   }
                 ]
               },
@@ -762,7 +820,11 @@
                   "if": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsif",
                     "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-                    "type": ["boolean", "number", "string"]
+                    "type": [
+                      "boolean",
+                      "number",
+                      "string"
+                    ]
                   },
                   "name": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname",
@@ -832,8 +894,12 @@
                   }
                 },
                 "dependencies": {
-                  "working-directory": ["run"],
-                  "shell": ["run"]
+                  "working-directory": [
+                    "run"
+                  ],
+                  "shell": [
+                    "run"
+                  ]
                 },
                 "additionalProperties": false
               }
@@ -911,7 +977,9 @@
               "type": "number"
             }
           },
-          "required": ["matrix"],
+          "required": [
+            "matrix"
+          ],
           "additionalProperties": false
         },
         "continue-on-error": {
@@ -959,7 +1027,9 @@
           ]
         }
       },
-      "required": ["runs-on"],
+      "required": [
+        "runs-on"
+      ],
       "additionalProperties": false
     }
   },
@@ -995,9 +1065,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1035,9 +1113,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["completed", "requested", "rerequested"]
+                    "enum": [
+                      "completed",
+                      "requested",
+                      "rerequested"
+                    ]
                   },
-                  "default": ["completed", "requested", "rerequested"]
+                  "default": [
+                    "completed",
+                    "requested",
+                    "rerequested"
+                  ]
                 }
               }
             },
@@ -1113,9 +1199,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1138,9 +1232,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1202,9 +1304,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1217,9 +1327,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["added", "edited", "deleted"]
+                    "enum": [
+                      "added",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["added", "edited", "deleted"]
+                  "default": [
+                    "added",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1232,9 +1350,13 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["checks_requested"]
+                    "enum": [
+                      "checks_requested"
+                    ]
                   },
-                  "default": ["checks_requested"]
+                  "default": [
+                    "checks_requested"
+                  ]
                 }
               }
             },
@@ -1247,7 +1369,13 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "closed", "opened", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "closed",
+                      "opened",
+                      "edited",
+                      "deleted"
+                    ]
                   },
                   "default": [
                     "created",
@@ -1329,9 +1457,19 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "updated", "moved", "deleted"]
+                    "enum": [
+                      "created",
+                      "updated",
+                      "moved",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "updated", "moved", "deleted"]
+                  "default": [
+                    "created",
+                    "updated",
+                    "moved",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1369,7 +1507,11 @@
                       "auto_merge_disabled"
                     ]
                   },
-                  "default": ["opened", "synchronize", "reopened"]
+                  "default": [
+                    "opened",
+                    "synchronize",
+                    "reopened"
+                  ]
                 }
               },
               "patternProperties": {
@@ -1388,9 +1530,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["submitted", "edited", "dismissed"]
+                    "enum": [
+                      "submitted",
+                      "edited",
+                      "dismissed"
+                    ]
                   },
-                  "default": ["submitted", "edited", "dismissed"]
+                  "default": [
+                    "submitted",
+                    "edited",
+                    "dismissed"
+                  ]
                 }
               }
             },
@@ -1403,9 +1553,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1438,7 +1596,11 @@
                       "auto_merge_disabled"
                     ]
                   },
-                  "default": ["opened", "synchronize", "reopened"]
+                  "default": [
+                    "opened",
+                    "synchronize",
+                    "reopened"
+                  ]
                 }
               },
               "patternProperties": {
@@ -1469,9 +1631,15 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["published", "updated"]
+                    "enum": [
+                      "published",
+                      "updated"
+                    ]
                   },
-                  "default": ["published", "updated"]
+                  "default": [
+                    "published",
+                    "updated"
+                  ]
                 }
               }
             },
@@ -1548,15 +1716,25 @@
                           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callinput_idtype",
                           "description": "Required if input is defined for the on.workflow_call keyword. The value of this parameter is a string specifying the data type of the input. This must be one of: boolean, number, or string.",
                           "type": "string",
-                          "enum": ["boolean", "number", "string"]
+                          "enum": [
+                            "boolean",
+                            "number",
+                            "string"
+                          ]
                         },
                         "default": {
                           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
                           "description": "The default value is used when an input parameter isn't specified in a workflow file.",
-                          "type": ["boolean", "number", "string"]
+                          "type": [
+                            "boolean",
+                            "number",
+                            "string"
+                          ]
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -1580,7 +1758,9 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["required"],
+                      "required": [
+                        "required"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -1623,7 +1803,12 @@
                         "type": {
                           "description": "A string representing the type of the input.",
                           "type": "string",
-                          "enum": ["string", "choice", "boolean", "environment"]
+                          "enum": [
+                            "string",
+                            "choice",
+                            "boolean",
+                            "environment"
+                          ]
                         },
                         "options": {
                           "$comment": "https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows",
@@ -1643,7 +1828,9 @@
                                 "const": "boolean"
                               }
                             },
-                            "required": ["type"]
+                            "required": [
+                              "type"
+                            ]
                           },
                           "then": {
                             "properties": {
@@ -1667,14 +1854,20 @@
                                 "const": "choice"
                               }
                             },
-                            "required": ["type"]
+                            "required": [
+                              "type"
+                            ]
                           },
                           "then": {
-                            "required": ["options"]
+                            "required": [
+                              "options"
+                            ]
                           }
                         }
                       ],
-                      "required": ["description"],
+                      "required": [
+                        "description"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -1691,9 +1884,15 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["requested", "completed"]
+                    "enum": [
+                      "requested",
+                      "completed"
+                    ]
                   },
-                  "default": ["requested", "completed"]
+                  "default": [
+                    "requested",
+                    "completed"
+                  ]
                 },
                 "workflows": {
                   "type": "array",
@@ -1783,6 +1982,9 @@
       "$ref": "#/definitions/permissions"
     }
   },
-  "required": ["on", "jobs"],
+  "required": [
+    "on",
+    "jobs"
+  ],
   "type": "object"
 }

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -5,11 +5,7 @@
   "definitions": {
     "architecture": {
       "type": "string",
-      "enum": [
-        "ARM32",
-        "x64",
-        "x86"
-      ]
+      "enum": ["ARM32", "x64", "x86"]
     },
     "branch": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestbranchestags",
@@ -37,9 +33,7 @@
           ]
         }
       },
-      "required": [
-        "group"
-      ],
+      "required": ["group"],
       "additionalProperties": false
     },
     "configuration": {
@@ -125,9 +119,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "image"
-      ],
+      "required": ["image"],
       "additionalProperties": false
     },
     "defaults": {
@@ -156,10 +148,7 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": [
-            "read-all",
-            "write-all"
-          ]
+          "enum": ["read-all", "write-all"]
         },
         {
           "$ref": "#/definitions/permissions-event"
@@ -213,11 +202,7 @@
     },
     "permissions-level": {
       "type": "string",
-      "enum": [
-        "read",
-        "write",
-        "none"
-      ]
+      "enum": ["read", "write", "none"]
     },
     "env": {
       "$comment": "https://docs.github.com/en/actions/learn-github-actions/environment-variables",
@@ -260,9 +245,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     },
     "event": {
@@ -336,11 +319,7 @@
     },
     "machine": {
       "type": "string",
-      "enum": [
-        "linux",
-        "macos",
-        "windows"
-      ]
+      "enum": ["linux", "macos", "windows"]
     },
     "name": {
       "type": "string",
@@ -378,26 +357,17 @@
           "allOf": [
             {
               "not": {
-                "required": [
-                  "branches",
-                  "branches-ignore"
-                ]
+                "required": ["branches", "branches-ignore"]
               }
             },
             {
               "not": {
-                "required": [
-                  "tags",
-                  "tags-ignore"
-                ]
+                "required": ["tags", "tags-ignore"]
               }
             },
             {
               "not": {
-                "required": [
-                  "paths",
-                  "paths-ignore"
-                ]
+                "required": ["paths", "paths-ignore"]
               }
             }
           ]
@@ -417,14 +387,7 @@
         {
           "type": "string",
           "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell",
-          "enum": [
-            "bash",
-            "pwsh",
-            "python",
-            "sh",
-            "cmd",
-            "powershell"
-          ]
+          "enum": ["bash", "pwsh", "python", "sh", "cmd", "powershell"]
         }
       ]
     },
@@ -474,11 +437,7 @@
         "if": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif",
           "description": "You can use the if conditional to prevent a job from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-          "type": [
-            "boolean",
-            "number",
-            "string"
-          ]
+          "type": ["boolean", "number", "string"]
         },
         "uses": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses",
@@ -500,9 +459,7 @@
             },
             {
               "type": "string",
-              "enum": [
-                "inherit"
-              ]
+              "enum": ["inherit"]
             }
           ]
         },
@@ -560,15 +517,10 @@
             "max-parallel": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel",
               "description": "The maximum number of jobs that can run simultaneously when using a matrix job strategy. By default, GitHub will maximize the number of jobs run in parallel depending on the available runners on GitHub-hosted virtual machines.",
-              "type": [
-                "number",
-                "string"
-              ]
+              "type": ["number", "string"]
             }
           },
-          "required": [
-            "matrix"
-          ],
+          "required": ["matrix"],
           "additionalProperties": false
         },
         "concurrency": {
@@ -584,9 +536,7 @@
           ]
         }
       },
-      "required": [
-        "uses"
-      ],
+      "required": ["uses"],
       "additionalProperties": false
     },
     "normalJob": {
@@ -771,11 +721,7 @@
         "if": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif",
           "description": "You can use the if conditional to prevent a job from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-          "type": [
-            "boolean",
-            "number",
-            "string"
-          ]
+          "type": ["boolean", "number", "string"]
         },
         "steps": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idsteps",
@@ -792,9 +738,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "uses"
-                    ]
+                    "required": ["uses"]
                   },
                   {
                     "type": "object",
@@ -803,9 +747,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "run"
-                    ]
+                    "required": ["run"]
                   }
                 ]
               },
@@ -820,11 +762,7 @@
                   "if": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsif",
                     "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-                    "type": [
-                      "boolean",
-                      "number",
-                      "string"
-                    ]
+                    "type": ["boolean", "number", "string"]
                   },
                   "name": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname",
@@ -894,12 +832,8 @@
                   }
                 },
                 "dependencies": {
-                  "working-directory": [
-                    "run"
-                  ],
-                  "shell": [
-                    "run"
-                  ]
+                  "working-directory": ["run"],
+                  "shell": ["run"]
                 },
                 "additionalProperties": false
               }
@@ -977,9 +911,7 @@
               "type": "number"
             }
           },
-          "required": [
-            "matrix"
-          ],
+          "required": ["matrix"],
           "additionalProperties": false
         },
         "continue-on-error": {
@@ -1027,9 +959,7 @@
           ]
         }
       },
-      "required": [
-        "runs-on"
-      ],
+      "required": ["runs-on"],
       "additionalProperties": false
     }
   },
@@ -1065,17 +995,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "created",
-                      "edited",
-                      "deleted"
-                    ]
+                    "enum": ["created", "edited", "deleted"]
                   },
-                  "default": [
-                    "created",
-                    "edited",
-                    "deleted"
-                  ]
+                  "default": ["created", "edited", "deleted"]
                 }
               }
             },
@@ -1113,17 +1035,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "completed",
-                      "requested",
-                      "rerequested"
-                    ]
+                    "enum": ["completed", "requested", "rerequested"]
                   },
-                  "default": [
-                    "completed",
-                    "requested",
-                    "rerequested"
-                  ]
+                  "default": ["completed", "requested", "rerequested"]
                 }
               }
             },
@@ -1199,17 +1113,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "created",
-                      "edited",
-                      "deleted"
-                    ]
+                    "enum": ["created", "edited", "deleted"]
                   },
-                  "default": [
-                    "created",
-                    "edited",
-                    "deleted"
-                  ]
+                  "default": ["created", "edited", "deleted"]
                 }
               }
             },
@@ -1232,17 +1138,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "created",
-                      "edited",
-                      "deleted"
-                    ]
+                    "enum": ["created", "edited", "deleted"]
                   },
-                  "default": [
-                    "created",
-                    "edited",
-                    "deleted"
-                  ]
+                  "default": ["created", "edited", "deleted"]
                 }
               }
             },
@@ -1304,17 +1202,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "created",
-                      "edited",
-                      "deleted"
-                    ]
+                    "enum": ["created", "edited", "deleted"]
                   },
-                  "default": [
-                    "created",
-                    "edited",
-                    "deleted"
-                  ]
+                  "default": ["created", "edited", "deleted"]
                 }
               }
             },
@@ -1327,17 +1217,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "added",
-                      "edited",
-                      "deleted"
-                    ]
+                    "enum": ["added", "edited", "deleted"]
                   },
-                  "default": [
-                    "added",
-                    "edited",
-                    "deleted"
-                  ]
+                  "default": ["added", "edited", "deleted"]
                 }
               }
             },
@@ -1350,13 +1232,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "checks_requested"
-                    ]
+                    "enum": ["checks_requested"]
                   },
-                  "default": [
-                    "checks_requested"
-                  ]
+                  "default": ["checks_requested"]
                 }
               }
             },
@@ -1369,13 +1247,7 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "created",
-                      "closed",
-                      "opened",
-                      "edited",
-                      "deleted"
-                    ]
+                    "enum": ["created", "closed", "opened", "edited", "deleted"]
                   },
                   "default": [
                     "created",
@@ -1457,19 +1329,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "created",
-                      "updated",
-                      "moved",
-                      "deleted"
-                    ]
+                    "enum": ["created", "updated", "moved", "deleted"]
                   },
-                  "default": [
-                    "created",
-                    "updated",
-                    "moved",
-                    "deleted"
-                  ]
+                  "default": ["created", "updated", "moved", "deleted"]
                 }
               }
             },
@@ -1507,11 +1369,7 @@
                       "auto_merge_disabled"
                     ]
                   },
-                  "default": [
-                    "opened",
-                    "synchronize",
-                    "reopened"
-                  ]
+                  "default": ["opened", "synchronize", "reopened"]
                 }
               },
               "patternProperties": {
@@ -1530,17 +1388,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "submitted",
-                      "edited",
-                      "dismissed"
-                    ]
+                    "enum": ["submitted", "edited", "dismissed"]
                   },
-                  "default": [
-                    "submitted",
-                    "edited",
-                    "dismissed"
-                  ]
+                  "default": ["submitted", "edited", "dismissed"]
                 }
               }
             },
@@ -1553,17 +1403,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "created",
-                      "edited",
-                      "deleted"
-                    ]
+                    "enum": ["created", "edited", "deleted"]
                   },
-                  "default": [
-                    "created",
-                    "edited",
-                    "deleted"
-                  ]
+                  "default": ["created", "edited", "deleted"]
                 }
               }
             },
@@ -1596,11 +1438,7 @@
                       "auto_merge_disabled"
                     ]
                   },
-                  "default": [
-                    "opened",
-                    "synchronize",
-                    "reopened"
-                  ]
+                  "default": ["opened", "synchronize", "reopened"]
                 }
               },
               "patternProperties": {
@@ -1631,15 +1469,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "published",
-                      "updated"
-                    ]
+                    "enum": ["published", "updated"]
                   },
-                  "default": [
-                    "published",
-                    "updated"
-                  ]
+                  "default": ["published", "updated"]
                 }
               }
             },
@@ -1716,25 +1548,15 @@
                           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callinput_idtype",
                           "description": "Required if input is defined for the on.workflow_call keyword. The value of this parameter is a string specifying the data type of the input. This must be one of: boolean, number, or string.",
                           "type": "string",
-                          "enum": [
-                            "boolean",
-                            "number",
-                            "string"
-                          ]
+                          "enum": ["boolean", "number", "string"]
                         },
                         "default": {
                           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
                           "description": "The default value is used when an input parameter isn't specified in a workflow file.",
-                          "type": [
-                            "boolean",
-                            "number",
-                            "string"
-                          ]
+                          "type": ["boolean", "number", "string"]
                         }
                       },
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "additionalProperties": false
                     }
                   },
@@ -1758,9 +1580,7 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "required"
-                      ],
+                      "required": ["required"],
                       "additionalProperties": false
                     }
                   },
@@ -1803,12 +1623,7 @@
                         "type": {
                           "description": "A string representing the type of the input.",
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "choice",
-                            "boolean",
-                            "environment"
-                          ]
+                          "enum": ["string", "choice", "boolean", "environment"]
                         },
                         "options": {
                           "$comment": "https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows",
@@ -1828,9 +1643,7 @@
                                 "const": "boolean"
                               }
                             },
-                            "required": [
-                              "type"
-                            ]
+                            "required": ["type"]
                           },
                           "then": {
                             "properties": {
@@ -1854,20 +1667,14 @@
                                 "const": "choice"
                               }
                             },
-                            "required": [
-                              "type"
-                            ]
+                            "required": ["type"]
                           },
                           "then": {
-                            "required": [
-                              "options"
-                            ]
+                            "required": ["options"]
                           }
                         }
                       ],
-                      "required": [
-                        "description"
-                      ],
+                      "required": ["description"],
                       "additionalProperties": false
                     }
                   },
@@ -1884,15 +1691,9 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "requested",
-                      "completed"
-                    ]
+                    "enum": ["requested", "completed"]
                   },
-                  "default": [
-                    "requested",
-                    "completed"
-                  ]
+                  "default": ["requested", "completed"]
                 },
                 "workflows": {
                   "type": "array",
@@ -1982,9 +1783,6 @@
       "$ref": "#/definitions/permissions"
     }
   },
-  "required": [
-    "on",
-    "jobs"
-  ],
+  "required": ["on", "jobs"],
   "type": "object"
 }


### PR DESCRIPTION
GitHub workflows have a ```max-parallel``` setting that requires a number.

However, it is possible to pass this number in as a variable value.

The current schema only allows an actual number to be passed, passing in a variable value (which is a string) results in vscode highlighting this as an error (screenshot below).

This PR will allow ```max-parallel``` to be a number or a string.

![image](https://user-images.githubusercontent.com/61512176/230397095-71a1da54-b931-4403-8201-11de855652b1.png)
