### PR TITLE
Improve env consistency of GitHub Actions and Workflow

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -6,7 +6,12 @@
     "expressionSyntax": {
       "type": "string",
       "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
-      "pattern": "^\\$\\{\\{.*\\}\\}$"
+      "pattern": "^\\$\\{\\{(.|[\r\n])*\\}\\}$"
+    },
+    "stringContainingExpressionSyntax": {
+      "type": "string",
+      "$comment": "escape `{` and `}` in pattern to be unicode compatible (#1360)",
+      "pattern": "^.*\\$\\{\\{(.|[\r\n])*\\}\\}.*$"
     },
     "pre-if": {
       "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#pre-if",
@@ -180,10 +185,27 @@
         "env": {
           "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsenv",
           "description": "Specifies a key/value map of environment variables to set in the container environment.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/stringContainingExpressionSyntax"
+            }
+          ]
         },
         "entrypoint": {
           "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsentrypoint",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

According to the issue, there was a mismatch between documentation - one section was a bit more vague than the other. So even though we typically don't write schemas for "undocumented things", a similar key is documented in another place, and people are migrating between formats so it only makes sense to make them compatible.

Closes #3045
Closes #2935 (resolved; issue for another project)
Closes #2878 (resolved / duplicate of 2427)