### PR TITLE
Deprecate dot-net section in favour of dotnet section for Qodana for NET linter

### DIFF
--- a/src/schemas/json/qodana-1.0.json
+++ b/src/schemas/json/qodana-1.0.json
@@ -191,8 +191,36 @@
       },
       "additionalProperties": false
     },
+    "dotnet": {
+      "description": "Configuration for .NET solutions and projects",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "solution": {
+              "description": "The name of a .NET solution inside the Qodana project",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "project": {
+              "description": "The name of a .NET project inside the Qodana project",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "dot-net": {
       "description": "Configuration for .NET solutions and projects",
+      "deprecated": true,
       "anyOf": [
         {
           "type": "object",

--- a/src/schemas/json/qodana-1.0.json
+++ b/src/schemas/json/qodana-1.0.json
@@ -215,6 +215,28 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "configuration": {
+              "description": "The name of a configuration to be used for .NET solution or project",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "platform": {
+              "description": "The name of a platform to be used for .NET solution or project",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -238,6 +260,28 @@
           "properties": {
             "project": {
               "description": "The name of a .NET project inside the Qodana project",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "configuration": {
+              "description": "The name of a configuration to be used for .NET solution or project",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "platform": {
+              "description": "The name of a platform to be used for .NET solution or project",
               "type": "string",
               "minLength": 1
             }


### PR DESCRIPTION
Correct schema due to the recent changes in Qodana Yaml configuration file.
