### PR TITLE
Allow github-workflows expression syntax in 'matrix.(in|ex)clude'

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -419,6 +419,53 @@
         }
       ]
     },
+    "matrix": {
+      "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix",
+      "description": "A build matrix is a set of different configurations of the virtual environment. For example you might run a job against more than one supported version of a language, operating system, or tool. Each configuration is a copy of the job that runs and reports a status.\nYou can specify a matrix by supplying an array for the configuration options. For example, if the GitHub virtual environment supports Node.js versions 6, 8, and 10 you could specify an array of those versions in the matrix.\nWhen you define a matrix of operating systems, you must set the required runs-on keyword to the operating system of the current job, rather than hard-coding the operating system name. To access the operating system name, you can use the matrix.os context parameter to set runs-on. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/expressionSyntax"
+        }
+      ],
+      "patternProperties": {
+        "^(in|ex)clude$": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/expressionSyntax"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/configuration"
+                }
+              },
+              "minItems": 1
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/configuration"
+            },
+            "minItems": 1
+          },
+          {
+            "$ref": "#/definitions/expressionSyntax"
+          }
+        ]
+      },
+      "minProperties": 1
+    },
     "reusableWorkflowCallJob": {
       "$comment": "https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow",
       "description": "Each job must have an id to associate with the job. The key job_id is a string and its value is a map of the job's configuration data. You must replace <job_id> with a string that is unique to the jobs object. The <job_id> must start with a letter or _ and contain only alphanumeric characters, -, or _.",
@@ -470,44 +517,7 @@
           "type": "object",
           "properties": {
             "matrix": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix",
-              "description": "A build matrix is a set of different configurations of the virtual environment. For example you might run a job against more than one supported version of a language, operating system, or tool. Each configuration is a copy of the job that runs and reports a status.\nYou can specify a matrix by supplying an array for the configuration options. For example, if the GitHub virtual environment supports Node.js versions 6, 8, and 10 you could specify an array of those versions in the matrix.\nWhen you define a matrix of operating systems, you must set the required runs-on keyword to the operating system of the current job, rather than hard-coding the operating system name. To access the operating system name, you can use the matrix.os context parameter to set runs-on. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-              "oneOf": [
-                {
-                  "type": "object"
-                },
-                {
-                  "$ref": "#/definitions/expressionSyntax"
-                }
-              ],
-              "patternProperties": {
-                "^(in|ex)clude$": {
-                  "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build",
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "$ref": "#/definitions/configuration"
-                    }
-                  },
-                  "minItems": 1
-                }
-              },
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/configuration"
-                    },
-                    "minItems": 1
-                  },
-                  {
-                    "$ref": "#/definitions/expressionSyntax"
-                  }
-                ]
-              },
-              "minProperties": 1
+              "$ref": "#/definitions/matrix"
             },
             "fail-fast": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast",
@@ -889,44 +899,7 @@
           "type": "object",
           "properties": {
             "matrix": {
-              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix",
-              "description": "A build matrix is a set of different configurations of the virtual environment. For example you might run a job against more than one supported version of a language, operating system, or tool. Each configuration is a copy of the job that runs and reports a status.\nYou can specify a matrix by supplying an array for the configuration options. For example, if the GitHub virtual environment supports Node.js versions 6, 8, and 10 you could specify an array of those versions in the matrix.\nWhen you define a matrix of operating systems, you must set the required runs-on keyword to the operating system of the current job, rather than hard-coding the operating system name. To access the operating system name, you can use the matrix.os context parameter to set runs-on. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-              "oneOf": [
-                {
-                  "type": "object"
-                },
-                {
-                  "$ref": "#/definitions/expressionSyntax"
-                }
-              ],
-              "patternProperties": {
-                "^(in|ex)clude$": {
-                  "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build",
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "$ref": "#/definitions/configuration"
-                    }
-                  },
-                  "minItems": 1
-                }
-              },
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/configuration"
-                    },
-                    "minItems": 1
-                  },
-                  {
-                    "$ref": "#/definitions/expressionSyntax"
-                  }
-                ]
-              },
-              "minProperties": 1
+              "$ref": "#/definitions/matrix"
             },
             "fail-fast": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast",

--- a/src/test/github-workflow/matrix_include_expression.yaml
+++ b/src/test/github-workflow/matrix_include_expression.yaml
@@ -1,0 +1,19 @@
+name: Test on Pull
+on:
+  - push
+jobs:
+  build:
+    strategy:
+      matrix:
+        node-version:
+          - 11
+          - 12
+        include: '${{ fromJSON(needs.job1.outputs.generated_matrix) }}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm run lint
+      - run: npm test


### PR DESCRIPTION
`strategy.matrix.include` could contain an expression string, so convert the `include/exclude` definition to allow for expression strings via a oneOf.

(Requested downstream in python-jsonschema/check-jsonschema#272)

In support of this change, I compared both copies of the `matrix` definition and found them to be identical. Therefore, they have been refactored into a definition for matrix config.

A new test for `include: ${{ ... }}` has been added to exercise this new branching within the schema.
