### PR TITLE
fix a typo in the crowdsec scenario Schema fileMatch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1170,7 +1170,7 @@
     {
       "name": "Crowdsec scenario Schema",
       "description": "A YAML schema for Crowdsec scenario configuration files",
-      "fileMatch": ["**/scenarioss/*/*.yaml"],
+      "fileMatch": ["**/scenarios/*/*.yaml"],
       "url": "https://raw.githubusercontent.com/crowdsecurity/crowdsec-yaml-schemas/main/scenario_schema.yaml"
     },
     {


### PR DESCRIPTION
Hi, 

I submitted some time ago some links to our schema for crowdsec parsers and scenarios. I just found out that there was a typo in my initial PR, so here's a PR to fix that.

Thank you !

I didn't put CI tests there for two reasons:
* as the schema are only link to schema store on our side, I believe it's not mandatory
* we have all the schema tested on our side in our CI. We even test all our files against the schemas.
