### PR TITLE
Rename Cargo.toml to "Cargo Manifest"

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -758,8 +758,8 @@
       }
     },
     {
-      "name": "Cargo Config Schema",
-      "description": "Configuration for Cargo, the Rust package manager and build tool",
+      "name": "Cargo Manifest",
+      "description": "Manifest for Cargo, the Rust package manager and build tool",
       "fileMatch": ["Cargo.toml"],
       "url": "https://json.schemastore.org/cargo.json"
     },


### PR DESCRIPTION
See upstream references: [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) vs [configuration](https://doc.rust-lang.org/cargo/reference/config.html).

It was a bit of a misnomer to call this "Cargo config", which is actually a different schema than what `cargo.json` represents (the manifest).

If configuration is added later, it could probably be called `cargo-config.json` or something, and titled correctly as e.g. `Cargo configuration`.
