### PR TITLE
Fix breaking change from #2966

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1628,7 +1628,13 @@
                           "description": "A string representing the type of the input.",
                           "$comment": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputsinput_idtype",
                           "type": "string",
-                          "enum": ["string", "choice", "boolean", "number", "environment"]
+                          "enum": [
+                            "string",
+                            "choice",
+                            "boolean",
+                            "number",
+                            "environment"
+                          ]
                         },
                         "options": {
                           "$comment": "https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows",

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1628,7 +1628,7 @@
                           "description": "A string representing the type of the input.",
                           "$comment": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputsinput_idtype",
                           "type": "string",
-                          "enum": ["string", "choice", "boolean", "number"]
+                          "enum": ["string", "choice", "boolean", "number", "environment"]
                         },
                         "options": {
                           "$comment": "https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows",
@@ -1688,6 +1688,23 @@
                             "properties": {
                               "default": {
                                 "type": "number"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "if": {
+                            "properties": {
+                              "type": {
+                                "const": "environment"
+                              }
+                            },
+                            "required": ["type"]
+                          },
+                          "then": {
+                            "properties": {
+                              "default": {
+                                "type": "string"
                               }
                             }
                           }

--- a/src/test/github-workflow/workflow_dispatch-inputs.yaml
+++ b/src/test/github-workflow/workflow_dispatch-inputs.yaml
@@ -29,6 +29,9 @@ on:
       no-default-number:
         type: number
         description: no-default number description
+      env: # (required is optional)
+        type: environment
+        description: environment
       choice:
         required: false
         type: choice


### PR DESCRIPTION
Adds `environment` back for `workflow_dispatch` inputs on GitHub Actions workflows

See https://github.com/SchemaStore/schemastore/pull/2966#issuecomment-1587897802