### PR TITLE
Werf schemes

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4982,7 +4982,7 @@
     {
       "description": "Werf Dockerfile image section",
       "fileMatch": [ "werf.yaml" ],
-      "name": "werf-docker-1.2",
+      "name": "werf-docker-1.2.json",
       "url": "https://json.schemastore.org/werf-docker-1.2.json"
     }
   ],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4981,7 +4981,7 @@
     },
     {
       "description": "Werf Dockerfile image section",
-      "fileMatch": [ "werf.yaml" ],
+      "fileMatch": ["werf.yaml"],
       "name": "werf-docker-1.2.json",
       "url": "https://json.schemastore.org/werf-docker-1.2.json"
     }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4960,6 +4960,30 @@
       "description": "auto api case schema",
       "fileMatch": ["**/test_data/*.yml"],
       "url": "https://json.schemastore.org/case_schema.json"
+    },
+    {
+      "description": "Werf meta information",
+      "fileMatch": ["werf.yaml"],
+      "name": "werf-meta-1.2.json",
+      "url": "https://json.schemastore.org/werf-meta-1.2.json"
+    },
+    {
+      "description": "Werf giterminism",
+      "fileMatch": ["werf-giterminism.yaml"],
+      "name": "werf-giterminism-1.2.json",
+      "url": "https://json.schemastore.org/werf-giterminism-1.2.json"
+    },
+    {
+      "description": "Werf Stapel image section",
+      "fileMatch": ["werf.yaml"],
+      "name": "werf-stapel-1.2.json",
+      "url": "https://json.schemastore.org/werf-stapel-1.2.json"
+    },
+    {
+      "description": "Werf Dockerfile image section",
+      "fileMatch": [ "werf.yaml" ],
+      "name": "werf-docker-1.2",
+      "url": "https://json.schemastore.org/werf-docker-1.2.json"
     }
   ],
   "version": 1

--- a/src/schemas/json/werf-docker-1.2.json
+++ b/src/schemas/json/werf-docker-1.2.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "Werf. Missing part of your CI/CD system https://werf.io/ docs for this file https://werf.io/documentation/v1.2/reference/werf_yaml.html",
+  "$ref": "#/definitions/Docker",
+  "description": "Werf",
+  "definitions": {
+    "Docker": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "One or more unique names for image"
+        },
+        "dockerfile": {
+          "type": "string",
+          "description": "Dockerfile path relative to the context PATH"
+        },
+        "staged": {
+          "type": "boolean",
+          "description": "Enable layer-by-layer caching of Dockerfile instructions in container registry"
+        },
+        "context": {
+          "type": "string",
+          "description": "Build context PATH inside project directory"
+        },
+        "platform": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of target platforms for this image (for example `['linux/amd64', 'linux/arm64', 'linux/arm/v8']`)"
+        },
+        "contextAddFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Untracked files and directories for adding to build context. The paths must be relative to context PATH"
+        },
+        "target": {
+          "type": "string",
+          "description": "Specific Dockerfile stage (last one by default, see docker build --target option)"
+        },
+        "args": {
+          "type": "object",
+          "description": "Variables for ARG dockerfile instructions (see docker build --build-arg option)"
+        },
+        "addHost": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Custom host-to-IP mapping (host:ip) (see docker build --add-host option)"
+        },
+        "network": {
+          "type": "string",
+          "description": "The networking mode for the RUN instructions during build (see docker build --network option)"
+        },
+        "ssh": {
+          "type": "string",
+          "description": "SSH agent socket or keys to the build (only if BuildKit enabled) (see docker build --ssh option)"
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Dependency"
+          },
+          "description": "Dependencies images for current image"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Dockerfile image section"
+    },
+    "Dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Dependency image name, which should be built before building current image"
+        },
+        "imports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Import"
+          },
+          "description": "Define target build args to import image information into current image (optional)"
+        }
+      },
+      "title": "Dependency"
+    },
+    "Import": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ImageName",
+            "ImageDigest",
+            "ImageRepo",
+            "ImageTag"
+          ],
+          "description": "Type of image info: ImageName, ImageDigest, ImageRepo or ImageTag"
+        },
+        "targetBuildArg": {
+          "type": "string",
+          "description": "Name of build argument which will contain specified type of information about image"
+        }
+      },
+      "title": "Import"
+    }
+  }
+}

--- a/src/schemas/json/werf-docker-1.2.json
+++ b/src/schemas/json/werf-docker-1.2.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$comment": "Werf. Missing part of your CI/CD system https://werf.io/ docs for this file https://werf.io/documentation/v1.2/reference/werf_yaml.html",
   "$ref": "#/definitions/Docker",
-  "description": "Werf",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Docker": {
       "type": "object",
@@ -79,9 +78,7 @@
           "description": "Dependencies images for current image"
         }
       },
-      "required": [
-        "image"
-      ],
+      "required": ["image"],
       "title": "Dockerfile image section"
     },
     "Dependency": {
@@ -108,12 +105,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "ImageName",
-            "ImageDigest",
-            "ImageRepo",
-            "ImageTag"
-          ],
+          "enum": ["ImageName", "ImageDigest", "ImageRepo", "ImageTag"],
           "description": "Type of image info: ImageName, ImageDigest, ImageRepo or ImageTag"
         },
         "targetBuildArg": {
@@ -123,5 +115,6 @@
       },
       "title": "Import"
     }
-  }
+  },
+  "description": "Werf"
 }

--- a/src/schemas/json/werf-giterminism-1.2.json
+++ b/src/schemas/json/werf-giterminism-1.2.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "Werf. Missing part of your CI/CD system https://werf.io/ docs for this file https://werf.io/documentation/v1.2/reference/werf_giterminism_yaml.html",
+  "$ref": "#/definitions/Giterminism",
+  "description": "Werf",
+  "definitions": {
+    "Giterminism": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "giterminismConfigVersion": {
+          "type": "integer",
+          "enum": [ 1 ],
+          "description": "Config syntax version. It should be 1 for now"
+        },
+        "cli": {
+          "$ref": "#/definitions/CLI",
+          "description": "The rules of loosening giterminism for the CLI"
+        },
+        "config": {
+          "$ref": "#/definitions/Config",
+          "description": "The rules of loosening giterminism for the werf configuration file (werf.yaml)"
+        },
+        "helm": {
+          "$ref": "#/definitions/Helm"
+        }
+      },
+      "required": [
+        "giterminismConfigVersion"
+      ],
+      "title": "Giterminism"
+    },
+    "CLI": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowCustomTags": {
+          "type": "boolean",
+          "description": "Allow the use of --use-custom-tag option"
+        }
+      },
+      "title": "CLI"
+    },
+    "Config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowUncommitted": {
+          "type": "boolean",
+          "description": "Read the configuration file from the project directory despite the state in git repository and .gitignore rules"
+        },
+        "allowUncommittedTemplates": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Read the certain configuration file templates (.werf/**/*.tmpl) from the project directory despite the state in git repository and .gitignore rules"
+        },
+        "goTemplateRendering": {
+          "$ref": "#/definitions/GoTemplateRendering",
+          "description": "The rules for the Go-template functions"
+        },
+        "stapel": {
+          "$ref": "#/definitions/Stapel",
+          "description": "The rules for the stapel image"
+        },
+        "dockerfile": {
+          "$ref": "#/definitions/Dockerfile",
+          "description": "The rules for the dockerfile image"
+        }
+      },
+      "title": "Config"
+    },
+    "Dockerfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowUncommitted": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Read the certain dockerfiles from the project directory despite the state in git repository and .gitignore rules"
+        },
+        "allowUncommittedDockerignoreFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Read the certain .dockerignore files from the project directory despite the state in git repository and .gitignore rules"
+        },
+        "allowContextAddFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allow the use of the certain files or directories from the project directory with contextAddFiles directive. More details"
+        }
+      },
+      "title": "Dockerfile"
+    },
+    "GoTemplateRendering": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowEnvVariables": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allow the use of certain environment variables (using env function). More details https://werf.io/documentation/v1.2/usage/project_configuration/giterminism.html#env"
+        },
+        "allowUncommittedFiles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Read the certain configuration files from the project directory despite the state in git repository and .gitignore rules (using .Files.Get and .Files.Glob functions)"
+          }
+        }
+      },
+      "title": "GoTemplateRendering"
+    },
+    "Stapel": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowFromLatest": {
+          "type": "boolean",
+          "description": "Allow the use of fromLatest directive. More details https://werf.io/documentation/v1.2/usage/project_configuration/giterminism.html#fromlatest"
+        },
+        "git": {
+          "$ref": "#/definitions/Git",
+          "description": "The rules for the git directive"
+        },
+        "mount": {
+          "$ref": "#/definitions/Mount",
+          "description": "The rules for the mount directive"
+        }
+      },
+      "title": "Stapel"
+    },
+    "Git": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowBranch": {
+          "type": "string",
+          "description": "Allow the use of branch directive. More details https://werf.io/documentation/v1.2/usage/project_configuration/giterminism.html#branch"
+        }
+      },
+      "title": "Git"
+    },
+    "Mount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowBuildDir": {
+          "type": "string",
+          "description": "Allow the use of build_dir mount ({ from: build_dir, ... }). More details https://werf.io/documentation/v1.2/usage/project_configuration/giterminism.html#build_dir"
+        },
+        "allowFromPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allow the use of certain fromPath mounts ({ fromPath: <path>, ... }). More details https://werf.io/documentation/v1.2/usage/project_configuration/giterminism.html#frompath"
+        }
+      },
+      "title": "Mount"
+    },
+    "Helm": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowUncommittedFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "Helm"
+    }
+  }
+}

--- a/src/schemas/json/werf-giterminism-1.2.json
+++ b/src/schemas/json/werf-giterminism-1.2.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$comment": "Werf. Missing part of your CI/CD system https://werf.io/ docs for this file https://werf.io/documentation/v1.2/reference/werf_giterminism_yaml.html",
   "$ref": "#/definitions/Giterminism",
-  "description": "Werf",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Giterminism": {
       "type": "object",
@@ -10,7 +9,7 @@
       "properties": {
         "giterminismConfigVersion": {
           "type": "integer",
-          "enum": [ 1 ],
+          "enum": [1],
           "description": "Config syntax version. It should be 1 for now"
         },
         "cli": {
@@ -25,9 +24,7 @@
           "$ref": "#/definitions/Helm"
         }
       },
-      "required": [
-        "giterminismConfigVersion"
-      ],
+      "required": ["giterminismConfigVersion"],
       "title": "Giterminism"
     },
     "CLI": {
@@ -181,5 +178,6 @@
       },
       "title": "Helm"
     }
-  }
+  },
+  "description": "Werf"
 }

--- a/src/schemas/json/werf-meta-1.2.json
+++ b/src/schemas/json/werf-meta-1.2.json
@@ -1,9 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$comment": "Werf. Missing part of your CI/CD system https://werf.io/ docs for this file https://werf.io/documentation/v1.2/reference/werf_yaml.html",
   "$ref": "#/definitions/WerfMeta",
-  "description": "Werf meta section",
-  "title": "Werf",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "WerfMeta": {
       "type": "object",
@@ -17,9 +15,7 @@
         "configVersion": {
           "description": "Config syntax version. It should always be 1 for now",
           "type": "integer",
-          "enum": [
-            1
-          ]
+          "enum": [1]
         },
         "build": {
           "description": "Common build settings",
@@ -38,10 +34,7 @@
           "$ref": "#/definitions/GitWorktree"
         }
       },
-      "required": [
-        "configVersion",
-        "project"
-      ]
+      "required": ["configVersion", "project"]
     },
     "Build": {
       "type": "object",
@@ -119,18 +112,11 @@
         },
         "operator": {
           "type": "string",
-          "enum": [
-            "And",
-            "Or"
-          ],
+          "enum": ["And", "Or"],
           "description": "Check both conditions or any of them (default `And`)"
         }
       },
-      "required": [
-        "in",
-        "last",
-        "operator"
-      ],
+      "required": ["in", "last", "operator"],
       "title": "ImagesPerReference"
     },
     "References": {
@@ -150,11 +136,7 @@
           "description": "The set of rules to limit references on the basis of the date when the git tag was created or the activity in the git branch"
         }
       },
-      "required": [
-        "branch",
-        "limit",
-        "tag"
-      ],
+      "required": ["branch", "limit", "tag"],
       "title": "References"
     },
     "Deploy": {
@@ -205,5 +187,7 @@
       "required": [],
       "title": "GitWorktree"
     }
-  }
+  },
+  "description": "Werf meta section",
+  "title": "Werf"
 }

--- a/src/schemas/json/werf-meta-1.2.json
+++ b/src/schemas/json/werf-meta-1.2.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "Werf. Missing part of your CI/CD system https://werf.io/ docs for this file https://werf.io/documentation/v1.2/reference/werf_yaml.html",
+  "$ref": "#/definitions/WerfMeta",
+  "description": "Werf meta section",
+  "title": "Werf",
+  "definitions": {
+    "WerfMeta": {
+      "type": "object",
+      "description": "Meta section",
+      "additionalProperties": false,
+      "properties": {
+        "project": {
+          "description": "Unique project name",
+          "type": "string"
+        },
+        "configVersion": {
+          "description": "Config syntax version. It should always be 1 for now",
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        },
+        "build": {
+          "description": "Common build settings",
+          "$ref": "#/definitions/Build"
+        },
+        "deploy": {
+          "description": "Settings for deployment",
+          "$ref": "#/definitions/Deploy"
+        },
+        "cleanup": {
+          "description": "Settings for cleaning up irrelevant images",
+          "$ref": "#/definitions/Cleanup"
+        },
+        "gitWorktree": {
+          "description": "Configure how werf handles git worktree of the project",
+          "$ref": "#/definitions/GitWorktree"
+        }
+      },
+      "required": [
+        "configVersion",
+        "project"
+      ]
+    },
+    "Build": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "platform": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Common list of target platforms for all images (for example ['linux/amd64', 'linux/arm64', 'linux/arm/v8'])"
+        }
+      },
+      "required": [],
+      "title": "Build"
+    },
+    "Cleanup": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disableKubernetesBasedPolicy": {
+          "type": "boolean",
+          "description": "Disable a cleanup policy that allows not to remove images deployed in Kubernetes from the container registry"
+        },
+        "disableGitHistoryBasedPolicy": {
+          "type": "boolean",
+          "description": "Disable a cleanup policy that allows not to remove images taking into account user-defined policies by the Git history (keepPolicies)"
+        },
+        "disableBuiltWithinLastNHoursPolicy": {
+          "type": "boolean",
+          "description": "Disable a cleanup policy that allows not to remove images built in last hours (keepImagesBuiltWithinLastNHours)"
+        },
+        "keepImagesBuiltWithinLastNHours": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The minimum number of hours that must elapse since the image is built (default 2)"
+        },
+        "keepPolicies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeepPolicy"
+          },
+          "description": "Set of policies to select relevant images using the Git history"
+        }
+      },
+      "required": [],
+      "title": "Cleanup"
+    },
+    "KeepPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "references": {
+          "$ref": "#/definitions/References",
+          "description": "References to perform scanning on"
+        },
+        "imagesPerReference": {
+          "$ref": "#/definitions/ImagesPerReference"
+        }
+      },
+      "required": [],
+      "title": "KeepPolicy"
+    },
+    "ImagesPerReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "last": {
+          "type": "integer",
+          "description": "To select n last references last n references from those defined in the branch or tag (default `-1)`"
+        },
+        "in": {
+          "type": "string",
+          "description": "To select git tags that were created during the specified period or git branches that were active during the period"
+        },
+        "operator": {
+          "type": "string",
+          "enum": [
+            "And",
+            "Or"
+          ],
+          "description": "Check both conditions or any of them (default `And`)"
+        }
+      },
+      "required": [
+        "in",
+        "last",
+        "operator"
+      ],
+      "title": "ImagesPerReference"
+    },
+    "References": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "type": "string",
+          "description": "One or more git origin branches"
+        },
+        "tag": {
+          "type": "string",
+          "description": "One or more git origin tags"
+        },
+        "limit": {
+          "$ref": "#/definitions/ImagesPerReference",
+          "description": "The set of rules to limit references on the basis of the date when the git tag was created or the activity in the git branch"
+        }
+      },
+      "required": [
+        "branch",
+        "limit",
+        "tag"
+      ],
+      "title": "References"
+    },
+    "Deploy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "helmChartDir": {
+          "type": "string",
+          "description": "Path to the helm chart directory of the project (default `.helm`)"
+        },
+        "helmRelease": {
+          "type": "string",
+          "description": "Release name template (default `[[ project ]]-[[ env ]]`)"
+        },
+        "helmReleaseSlug": {
+          "type": "boolean",
+          "description": "Release name slugification (default `true`)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Kubernetes namespace template (default `[[ project ]]-[[ env ]]`)"
+        },
+        "namespaceSlug": {
+          "type": "boolean",
+          "description": "Kubernetes namespace slugification (default `true`)"
+        }
+      },
+      "required": [],
+      "title": "Deploy"
+    },
+    "GitWorktree": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "forceShallowClone": {
+          "type": "boolean",
+          "description": "Force werf to use shallow clone despite restrictions"
+        },
+        "allowUnshallow": {
+          "type": "boolean",
+          "description": "Allow werf to automatically convert project shallow git clone to full one during build process when needed (default `true`)"
+        },
+        "allowFetchOriginBranchesAndTags": {
+          "type": "boolean",
+          "description": "Allow werf to synchronize git branches and tags with remote origin during cleanup process when needed (default `true`)"
+        }
+      },
+      "required": [],
+      "title": "GitWorktree"
+    }
+  }
+}

--- a/src/schemas/json/werf-stapel-1.2.json
+++ b/src/schemas/json/werf-stapel-1.2.json
@@ -1,0 +1,443 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "Werf. Missing part of your CI/CD system https://werf.io/ docs for this file https://werf.io/documentation/v1.2/reference/werf_yaml.html",
+  "$ref": "#/definitions/WerfStapel",
+  "description": "Werf",
+  "definitions": {
+    "WerfStapel": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "One or more unique names for image"
+        },
+        "artifact": {
+          "type": "string",
+          "description": "The unique name for artifact. More details https://werf.io/documentation/v1.2/usage/build/stapel/imports.html"
+        },
+        "platform": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of target platforms for this image (for example ['linux/amd64', 'linux/arm64', 'linux/arm/v8'])"
+        },
+        "from": {
+          "type": "string",
+          "description": "The name of a base image. More details https://werf.io/documentation/v1.2/usage/build/stapel/base.htmlfrom-fromlatest"
+        },
+        "fromLatest": {
+          "type": "boolean",
+          "description": "To use actual base image without caching. More details https://werf.io/documentation/v1.2/usage/build/stapel/base.htmlfrom-fromlatest"
+        },
+        "fromImage": {
+          "type": "string",
+          "description": "To use image as base image by image name. More details https://werf.io/documentation/v1.2/usage/build/stapel/base.htmlfromimage-and-fromartifact"
+        },
+        "fromArtifact": {
+          "type": "string",
+          "description": "To use artifact as base image by artifact name. More details https://werf.io/documentation/v1.2/usage/build/stapel/base.htmlfromimage-and-fromartifact"
+        },
+        "fromCacheVersion": {
+          "type": "string",
+          "description": "Cache version. More details https://werf.io/documentation/v1.2/usage/build/stapel/base.htmlfromcacheversion"
+        },
+        "git": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Git"
+          },
+          "description": "Set of directives to add source files from git repositories (both the project repository and any other). More details https://werf.io/documentation/v1.2/usage/build/stapel/git.html"
+        },
+        "shell": {
+          "$ref": "#/definitions/Ansible",
+          "description": "Shell assembly instructions. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmlshell"
+        },
+        "ansible": {
+          "$ref": "#/definitions/Ansible",
+          "description": "Ansible assembly instructions. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmlansible"
+        },
+        "docker": {
+          "$ref": "#/definitions/Docker",
+          "description": "Set of directives to effect on an image manifest. More details  https://werf.io/documentation/v1.2/usage/build/stapel/dockerfile.html"
+        },
+        "mount": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Mount"
+          },
+          "description": "Mount points. More details https://werf.io/documentation/v1.2/usage/build/stapel/mounts.html"
+        },
+        "import": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Import"
+          },
+          "description": "Imports. More details https://werf.io/documentation/v1.2/usage/build/stapel/imports.html"
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Dependency"
+          },
+          "description": "Dependencies images for current image"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Stapel image/artifact section"
+    },
+    "Ansible": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "beforeInstall": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands for beforeInstall stage. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmlshell"
+        },
+        "install": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands for install stage. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmlshell"
+        },
+        "beforeSetup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands for beforeSetup stage. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmlshell"
+        },
+        "setup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands for setup stage. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmlshell"
+        },
+        "cacheVersion": {
+          "type": "string",
+          "description": "Common cache version. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmldependency-on-the-cacheversion"
+        },
+        "beforeInstallCacheVersion": {
+          "type": "string",
+          "description": "Cache version for beforeInstall stage. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmldependency-on-the-cacheversion"
+        },
+        "installCacheVersion": {
+          "type": "string",
+          "description": "Cache version for install stage. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmldependency-on-the-cacheversion"
+        },
+        "beforeSetupCacheVersion": {
+          "type": "string",
+          "description": "Cache version for beforeSetup stage. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmldependency-on-the-cacheversion"
+        },
+        "setupCacheVersion": {
+          "type": "string",
+          "description": "Cache version for setup stage. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmldependency-on-the-cacheversion"
+        }
+      },
+      "title": "Ansible"
+    },
+    "Dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Dependency image name, which should be built before building current image"
+        },
+        "before": {
+          "type": "string",
+          "description": "The stage name before which image info should be imported (specify install or setup). Specified target env variables will be available at user stages after stage specified by this directive."
+        },
+        "after": {
+          "type": "string",
+          "description": "The stage name after which image info should be imported (specify install or setup). Specified target env variables will be available at user stages after stage specified by this directive."
+        },
+        "imports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DependencyImport"
+          },
+          "description": "Define target environment variables to import image information into current image (optional)"
+        }
+      },
+      "title": "Dependency"
+    },
+    "DependencyImport": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of image info: ImageName, ImageDigest, ImageRepo or ImageTag",
+          "enum": [
+            "ImageName",
+            "ImageDigest",
+            "ImageRepo",
+            "ImageTag"
+          ]
+        },
+        "targetEnv": {
+          "type": "string",
+          "description": "Name of environment variable which will contain specified type of information about image"
+        }
+      },
+      "title": "DependencyImport"
+    },
+    "Docker": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "exactValues": {
+          "type": "string",
+          "description": "Set specified options values as-is, including unescaped quotes and spaces. Option affects only docker-server backend and does not affect buildah backend. "
+        },
+        "USER": {
+          "type": "string",
+          "description": "The user name (or UID) and optionally the user group (or GID). More details https://docs.docker.com/engine/reference/builder/user"
+        },
+        "WORKDIR": {
+          "type": "string",
+          "description": "The working directory. More details https://docs.docker.com/engine/reference/builder/workdir"
+        },
+        "VOLUME": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Mount points. More details https://docs.docker.com/engine/reference/builder/volume"
+        },
+        "ENV": {
+          "type": "object",
+          "description": "The environment variables. More details https://docs.docker.com/engine/reference/builder/env"
+        },
+        "LABEL": {
+          "type": "object",
+          "description": "The metadata to an image. More details https://docs.docker.com/engine/reference/builder/label"
+        },
+        "EXPOSE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "To inform Docker that the container listens on the specified network ports at runtime. More details https://docs.docker.com/engine/reference/builder/expose"
+        },
+        "ENTRYPOINT": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "To configure a container that will run as an executable. Shell and exec forms are supported. More details https://docs.docker.com/engine/reference/builder/entrypoint"
+        },
+        "CMD": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "To provide default arguments for the ENTRYPOINT to configure a container that will run as an executable. Shell and exec forms are supported. More details https://docs.docker.com/engine/reference/builder/cmd"
+        },
+        "HEALTHCHECK": {
+          "type": "string",
+          "description": "To tell Docker how to test a container to check that it is still working. More details https://docs.docker.com/engine/reference/builder/healthcheck"
+        }
+      },
+      "title": "Docker"
+    },
+    "Git": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The address of the remote repository. More details https://werf.io/documentation/v1.2/usage/build/stapel/git.htmlworking-with-remote-repositories"
+        },
+        "branch": {
+          "type": "string",
+          "description": "The branch name. More details https://werf.io/documentation/v1.2/usage/build/stapel/git.htmlsyntax-of-a-git-mapping"
+        },
+        "commit": {
+          "type": "string",
+          "description": "The commit"
+        },
+        "tag": {
+          "type": "string",
+          "description": "The tag name"
+        },
+        "add": {
+          "type": "string",
+          "description": "A source path in a repository. More details https://werf.io/documentation/v1.2/usage/build/stapel/git.htmlcopying-directories"
+        },
+        "to": {
+          "type": "string",
+          "description": "A destination path in image. More details https://werf.io/documentation/v1.2/usage/build/stapel/git.htmlcopying-directories"
+        },
+        "owner": {
+          "type": "string",
+          "description": "The name or UID of the owner. More details https://werf.io/documentation/v1.2/usage/build/stapel/git.htmlchanging-the-owner"
+        },
+        "group": {
+          "type": "string",
+          "description": "The name or GID of the owner's group. More details https://werf.io/documentation/v1.2/usage/build/stapel/git.htmlchanging-the-owner"
+        },
+        "includePaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Globs for including. More details https://werf.io/documentation/v1.2/usage/build/stapel/git.htmlusing-filters"
+        },
+        "excludePaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Globs for excluding. More details https://werf.io/documentation/v1.2/usage/build/stapel/git.htmlusing-filters"
+        },
+        "stageDependencies": {
+          "$ref": "#/definitions/StageDependencies",
+          "description": "The organization of restarting assembly instructions when defined changes occur in the git repository. More details https://werf.io/documentation/v1.2/usage/build/stapel/instructions.htmldependency-on-changes-in-the-git-repo"
+        }
+      },
+      "title": "Git"
+    },
+    "StageDependencies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "install": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Globs for install stage"
+        },
+        "beforeSetup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Globs for beforeSetup stage"
+        },
+        "setup": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Globs for setup stage"
+        }
+      },
+      "title": "StageDependencies"
+    },
+    "Import": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "description": "The artifact name from which you want to copy files"
+        },
+        "image": {
+          "type": "string",
+          "description": "The image name from which you want to copy files"
+        },
+        "stage": {
+          "type": "string",
+          "description": "The stage name from which you want to copy files (the latest one by default)"
+        },
+        "before": {
+          "type": "string",
+          "description": "The stage name before which to perform importing files. At present, only install and setup stages are supported"
+        },
+        "after": {
+          "type": "string",
+          "description": "The stage name after which to perform importing files. At present, only install and setup stages are supported"
+        },
+        "add": {
+          "type": "string",
+          "description": "The absolute file or folder path in source image for copying"
+        },
+        "to": {
+          "type": "string",
+          "description": "The absolute path in destination image. In case of absence, destination path equals source path"
+        },
+        "owner": {
+          "type": "string",
+          "description": "The name or UID of the owner"
+        },
+        "group": {
+          "type": "string",
+          "description": "The name or GID of the owner's group"
+        },
+        "includePaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Globs for including"
+        },
+        "excludePaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Globs for excluding"
+        }
+      },
+      "title": "Import"
+    },
+    "Mount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Service folder name",
+          "enum": [
+            "tmp_dir",
+            "build_dir"
+          ]
+        },
+        "fromPath": {
+          "type": "string",
+          "description": "Absolute or relative path to an arbitrary file or folder on host"
+        },
+        "to": {
+          "type": "string",
+          "description": "Absolute path in image"
+        }
+      },
+      "title": "Mount"
+    }
+  }
+}

--- a/src/schemas/json/werf-stapel-1.2.json
+++ b/src/schemas/json/werf-stapel-1.2.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$comment": "Werf. Missing part of your CI/CD system https://werf.io/ docs for this file https://werf.io/documentation/v1.2/reference/werf_yaml.html",
   "$ref": "#/definitions/WerfStapel",
-  "description": "Werf",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "WerfStapel": {
       "type": "object",
@@ -94,9 +93,7 @@
           "description": "Dependencies images for current image"
         }
       },
-      "required": [
-        "image"
-      ],
+      "required": ["image"],
       "title": "Stapel image/artifact section"
     },
     "Ansible": {
@@ -187,12 +184,7 @@
         "type": {
           "type": "string",
           "description": "Type of image info: ImageName, ImageDigest, ImageRepo or ImageTag",
-          "enum": [
-            "ImageName",
-            "ImageDigest",
-            "ImageRepo",
-            "ImageTag"
-          ]
+          "enum": ["ImageName", "ImageDigest", "ImageRepo", "ImageTag"]
         },
         "targetEnv": {
           "type": "string",
@@ -423,10 +415,7 @@
         "from": {
           "type": "string",
           "description": "Service folder name",
-          "enum": [
-            "tmp_dir",
-            "build_dir"
-          ]
+          "enum": ["tmp_dir", "build_dir"]
         },
         "fromPath": {
           "type": "string",
@@ -439,5 +428,6 @@
       },
       "title": "Mount"
     }
-  }
+  },
+  "description": "Werf"
 }


### PR DESCRIPTION
### [Werf](https://github.com/werf/werf) is a CNCF Sandbox CLI tool to implement full-cycle CI/CD to Kubernetes easily.
I use werf at work and i really want have it in your collection.

Werf use only 2 files:
- `werf.yaml`
- `werf-giterminism.yaml`

But werf contains 3 different sections in `werf.yaml` and one in `werf-giterminism.yaml`