### PR TITLE
Update maxDequeueCount to poisonBlobThreshold

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -1355,7 +1355,7 @@
                   "type": "integer",
                   "minimum": 1
                 },
-                "maxDequeueCount": {
+                "poisonBlobThreshold": {
                   "description": "The number of times to try processing a message before moving it to the poison queue.",
                   "type": "integer",
                   "minimum": 1,

--- a/src/test/host/host.v2.json
+++ b/src/test/host/host.v2.json
@@ -14,7 +14,7 @@
   "extensions": {
     "blobs": {
       "maxDegreeOfParallelism": 4,
-      "maxDequeueCount": 3
+      "poisonBlobThreshold": 3
     },
     "cosmosDB": {
       "connectionMode": "Gateway",


### PR DESCRIPTION
The `maxDequeueCount` property had been renamed to `poisonBlobThreshold`; functionality is still the same.
