### PR TITLE
Update FoundryVTT manifest schema to allow newer discord usernames

### DIFF
--- a/src/schemas/json/foundryvtt-base-package-manifest.json
+++ b/src/schemas/json/foundryvtt-base-package-manifest.json
@@ -159,8 +159,8 @@
           },
           "discord": {
             "type": "string",
-            "pattern": "^.+#\\d+$",
-            "examples": ["discordID#0001"]
+            "pattern": "^.+#\\d+$|^[a-z0-9._]+$",
+            "examples": ["oldDiscordID#0001", "new_2023_discord_id"]
           },
           "flags": {
             "$ref": "#/definitions/Flags"

--- a/src/test/foundryvtt-module-manifest/pf2e-abomination-vaults_module.json
+++ b/src/test/foundryvtt-module-manifest/pf2e-abomination-vaults_module.json
@@ -2,7 +2,7 @@
   "authors": [
     {
       "name": "Andrew Clayton",
-      "discord": "Atropos#3814",
+      "discord": "atropos",
       "url": "https://foundryvtt.com"
     },
     {

--- a/src/test/foundryvtt-module-manifest/remote-highlight-ui_module.json
+++ b/src/test/foundryvtt-module-manifest/remote-highlight-ui_module.json
@@ -2,7 +2,7 @@
   "authors": [
     {
       "name": "shem",
-      "discord": "shem#0226",
+      "discord": "shemetz",
       "email": "itamarcu+foundry@gmail.com",
       "reddit": "u/Shemetz"
     }


### PR DESCRIPTION
This is a small update to one FoundryVTT schema field, which allows an author to include their discord username.  Previously, discord usernames were nearly freeform strings that ended with a hash and four digits, e.g. `Blah!blah b𝖑𝖆h#1234`.  The [new username scheme](https://discord.com/blog/usernames) (changed on 2023-05) is simply alphanumerics plus period and underscore, e.g. `blah_blah.17.blah`.

This PR updates that field and also updates two tests to verify it.  The old username standard could be removed soon, but I chose to keep it - in part because discord username rollout is [ongoing and not yet complete](https://discordrollout.nekos.sh/).  If requested, I can remove it completely.

Note for context:  **FoundryVTT code does not check discord username format correctness**, so this schema change only matters for people who rely on IDE warnings from automatic schema tests (e.g. in IntelliJ/VSCode).