### PR TITLE
fix: Allow `patch.options` for Kustomization schema

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -638,9 +638,24 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "PatchesOptions": {
+      "properties": {
+        "allowNameChange": {
+          "type": "boolean"
+        },
+        "allowKindChange": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "PatchesPatchPath": {
       "required": ["path"],
       "properties": {
+        "options": {
+          "$ref": "#/definitions/PatchesOptions"
+        },
         "path": {
           "type": "string"
         },
@@ -654,6 +669,9 @@
     "PatchesInlinePatch": {
       "required": ["patch"],
       "properties": {
+        "options": {
+          "$ref": "#/definitions/PatchesOptions"
+        },
         "patch": {
           "type": "string"
         },

--- a/src/test/kustomization/2994.yml
+++ b/src/test/kustomization/2994.yml
@@ -1,0 +1,9 @@
+resources:
+  - deployment.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: Deployment
+    options:
+      allowNameChange: true
+      allowKindChange: true


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
