### PR TITLE
Add chrome-manifest `/content_scripts#world` field

### DIFF
--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -446,6 +446,12 @@
             "$ref": "#/definitions/scripts",
             "description": "The list of JavaScript files to be injected into matching pages. These are injected in the order they appear in this array."
           },
+          "world": {
+            "type": "string",
+            "description": "The JavaScript world for a script to execute within.",
+            "enum": ["ISOLATED", "MAIN"],
+            "default": "ISOLATED"
+          },
           "run_at": {
             "type": "string",
             "description": "Controls when the files in js are injected.",


### PR DESCRIPTION
The `world` field was added in chrome 95+ manifest v3 https://developer.chrome.com/docs/extensions/reference/scripting/#type-ExecutionWorld

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
