### PR TITLE
added extra rtx selectors

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2952,7 +2952,7 @@
     {
       "name": "rtx",
       "description": "JSON schema for rtx config, a polyglot dev tool manager",
-      "fileMatch": [".rtx.toml", "**/rtx/config.toml"],
+      "fileMatch": [".rtx.toml", ".rtx.*.toml", "**/rtx/config.toml"],
       "url": "https://rtx.pub/schema/rtx.json"
     },
     {


### PR DESCRIPTION
rtx now supports config files like the following:

* `.rtx.local.toml`
* `.rtx.production.toml`
* `.rtx.production.local.toml`

the environment is tied to `RTX_ENV` env var: https://github.com/jdxcode/rtx#experimental-config-environments

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
