### PR TITLE
fix: PyProject allow arbitrary `optional-dependencies`

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -974,7 +974,6 @@
           "title": "Project extra dependency requirements",
           "description": "keys are extra names",
           "type": "object",
-          "additionalProperties": false,
           "patternProperties": {
             "^([a-z\\d]|[a-z\\d]([a-z\\d-](?!--))*[a-z\\d])$": {
               "type": "array",

--- a/src/test/pyproject/3021.toml
+++ b/src/test/pyproject/3021.toml
@@ -1,0 +1,6 @@
+[project]
+name = "project"
+version = "0.1.0"
+
+[project.optional-dependencies]
+DEV = ["pytest"]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Fixes #3021
