### PR TITLE
nest-cli: add `builder`, `typeCheck`

### DIFF
--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -15,10 +15,23 @@
           "description": "(monorepo only) Points at the file containing the tsconfig.json settings that will be used when nest build or nest start is called without a project option (e.g., when the default project is built or started). 'nest build' will not work as expected without this file.",
           "$comment": "https://github.com/nestjs/nest-cli/blob/master/lib/compiler/defaults/webpac-defaults.ts"
         },
+        "builder": {
+          "default": "tsc",
+          "type": "string",
+          "enum": ["tsc", "webpack", "swc"],
+          "description": "Builder to be used (tsc, webpack, swc). For details on how to configure `SWC` see https://docs.nestjs.com/recipes/swc#getting-started",
+          "$comment": "https://github.com/nestjs/nest-cli/blob/master/commands/build.command.ts"
+        },
+        "typeCheck": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, enable type checking (when SWC is used). See https://docs.nestjs.com/recipes/swc#type-checking for details.",
+          "$comment": "https://github.com/nestjs/nest-cli/blob/master/commands/build.command.ts"
+        },
         "webpack": {
           "default": false,
           "type": "boolean",
-          "description": "If true, use webpack compiler. If false or not present, use tsc. In monorepo mode, the default is true (use webpack), in standard mode, the default is false (use tsc). See https://docs.nestjs.com/cli/monorepo#cli-properties for details.",
+          "description": "If true, use webpack compiler (deprecated option, use `builder` instead). If false or not present, use tsc. In monorepo mode, the default is true (use webpack), in standard mode, the default is false (use tsc). See https://docs.nestjs.com/cli/monorepo#cli-properties for details.",
           "$comment": "https://github.com/nestjs/nest-cli/blob/master/commands/build.command.ts"
         },
         "webpackConfigPath": {

--- a/src/test/nest-cli/nest-cli.json
+++ b/src/test/nest-cli/nest-cli.json
@@ -1,7 +1,8 @@
 {
   "collection": "@nestjs/schematics",
   "compilerOptions": {
-    "webpack": true,
+    "builder": "swc",
+    "typeCheck": true,
     "tsConfigPath": "apps/my-project/tsconfig.app.json",
     "plugins": [
       {


### PR DESCRIPTION
This adds `builder` and `typeCheck` to `compilerOptions`, and deprecates the `webpack` property as well.

Not 100% sure on the updates for `webpack`, since for versions <10 it's a valid option and the new ones are not present. I understand this is a single source of truth so assuming too much can be misleading. Open to suggestions on how to handle that.

More info on the new properties:
- [Getting Started - SWC - NestJS Docs](https://docs.nestjs.com/recipes/swc#installation)
- `builder`: https://github.com/nestjs/nest-cli/commit/f958183dcc9d721cb365294e8465d3fc28140240#diff-98d7b6f4e6b2b8ab7587be8554ddd787aa21d24eb06f8fbec36a777083c0577eR93
- `typeCheck`: https://github.com/nestjs/nest-cli/commit/f958183dcc9d721cb365294e8465d3fc28140240#diff-98d7b6f4e6b2b8ab7587be8554ddd787aa21d24eb06f8fbec36a777083c0577eR160
- Deprecated `webpack`: https://github.com/nestjs/nest-cli/commit/f958183dcc9d721cb365294e8465d3fc28140240#diff-50d4a261e8cf91b9d15210fb0ceb896e2bdeb6c63101b3efd357e88f115f341bR17

