### PR TITLE
Adding schema for firebase.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1589,6 +1589,12 @@
       "url": "https://ffizer.github.io/ffizer/ffizer.schema.json"
     },
     {
+      "name": "firebase-json",
+      "description": "JSON schema for firebase.json files.",
+      "fileMatch": ["**/firebase.json"],
+      "url": "https://raw.githubusercontent.com/firebase/firebase-tools/master/schema/firebase-config.json"
+    },
+    {
       "name": "first-timers-bot",
       "description": "A bot that helps onboarding new open-source contributors.",
       "fileMatch": ["**/.github/first-timers.yml"],


### PR DESCRIPTION
Adds a schema for firebase.json. This is a config file used by [firebase-tools](https://www.npmjs.com/package/firebase-tools) to declare what should be deployed to a users Firebase project.

We maintain this schema in the firebase-tools repo since we generate it from our TS types & have tests to ensure that it stays up to date when contributors make changes and add new features.