### PR TITLE
feat: Opt-in Integration of SchemaSafe

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache 2.0",
       "devDependencies": {
+        "@exodus/schemasafe": "^1.1.1",
         "@ltd/j-toml": "^1.38.0",
         "ajv": "^8.12.0",
         "ajv-draft-04": "^1.0.0",
@@ -82,6 +83,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/@exodus/schemasafe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.1.1.tgz",
+      "integrity": "sha512-Pd7+aGvWIaTDL5ecV4ZBEtBrjXnk8/ly5xyHbikxVhgcq7qhihzHWHbcYmFupQBT2A5ggNZGvT7Bpj0M6AKHjA==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/src/package.json
+++ b/src/package.json
@@ -26,6 +26,7 @@
     "coverage": "./scripts/coverage.sh"
   },
   "devDependencies": {
+    "@exodus/schemasafe": "^1.1.1",
     "@ltd/j-toml": "^1.38.0",
     "ajv": "^8.12.0",
     "ajv-draft-04": "^1.0.0",


### PR DESCRIPTION
This is the first step in addressing #3102. SchemaSafe lints are opt-in (pass the `--lint` flag) because I don't think it would be good to confuse newer contributors (that contribute schemas) with hundreds of lines of unrelated output when they run their tests. It might be worth investigating a `schema-validation.json['ajvNotStrictMode']`-like option, or just using a codemod/regexes to fix all issues alltogether.