### PR TITLE
fix: Allow `patch.options` in Kustomization schema

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -12,7 +12,11 @@
           "type": "array"
         },
         "behavior": {
-          "enum": ["create", "replace", "merge"]
+          "enum": [
+            "create",
+            "replace",
+            "merge"
+          ]
         },
         "env": {
           "description": "Deprecated.  Use envs instead.",
@@ -147,7 +151,11 @@
         },
         "valuesMerge": {
           "type": "string",
-          "enum": ["merge", "override", "replace"]
+          "enum": [
+            "merge",
+            "override",
+            "replace"
+          ]
         },
         "includeCRDs": {
           "type": "boolean"
@@ -525,7 +533,10 @@
     "PatchJson6902": {
       "oneOf": [
         {
-          "required": ["path", "target"],
+          "required": [
+            "path",
+            "target"
+          ],
           "properties": {
             "path": {
               "description": "relative file path for a json patch file inside a kustomization",
@@ -540,7 +551,10 @@
           "type": "object"
         },
         {
-          "required": ["patch", "target"],
+          "required": [
+            "patch",
+            "target"
+          ],
           "properties": {
             "patch": {
               "description": "inline json patch",
@@ -555,12 +569,22 @@
           "type": "object"
         },
         {
-          "required": ["op", "path"],
+          "required": [
+            "op",
+            "path"
+          ],
           "properties": {
             "op": {
               "description": "The operation",
               "type": "string",
-              "enum": ["add", "remove", "replace", "move", "copy", "test"]
+              "enum": [
+                "add",
+                "remove",
+                "replace",
+                "move",
+                "copy",
+                "test"
+              ]
             },
             "from": {
               "description": "The source location.",
@@ -590,7 +614,11 @@
       ]
     },
     "PatchTarget": {
-      "required": ["kind", "name", "version"],
+      "required": [
+        "kind",
+        "name",
+        "version"
+      ],
       "properties": {
         "group": {
           "type": "string"
@@ -638,9 +666,26 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "PatchesPatchPath": {
-      "required": ["path"],
+    "PatchesOptions": {
       "properties": {
+        "allowNameChange": {
+          "type": "boolean"
+        },
+        "allowKindChange": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PatchesPatchPath": {
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "options": {
+          "$ref": "#/definitions/PatchesOptions"
+        },
         "path": {
           "type": "string"
         },
@@ -652,8 +697,13 @@
       "additionalProperties": false
     },
     "PatchesInlinePatch": {
-      "required": ["patch"],
+      "required": [
+        "patch"
+      ],
       "properties": {
+        "options": {
+          "$ref": "#/definitions/PatchesOptions"
+        },
         "patch": {
           "type": "string"
         },
@@ -665,7 +715,10 @@
       "additionalProperties": false
     },
     "ReplacementsInline": {
-      "required": ["source", "targets"],
+      "required": [
+        "source",
+        "targets"
+      ],
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -717,7 +770,9 @@
           "description": "The N fields to write the value to",
           "type": "array",
           "items": {
-            "required": ["select"],
+            "required": [
+              "select"
+            ],
             "type": "object",
             "properties": {
               "select": {
@@ -804,7 +859,9 @@
       }
     },
     "ReplacementsPath": {
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -835,7 +892,11 @@
           "type": "array"
         },
         "behavior": {
-          "enum": ["create", "replace", "merge"]
+          "enum": [
+            "create",
+            "replace",
+            "merge"
+          ]
         },
         "env": {
           "type": "string"
@@ -878,7 +939,9 @@
       "type": "object"
     },
     "Target": {
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "apiVersion": {
           "type": "string"
@@ -901,7 +964,10 @@
     },
     "Var": {
       "description": "Represents a variable whose value will be sourced from a field in a Kubernetes object.",
-      "required": ["name", "objref"],
+      "required": [
+        "name",
+        "objref"
+      ],
       "properties": {
         "fieldref": {
           "description": "Refers to the field of the object referred to by objref whose value will be extracted for use in replacing $(FOO)",

--- a/src/test/kustomization/2994.yml
+++ b/src/test/kustomization/2994.yml
@@ -1,0 +1,9 @@
+resources:
+- deployment.yaml
+patches:
+- path: patch.yaml
+  target:
+    kind: Deployment
+  options:
+    allowNameChange: true
+    allowKindChange: true


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Closes #2994