### PR TITLE
fix: rule name within stylelintrc.json

### DIFF
--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -958,7 +958,7 @@
           "description": "Require a newline or disallow whitespace before the closing brace of blocks",
           "$ref": "#/definitions/newlineRule"
         },
-        "block-closing-brace-space-afte": {
+        "block-closing-brace-space-after": {
           "description": "Require a single space or disallow whitespace after the closing brace of blocks",
           "$ref": "#/definitions/newlineSpaceRule"
         },


### PR DESCRIPTION
invalid -> valid rule name.

```bash
$ \grep -nrw 'block-closing-brace-space-afte' | \tr -s \\40
schemastore/src/schemas/json/stylelintrc.json:961: "block-closing-brace-space-afte": {
$ : single occurrence located
$
```

rule name source of truth:
https://stylelint.io/user-guide/rules/block-closing-brace-space-after/

cheers,
-lh