### PR TITLE
catalog: allow .yaml extension for dependabot config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1263,7 +1263,7 @@
     {
       "name": "dependabot-v2.json",
       "description": "A JSON schema for the GitHub Action's dependabot.yml files",
-      "fileMatch": ["**/.github/dependabot.yml"],
+      "fileMatch": ["**/.github/dependabot.yml", "**/.github/dependabot.yaml"],
       "url": "https://json.schemastore.org/dependabot-2.0.json"
     },
     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
Dependabot respects the `.yaml` extension for its configuration file. This PR updates the SchemaStore catalog to serve the schema for that version of the file name.