### PR TITLE
Add scrape_config_files to prometheus.json

### DIFF
--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -1092,6 +1092,13 @@
         "required": ["url"]
       }
     },
+    "scrape_config_files": {
+      "description": "Scrape config files specifies a list of globs. Scrape configs are read from all matching files and appended to the list of scrape configs.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/filepath_glob"
+      }
+    },
     "scrape_configs": {
       "description": "A list of scrape configurations.",
       "type": ["array", "null"],

--- a/src/test/prometheus/prometheus.json
+++ b/src/test/prometheus/prometheus.json
@@ -69,6 +69,7 @@
     }
   ],
   "rule_files": ["first.rules", "my/*.rules"],
+  "scrape_config_files": ["first.yml", "scrape_configs/*.yml"],
   "scrape_configs": [
     {
       "job_name": "prometheus",


### PR DESCRIPTION
The `scrape_config_files` value is valid [in Prometheus config file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file) [as of version `2.43.0`](https://github.com/prometheus/prometheus/issues/8543). 

https://github.com/prometheus/prometheus/issues/12194