### PR TITLE
add dprint.json to catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1398,6 +1398,17 @@
       "url": "https://json.schemastore.org/dotnetcli.host.json"
     },
     {
+      "name": "dprint.json",
+      "description": "dprint configuration file",
+      "fileMatch": [
+        "dprint.json",
+        "dprint.jsonc",
+        ".dprint.json",
+        ".dprint.jsonc"
+      ],
+      "url": "https://dprint.dev/schemas/v0.json"
+    },
+    {
       "name": "drone.json",
       "description": "Drone CI configuration file",
       "fileMatch": [".drone.yml"],


### PR DESCRIPTION
Adds schema for [dprint](https://dprint.dev/)'s configuration file.
