### PR TITLE
Add DDEV project config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1302,6 +1302,18 @@
       "url": "https://json.schemastore.org/datalogic-scan2deploy-ce.json"
     },
     {
+      "name": "ddev-global",
+      "description": "DDEV global configuration file",
+      "fileMatch": ["**/.ddev/global_config.yaml"],
+      "url": "https://raw.githubusercontent.com/ddev/ddev/master/pkg/globalconfig/schema.json"
+    },
+    {
+      "name": "ddev-project",
+      "description": "DDEV project configuration file",
+      "fileMatch": ["**/.ddev/config*.yaml"],
+      "url": "https://raw.githubusercontent.com/ddev/ddev/master/pkg/ddevapp/schema.json"
+    },
+    {
       "name": "debugsettings.json",
       "description": "A JSON schema for the ASP.NET DebugSettings.json files",
       "fileMatch": ["debugsettings.json"],


### PR DESCRIPTION
Hello!

I would like to contribute an addition to the schemastore project for the [DDEV project config](https://ddev.readthedocs.io/en/stable/) configuration file schema.

Discussing with the maintainer of DDEV, self hosting the schema within DDEV makes the most sense to ensure configuration options and changes are able to be made accordingly per releases. Before self hosting the schema was tested against a valid config.yaml file and passes strict validation tests. However as we are self hosting the schema was cannot utilise these tests I don't think, but we are looking to implement these into CI process within DDEV itself.

Schema reference: https://raw.githubusercontent.com/ddev/ddev/master/pkg/ddevapp/schema.json

Reading the contributing guidelines and because this is a new schema, I believe adding a URL rerference is only required, looking at other examples, but do let me know if there's anything further needed!

@rfay @nico-loeber