### PR TITLE
feat(nest-cli): add `manualRestart` flag to 'nest-cli.json' options

### DIFF
--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -53,7 +53,12 @@
           "type": "boolean",
           "default": false,
           "description": "If true, whenever the compiler is invoked, it will first remove the compilation output directory (as configured in tsconfig.json, where the default is ./dist)."
-        }
+        },
+        "manualRestart": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, enables the shortcut `rs` to manually restart the server."
+        }        
       },
       "additionalProperties": false
     },

--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -58,7 +58,7 @@
           "type": "boolean",
           "default": false,
           "description": "If true, enables the shortcut `rs` to manually restart the server."
-        }        
+        }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

a reference to this option: https://docs.nestjs.com/cli/monorepo#global-compiler-options