### PR TITLE
Updating UTAM page object schema for v2.0.4

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3726,6 +3726,7 @@
       "url": "https://json.schemastore.org/utam-page-object.json",
       "versions": {
         "1.5.0": "https://json.schemastore.org/utam-page-object-1.5.0.json",
+        "2.0.3": "https://json.schemastore.org/utam-page-object-2.0.3.json",
         "current": "https://json.schemastore.org/utam-page-object.json"
       }
     },

--- a/src/negative_test/utam-page-object/invalid-element-type.utam.json
+++ b/src/negative_test/utam-page-object/invalid-element-type.utam.json
@@ -1,0 +1,20 @@
+{
+  "elements": [
+    {
+      "name": "menu",
+      "selector": {
+        "css": ".menu"
+      },
+      "elements": [
+        {
+          "public": true,
+          "name": "grammarMenuItem",
+          "selector": {
+            "css": "[data-navbar-id='grammar']"
+          },
+          "type": ["invalid"]
+        }
+      ]
+    }
+  ]
+}

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -188,6 +188,7 @@
     "up.json",
     "utam-page-object.json",
     "utam-page-object-1.5.0.json",
+    "utam-page-object-2.0.3.json",
     "vega-lite.json",
     "vs-nesting.json",
     "vsext.json",

--- a/src/schemas/json/utam-page-object-2.0.3.json
+++ b/src/schemas/json/utam-page-object-2.0.3.json
@@ -174,15 +174,17 @@
         },
         "type": {
           "type": ["string", "array"],
-          "items": {
-            "enum": [
-              "actionable",
-              "clickable",
-              "editable",
-              "draggable",
-              "touchable"
-            ]
-          }
+          "items": [
+            {
+              "enum": [
+                "actionable",
+                "clickable",
+                "editable",
+                "draggable",
+                "touchable"
+              ]
+            }
+          ]
         },
         "selector": {
           "$ref": "#/definitions/selector"
@@ -383,15 +385,17 @@
         },
         "returnType": {
           "type": ["string", "array"],
-          "items": {
-            "enum": [
-              "actionable",
-              "clickable",
-              "editable",
-              "draggable",
-              "touchable"
-            ]
-          }
+          "items": [
+            {
+              "enum": [
+                "actionable",
+                "clickable",
+                "editable",
+                "draggable",
+                "touchable"
+              ]
+            }
+          ]
         },
         "returnAll": {
           "type": "boolean",
@@ -642,15 +646,17 @@
     },
     "type": {
       "type": ["string", "array"],
-      "items": {
-        "enum": [
-          "actionable",
-          "clickable",
-          "editable",
-          "draggable",
-          "touchable"
-        ]
-      }
+      "items": [
+        {
+          "enum": [
+            "actionable",
+            "clickable",
+            "editable",
+            "draggable",
+            "touchable"
+          ]
+        }
+      ]
     },
     "shadow": {
       "type": "object",

--- a/src/test/utam-page-object/valid-page-object.utam.json
+++ b/src/test/utam-page-object/valid-page-object.utam.json
@@ -22,7 +22,7 @@
             },
             {
               "public": true,
-              "type": "clickable",
+              "type": ["clickable", "actionable"],
               "name": "menuItems",
               "selector": {
                 "css": "li",


### PR DESCRIPTION
Updating the UTAM page object JSON schema for UI Page Objects using the UI Test Automation Model to version 2.0.4
More information on the page object model here - https://utam.dev/	