### PR TITLE
Added an updated version of the SDF schema to the schema store.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3311,7 +3311,11 @@
       "name": "Semantic Data Fabric (SDF) file",
       "description": "The schema definition for all available SDF blocks",
       "fileMatch": ["*.sdf.yml"],
-      "url": "https://cdn.sdf.com/schemas/sdf-schema-1.0.json"
+      "url": "https://cdn.sdf.com/schemas/sdf-schema-1.1.json",
+      "versions": {
+        "1.0": "https://cdn.sdf.com/schemas/sdf-schema-1.0.json",
+        "1.1": "https://cdn.sdf.com/schemas/sdf-schema-1.1.json"
+      }
     },
     {
       "name": "semantic-release",


### PR DESCRIPTION
Hello,
  In this PR are 2 changes. First, a 'versions' section for SDF since there are now multiple versions of the SDF schema. Second, an updated reference to the primary schema (now 1.1). 
