### PR TITLE
Allow lint-staged YAML config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3899,7 +3899,12 @@
     {
       "name": ".lintstagedrc",
       "description": "JSON schema for lint-staged config",
-      "fileMatch": [".lintstagedrc", ".lintstagedrc.json"],
+      "fileMatch": [
+        ".lintstagedrc",
+        ".lintstagedrc.json",
+        ".lintstagedrc.yaml",
+        ".lintstagedrc.yml"
+      ],
       "url": "https://json.schemastore.org/lintstagedrc.schema.json"
     },
     {


### PR DESCRIPTION
[lint-staged](https://www.npmjs.com/package/lint-staged) supports YAML configuration files too, as it depends on [cosmiconfig](https://www.npmjs.com/package/cosmiconfig). This PR adds a file list similar to e.g., eslintrc and prettierrc, since those use the same library.