### PR TITLE
Feature: add `bashly` support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "yaml.schemas": {
-    "src/schemas/json/minecraft-configured-carver.json": "test.yaml"
-  }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "yaml.schemas": {
+    "src/schemas/json/minecraft-configured-carver.json": "test.yaml"
+  }
+}

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4776,13 +4776,13 @@
     },
     {
       "name": "Bashly",
-      "description": "Bashly CLI config",
+      "description": "Bashly CLI",
       "fileMatch": ["bashly.yml", "bashly.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/bashly.json"
     },
     {
       "name": "Bashly strings",
-      "description": "Bashly string's config",
+      "description": "Bashly strings",
       "fileMatch": ["bashly-strings.yml", "bashly-strings.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/strings.json"
     }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4775,13 +4775,13 @@
       "url": "https://json.schemastore.org/es6importsorterrc.json"
     },
     {
-      "name": "Bashly",
+      "name": "bashly.yml",
       "description": "Bashly CLI",
       "fileMatch": ["bashly.yml", "bashly.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/bashly.json"
     },
     {
-      "name": "Bashly",
+      "name": "bashly-settings.yml",
       "description": "Bashly settings",
       "fileMatch": [
         "bashly-settings.yml",
@@ -4790,7 +4790,7 @@
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/settings.json"
     },
     {
-      "name": "Bashly strings",
+      "name": "bashly-strings.yml",
       "description": "Bashly strings",
       "fileMatch": ["bashly-strings.yml", "bashly-strings.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/strings.json"

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4783,10 +4783,7 @@
     {
       "name": "Bashly strings",
       "description": "Bashly string's config",
-      "fileMatch": [
-        "bashly-strings.yml",
-        "bashly-strings.yaml"
-      ],
+      "fileMatch": ["bashly-strings.yml", "bashly-strings.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/strings.json"
     }
   ],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4779,6 +4779,15 @@
       "description": "Bashly CLI config",
       "fileMatch": ["bashly.yml", "bashly.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/bashly.json"
+    },
+    {
+      "name": "Bashly strings",
+      "description": "Bashly CLI string's config",
+      "fileMatch": [
+        "bashly-strings.yml",
+        "bashly-strings.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/strings.json"
     }
   ],
   "version": 1

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4777,10 +4777,7 @@
     {
       "name": "Bashly",
       "description": "Bashly CLI config",
-      "fileMatch": [
-        "bashly.yml",
-        "bashly.yaml"
-      ],
+      "fileMatch": ["bashly.yml", "bashly.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schema.json"
     }
   ],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4773,6 +4773,15 @@
       "description": "The configuration file used for ES6 Import Sorter - a vscode extention .",
       "fileMatch": [".es6importsorterrc.json"],
       "url": "https://json.schemastore.org/es6importsorterrc.json"
+    },
+    {
+      "name": "Bashly",
+      "description": "Bashly CLI config",
+      "fileMatch": [
+        "bashly.yml",
+        "bashly.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schema.json"
     }
   ],
   "version": 1

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4781,6 +4781,15 @@
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/bashly.json"
     },
     {
+      "name": "Bashly",
+      "description": "Bashly settings",
+      "fileMatch": [
+        "bashly-settings.yml",
+        "bashly-settings.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/settings.json"
+    },
+    {
       "name": "Bashly strings",
       "description": "Bashly strings",
       "fileMatch": ["bashly-strings.yml", "bashly-strings.yaml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4782,7 +4782,7 @@
     },
     {
       "name": "Bashly strings",
-      "description": "Bashly CLI string's config",
+      "description": "Bashly string's config",
       "fileMatch": [
         "bashly-strings.yml",
         "bashly-strings.yaml"

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4778,7 +4778,7 @@
       "name": "Bashly",
       "description": "Bashly CLI config",
       "fileMatch": ["bashly.yml", "bashly.yaml"],
-      "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schema.json"
+      "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/bashly.json"
     }
   ],
   "version": 1


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

[Bashly](https://github.com/DannyBen/bashly/tree/master) is a command line application (written in Ruby) that lets you generate feature-rich bash command line tools.