### PR TITLE
Update Umbraco package.manifest and add new properties included in v12

### DIFF
--- a/src/schemas/json/package.manifest.json
+++ b/src/schemas/json/package.manifest.json
@@ -296,19 +296,25 @@
     }
   },
   "properties": {
+    "id": {
+      "type": "string",
+      "description": "The (NuGet) package ID, shown in the backoffice and included in package telemetry as unique identifier (supported in v12+). Also used to retrieve the assembly informational version if no explicit `version` and `versionAssemlbyName` is set."
+    },
     "name": {
       "type": "string",
-      "description": "An optional friendly package name. If not specified then the directory name is used.",
-      "minLength": 1
+      "description": "The (friendly) package name, shown in the backoffice and included in package telemetry. If not specified, uses the directory name instead."
     },
     "version": {
       "type": "string",
-      "description": "The version of your package, if this is not specified there will be no version specific information for your package for telemtry",
-      "minLength": 1
+      "description": "The package version, shown in the backoffice and included in package telemetry. If not specified, uses the `versionAssemblyName` or `id` to retrieve the assembly informational version."
+    },
+    "versionAssemblyName": {
+      "type": "string",
+      "description": "The assembly name to retrieve the informational version, if no explicit `version` is set. If not specified, uses the `id` instead (supported in v12+)."
     },
     "allowPackageTelemetry": {
       "type": "boolean",
-      "description": "Allows you to entirely disable telemetry for your package if set to false, defaults to true.",
+      "description": "Allows you to opt-out of including your package in telemetry reports if set to false, defaults to true.",
       "default": true
     },
     "packageView": {

--- a/src/schemas/json/package.manifest.json
+++ b/src/schemas/json/package.manifest.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "JSON schema for Umbraco package.manifest files.",
   "definitions": {
     "editor": {
       "description": "This describes details about the editor.",
@@ -18,7 +17,7 @@
         "valueType": {
           "type": "string",
           "description": "This is the type of data you want your property editor to save to the database.",
-          "enum": [ "STRING", "JSON", "DATETIME", "TEXT", "INT" ]
+          "enum": ["STRING", "JSON", "DATETIME", "TEXT", "INT"]
         },
         "validation": {
           "description": "Object describing required validators on the editor.",
@@ -38,7 +37,7 @@
     },
     "editors": {
       "type": "object",
-      "required": [ "name", "alias", "editor" ],
+      "required": ["name", "alias", "editor"],
       "properties": {
         "alias": {
           "type": "string",
@@ -73,7 +72,7 @@
     },
     "gridEditor": {
       "type": "object",
-      "required": [ "name", "alias", "view" ],
+      "required": ["name", "alias", "view"],
       "properties": {
         "name": {
           "type": "string",
@@ -183,7 +182,7 @@
       "description": "A dashboard to display contextual information when in a section/application.",
       "type": "object",
       "additionalProperties": false,
-      "required": [ "alias", "view", "sections" ],
+      "required": ["alias", "view", "sections"],
       "properties": {
         "alias": {
           "type": "string",
@@ -228,10 +227,10 @@
             },
             "oneOf": [
               {
-                "required": [ "deny" ]
+                "required": ["deny"]
               },
               {
-                "required": [ "grant" ]
+                "required": ["grant"]
               }
             ]
           }
@@ -242,7 +241,7 @@
       "description": "A section/application to extend the backoffice.",
       "type": "object",
       "additionalProperties": false,
-      "required": [ "name", "alias" ],
+      "required": ["name", "alias"],
       "properties": {
         "name": {
           "type": "string",
@@ -260,7 +259,7 @@
       "description": "A section/application to extend the backoffice.",
       "type": "object",
       "additionalProperties": false,
-      "required": [ "name", "alias", "icon", "view" ],
+      "required": ["name", "alias", "icon", "view"],
       "properties": {
         "name": {
           "type": "string",
@@ -296,7 +295,6 @@
       }
     }
   },
-  "type": "object",
   "properties": {
     "id": {
       "type": "string",
@@ -327,7 +325,7 @@
     "bundleOptions": {
       "type": "string",
       "description": "Default: The assets will be bundled with the typical packages bundle. None: The assets in the package will not be processed at all and will all be requested as individual assets in debug and production. Independent: The packages assets will be processed as it's own separate bundle (in debug, files will not be processed).",
-      "enum": [ "Default", "None", "Independent" ]
+      "enum": ["Default", "None", "Independent"]
     },
     "javascript": {
       "type": "array",
@@ -403,5 +401,7 @@
         "$ref": "#/definitions/contentApp"
       }
     }
-  }
+  },
+  "title": "JSON schema for Umbraco package.manifest files.",
+  "type": "object"
 }

--- a/src/schemas/json/package.manifest.json
+++ b/src/schemas/json/package.manifest.json
@@ -1,47 +1,48 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON schema for Umbraco package.manifest files.",
   "definitions": {
     "editor": {
-      "description": "This describes details about the editor",
+      "description": "This describes details about the editor.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "view": {
           "type": "string",
-          "description": "This is the full path to the HTML view for your property editor"
+          "description": "This is the full path to the HTML view for your property editor."
         },
         "hideLabel": {
           "type": "boolean",
-          "description": "If set to true this hides the label for the property editor when used in Umbraco on a document type"
+          "description": "If set to true, this hides the label for the property editor when used on a document type."
         },
         "valueType": {
           "type": "string",
-          "description": "This is the type of data you want your property editor to save to Umbraco",
-          "enum": ["STRING", "JSON", "DATETIME", "TEXT", "INT"]
+          "description": "This is the type of data you want your property editor to save to the database.",
+          "enum": [ "STRING", "JSON", "DATETIME", "TEXT", "INT" ]
         },
         "validation": {
-          "description": "Object describing required validators on the editor",
+          "description": "Object describing required validators on the editor.",
           "type": "object"
         },
         "isReadOnly": {
           "type": "boolean",
-          "description": "If set to true this makes the property editor read only",
+          "description": "If set to true, this makes the property editor read-only.",
           "default": false
         },
         "supportsReadOnly": {
           "type": "boolean",
-          "description": "If set to true, it will disable the default umbraco read only overlay and use the one thats implemented instead",
+          "description": "If set to true, this will disable the default read-only overlay and requires the editor to implement support for this instead.",
           "default": false
         }
       }
     },
     "editors": {
       "type": "object",
-      "required": ["name", "alias", "editor"],
+      "required": [ "name", "alias", "editor" ],
       "properties": {
         "alias": {
           "type": "string",
-          "description": "This must be a unique alias to your property editor"
+          "description": "This must be a unique alias to your property editor."
         },
         "defaultConfig": {
           "type": "object",
@@ -53,71 +54,71 @@
         },
         "isParameterEditor": {
           "type": "boolean",
-          "description": "Enables the property editor as a macro parameter editor can be true/false",
+          "description": "Enables the property editor as a macro parameter editor.",
           "default": false
         },
         "name": {
           "type": "string",
-          "description": "The friendly name of the property editor, shown in the Umbraco backoffice"
+          "description": "The friendly name of the property editor, shown in the backoffice."
         },
         "icon": {
           "type": "string",
-          "description": "A CSS class for the icon to be used in the 'Select Editor' dialog eg: icon-autofill"
+          "description": "A CSS class for the icon to be used in the 'Select Editor' dialog, e.g. `icon-autofill`."
         },
         "group": {
           "type": "string",
-          "description": "The group to place this editor in within the 'Select Editor' dialog. Use a new group name or alternatively use an existing one such as 'Pickers'"
+          "description": "The group to place this editor in within the 'Select Editor' dialog. Use a new group name or alternatively use an existing one such as `Pickers`."
         }
       }
     },
     "gridEditor": {
       "type": "object",
-      "required": ["name", "alias", "view"],
+      "required": [ "name", "alias", "view" ],
       "properties": {
         "name": {
           "type": "string",
-          "description": "The friendly name of the grid editor, shown in the Umbraco backoffice"
+          "description": "The friendly name of the grid editor, shown in the backoffice."
         },
         "alias": {
           "type": "string",
-          "description": "This must be a unique alias to your grid editor"
+          "description": "This must be a unique alias to your grid editor."
         },
         "icon": {
           "type": "string",
-          "description": "A CSS class for the icon to be used in the 'Select Editor' dialog eg: icon-autofill"
+          "description": "A CSS class for the icon to be used in the 'Select Editor' dialog, e.g. `icon-autofill`."
         },
         "view": {
           "type": "string",
-          "description": "This is backoffice HTML view for your grid editor. Either refers to one of the built-in view (textstring, rte, embed, macro, media) or the full path to a custom view eg.: '~/App_Plugins/FolderName/editor.html'"
+          "description": "This is backoffice HTML view for your grid editor. Either refers to one of the built-in view (textstring, rte, embed, macro, media) or the full path to a custom view, e.g. `~/App_Plugins/FolderName/editor.html`."
         },
         "render": {
           "type": "string",
-          "description": "This is front end razor view for your grid editor. Accepts full path to a custom view eg.: '~/App_Plugins/FolderName/editor.cshtml"
+          "description": "This is front end Razor view for your grid editor. Accepts full path to a custom view, e.g. `~/App_Plugins/FolderName/editor.cshtml`."
         },
         "config": {
           "type": "object",
-          "description": "Configuration for the grid editor. Can be used with textstring and media views or for custom configuration properties",
+          "description": "Configuration for the grid editor. Can be used with textstring and media views or for custom configuration properties.",
           "minProperties": 1,
           "properties": {
             "style": {
               "type": "string",
-              "description": "If used with the textstring view this accepts inline css to style the textstring box eg.: font-size: 30px; line-height: 40px; font-weight: bold"
+              "description": "If used with the textstring view, this accepts inline CSS to style the textstring box, e.g. `font-size: 30px; line-height: 40px; font-weight: bold;`."
             },
             "markup": {
               "type": "string",
-              "description": "If used with the textstring view this allows wrapping the value in custom markup eg.: <h2>#value#</h2>"
+              "description": "If used with the textstring view, this allows wrapping the value in custom markup, e.g. `<h2>#value#</h2>`."
             },
             "size": {
               "type": "object",
-              "description": "If used with the media view this accepts hight and width key/value pairs for cropping",
+              "description": "If used with the media view, this accepts hight and width key/value pairs for cropping.",
               "properties": {
                 "height": {
                   "type": "integer",
-                  "description": "Height of image in pixels"
+                  "description": "Height of image in pixels."
                 },
                 "width": {
                   "type": "integer",
-                  "description": "Width of image in pixels"
+                  "description": "Width of image in pixels."
                 }
               }
             }
@@ -130,7 +131,7 @@
       "properties": {
         "prevalues": {
           "type": "object",
-          "description": "This is an object that stores an array of prevalue fields or options to configure your property editor",
+          "description": "This is an object that stores an array of prevalue fields or options to configure your property editor.",
           "properties": {
             "fields": {
               "$ref": "#/definitions/fields"
@@ -141,7 +142,7 @@
     },
     "fields": {
       "type": "array",
-      "description": "This is the collection of prevalue fields",
+      "description": "This is the collection of prevalue fields.",
       "minItems": 1,
       "items": {
         "type": "object",
@@ -149,20 +150,20 @@
         "properties": {
           "key": {
             "type": "string",
-            "description": "A unique key for the prevalue field",
+            "description": "A unique key for the prevalue field.",
             "minLength": 1
           },
           "label": {
             "type": "string",
-            "description": "The user friendly label for the prevalue"
+            "description": "The user friendly label for the prevalue."
           },
           "description": {
             "type": "string",
-            "description": "A more detailed description for the user"
+            "description": "A more detailed description for the user."
           },
           "view": {
             "type": "string",
-            "description": "The type of editor to use for this prevalue field"
+            "description": "The type of editor to use for this prevalue field."
           },
           "validation": {
             "type": "array",
@@ -179,24 +180,24 @@
       }
     },
     "dashboard": {
-      "description": "An Umbraco dashboard to display contextual information when in a section/application",
+      "description": "A dashboard to display contextual information when in a section/application.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["alias", "view", "sections"],
+      "required": [ "alias", "view", "sections" ],
       "properties": {
         "alias": {
           "type": "string",
-          "description": "The alias of the dashboard which can be queried via Dashboard Service API",
+          "description": "The alias of the dashboard which can be queried via the Dashboard Service API.",
           "minLength": 1
         },
         "view": {
           "type": "string",
-          "description": "This is the full path to the HTML view for your dashboard",
+          "description": "This is the full path to the HTML view for your dashboard.",
           "minLength": 1
         },
         "sections": {
           "type": "array",
-          "description": "A list of section/application aliases that the dashboard should be visible in",
+          "description": "A list of section/application aliases that the dashboard should be visible in.",
           "uniqueItems": true,
           "minItems": 1,
           "items": {
@@ -210,7 +211,7 @@
         },
         "access": {
           "type": "array",
-          "description": "A list of what user groups aliases are granted or denied permission to see the dashboard. This is optional. If not specified all users will have grant access",
+          "description": "A list of what user groups aliases are granted or denied permission to see the dashboard. All users will have access if not specified.",
           "uniqueItems": true,
           "minItems": 1,
           "items": {
@@ -218,19 +219,19 @@
             "properties": {
               "deny": {
                 "type": "string",
-                "description": "A user group alias who is denied access"
+                "description": "A user group alias who is denied access."
               },
               "grant": {
                 "type": "string",
-                "description": "A user group alias who is granted access"
+                "description": "A user group alias who is granted access."
               }
             },
             "oneOf": [
               {
-                "required": ["deny"]
+                "required": [ "deny" ]
               },
               {
-                "required": ["grant"]
+                "required": [ "grant" ]
               }
             ]
           }
@@ -238,63 +239,64 @@
       }
     },
     "section": {
-      "description": "An Umbraco section/application to extend the backoffice",
+      "description": "A section/application to extend the backoffice.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "alias"],
+      "required": [ "name", "alias" ],
       "properties": {
         "name": {
           "type": "string",
-          "description": "The friendly name of the section/application, shown in the Umbraco backoffice",
+          "description": "The friendly name of the section/application, shown in the backoffice.",
           "minLength": 1
         },
         "alias": {
           "type": "string",
-          "description": "The alias of the section/application which can be queried via Section Service API",
+          "description": "The alias of the section/application which can be queried via the Section Service API.",
           "minLength": 1
         }
       }
     },
     "contentApp": {
-      "description": "An Umbraco section/application to extend the backoffice",
+      "description": "A section/application to extend the backoffice.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "alias", "icon", "view"],
+      "required": [ "name", "alias", "icon", "view" ],
       "properties": {
         "name": {
           "type": "string",
-          "description": "The friendly name of the content app that appears under the icon",
+          "description": "The friendly name of the content app that appears under the icon.",
           "minLength": 1
         },
         "alias": {
           "type": "string",
-          "description": "A unique alias of the content app",
+          "description": "A unique alias of the content app.",
           "minLength": 1
         },
         "icon": {
           "type": "string",
-          "description": "A CSS class for the icon to be used for the content app eg: icon-calculator"
+          "description": "A CSS class for the icon to be used for the content app, e.g. `icon-calculator`."
         },
         "view": {
           "type": "string",
-          "description": "This is the full path to the HTML view for your content app"
+          "description": "This is the full path to the HTML view for your content app."
         },
         "weight": {
           "type": "integer",
-          "description": "The weight (sort order) of the content app. Default is 0, use values between -99 and +99 to appear between the existing Content (-100) and Info (100) apps"
+          "description": "The weight (sort order) of the content app. Default is 0, use values between -99 and +99 to appear between the existing Content (-100) and Info (100) apps."
         },
         "show": {
           "type": "array",
-          "description": "A list of rules to show or hide the content app based on content, media & member types",
+          "description": "A list of rules to show or hide the content app based on content, media and member types.",
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "description": "See documentation for example of rules https://our.umbraco.com/Documentation/Extending/Content-Apps/#limiting-according-to-type"
+            "description": "See documentation for examples of rules: https://our.umbraco.com/Documentation/Extending/Content-Apps/#limiting-according-to-type."
           }
         }
       }
     }
   },
+  "type": "object",
   "properties": {
     "id": {
       "type": "string",
@@ -319,17 +321,17 @@
     },
     "packageView": {
       "type": "string",
-      "description": "The full path to a HTML view for your package to help users maintain configuration data when viewing installed packages within Umbraco",
+      "description": "The full path to an HTML view for your package to help users maintain configuration data when viewing installed packages in the backoffice.",
       "minLength": 1
     },
     "bundleOptions": {
       "type": "string",
-      "description": "DEFAULT: The assets will be bundled with the typical packages bundle.  NONE: The assets in the package will not be processed at all and will all be requested as individual assets in debug and production.      INDEPENDENT: The packages assets will be processed as it's own separate bundle. (in debug, files will not be processed)",
-      "enum": ["Default", "None", "Independent"]
+      "description": "Default: The assets will be bundled with the typical packages bundle. None: The assets in the package will not be processed at all and will all be requested as individual assets in debug and production. Independent: The packages assets will be processed as it's own separate bundle (in debug, files will not be processed).",
+      "enum": [ "Default", "None", "Independent" ]
     },
     "javascript": {
       "type": "array",
-      "description": "A list of Javascript files with full path to load for your property editor",
+      "description": "A list of JavaScript files with full path to load in the backoffice.",
       "uniqueItems": true,
       "items": {
         "type": "string"
@@ -337,7 +339,7 @@
     },
     "css": {
       "type": "array",
-      "description": "A list of CSS files with full path to load for your property editor",
+      "description": "A list of CSS files with full path to load in the backoffice.",
       "uniqueItems": true,
       "items": {
         "type": "string"
@@ -376,7 +378,7 @@
     },
     "dashboards": {
       "type": "array",
-      "description": "V8: Returns an array of dashboards, each object specified a dashboard to make available in the backoffice.",
+      "description": "Returns an array of dashboards, each object specified a dashboard to make available in the backoffice.",
       "uniqueItems": true,
       "minItems": 1,
       "items": {
@@ -385,7 +387,7 @@
     },
     "sections": {
       "type": "array",
-      "description": "V8: Returns an array of sections/applications to add to the Umbraco backoffice.",
+      "description": "Returns an array of sections/applications to add to the backoffice.",
       "uniqueItems": true,
       "minItems": 1,
       "items": {
@@ -394,14 +396,12 @@
     },
     "contentApps": {
       "type": "array",
-      "description": "V8: Returns an array of Content Apps to add to the Umbraco backoffice.",
+      "description": "Returns an array of Content Apps to add to the backoffice.",
       "uniqueItems": true,
       "minItems": 1,
       "items": {
         "$ref": "#/definitions/contentApp"
       }
     }
-  },
-  "title": "A schema for Umbraco's package.manifest files.",
-  "type": "object"
+  }
 }


### PR DESCRIPTION
Umbraco 12 (final release targeted for June 29) adds support for 2 new properties in the `package.manifest`:
- `id` - https://github.com/umbraco/Umbraco-CMS/pull/14047
- `versionAssemblyName` - https://github.com/umbraco/Umbraco-CMS/pull/14046

I've added these properties to the JSON schema and updated other descriptions (the auto fixes moved the title back to the original place).