### PR TITLE
fix: github workflow input types

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1623,7 +1623,7 @@
                         "type": {
                           "description": "A string representing the type of the input.",
                           "type": "string",
-                          "enum": ["string", "choice", "boolean", "environment"]
+                          "enum": ["string", "choice", "boolean", "number"]
                         },
                         "options": {
                           "$comment": "https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows",
@@ -1649,6 +1649,30 @@
                             "properties": {
                               "default": {
                                 "type": "boolean"
+                              }
+                            }
+                          },
+                          "else": {
+                            "properties": {
+                              "default": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "if": {
+                            "properties": {
+                              "type": {
+                                "const": "number"
+                              }
+                            },
+                            "required": ["type"]
+                          },
+                          "then" :{
+                            "properties": {
+                              "default": {
+                                "type": "number"
                               }
                             }
                           },

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1622,6 +1622,7 @@
                         },
                         "type": {
                           "description": "A string representing the type of the input.",
+                          "$comment": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputsinput_idtype",
                           "type": "string",
                           "enum": ["string", "choice", "boolean", "number"]
                         },
@@ -1640,6 +1641,23 @@
                           "if": {
                             "properties": {
                               "type": {
+                                "const": "string"
+                              }
+                            },
+                            "required": ["type"]
+                          },
+                          "then": {
+                            "properties": {
+                              "default": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "if": {
+                            "properties": {
+                              "type": {
                                 "const": "boolean"
                               }
                             },
@@ -1649,13 +1667,6 @@
                             "properties": {
                               "default": {
                                 "type": "boolean"
-                              }
-                            }
-                          },
-                          "else": {
-                            "properties": {
-                              "default": {
-                                "type": "string"
                               }
                             }
                           }
@@ -1673,13 +1684,6 @@
                             "properties": {
                               "default": {
                                 "type": "number"
-                              }
-                            }
-                          },
-                          "else": {
-                            "properties": {
-                              "default": {
-                                "type": "string"
                               }
                             }
                           }

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1669,7 +1669,7 @@
                             },
                             "required": ["type"]
                           },
-                          "then" :{
+                          "then": {
                             "properties": {
                               "default": {
                                 "type": "number"

--- a/src/test/github-workflow/workflow_dispatch-inputs.yaml
+++ b/src/test/github-workflow/workflow_dispatch-inputs.yaml
@@ -17,10 +17,10 @@ on:
         type: string
         description: string
         default: foo
-      env: # (required is optional)
-        type: environment
-        description: environment
-        default: ''
+      number:
+        type: number
+        description: number
+        default: 42
       choice:
         required: false
         type: choice

--- a/src/test/github-workflow/workflow_dispatch-inputs.yaml
+++ b/src/test/github-workflow/workflow_dispatch-inputs.yaml
@@ -20,8 +20,8 @@ on:
       empty-string:
         required: true
         type: string
-        default: ""
-        description: "bird is the word"
+        default: ''
+        description: 'bird is the word'
       number:
         type: number
         description: number

--- a/src/test/github-workflow/workflow_dispatch-inputs.yaml
+++ b/src/test/github-workflow/workflow_dispatch-inputs.yaml
@@ -17,10 +17,18 @@ on:
         type: string
         description: string
         default: foo
+      empty-string:
+        required: true
+        type: string
+        default: ""
+        description: "bird is the word"
       number:
         type: number
         description: number
         default: 42
+      no-default-number:
+        type: number
+        description: no-default number description
       choice:
         required: false
         type: choice


### PR DESCRIPTION
Fix the enum list of github workflow_dispatch input types. According to the documentation.

closes #2964
