### PR TITLE
Add schema for transcend-pathfinder.yml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3686,6 +3686,12 @@
       "url": "https://raw.githubusercontent.com/transcend-io/cli/main/transcend-yml-schema-v4.json"
     },
     {
+      "name": "transcend-pathfinder.yml",
+      "description": "JSON schema for Transcend's Pathfinder, a proxy that intercepts calls to AI tools to enable AI governance",
+      "fileMatch": ["transcend-pathfinder.yml", "transcend-pathfinder.yaml"],
+      "url": "https://raw.githubusercontent.com/transcend-io/cli/main/pathfinder-policy-yml-schema.json"
+    },
+    {
       "name": "trunk.yaml schema",
       "description": "Configuration schema for trunk, a powerful linter runner - https://docs.trunk.io",
       "fileMatch": ["trunk.yaml"],


### PR DESCRIPTION
This adds support for transcend-pathfinder.yml to use with [Transcend's Pathfinder](https://transcend.io/blog/introducing-pathfinder-ai-governance/).