### PR TITLE
fix: default file match for sam tempaltes

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1091,6 +1091,7 @@
       "name": "AWS CloudFormation Serverless Application Model (SAM)",
       "description": "The AWS Serverless Application Model (AWS SAM, previously known as Project Flourish) extends AWS CloudFormation to provide a simplified way of defining the Amazon API Gateway APIs, AWS Lambda functions, and Amazon DynamoDB tables needed by your serverless application.",
       "fileMatch": [
+        "template.yaml",
         "serverless.template",
         "*.sam.json",
         "*.sam.yml",


### PR DESCRIPTION
This PR modifies the catalog entry for the `AWS CloudFormation Serverless Application Model (SAM)` to add `template.yaml` to fileMatches for SAM templates as it's the default file name when creating and using SAM templates via [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-init.html).