### PR TITLE
Update mkdocs-1.0.json: allow null theme name

### DIFF
--- a/src/schemas/json/mkdocs-1.0.json
+++ b/src/schemas/json/mkdocs-1.0.json
@@ -80,8 +80,8 @@
               "properties": {
                 "name": {
                   "default": "mkdocs",
-                  "description": "The string name of a known installed theme.",
-                  "type": "string"
+                  "description": "The string name of a known installed theme, or null if using a local custom theme.",
+                  "type": ["string", "null"]
                 },
                 "locale": {
                   "default": "en",

--- a/src/test/mkdocs-1.0/custom-theme-test.yml
+++ b/src/test/mkdocs-1.0/custom-theme-test.yml
@@ -1,4 +1,4 @@
 site_name: Docs With Custom Theme
 theme:
-    name: null
-    custom_dir: 'custom_theme/'
+  name: null
+  custom_dir: 'custom_theme/'

--- a/src/test/mkdocs-1.0/custom-theme-test.yml
+++ b/src/test/mkdocs-1.0/custom-theme-test.yml
@@ -1,0 +1,4 @@
+site_name: Docs With Custom Theme
+theme:
+    name: null
+    custom_dir: 'custom_theme/'


### PR DESCRIPTION
Theme name can be null if custom_dir is set as per https://www.mkdocs.org/dev-guide/themes/
