### PR TITLE
feat(schema): Bump minecraft pack mcmeta format version from 12 to 15

### DIFF
--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -17,7 +17,7 @@
           "description": "A version for the current pack\nhttps://minecraft.fandom.com/wiki/Data_pack#Contents",
           "type": "integer",
           "minimum": 4,
-          "maximum": 12,
+          "maximum": 15,
           "default": 4
         }
       },


### PR DESCRIPTION
Hello.

Minecraft 1.20.1 was recently released, and the `pack_format` values in [this schema](https://github.com/SchemaStore/schemastore/blob/90e82345e3a8cd34badd10029d6ca76569de8c1c/src/schemas/json/minecraft-pack-mcmeta.json#L20) were extended accordingly, but the schema does not seem to have been updated.

This is a simple pull request to update it, and I would appreciate it if you could merge it.

Thank you.