### PR TITLE
 🐊Putout : printer options

### DIFF
--- a/src/schemas/json/putout.json
+++ b/src/schemas/json/putout.json
@@ -515,8 +515,19 @@
   },
   "properties": {
     "printer": {
-      "description": "Tell 🐊Putout which printer to use",
-      "type": "string"
+        "description": "Tell 🐊Putout which printer to use",
+        "oneOf": [{
+            "type": "string"
+        }, {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [{
+                "type": "string"
+            }, {
+                "type": "object"
+            }]
+        }]
     },
     "parser": {
       "description": "Tell 🐊Putout which parser to use",

--- a/src/schemas/json/putout.json
+++ b/src/schemas/json/putout.json
@@ -515,19 +515,25 @@
   },
   "properties": {
     "printer": {
-        "description": "Tell 🐊Putout which printer to use",
-        "oneOf": [{
-            "type": "string"
-        }, {
-            "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "items": [{
-                "type": "string"
-            }, {
-                "type": "object"
-            }]
-        }]
+      "description": "Tell 🐊Putout which printer to use",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        }
+      ]
     },
     "parser": {
       "description": "Tell 🐊Putout which parser to use",


### PR DESCRIPTION
Updated 🐊**Putout** schemas according to [v30](https://github.com/coderaiser/putout/releases/tag/v30.0.0), so there was a way to define `printer` options:

```json
{
    "printer": ["putout", {
        "format": {
            "indent": "[tab-character-here]"
        }
    }]
}
```
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
