### PR TITLE
Add UET BuildConfig.json schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4972,6 +4972,12 @@
       }
     },
     {
+      "name": "UET BuildConfig.json",
+      "description": "UET is an unofficial tool for Unreal Engine. The BuildConfig.json file allows you to specify how UET should build an Unreal Engine plugin, project or the engine itself.",
+      "fileMatch": ["BuildConfig.json"],
+      "url": "https://raw.githubusercontent.com/RedpointGames/uet-schema/main/root.json"
+    },
+    {
       "name": "Unreal Engine Uplugin",
       "description": "Unreal Engine plugin configuration file",
       "fileMatch": [".uplugin"],


### PR DESCRIPTION
This adds a catalog entry for UET's BuildConfig.json format. [UET](https://github.com/RedpointGames/uet) is an unofficial tool for building Unreal Engine plugins, projects and the engine itself.

The referenced schemas are automatically generated from the C# types and committed to the [UET schema repository](https://github.com/RedpointGames/uet-schema), so they are always up-to-date and correct.