### PR TITLE
[bx-ci] add new schema for Sonar exclusions

### DIFF
--- a/src/schemas/json/bxci.schema-2.x.json
+++ b/src/schemas/json/bxci.schema-2.x.json
@@ -141,13 +141,18 @@
         },
         "breaks_build": {
           "type": "boolean",
-          "description": "Waits for analysis result and breaks the build when the project fails for some quality gates.",
+          "description": "Waits for analysis result and breaks the build when the project fails for some quality gates",
           "default": false
         },
         "timeout": {
           "$ref": "#/definitions/timeout",
           "description": "Seconds to wait for the result of the quality gate. Only applies when breaks_build is set to true",
           "default": 120
+        },
+        "exclusions": {
+          "type": "string",
+          "description": "Comma separated list of wildcard patterns defining files to be excluded from the SonarQube scan",
+          "examples": ["**/excluded-folder/**, **/example/*.html"]
         }
       },
       "additionalProperties": false

--- a/src/test/bxci.schema-2.x/bxci.yml
+++ b/src/test/bxci.schema-2.x/bxci.yml
@@ -11,6 +11,7 @@ config:
     commit_time_threshold: 2h
     static_analysis:
       enabled: false
+      exclusions: '**/one, **/two/**/*.html'
 
   branch:
     disable_validation: true


### PR DESCRIPTION
Adds new property for setting Sonar exclusions in BX CI.

cc @migalons 

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
