### PR TITLE
pants: make 2.16 the default schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5009,7 +5009,7 @@
       "name": "Pantsbuild",
       "description": "Pantsbuild configuration file",
       "fileMatch": ["pants*.toml"],
-      "url": "https://json.schemastore.org/pantsbuild-2.15.0.json",
+      "url": "https://json.schemastore.org/pantsbuild-2.16.0.json",
       "versions": {
         "2.14.0": "https://json.schemastore.org/pantsbuild-2.14.0.json",
         "2.15.0": "https://json.schemastore.org/pantsbuild-2.15.0.json",


### PR DESCRIPTION
Making the 2.16 the latest and the default schema