### PR TITLE
[bx-ci] add new schemas for setting CheckMarx thresholds

### DIFF
--- a/src/negative_test/bxci.schema-2.x/bxci-wrong-checkmarx-thresholds.yml
+++ b/src/negative_test/bxci.schema-2.x/bxci-wrong-checkmarx-thresholds.yml
@@ -1,0 +1,14 @@
+project:
+  name: any
+
+config:
+  build:
+    checkmarx:
+      highThreshold: '1'
+      mediumThreshold: '1'
+      lowThreshold: '1'
+
+stages:
+  first:
+    steps:
+      - echo "Hello"

--- a/src/schemas/json/bxci.schema-2.x.json
+++ b/src/schemas/json/bxci.schema-2.x.json
@@ -41,7 +41,8 @@
         },
         "branch_pattern": {
           "$ref": "#/definitions/branchPattern",
-          "description": "Specifies in which branches this stage will be executed"
+          "description": "Specifies in which branches this stage will be executed",
+          "default": "^master$|^release/.*$"
         },
         "groupId": {
           "type": "string",
@@ -107,6 +108,26 @@
           "type": "boolean",
           "default": true,
           "description": "Sets whether the scan should be executed synchronously (default). The Synchronous mode allows viewing scan results in Jenkins"
+        },
+        "vulnerabilityThresholdEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Sets whether the scan should fail if the number of vulnerabilities is above the configured thresholds. This option is only available if the waitForResultsEnabled parameter is enabled"
+        },
+        "highThreshold": {
+          "type": "integer",
+          "default": 0,
+          "description": "Sets the maximum number of High vulnerabilities allowed"
+        },
+        "mediumThreshold": {
+          "type": "integer",
+          "default": 10,
+          "description": "Sets the maximum number of Medium vulnerabilities allowed"
+        },
+        "lowThreshold": {
+          "type": "integer",
+          "default": null,
+          "description": "Sets the maximum number of Low vulnerabilities allowed"
         }
       },
       "additionalProperties": false

--- a/src/test/bxci.schema-2.x/bxci-checkmarx.yml
+++ b/src/test/bxci.schema-2.x/bxci-checkmarx.yml
@@ -19,6 +19,10 @@ config:
       sourceEncoding: '5'
       useOwnServerCredentials: true
       waitForResultsEnabled: false
+      vulnerabilityThresholdEnabled: false
+      highThreshold: 1
+      mediumThreshold: 3
+      lowThreshold: 5
 
 stages:
   first:


### PR DESCRIPTION
Adds new schemas for setting CheckMarx thresholds.

cc @migalons 

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
