### PR TITLE
fix: Upgrade usages of `draft-03` and `draft-06`

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -973,8 +973,6 @@
   ],
   "skiptest": [
     "---> Add JSON schema to skiptest[] to skip the whole validation process <---",
-    "---> ninjs-1.0.json use 'draft-03' is not supported by validator <---",
-    "ninjs-1.0.json",
     "---> below this line are schemas that _were) checked with tv4, but have not yet been fixed to validate under AJV <---",
     "cloudify.json",
     "tslint.json",

--- a/src/schemas/json/asmdef.json
+++ b/src/schemas/json/asmdef.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
       "properties": {

--- a/src/schemas/json/avro-avsc.json
+++ b/src/schemas/json/avro-avsc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "avroSchema": {
       "title": "Avro Schema",

--- a/src/schemas/json/install.json
+++ b/src/schemas/json/install.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "src": {
       "type": "string",

--- a/src/schemas/json/ninjs-1.0.json
+++ b/src/schemas/json/ninjs-1.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-03/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "description": "A news item as JSON object -- copyright 2013 IPTC - International Press Telecommunications Council - www.iptc.org - This document is published under the Creative Commons Attribution 3.0 license, see  http://creativecommons.org/licenses/by/3.0/  $$comment: as of 2013-11-07, edited by MS for the IPTC ninjs-dev group ",
   "id": "http://www.iptc.org/std/ninjs/ninjs-schema_1.0.json#",
@@ -17,8 +17,7 @@
     "uri": {
       "description": "The identifier for this news object",
       "type": "string",
-      "format": "uri",
-      "required": true
+      "format": "uri"
     },
     "type": {
       "description": "The generic news type of this news object",
@@ -311,6 +310,7 @@
       }
     }
   },
+  "required": ["uri"],
   "title": "IPTC ninjs - News in JSON - version 1.0 (approved on 23 October 2013)",
   "type": "object"
 }

--- a/src/schemas/json/one-service-descriptor-schema-0.1.json
+++ b/src/schemas/json/one-service-descriptor-schema-0.1.json
@@ -1,6 +1,6 @@
 {
   "$ref": "#/definitions/ServiceDescriptor",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "ServiceDescriptor": {
       "type": "object",

--- a/src/schemas/json/petstore-v1.0.json
+++ b/src/schemas/json/petstore-v1.0.json
@@ -1,6 +1,6 @@
 {
   "$ref": "#/definitions/Welcome9",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Welcome9": {
       "type": "object",

--- a/src/schemas/json/up.json
+++ b/src/schemas/json/up.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "name": {
       "type": "string",

--- a/src/test/petstore-v1.0/petstore.json
+++ b/src/test/petstore-v1.0/petstore.json
@@ -1,6 +1,6 @@
 {
   "$ref": "#/definitions/Welcome9",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Welcome9": {
       "type": "object",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Dealing with a smaller set of JSON Schema versions will make it easier to tackle #2427. When using downgrading (or upgrading) schemas, there is a smaller set of schemas to transform from/to.
