### PR TITLE
Allow `uint8` as an unknown format for Ruff

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -699,7 +699,7 @@
       "pyproject.json": {
         "externalSchema": ["ruff.json"],
         "unknownKeywords": ["x-taplo", "x-taplo-info"],
-        "unknownFormat": ["uint", "int"]
+        "unknownFormat": ["uint8", "uint", "int"]
       }
     },
     {
@@ -709,7 +709,7 @@
     },
     {
       "ruff.json": {
-        "unknownFormat": ["uint", "int"]
+        "unknownFormat": ["uint8", "uint", "int"]
       }
     },
     {


### PR DESCRIPTION
It looks like the Rust JSON Schema generator will generate `uint8` for any fields marked with Rust's `uint8` type. We now have some such options -- I had to manually change them to `uint` in the last update. SchemaStore already marks `uint` as an unknown field, so it seems reasonable to add `uint8` here.