### PR TITLE
feat: support tagliatelle v0.5.0

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -2248,6 +2248,7 @@
                         "pascal",
                         "kebab",
                         "snake",
+                        "upperSnake",
                         "goCamel",
                         "goPascal",
                         "goKebab",

--- a/src/test/golangci-lint/example-values.json
+++ b/src/test/golangci-lint/example-values.json
@@ -1377,7 +1377,9 @@
           "xml": "camel",
           "bson": "camel",
           "avro": "snake",
-          "mapstructure": "kebab"
+          "mapstructure": "kebab",
+          "env": "upperSnake",
+          "envconfig": "upperSnake"
         }
       }
     },


### PR DESCRIPTION
Minor change to the golangci-lint tagliatelle schema to add support for v0.5.0 which adds `upperSnake` casing.

Related:

- https://github.com/ldez/tagliatelle/pull/17
- https://github.com/golangci/golangci-lint/pull/3816