### PR TITLE
Update IMG Catapult schema to add new fields

### DIFF
--- a/src/schemas/json/img-catapult-psp-1.0.0.json
+++ b/src/schemas/json/img-catapult-psp-1.0.0.json
@@ -127,6 +127,14 @@
         "headersDirectory": {
           "$ref": "#/$defs/supportPackDirectory",
           "description": "Directory containing header files for use with the platform"
+        },
+        "remoteHost": {
+          "type": "string",
+          "description": "Hostname or IP address for debug connection to remote machines"
+        },
+        "remoteUsername": {
+          "type": "string",
+          "description": "Username for debug connection to remote machines"
         }
       }
     }

--- a/src/schemas/json/img-catapult-psp-1.0.0.json
+++ b/src/schemas/json/img-catapult-psp-1.0.0.json
@@ -94,7 +94,7 @@
         "launchConfig": {
           "type": "string",
           "description": "Launch configuration for platform",
-          "pattern": "^(Alpine Model|Catapult Model|OpenOCD|Whisper)$"
+          "pattern": "^(Alpine Model|Catapult Model|OpenOCD|Whisper|RemoteLinux)$"
         },
         "gdbAutoRunCommandString": {
           "type": "string",

--- a/src/test/img-catapult-psp-1.0.0/contents.yaml
+++ b/src/test/img-catapult-psp-1.0.0/contents.yaml
@@ -33,3 +33,5 @@ platform:
     path: libs
   headersDirectory:
     path: headers
+  remoteHost: https://127.0.0.1:7812
+  remoteUsername: test-user  


### PR DESCRIPTION
Updates to IMG Catapult PSP schema - adding additional optional fields. Backwards compatible with previous version.  
