### PR TITLE
Fix `language` key for LazyGit

### DIFF
--- a/src/schemas/json/lazygit.json
+++ b/src/schemas/json/lazygit.json
@@ -104,7 +104,7 @@
           "title": "language",
           "description": "A language\nhttps://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#default",
           "type": "string",
-          "enum": ["auto", "en", "zh", "pl", "nl", "ja", "ko", "ru"],
+          "enum": ["auto", "en", "zh-CN", "zh-TW", "pl", "nl", "ja", "ko", "ru"],
           "default": "auto"
         },
         "timeFormat": {

--- a/src/schemas/json/lazygit.json
+++ b/src/schemas/json/lazygit.json
@@ -104,7 +104,17 @@
           "title": "language",
           "description": "A language\nhttps://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#default",
           "type": "string",
-          "enum": ["auto", "en", "zh-CN", "zh-TW", "pl", "nl", "ja", "ko", "ru"],
+          "enum": [
+            "auto",
+            "en",
+            "zh-CN",
+            "zh-TW",
+            "pl",
+            "nl",
+            "ja",
+            "ko",
+            "ru"
+          ],
           "default": "auto"
         },
         "timeFormat": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Fixes issue referred in [this](https://github.com/SchemaStore/schemastore/pull/3121#issuecomment-1667334934) comment.