### PR TITLE
Basic support for lazydocker

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5147,13 +5147,13 @@
       "url": "https://json.schemastore.org/micro-syntax.json"
     },
     {
-      "name": "config.yml",
+      "name": "lazygit",
       "description": "Lazy Git settings",
       "url": "https://json.schemastore.org/lazygit.json",
       "fileMatch": ["**/lazygit/config.yml"]
     },
     {
-      "name": "config.yml",
+      "name": "lazydocker",
       "description": "Lazy Docker settings",
       "url": "https://json.schemastore.org/lazydocker.json",
       "fileMatch": ["**/lazydocker/config.yml"]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5151,6 +5151,12 @@
       "description": "Lazy Git settings",
       "url": "https://json.schemastore.org/lazygit.json",
       "fileMatch": ["**/lazygit/config.yml"]
+    },
+    {
+      "name": "config.yml",
+      "description": "Lazy Docker settings",
+      "url": "https://json.schemastore.org/lazydocker.json",
+      "fileMatch": ["**/lazydocker/config.yml"]
     }
   ],
   "version": 1

--- a/src/schemas/json/lazydocker.json
+++ b/src/schemas/json/lazydocker.json
@@ -1,0 +1,441 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "color": {
+      "type": "string",
+      "oneOf": [
+        {
+          "enum": [
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "magenta",
+            "cyan",
+            "white",
+            "bold",
+            "default",
+            "reverse",
+            "underline",
+            "strikethrough"
+          ]
+        },
+        {
+          "pattern": "^#[0-9a-fA-F]{6}$",
+          "examples": [
+            "#ff00ff"
+          ]
+        }
+      ]
+    }
+  },
+  "description": "Settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+  "properties": {
+    "gui": {
+      "title": "gui",
+      "description": "UI settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+      "type": "object",
+      "properties": {
+        "scrollHeight": {
+          "title": "scroll height",
+          "description": "A scroll height\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "integer",
+          "minimum": 1,
+          "default": 2
+        },
+        "language": {
+          "title": "language",
+          "description": "A language\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "enum": [
+            "auto",
+            "en",
+            "pl",
+            "nl",
+            "de",
+            "tr"
+          ],
+          "default": "auto"
+        },
+        "theme": {
+          "title": "theme",
+          "description": "Theme settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "object",
+          "properties": {
+            "activeBorderColor": {
+              "title": "active border color",
+              "description": "An active border color\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+              "type": "array",
+              "uniqueItems": true,
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/color"
+              }
+            },
+            "inactiveBorderColor": {
+              "title": "inactive border color",
+              "description": "An inactive border color\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+              "type": "array",
+              "uniqueItems": true,
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/color"
+              }
+            },
+            "selectedLineBgColor": {
+              "title": "selected line background color",
+              "description": "A selected line background color\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+              "type": "array",
+              "uniqueItems": true,
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/color"
+              }
+            },
+            "optionsTextColor": {
+              "title": "options text color",
+              "description": "An option text color\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+              "type": "array",
+              "uniqueItems": true,
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/color"
+              }
+            }
+          }
+        },
+        "returnImmediately": {
+          "title": "return immediately",
+          "description": "Whether to return immediately\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "boolean",
+          "default": false
+        },
+        "wrapMainPanel": {
+          "title": "wrap main panel",
+          "description": "Whether to wrap main panel\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "boolean",
+          "default": true
+        },
+        "sidePanelWidth": {
+          "title": "side panel width",
+          "description": "A side panel ratio of screen's width\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "number",
+          "minimum": 0,
+          "default": 0.333
+        },
+        "showBottomLine": {
+          "title": "show bottom line",
+          "description": "Whether to show bottom line\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "boolean",
+          "default": true
+        },
+        "expandFocusedSidePanel": {
+          "title": "expand focused side panel",
+          "description": "Whether to expand focused side panel\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "boolean",
+          "default": false
+        },
+        "screenMode": {
+          "title": "screen mode",
+          "description": "A screen mode\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "enum": [
+            "normal",
+            "half",
+            "fullscreen"
+          ],
+          "default": "normal"
+        },
+        "containerStatusHealthStyle": {
+          "title": "container status health style",
+          "description": "A style of container status and it's health display\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "enum": [
+            "long",
+            "short",
+            "icon"
+          ],
+          "default": "long"
+        }
+      }
+    },
+    "logs": {
+      "title": "logs",
+      "description": "Log settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+      "type": "object",
+      "properties": {
+        "timestamps": {
+          "title": "timestamps",
+          "description": "Whether to show timestamps\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "boolean",
+          "default": false
+        },
+        "since": {
+          "title": "since",
+          "description": "A start time\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "60m"
+        },
+        "tail": {
+          "title": "tail",
+          "description": "A last line count\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer",
+              "minimum": 0,
+              "examples": [
+                200
+              ]
+            }
+          ],
+          "default": ""
+        }
+      }
+    },
+    "commandTemplates": {
+      "title": "command templates",
+      "description": "Command templates\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+      "type": "object",
+      "properties": {
+        "dockerCompose": {
+          "title": "docker compose",
+          "description": "A docker compose command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "docker-compose"
+        },
+        "restartService": {
+          "title": "restart service",
+          "description": "A restart service command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} restart {{ .Service.Name }}"
+        },
+        "up": {
+          "title": "up",
+          "description": "An up command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} up -d"
+        },
+        "down": {
+          "title": "down",
+          "description": "A down command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} down"
+        },
+        "downWithVolumes": {
+          "title": "down with volumes",
+          "description": "A down with volumes command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} down --volumes"
+        },
+        "upService": {
+          "title": "up service",
+          "description": "An up service command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} up -d {{ .Service.Name }}"
+        },
+        "startService": {
+          "title": "start service",
+          "description": "A start service command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} start {{ .Service.Name }}"
+        },
+        "stopService": {
+          "title": "stop service",
+          "description": "A stop service command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} stop {{ .Service.Name }}"
+        },
+        "serviceLogs": {
+          "title": "service logs",
+          "description": "A service logs command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} logs --since=60m --follow {{ .Service.Name }}"
+        },
+        "viewServiceLogs": {
+          "title": "view service logs",
+          "description": "A view service logs command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} logs --follow {{ .Service.Name }}"
+        },
+        "rebuildService": {
+          "title": "rebuild service",
+          "description": "A rebuild service command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} up -d --build {{ .Service.Name }}"
+        },
+        "recreateService": {
+          "title": "recreate service",
+          "description": "A recreate service command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} up -d --force-recreate {{ .Service.Name }}"
+        },
+        "allLogs": {
+          "title": "all logs",
+          "description": "An all logs command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} logs --tail=300 --follow"
+        },
+        "viewAlLogs": {
+          "title": "view al logs",
+          "description": "A view al logs command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} logs"
+        },
+        "dockerComposeConfig": {
+          "title": "docker compose config",
+          "description": "A docker compose config command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} config"
+        },
+        "checkDockerComposeConfig": {
+          "title": "check docker compose config",
+          "description": "A check docker compose config command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} config --quiet"
+        },
+        "serviceTop": {
+          "title": "service top",
+          "description": "A service top command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "{{ .DockerCompose }} top {{ .Service.Name }}"
+        }
+      }
+    },
+    "os": {
+      "title": "os",
+      "description": "OS settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+      "type": "object",
+      "properties": {
+        "openCommand": {
+          "title": "open command",
+          "description": "An open command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "open {{filename}}"
+        },
+        "openLinkCommand": {
+          "title": "open link command",
+          "description": "An open link command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "string",
+          "default": "open {{link}}"
+        }
+      }
+    },
+    "stats": {
+      "title": "stats",
+      "description": "Statistic settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+      "type": "object",
+      "properties": {
+        "graphs": {
+          "title": "graphs",
+          "description": "Graph settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "caption": {
+                "title": "caption",
+                "description": "A caption\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+                "type": "string",
+                "examples": [
+                  "CPU (%)"
+                ]
+              },
+              "statPath": {
+                "title": "stat path",
+                "description": "A path\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+                "type": "string",
+                "examples": [
+                  "DerivedStats.CPUPercentage"
+                ]
+              },
+              "color": {
+                "title": "color",
+                "description": "A color\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+                "$ref": "#/definitions/color"
+              }
+            }
+          }
+        }
+      }
+    },
+    "customCommands": {
+      "title": "custom commands",
+      "description": "Custom commands\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+      "type": "object",
+      "properties": {
+        "containers": {
+          "title": "containers",
+          "description": "Container settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "title": "name",
+                "description": "A name\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+                "type": "string",
+                "examples": [
+                  "bash"
+                ]
+              },
+              "attach": {
+                "title": "attach",
+                "description": "Whether to attach\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+                "type": "boolean"
+              },
+              "command": {
+                "title": "command",
+                "description": "A command\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+                "type": "string",
+                "examples": [
+                  "docker exec -it {{ .Container.ID }} bash"
+                ]
+              },
+              "serviceNames": {
+                "title": "service names",
+                "description": "Service names\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "description": "A service name\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+                  "type": "string"
+                },
+                "default": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "replacements": {
+      "title": "replacements",
+      "description": "Replacement settings\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+      "type": "object",
+      "patternProperties": {
+        ".": {
+          "title": "replacement group",
+          "description": "A replacement group\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "title": "replacement",
+              "description": "A replacement\nhttps://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md#default",
+              "type": "string",
+              "examples": [
+                "<dev>",
+                "<prod>"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "title": "ui settings",
+  "type": "object"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Note that not all properties are supported now, just those mentioned [here](https://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md) directly. For that reason, no `"additionalProperties": false` appear.