### PR TITLE
Clang-format 16 and minor cleanup

### DIFF
--- a/src/schemas/json/clang-format.json
+++ b/src/schemas/json/clang-format.json
@@ -523,7 +523,7 @@
       "type": "boolean"
     },
     "FixNamespaceComments": {
-      "description": "clang-format 5\r\r If true, clang-format adds missing namespace end comments for short namespaces and fixes invalid existing ones. This doesn’t affect short namespaces, which are controlled by \"ShortNamespaceLines\".",
+      "description": "clang-format 5\r\r If true, clang-format adds missing namespace end comments for short namespaces and fixes invalid existing ones. This doesn't affect short namespaces, which are controlled by \"ShortNamespaceLines\".",
       "type": "boolean"
     },
     "ForEachMacros": {


### PR DESCRIPTION
- Added definitions for clang-format 16 options.
- Cleaned up descriptions.
- Reformatted for consistency (order of "description" and "type" was inconsistent)