### PR TITLE
ci: Fix Prettier version and plugins to known working versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.0"
+    rev: "v2.7.1"
     hooks:
       - id: prettier
         types_or: [yaml, json, javascript, css, markdown]
         always_run: true
         additional_dependencies:
-          - prettier
-          - prettier-plugin-sort-json
+          - prettier@2.8.3
+          - prettier-plugin-sort-json@1.0.0

--- a/src/.prettierrc.json
+++ b/src/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "semi": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "all"
 }

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -3,12 +3,7 @@
 }
 
 body {
-  font:
-    18px/1.5 'Segoe UI',
-    'Segoe WP Light',
-    'Segoe WP',
-    Tahoma,
-    Arial,
+  font: 18px/1.5 'Segoe UI', 'Segoe WP Light', 'Segoe WP', Tahoma, Arial,
     sans-serif;
   margin: 0;
   background: white;

--- a/src/schemas/json/vtesttree-schema.json
+++ b/src/schemas/json/vtesttree-schema.json
@@ -1,8 +1,6 @@
 {
-  "type": "object",
   "$ref": "#/definitions/51e8/full",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Json schema for vtesttree.yaml files.",
   "definitions": {
     "51e8": {
       "full": {
@@ -307,5 +305,7 @@
         ]
       }
     }
-  }
+  },
+  "title": "Json schema for vtesttree.yaml files.",
+  "type": "object"
 }


### PR DESCRIPTION
In the process of making other PRs, I noticed CI was acting funny. I [tried to](https://github.com/SchemaStore/schemastore/pull/3083) fix things by updating the local version of prettier in `package.json` to `v3.0.0`, but that didn't make CI pass (even though I ran `lint-staged` locally and everything worked).

Issues might be related to the new release of Prettier v3.0.0 - our `prettier-plugin-sort-json` doesn't explicitly say it's compatible with the newer version (it hasn't been updated in a while). It makes sense since `vtestschema-json` is properly sorted once we go back to v2.7. This commit pins versions to known old versions that still work, we can always update later.

Prettier changes the default of `trailingComma` to  `all`. Since it appears that things have already been formatted, keep that setting to prevent reverting unnecessary to older formatting.