### PR TITLE
Add "npm" type to VSCode `tasks.json` schema (#2900)

### DIFF
--- a/src/schemas/json/task.json
+++ b/src/schemas/json/task.json
@@ -78,7 +78,7 @@
         },
         "type": {
           "description": "The type of a custom task. Tasks of type \"shell\" are executed\ninside a shell (e.g. bash, cmd, powershell, ...)",
-          "enum": ["process", "shell"],
+          "enum": ["process", "shell", "npm"],
           "type": "string"
         }
       },
@@ -351,7 +351,7 @@
         },
         "type": {
           "description": "The type of a custom task. Tasks of type \"shell\" are executed\ninside a shell (e.g. bash, cmd, powershell, ...)",
-          "enum": ["process", "shell"],
+          "enum": ["process", "shell", "npm"],
           "type": "string"
         }
       },
@@ -423,7 +423,7 @@
     },
     "type": {
       "description": "The type of a custom task. Tasks of type \"shell\" are executed\ninside a shell (e.g. bash, cmd, powershell, ...)",
-      "enum": ["process", "shell"],
+      "enum": ["process", "shell", "npm"],
       "type": "string"
     },
     "version": {


### PR DESCRIPTION
Fixes #2900.

Personally, I advocate removing schemas for VSCode config files altogether as they are arbitrarily extensible by extensions and will hence tend to produce many false positives. In addition, VSCode has schemas for their config files according to https://github.com/microsoft/vscode/issues/135155#issuecomment-945630929:

> We have schemas for all our configuration files. What's special is that they are generated dynamically based on the extensions installed and features implemented. They are available though a virtual file system and they can be accessed when running in VS Code e.g. through vscode://schemas/settings/default.
>
> We don't want to publish on the schema store and maintain these. Most of these schemas change a lot and depend on the extensions installed, and the settings, tasks, debuggers they contribute.

In the meantime, I have opened this simpler pull request addressing one such false positive to promote discussion.