### PR TITLE
Allow yaml and yml extensions for Prometheus schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2936,7 +2936,12 @@
       "name": "prometheus.rules.json",
       "description": "Prometheus rules file",
       "fileMatch": [
-        "*.rules.yml", "*.rules.yaml", "*rules.yml", "*rules.yaml", "rules.yml", "rules.yaml"
+        "*.rules.yml",
+        "*.rules.yaml",
+        "*rules.yml",
+        "*rules.yaml",
+        "rules.yml",
+        "rules.yaml"
       ],
       "url": "https://json.schemastore.org/prometheus.rules.json"
     },
@@ -2944,8 +2949,18 @@
       "name": "prometheus.rules.test.json",
       "description": "Prometheus rules test file",
       "fileMatch": [
-        "*.tests.yml", "*.tests.yaml", "*tests.yml", "*tests.yaml", "tests.yml", "tests.yaml",
-        "*.test.yml", "*.test.yaml", "*test.yml", "*test.yaml", "test.yml", "test.yaml"
+        "*.tests.yml",
+        "*.tests.yaml",
+        "*tests.yml",
+        "*tests.yaml",
+        "tests.yml",
+        "tests.yaml",
+        "*.test.yml",
+        "*.test.yaml",
+        "*test.yml",
+        "*test.yaml",
+        "test.yml",
+        "test.yaml"
       ],
       "url": "https://json.schemastore.org/prometheus.rules.test.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2935,13 +2935,18 @@
     {
       "name": "prometheus.rules.json",
       "description": "Prometheus rules file",
-      "fileMatch": ["*.rules"],
+      "fileMatch": [
+        "*.rules.yml", "*.rules.yaml", "*rules.yml", "*rules.yaml", "rules.yml", "rules.yaml"
+      ],
       "url": "https://json.schemastore.org/prometheus.rules.json"
     },
     {
       "name": "prometheus.rules.test.json",
       "description": "Prometheus rules test file",
-      "fileMatch": ["*.rules.test"],
+      "fileMatch": [
+        "*.tests.yml", "*.tests.yaml", "*tests.yml", "*tests.yaml", "tests.yml", "tests.yaml",
+        "*.test.yml", "*.test.yaml", "*test.yml", "*test.yaml", "test.yml", "test.yaml"
+      ],
       "url": "https://json.schemastore.org/prometheus.rules.test.json"
     },
     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

This PR changes the `fileMatch` rules for Prometheus rules and Prometheus test files. It expands it to match more files, but it also removes the existing matches which I don't think were doing anything.

I don't see a single Prometheus file across GitHub that ends with ".rules" ([search query used](https://github.com/search?q=path%3A**%2F.rules&type=code&p=3)), so I don't think the existing rules file match is doing anything. I think the same is true for the test file pattern match I added.

Looking for Prometheus rules tests, I find that [most of them end with something like tests.yml](https://github.com/search?q=alert_rule_test+lang%3AYAML&type=code&ref=advsearch&p=4), so I've added some patterns for those.