### PR TITLE
Minecraft Trim Material Schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2472,6 +2472,13 @@
       "fileMatch": ["**/assets/*/textures/**/*.png.mcmeta"],
       "url": "https://json.schemastore.org/minecraft-texture-mcmeta.json"
     },
+
+    {
+      "name": "Minecraft Data Pack Trim Material",
+      "description": "Configuration file defining a trim material for a data pack for Minecraft.",
+      "fileMatch": ["**/data/*/trim_material/*.json"],
+      "url": "https://json.schemastore.org/minecraft-trim-material.json"
+    },
     {
       "name": "MkDocs Configuration 1.0",
       "description": "JSON schema for MkDocs configuration file",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2472,7 +2472,6 @@
       "fileMatch": ["**/assets/*/textures/**/*.png.mcmeta"],
       "url": "https://json.schemastore.org/minecraft-texture-mcmeta.json"
     },
-
     {
       "name": "Minecraft Data Pack Trim Material",
       "description": "Configuration file defining a trim material for a data pack for Minecraft.",

--- a/src/schemas/json/minecraft-trim-material.json
+++ b/src/schemas/json/minecraft-trim-material.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "A trim material for a Minecraft data pack config schema",
+  "properties": {
+    "asset_name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type":"string"
+        },
+        "translate": {
+          "type":"string"
+        }
+      },
+      "required": ["color", "translate"]
+    },
+    "ingredient": {
+      "type":"string"
+    },
+    "item_model_index": {
+      "type":"number"
+    }
+  },
+  "required": ["asset_name", "description", "ingredient", "item_model_index"],
+  "title": "Minecraft Data Pack Tag",
+  "type": "object"
+}

--- a/src/test/minecraft-trim-material/default.json
+++ b/src/test/minecraft-trim-material/default.json
@@ -1,0 +1,9 @@
+{
+  "asset_name": "dirt",
+  "description": {
+    "color": "#B4684D",
+    "translate": "trim_material.minecraft.dirt"
+  },
+  "ingredient": "minecraft:dirt",
+  "item_model_index": 0.5
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the lowest possible schema draft needed, preferably Draft v4.
JSON formatted according to the .editorconfig settings.

-->

All is in the title ^^

https://www.minecraft.net/en-us/article/minecraft-snapshot-23w04a
