### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -140,8 +140,7 @@
       "properties": {
         "extend-function-names": {
           "description": "Additional function names to consider as internationalization calls, in addition to those included in `function-names`.",
-          "default": [],
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -610,16 +609,6 @@
       },
       "additionalProperties": false
     },
-    "PyUpgradeOptions": {
-      "type": "object",
-      "properties": {
-        "keep-runtime-typing": {
-          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Optional[str]` -> `str | None`) rewrites even if a file imports `from __future__ import annotations`. Note that this setting is only applicable when the target Python version is below 3.9 and 3.10 respectively, and enabling it is equivalent to disabling `use-pep585-annotation` (`UP006`) and `use-pep604-annotation` (`UP007`) entirely.",
-          "type": ["boolean", "null"]
-        }
-      },
-      "additionalProperties": false
-    },
     "Pycodestyle": {
       "type": "object",
       "properties": {
@@ -774,6 +763,12 @@
         "ARG003",
         "ARG004",
         "ARG005",
+        "ASYNC",
+        "ASYNC1",
+        "ASYNC10",
+        "ASYNC100",
+        "ASYNC101",
+        "ASYNC102",
         "B",
         "B0",
         "B00",
@@ -935,6 +930,37 @@
         "E1",
         "E10",
         "E101",
+        "E111",
+        "E112",
+        "E113",
+        "E114",
+        "E115",
+        "E116",
+        "E117",
+        "E201",
+        "E202",
+        "E203",
+        "E211",
+        "E221",
+        "E222",
+        "E223",
+        "E224",
+        "E225",
+        "E226",
+        "E227",
+        "E228",
+        "E231",
+        "E251",
+        "E252",
+        "E261",
+        "E262",
+        "E265",
+        "E266",
+        "E271",
+        "E272",
+        "E273",
+        "E274",
+        "E275",
         "E4",
         "E40",
         "E401",
@@ -1047,12 +1073,20 @@
         "F9",
         "F90",
         "F901",
+        "FA",
+        "FA1",
+        "FA10",
+        "FA100",
         "FBT",
         "FBT0",
         "FBT00",
         "FBT001",
         "FBT002",
         "FBT003",
+        "FLY",
+        "FLY0",
+        "FLY00",
+        "FLY002",
         "G",
         "G0",
         "G00",
@@ -1148,6 +1182,7 @@
         "PGH002",
         "PGH003",
         "PGH004",
+        "PGH005",
         "PIE",
         "PIE7",
         "PIE79",
@@ -1185,6 +1220,9 @@
         "PLE0116",
         "PLE0117",
         "PLE0118",
+        "PLE02",
+        "PLE024",
+        "PLE0241",
         "PLE03",
         "PLE030",
         "PLE0302",
@@ -1257,6 +1295,12 @@
         "PLW012",
         "PLW0120",
         "PLW0129",
+        "PLW013",
+        "PLW0130",
+        "PLW0131",
+        "PLW04",
+        "PLW040",
+        "PLW0406",
         "PLW06",
         "PLW060",
         "PLW0602",
@@ -1272,6 +1316,10 @@
         "PLW29",
         "PLW290",
         "PLW2901",
+        "PLW3",
+        "PLW33",
+        "PLW330",
+        "PLW3301",
         "PT",
         "PT0",
         "PT00",
@@ -1344,6 +1392,7 @@
         "PYI010",
         "PYI011",
         "PYI012",
+        "PYI013",
         "PYI014",
         "PYI015",
         "PYI016",
@@ -1352,6 +1401,11 @@
         "PYI021",
         "PYI03",
         "PYI033",
+        "PYI04",
+        "PYI042",
+        "PYI043",
+        "PYI05",
+        "PYI052",
         "Q",
         "Q0",
         "Q00",
@@ -1385,6 +1439,8 @@
         "RUF007",
         "RUF008",
         "RUF009",
+        "RUF01",
+        "RUF010",
         "RUF1",
         "RUF10",
         "RUF100",
@@ -1437,6 +1493,7 @@
         "S509",
         "S6",
         "S60",
+        "S601",
         "S602",
         "S603",
         "S604",
@@ -1510,6 +1567,16 @@
         "TCH003",
         "TCH004",
         "TCH005",
+        "TD",
+        "TD0",
+        "TD00",
+        "TD001",
+        "TD002",
+        "TD003",
+        "TD004",
+        "TD005",
+        "TD006",
+        "TD007",
         "TID",
         "TID2",
         "TID25",
@@ -1529,6 +1596,7 @@
         "TRY30",
         "TRY300",
         "TRY301",
+        "TRY302",
         "TRY4",
         "TRY40",
         "TRY400",
@@ -1683,11 +1751,28 @@
         "type": "string"
       }
     },
+    "extend-fixable": {
+      "description": "A list of rule codes or prefixes to consider autofixable, in addition to those specified by `fixable`.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/RuleSelector"
+      }
+    },
     "extend-include": {
       "description": "A list of file patterns to include when linting, in addition to those specified by `include`.\n\nInclusion are based on globs, and should be single-path patterns, like `*.pyw`, to include any file with the `.pyw` extension.\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
       "type": ["array", "null"],
       "items": {
         "type": "string"
+      }
+    },
+    "extend-per-file-ignores": {
+      "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, in addition to any rules excluded by `per-file-ignores`.",
+      "type": ["object", "null"],
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/RuleSelector"
+        }
       }
     },
     "extend-select": {
@@ -1885,7 +1970,7 @@
       ]
     },
     "force-exclude": {
-      "description": "Whether to enforce `exclude` and `extend-exclude` patterns, even for paths that are passed to Ruff explicitly. Typically, Ruff will lint any paths passed in directly, even if they would typically be excluded. Setting `force-exclude = true` will cause Ruff to respect these exclusions unequivocally.\n\nThis is useful for [`pre-commit`](https://pre-commit.com/), which explicitly passes all changed files to the [`ruff-pre-commit`](https://github.com/charliermarsh/ruff-pre-commit) plugin, regardless of whether they're marked as excluded by Ruff's own settings.",
+      "description": "Whether to enforce `exclude` and `extend-exclude` patterns, even for paths that are passed to Ruff explicitly. Typically, Ruff will lint any paths passed in directly, even if they would typically be excluded. Setting `force-exclude = true` will cause Ruff to respect these exclusions unequivocally.\n\nThis is useful for [`pre-commit`](https://pre-commit.com/), which explicitly passes all changed files to the [`ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) plugin, regardless of whether they're marked as excluded by Ruff's own settings.",
       "type": ["boolean", "null"]
     },
     "format": {
@@ -2006,17 +2091,6 @@
         }
       ]
     },
-    "pyupgrade": {
-      "description": "Options for the `pyupgrade` plugin.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PyUpgradeOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "required-version": {
       "description": "Require a specific version of Ruff to be running (useful for unifying results across many environments, e.g., with a `pyproject.toml` file).",
       "anyOf": [
@@ -2085,10 +2159,6 @@
       "items": {
         "$ref": "#/definitions/RuleSelector"
       }
-    },
-    "update-check": {
-      "description": "Enable or disable automatic update checks (overridden by the `--update-check` and `--no-update-check` command-line flags).",
-      "type": ["boolean", "null"]
     }
   },
   "title": "Options",


### PR DESCRIPTION
This updates ruff's JSON schema to [c6e5fed6587c95839a814ee8dfa845b465351229](https://github.com/charliermarsh/ruff/commit/c6e5fed6587c95839a814ee8dfa845b465351229)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
