### PR TITLE
Fix schema Ansible Argument Specs dead URL

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -116,7 +116,7 @@
     {
       "name": "Ansible Argument Specs",
       "description": "Ansible meta/argument_specs.yml file",
-      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/arg_specs.json",
+      "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/role-arg-spec.json",
       "fileMatch": ["**/meta/argument_specs.yml"]
     },
     {


### PR DESCRIPTION
The URL of the schema "Ansible Argument Specs" is dead, returning 404. Why? The JSON file has been renamed.

Currently the entry in the catalog points to: <https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/arg_specs.json>

The new URL must be this: <https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/role-arg-spec.json>

Renaming occurred in the following pull request: <https://github.com/ansible/ansible-lint/pull/3243>

Can @ssbarnea approve this?

---

Noticed this due to error in VS Code:

![image](https://user-images.githubusercontent.com/24834206/236687748-b2593230-afa9-4956-8182-b952e56cda3e.png)
