### PR TITLE
add larger runners

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2948,20 +2948,7 @@
     {
       "name": "prometheus.rules.test.json",
       "description": "Prometheus rules test file",
-      "fileMatch": [
-        "*.tests.yml",
-        "*.tests.yaml",
-        "*tests.yml",
-        "*tests.yaml",
-        "tests.yml",
-        "tests.yaml",
-        "*.test.yml",
-        "*.test.yaml",
-        "*test.yml",
-        "*test.yaml",
-        "test.yml",
-        "test.yaml"
-      ],
+      "fileMatch": ["*.tests.yml", "*.tests.yaml", "*.test.yml", "*.test.yaml"],
       "url": "https://json.schemastore.org/prometheus.rules.test.json"
     },
     {

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -5,7 +5,11 @@
   "definitions": {
     "architecture": {
       "type": "string",
-      "enum": ["ARM32", "x64", "x86"]
+      "enum": [
+        "ARM32",
+        "x64",
+        "x86"
+      ]
     },
     "branch": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestbranchestags",
@@ -33,7 +37,9 @@
           ]
         }
       },
-      "required": ["group"],
+      "required": [
+        "group"
+      ],
       "additionalProperties": false
     },
     "configuration": {
@@ -119,7 +125,9 @@
           "type": "string"
         }
       },
-      "required": ["image"],
+      "required": [
+        "image"
+      ],
       "additionalProperties": false
     },
     "defaults": {
@@ -148,7 +156,10 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": ["read-all", "write-all"]
+          "enum": [
+            "read-all",
+            "write-all"
+          ]
         },
         {
           "$ref": "#/definitions/permissions-event"
@@ -202,7 +213,11 @@
     },
     "permissions-level": {
       "type": "string",
-      "enum": ["read", "write", "none"]
+      "enum": [
+        "read",
+        "write",
+        "none"
+      ]
     },
     "env": {
       "$comment": "https://docs.github.com/en/actions/learn-github-actions/environment-variables",
@@ -245,7 +260,9 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": false
     },
     "event": {
@@ -319,7 +336,11 @@
     },
     "machine": {
       "type": "string",
-      "enum": ["linux", "macos", "windows"]
+      "enum": [
+        "linux",
+        "macos",
+        "windows"
+      ]
     },
     "name": {
       "type": "string",
@@ -357,17 +378,26 @@
           "allOf": [
             {
               "not": {
-                "required": ["branches", "branches-ignore"]
+                "required": [
+                  "branches",
+                  "branches-ignore"
+                ]
               }
             },
             {
               "not": {
-                "required": ["tags", "tags-ignore"]
+                "required": [
+                  "tags",
+                  "tags-ignore"
+                ]
               }
             },
             {
               "not": {
-                "required": ["paths", "paths-ignore"]
+                "required": [
+                  "paths",
+                  "paths-ignore"
+                ]
               }
             }
           ]
@@ -387,7 +417,14 @@
         {
           "type": "string",
           "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell",
-          "enum": ["bash", "pwsh", "python", "sh", "cmd", "powershell"]
+          "enum": [
+            "bash",
+            "pwsh",
+            "python",
+            "sh",
+            "cmd",
+            "powershell"
+          ]
         }
       ]
     },
@@ -437,7 +474,11 @@
         "if": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif",
           "description": "You can use the if conditional to prevent a job from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-          "type": ["boolean", "number", "string"]
+          "type": [
+            "boolean",
+            "number",
+            "string"
+          ]
         },
         "uses": {
           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iduses",
@@ -459,7 +500,9 @@
             },
             {
               "type": "string",
-              "enum": ["inherit"]
+              "enum": [
+                "inherit"
+              ]
             }
           ]
         },
@@ -517,10 +560,15 @@
             "max-parallel": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel",
               "description": "The maximum number of jobs that can run simultaneously when using a matrix job strategy. By default, GitHub will maximize the number of jobs run in parallel depending on the available runners on GitHub-hosted virtual machines.",
-              "type": ["number", "string"]
+              "type": [
+                "number",
+                "string"
+              ]
             }
           },
-          "required": ["matrix"],
+          "required": [
+            "matrix"
+          ],
           "additionalProperties": false
         },
         "concurrency": {
@@ -536,7 +584,9 @@
           ]
         }
       },
-      "required": ["uses"],
+      "required": [
+        "uses"
+      ],
       "additionalProperties": false
     },
     "normalJob": {
@@ -661,6 +711,28 @@
                   "additionalItems": {
                     "type": "string"
                   }
+                },
+                {
+                  "items": [
+                    {
+                      "const": "linux"
+                    }
+                  ],
+                  "minItems": 1,
+                  "additionalItems": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "items": [
+                    {
+                      "const": "windows"
+                    }
+                  ],
+                  "minItems": 1,
+                  "additionalItems": {
+                    "type": "string"
+                  }
                 }
               ]
             },
@@ -725,7 +797,11 @@
         "if": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif",
           "description": "You can use the if conditional to prevent a job from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-          "type": ["boolean", "number", "string"]
+          "type": [
+            "boolean",
+            "number",
+            "string"
+          ]
         },
         "steps": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idsteps",
@@ -742,7 +818,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["uses"]
+                    "required": [
+                      "uses"
+                    ]
                   },
                   {
                     "type": "object",
@@ -751,7 +829,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["run"]
+                    "required": [
+                      "run"
+                    ]
                   }
                 ]
               },
@@ -766,7 +846,11 @@
                   "if": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsif",
                     "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-                    "type": ["boolean", "number", "string"]
+                    "type": [
+                      "boolean",
+                      "number",
+                      "string"
+                    ]
                   },
                   "name": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname",
@@ -836,8 +920,12 @@
                   }
                 },
                 "dependencies": {
-                  "working-directory": ["run"],
-                  "shell": ["run"]
+                  "working-directory": [
+                    "run"
+                  ],
+                  "shell": [
+                    "run"
+                  ]
                 },
                 "additionalProperties": false
               }
@@ -912,10 +1000,15 @@
             "max-parallel": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel",
               "description": "The maximum number of jobs that can run simultaneously when using a matrix job strategy. By default, GitHub will maximize the number of jobs run in parallel depending on the available runners on GitHub-hosted virtual machines.",
-              "type": ["number", "string"]
+              "type": [
+                "number",
+                "string"
+              ]
             }
           },
-          "required": ["matrix"],
+          "required": [
+            "matrix"
+          ],
           "additionalProperties": false
         },
         "continue-on-error": {
@@ -963,7 +1056,9 @@
           ]
         }
       },
-      "required": ["runs-on"],
+      "required": [
+        "runs-on"
+      ],
       "additionalProperties": false
     }
   },
@@ -999,9 +1094,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1039,9 +1142,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["completed", "requested", "rerequested"]
+                    "enum": [
+                      "completed",
+                      "requested",
+                      "rerequested"
+                    ]
                   },
-                  "default": ["completed", "requested", "rerequested"]
+                  "default": [
+                    "completed",
+                    "requested",
+                    "rerequested"
+                  ]
                 }
               }
             },
@@ -1117,9 +1228,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1142,9 +1261,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1206,9 +1333,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1221,9 +1356,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["added", "edited", "deleted"]
+                    "enum": [
+                      "added",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["added", "edited", "deleted"]
+                  "default": [
+                    "added",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1236,9 +1379,13 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["checks_requested"]
+                    "enum": [
+                      "checks_requested"
+                    ]
                   },
-                  "default": ["checks_requested"]
+                  "default": [
+                    "checks_requested"
+                  ]
                 }
               }
             },
@@ -1251,7 +1398,13 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "closed", "opened", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "closed",
+                      "opened",
+                      "edited",
+                      "deleted"
+                    ]
                   },
                   "default": [
                     "created",
@@ -1333,9 +1486,19 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "updated", "moved", "deleted"]
+                    "enum": [
+                      "created",
+                      "updated",
+                      "moved",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "updated", "moved", "deleted"]
+                  "default": [
+                    "created",
+                    "updated",
+                    "moved",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1373,7 +1536,11 @@
                       "auto_merge_disabled"
                     ]
                   },
-                  "default": ["opened", "synchronize", "reopened"]
+                  "default": [
+                    "opened",
+                    "synchronize",
+                    "reopened"
+                  ]
                 }
               },
               "patternProperties": {
@@ -1392,9 +1559,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["submitted", "edited", "dismissed"]
+                    "enum": [
+                      "submitted",
+                      "edited",
+                      "dismissed"
+                    ]
                   },
-                  "default": ["submitted", "edited", "dismissed"]
+                  "default": [
+                    "submitted",
+                    "edited",
+                    "dismissed"
+                  ]
                 }
               }
             },
@@ -1407,9 +1582,17 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["created", "edited", "deleted"]
+                    "enum": [
+                      "created",
+                      "edited",
+                      "deleted"
+                    ]
                   },
-                  "default": ["created", "edited", "deleted"]
+                  "default": [
+                    "created",
+                    "edited",
+                    "deleted"
+                  ]
                 }
               }
             },
@@ -1442,7 +1625,11 @@
                       "auto_merge_disabled"
                     ]
                   },
-                  "default": ["opened", "synchronize", "reopened"]
+                  "default": [
+                    "opened",
+                    "synchronize",
+                    "reopened"
+                  ]
                 }
               },
               "patternProperties": {
@@ -1473,9 +1660,15 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["published", "updated"]
+                    "enum": [
+                      "published",
+                      "updated"
+                    ]
                   },
-                  "default": ["published", "updated"]
+                  "default": [
+                    "published",
+                    "updated"
+                  ]
                 }
               }
             },
@@ -1552,15 +1745,25 @@
                           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callinput_idtype",
                           "description": "Required if input is defined for the on.workflow_call keyword. The value of this parameter is a string specifying the data type of the input. This must be one of: boolean, number, or string.",
                           "type": "string",
-                          "enum": ["boolean", "number", "string"]
+                          "enum": [
+                            "boolean",
+                            "number",
+                            "string"
+                          ]
                         },
                         "default": {
                           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputsinput_iddefault",
                           "description": "The default value is used when an input parameter isn't specified in a workflow file.",
-                          "type": ["boolean", "number", "string"]
+                          "type": [
+                            "boolean",
+                            "number",
+                            "string"
+                          ]
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -1584,7 +1787,9 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["required"],
+                      "required": [
+                        "required"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -1654,7 +1859,9 @@
                                 "const": "string"
                               }
                             },
-                            "required": ["type"]
+                            "required": [
+                              "type"
+                            ]
                           },
                           "then": {
                             "properties": {
@@ -1671,7 +1878,9 @@
                                 "const": "boolean"
                               }
                             },
-                            "required": ["type"]
+                            "required": [
+                              "type"
+                            ]
                           },
                           "then": {
                             "properties": {
@@ -1688,7 +1897,9 @@
                                 "const": "number"
                               }
                             },
-                            "required": ["type"]
+                            "required": [
+                              "type"
+                            ]
                           },
                           "then": {
                             "properties": {
@@ -1705,7 +1916,9 @@
                                 "const": "environment"
                               }
                             },
-                            "required": ["type"]
+                            "required": [
+                              "type"
+                            ]
                           },
                           "then": {
                             "properties": {
@@ -1722,14 +1935,20 @@
                                 "const": "choice"
                               }
                             },
-                            "required": ["type"]
+                            "required": [
+                              "type"
+                            ]
                           },
                           "then": {
-                            "required": ["options"]
+                            "required": [
+                              "options"
+                            ]
                           }
                         }
                       ],
-                      "required": ["description"],
+                      "required": [
+                        "description"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -1746,9 +1965,15 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["requested", "completed"]
+                    "enum": [
+                      "requested",
+                      "completed"
+                    ]
                   },
-                  "default": ["requested", "completed"]
+                  "default": [
+                    "requested",
+                    "completed"
+                  ]
                 },
                 "workflows": {
                   "type": "array",
@@ -1838,6 +2063,9 @@
       "$ref": "#/definitions/permissions"
     }
   },
-  "required": ["on", "jobs"],
+  "required": [
+    "on",
+    "jobs"
+  ],
   "type": "object"
 }

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -718,7 +718,8 @@
                       "const": "linux"
                     }
                   ],
-                  "minItems": 1,
+                  "minItems": 2,
+                  "maxItems": 2,
                   "additionalItems": {
                     "type": "string"
                   }
@@ -729,7 +730,8 @@
                       "const": "windows"
                     }
                   ],
-                  "minItems": 1,
+                  "minItems": 2,
+                  "maxItems": 2,
                   "additionalItems": {
                     "type": "string"
                   }


### PR DESCRIPTION
GitHub has introduced the ability to spin up GitHub hosted large runners.

https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners

These runners have a pre-defined label of either ```linux``` or ```windows``` plus a single user-defined label.

This PR allows the YAML formatter to handle large runners in ```github-workflow.json```.

Screenshot showing a large runner, as can be seen only two labels are attached, and it is not possible to add more.


![image](https://github.com/SchemaStore/schemastore/assets/61512176/94b27ea8-a8ee-44f1-9576-04bc8df4d4c6)


