### PR TITLE
Adding initial schema reference for the Semantic Data Fabric (SDF)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3155,6 +3155,12 @@
       "url": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json"
     },
     {
+      "name": "Semantic Data Fabric (SDF) file",
+      "description": "The schema definition for all available SDF blocks",
+      "fileMatch": [".sdf.yml"],
+      "url": "https://cdn.sdf.com/schemas/sdf-schema-1.0.json"
+    },
+    {
       "name": "semantic-release",
       "description": "Configuration for semantic-release",
       "fileMatch": [


### PR DESCRIPTION
Hello, please see my submission for adding SDF Schema 1.0.

I have read the contribution guidelines. Since we are referencing a schema file hosted on our CDN, I have not added additional tests. Please let me know if this is a requirement.

Thank you.