### PR TITLE
Recommend draft-07 over draft-04

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
 
 Adding a JSON schema file to the catalog is required.
 Add tests files. (.json, .yml, .yaml or .toml)
-Use the lowest possible schema draft needed, preferably Draft v4.
+Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
 JSON formatted according to the .editorconfig settings.
 
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ After adding a schema file in `src/schemas`, register them in alphabetical order
 
 ### Best practices
 
-✔️ **Use** the lowest possible schema draft needed, preferably Draft v4, to ensure interoperability with as many supported editors, IDEs and parsers as possible.
+✔️ **Use** the most recent JSON Schema version (specified by `$schema`) that's widely supported by editors and IDEs. Currently, the best supported version is `draft-07`. Later versions of JSON Schema are not recommended for use in SchemaStore until editor/IDE support improves for those versions.
 
 ✔️ **Use** [`base.json`][base] schema for `draft-07` and [`base-04.json`][base-04] for `draft-04` with some common types for all schemas.
 
@@ -91,7 +91,7 @@ If you wish to retain full control over your schema definition, simply register 
 ### How to `$ref` from `schema_x.json` to `schema_y.json`
 
 - Both schemas must exist [locally](src/schemas/json) in SchemaStore.
-- Both schemas must have the same draft (example draft-04)
+- Both schemas must have the same draft (example draft-07)
 - `schema_y.json` must have `id` or `$id` with this value `"https://json.schemastore.org/schema_y.json"`
 - In `schema_x.json`, add ref to `schema_y.json`: `"$ref": "https://json.schemastore.org/schema_y.json#..."`
 - In [schema-validation.json](src/schema-validation.json), in `"options": []` list add


### PR DESCRIPTION
This is the easy fix for https://github.com/SchemaStore/schemastore/issues/2427. We also discussed a more involved solution involving using [AlterSchema](https://github.com/sourcemeta/alterschema) to provide whatever version the consumer requires regardless of what version is used in SchemaStore. This is not that. This is just changing the recommendation from draft-04 to draft-07 as the version currently best supported by editors and IDEs.

Other than recommending draft-07, I also changed the advice from using the oldest version to using the most recent well supported version. To summarize the discussion in the issue, recommending the oldest version is not the best way to ensure the widest interoperability because older versions are not compatible with new versions and there is a trend of implementations dropping support for older versions.