### PR TITLE
chore: Update Prettier

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-promise": "^6.1.1",
         "find-duplicated-property-keys": "^1.2.9",
         "grunt": "^1.6.0",
-        "prettier": "^2.8.3",
+        "prettier": "^3.0.0",
         "prettier-plugin-sort-json": "^1.0.0",
         "tv4": "^1.3.0",
         "yaml": "^2.2.1"
@@ -3160,15 +3160,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/src/package.json
+++ b/src/package.json
@@ -17,6 +17,11 @@
     "url": "https://github.com/schemastore/SchemaStore"
   },
   "type": "commonjs",
+  "overrides": {
+    "prettier-plugin-sort-json": {
+      "prettier": "^3.0.0"
+    }
+  },
   "scripts": {
     "build": "npm run eslint_check && grunt && ./scripts/dirty_repository_check.sh",
     "eslint_check": "eslint Gruntfile.cjs",
@@ -41,7 +46,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "find-duplicated-property-keys": "^1.2.9",
     "grunt": "^1.6.0",
-    "prettier": "^2.8.3",
+    "prettier": "^3.0.0",
     "prettier-plugin-sort-json": "^1.0.0",
     "tv4": "^1.3.0",
     "yaml": "^2.2.1"


### PR DESCRIPTION
Updates local prettier to match one in [.pre-commit-config.yaml](https://github.com/SchemaStore/schemastore/blob/master/.pre-commit-config.yaml)


CI seems to be working for other people, but [not me](https://github.com/SchemaStore/schemastore/pull/3071). It might be possible that everything needs to be reverted back to 2.7 since prettier-plugin-sort-json claims to only be compatible with 2.x