### PR TITLE
Revert loose filematches introduced in #3003

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2951,16 +2951,8 @@
       "fileMatch": [
         "*.tests.yml",
         "*.tests.yaml",
-        "*tests.yml",
-        "*tests.yaml",
-        "tests.yml",
-        "tests.yaml",
         "*.test.yml",
-        "*.test.yaml",
-        "*test.yml",
-        "*test.yaml",
-        "test.yml",
-        "test.yaml"
+        "*.test.yaml"
       ],
       "url": "https://json.schemastore.org/prometheus.rules.test.json"
     },


### PR DESCRIPTION
"test.yml" is not a precise enough match for a Prometheus rules test file and is causing files to match the wrong schema.

I'd rather replace these matches with a better match, but I'm not familiar enough with Prometheus rules test files to make that change. In the meantime they should be reverted/deleted.

CC @MichaelSnowden FYI
