### PR TITLE
fix safebox filematch pattern

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4903,7 +4903,7 @@
     {
       "name": "Safebox Config Schema",
       "description": "Schema for https://github.com/monebag/safebox",
-      "fileMatch": ["*safebox*.yaml"],
+      "fileMatch": ["*safebox*.yaml", "*safebox*.yml"],
       "url": "https://json.schemastore.org/safebox-schema-v1.0.0.json"
     },
     {


### PR DESCRIPTION
fixed the filematch pattern for safebox to include both `yml` and `yaml` extensions
