### PR TITLE
json: support queue attribute for project-template

### DIFF
--- a/src/schemas/json/zuul.json
+++ b/src/schemas/json/zuul.json
@@ -423,6 +423,10 @@
         "promote": {
           "$ref": "#/definitions/PipelineModel"
         },
+        "queue": {
+          "title": "Queue",
+          "type": "string"
+        },
         "release": {
           "$ref": "#/definitions/PipelineModel"
         },

--- a/src/test/zuul/jobs.yaml
+++ b/src/test/zuul/jobs.yaml
@@ -68,6 +68,7 @@
 - project-template:
     name: sample-template
     description: Description
+    queue: test
     vars:
       var_from_template: foo
     post:
@@ -84,6 +85,7 @@
 - project:
     name: Sample project
     queue: test
+    default-branch: main
     description: Description
     templates:
       - sample-template


### PR DESCRIPTION
The queue attribute was supported for `project` with #2817. Since
`project-template` shares most of the attributes with `project`, it
should be allowed there as well [1].

[1]: https://zuul-ci.org/docs/zuul/latest/config/project.html#project-template
