### PR TITLE
Fix: Add "MsixPackage" to "launchsettings.json" (#3142)

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -79,7 +79,8 @@
             "IISExpress",
             "DebugRoslynComponent",
             "Docker",
-            "DockerCompose"
+            "DockerCompose",
+            "MsixPackage"
           ],
           "default": "",
           "minLength": 1


### PR DESCRIPTION
The [`launchsettings.json`](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/launchsettings.json#L82C15-L82C15) schema should include the `"commandName"` enum value for `"MsixPackage"`, as described in the [documentation for working with the Windows App SDK](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/single-project-msix?tabs=csharp#step-2-edit-the-application-project-settings).