### PR TITLE
fix: not allowed `$schema` in djlint configuration

### DIFF
--- a/src/schemas/json/djlint.json
+++ b/src/schemas/json/djlint.json
@@ -2,6 +2,7 @@
   "$comment": "Source: https://www.djlint.com/docs/configuration",
   "$id": "https://json.schemastore.org/djlint.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
   "default": {
     "format_attribute_template_tags": false,
     "profile": "html"
@@ -14,7 +15,11 @@
       "type": "object"
     }
   },
+  "description": "JSON schema fcor djLint's configuration file",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "blank_line_after_tag": {
       "type": "string"
     },
@@ -127,8 +132,6 @@
       "type": "boolean"
     }
   },
-  "additionalProperties": false,
   "title": "djlint schema",
-  "description": "JSON schema for djLint's configuration file",
   "type": "object"
 }

--- a/src/test/djlint/.djlintrc.json
+++ b/src/test/djlint/.djlintrc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./djlint.json",
   "blank_line_after_tag": "load,extends,include",
   "blank_line_before_tag": "load,extends,include",
   "close_void_tags": true,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->


* sorting the `src/schemas/json/djlint.json` file
* add `$schema` field to fix not allowed message
