### PR TITLE
Create gocfl-info-1.0.json

### DIFF
--- a/src/schemas/json/gocfl-info-1.0.json
+++ b/src/schemas/json/gocfl-info-1.0.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/Info",
+  "$defs": {
+    "Info": {
+      "properties": {
+        "signature": {
+          "type": "string",
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "[a-zA-Z0-9/.-:-]+",
+          "title": "archival signature",
+          "description": "unique identifier within the archive system"
+        },
+        "organisation_id": {
+          "type": "string",
+          "pattern": "[a-zA-Z0-9/.-:-]+",
+          "title": "organisation identifier",
+          "description": "id or abbreviation of organisation responsible for the object"
+        },
+        "organisation": {
+          "type": "string",
+          "title": "organisation name",
+          "description": "name of organisation responsible for the object"
+        },
+        "collection_id": {
+          "type": "string",
+          "pattern": "[a-zA-Z0-9/._:-]+",
+          "title": "collection identifier",
+          "description": "id of collection the object belongs to"
+        },
+        "collection": {
+          "type": "string",
+          "title": "collection name",
+          "description": "name of collection the object belongs to"
+        },
+        "sets": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "title": "sets",
+          "description": "list of datasets object is belonging to"
+        },
+        "identifiers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "title": "identifiers",
+          "description": "list of identifiers"
+        },
+        "title": {
+          "type": "string",
+          "title": "title",
+          "description": "title of object"
+        },
+        "alternative_titles": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "title": "alternative titles",
+          "description": "list of alternative titles of this object or parts of it"
+        },
+        "description": {
+          "type": "string"
+        },
+        "keywords": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "user": {
+          "type": "string",
+          "title": "user",
+          "description": "name of person ingesting this object"
+        },
+        "address": {
+          "type": "string",
+          "title": "address",
+          "description": "adress of person ingesting this archive (email"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "title": "creation date",
+          "description": "date"
+        },
+        "last_changed": {
+          "type": "string",
+          "format": "date-time",
+          "title": "last changed",
+          "description": "date"
+        },
+        "deprecates": {
+          "type": "string",
+          "title": "deprecates",
+          "description": "signature of object"
+        },
+        "references": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "references",
+          "description": "list of signatures"
+        },
+        "ingest_workflow": {
+          "type": "string",
+          "title": "ingest workflow",
+          "description": "name of the workflow"
+        },
+        "additional": {
+          "type":["number","string","boolean","object","array", "null"],
+          "title": "additional data",
+          "description": "unstructured additional data"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "signature",
+        "organisation_id",
+        "organisation",
+        "title",
+        "user",
+        "address",
+        "created",
+        "last_changed"
+      ]
+    }
+  }
+}

--- a/src/schemas/json/gocfl-info-1.0.json
+++ b/src/schemas/json/gocfl-info-1.0.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$ref": "#/$defs/Info",
   "$defs": {
     "Info": {
       "properties": {
@@ -117,7 +115,7 @@
           "description": "name of the workflow"
         },
         "additional": {
-          "type":["number","string","boolean","object","array", "null"],
+          "type": ["number", "string", "boolean", "object", "array", "null"],
           "title": "additional data",
           "description": "unstructured additional data"
         }
@@ -135,5 +133,7 @@
         "last_changed"
       ]
     }
-  }
+  },
+  "$ref": "#/$defs/Info",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
 }


### PR DESCRIPTION
Schema for storing minimal semantic metadata in OCFL archive objects

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->
