### PR TITLE
fix(website): Tweak IDE extension links

### DIFF
--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -77,12 +77,12 @@
         <li>Neovim via <a href="https://github.com/b0o/SchemaStore.nvim" target="_blank">SchemaStore.nvim</a></li>
         <li>PhpStorm</li>
         <li>PyCharm</li>
-		<li>ReSharper</li>    
+		<li>ReSharper</li>
         <li>Rider</li>
         <li>RubyMine</li>
-		<li>SublimeText via <a href="https://packagecontrol.io/packages/LSP-json" target="_blank">LSP-json</a></li>
+		<li>SublimeText via <a href="https://packagecontrol.io/packages/LSP-json" target="_blank">LSP-json</a>,<a href="https://packagecontrol.io/packages/LSP-yaml" target="_blank">LSP-yaml</a></li>
         <li>Visual Studio</li>
-        <li>Visual Studio Code(<a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml" target="_blank">YAML</a>,<a href="https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore" target="_blank">JSON</a>)</li>
+        <li>Visual Studio Code (<a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml" target="_blank">YAML</a>,<a href="https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml" target="_blank">TOML</a>,<a href="https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore" target="_blank">JSON</a>)</li>
         <li>Visual Studio for Mac</li>
         <li>WebStorm</li>
     </ul>
@@ -94,7 +94,7 @@
     <h3 id="sponsor">Sponsorships <span style="color:mediumvioletred">♡</span></h3>
     <p>
         <img src="/img/sponsor.png" width="160" height="192" alt="Sponsor SchemaStore.org now" class="right" />
-		Over 700 GB of JSON schema files are served each day from SchemaStore.org. It's a big effort to maintain 
+		Over 700 GB of JSON schema files are served each day from SchemaStore.org. It's a big effort to maintain
 		and keep running, and it's all done by JSON Schema loving volunteers.
 
         If your business gets value from SchemaStore.org, please consider sponsoring to keep the project alive and healthy.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Primarily, this PR adds a link to the best (in terms of using SchemaStore) VSCode TOML Extension (to the front page) so it is more obvious that Schema Store is used for TOML files as well.

@madskristensen Also, a side-question, to make sure our expectations are aligned, am I correct to assume it's okay for me to merge my own smaller documentation fixes and my own new schemas, and tweaks to the Gruntfile.js (ex. #3163 and #3145) without your review? I know you're busy and I think I remember seeing past maintainers do these things, so I assumed it was OK, but I'm asking for your for confirmation just in case you don't think so. 

Closes #3144

