### PR TITLE
fix(swcrc-schema): add and remove properties, values

### DIFF
--- a/src/schemas/json/swcrc.json
+++ b/src/schemas/json/swcrc.json
@@ -187,10 +187,7 @@
               }
             },
             "coreJs": {
-              "$ref": "#/definitions/envVersion"
-            },
-            "corejs": {
-              "$ref": "#/definitions/envVersion"
+              "type": "string"
             },
             "targets": {
               "oneOf": [
@@ -226,6 +223,9 @@
               "type": "boolean"
             },
             "forceAllTransforms": {
+              "type": "boolean"
+            },
+            "bugfixes": {
               "type": "boolean"
             }
           },
@@ -519,7 +519,8 @@
                 "es2019",
                 "es2020",
                 "es2021",
-                "es2022"
+                "es2022",
+                "esnext"
               ]
             },
             "loose": {

--- a/src/test/swcrc/swcrc-test.json
+++ b/src/test/swcrc/swcrc-test.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "include": ["proposal-json-strings", "module"]
+    "include": ["proposal-json-strings", "module"],
+    "coreJs": "3.22"
   },
   "exclude": ["a"],
   "jsc": {
@@ -16,7 +17,7 @@
       }
     },
     "externalHelpers": false,
-    "target": "es3",
+    "target": "esnext",
     "loose": false
   },
   "minify": false,


### PR DESCRIPTION
The following pr updates `swcrc` schema.

### add

- The property [bugfixes](https://swc.rs/docs/configuration/compilation#envbugfixes) was missing from `env`
- The `esnext` [target](https://github.com/swc-project/swc/blob/2c441f5c8d8a0c28bae65bb557aa5902321d8450/node-swc/src/types.ts#L687) was missing from `jsc.target`


### fix and remove

https://github.com/SchemaStore/schemastore/blob/e321c0e165562a845e3d05b28f4ce2054bc11d7e/src/schemas/json/swcrc.json#L189-L194

Firstly acording to the [docs](https://swc.rs/docs/configuration/compilation#envcorejs), `coreJs` only accepts a `string` type, while the definitions from `envVersion` accept both `string` and `number` types.

Secondly, I'm not sure if this was a typo, but only [coreJs](https://swc.rs/docs/configuration/compilation#envcorejs) exists as you can also see [here](https://swc.rs/docs/configuration/supported-browsers#corejs) and in the types from the [repository](https://github.com/swc-project/swc/blob/2c441f5c8d8a0c28bae65bb557aa5902321d8450/node-swc/src/types.ts#L609). For this reason `corejs` was removed.

