### PR TITLE
fix: Add and fix more `id`/`$id` fields

### DIFF
--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -721,6 +721,9 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
     'Check that metadata fields like "$id" are correct.',
     function () {
       let countScan = 0
+      let totalMismatchIds = 0
+      let totalMissingIds = 0
+      let totalIncorrectIds = 0
       localSchemaFileAndTestFile(
         {
           schemaOnlyScan(schema) {
@@ -738,22 +741,70 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
 
             const schemaVersion = schema.jsonObj.$schema
             if (dollarlessIdSchemas.includes(schemaVersion)) {
+              if (schema.jsonObj.$id) {
+                grunt.log.warn(
+                  `Bad property of '$id'; expected 'id' for this schema version`,
+                )
+                ++totalMismatchIds
+                return
+              }
+
+              if (!schema.jsonObj.id) {
+                grunt.log.warn(
+                  `Missing property 'id' for schema 'src/schemas/json/${schema.jsonName}'`,
+                )
+                console.warn(
+                  `     expected value: https://json.schemastore.org/${schema.jsonName}`,
+                )
+                ++totalMissingIds
+                return
+              }
+
               if (
                 schema.jsonObj.id !==
                 `https://json.schemastore.org/${schema.jsonName}`
               ) {
                 grunt.log.warn(
-                  `Missing property "id" for schema '${schema.jsonName}'`,
+                  `Incorrect property 'id' for schema 'src/schemas/json/${schema.jsonName}'`,
                 )
+                console.warn(
+                  `     expected value: https://json.schemastore.org/${schema.jsonName}`,
+                )
+                console.warn(`     found value   : ${schema.jsonObj.id}`)
+                ++totalIncorrectIds
               }
             } else {
+              if (schema.jsonObj.id) {
+                grunt.log.warn(
+                  `Bad property of 'id'; expected '$id' for this schema version`,
+                )
+                ++totalMismatchIds
+                return
+              }
+
+              if (!schema.jsonObj.$id) {
+                grunt.log.warn(
+                  `Missing property '$id' for schema 'src/schemas/json/${schema.jsonName}'`,
+                )
+                console.warn(
+                  `     expected value: https://json.schemastore.org/${schema.jsonName}`,
+                )
+                ++totalMissingIds
+                return
+              }
+
               if (
                 schema.jsonObj.$id !==
                 `https://json.schemastore.org/${schema.jsonName}`
               ) {
                 grunt.log.warn(
-                  `Missing property "$id" for schema '${schema.jsonName}'`,
+                  `Incorrect property '$id' for schema 'src/schemas/json/${schema.jsonName}'`,
                 )
+                console.warn(
+                  `     expected value: https://json.schemastore.org/${schema.jsonName}`,
+                )
+                console.warn(`     found value   : ${schema.jsonObj.$id}`)
+                ++totalIncorrectIds
               }
             }
           },
@@ -763,6 +814,9 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
           skipReadFile: false,
         },
       )
+      grunt.log.ok(`Total missing ids: ${totalMissingIds}`)
+      grunt.log.ok(`Total mismatched ids: ${totalMismatchIds}`)
+      grunt.log.ok(`Total incorrect ids: ${totalIncorrectIds}`)
       grunt.log.ok(`Total files scan: ${countScan}`)
     },
   )

--- a/src/schemas/json/agripparc-1.2.json
+++ b/src/schemas/json/agripparc-1.2.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "id": "https://json.schemastore.org/agripparc-1.2.json",
   "properties": {
     "props": {
       "description": "Which prop declaration method to use",

--- a/src/schemas/json/agripparc-1.3.json
+++ b/src/schemas/json/agripparc-1.3.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "id": "https://json.schemastore.org/agripparc-1.3.json",
   "properties": {
     "props": {
       "description": "Which prop declaration method to use",

--- a/src/schemas/json/aiproj-1.0.json
+++ b/src/schemas/json/aiproj-1.0.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "description": "Settings for project analysis by the Application Inspector",
+  "id": "https://json.schemastore.org/aiproj-1.0.json",
   "properties": {
     "$schema": {
       "type": "string"

--- a/src/schemas/json/airlock-microgateway-3.0.json
+++ b/src/schemas/json/airlock-microgateway-3.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/airlock-microgateway-3.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {

--- a/src/schemas/json/airlock-microgateway-3.1.json
+++ b/src/schemas/json/airlock-microgateway-3.1.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/airlock-microgateway-3.1.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {

--- a/src/schemas/json/azure-iot-edge-deployment-template-1.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-1.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/azure-iot-edge-deployment-template-1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "moduleType": {

--- a/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
+++ b/src/schemas/json/azure-iot-edge-deployment-template-2.0.json
@@ -41,6 +41,7 @@
       "contentMediaType": "application/json"
     }
   },
+  "id": "https://json.schemastore.org/azure-iot-edge-deployment-template-2.0.json",
   "properties": {
     "modulesContent": {
       "type": "object",

--- a/src/schemas/json/azure-iot-edgeagent-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edgeagent-deployment-1.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/azure-iot-edgeagent-deployment-1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {

--- a/src/schemas/json/azure-iot-edgehub-deployment-1.0.json
+++ b/src/schemas/json/azure-iot-edgehub-deployment-1.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/azure-iot-edgehub-deployment-1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {

--- a/src/schemas/json/bxci.schema-1.0.1.json
+++ b/src/schemas/json/bxci.schema-1.0.1.json
@@ -1,4 +1,5 @@
 {
+  "$id": " https://json.schemastore.org/bxci.schema-1.0.1.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "branchPattern": {

--- a/src/schemas/json/bxci.schema-1.0.json
+++ b/src/schemas/json/bxci.schema-1.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/bxci.schema-1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "branchPattern": {

--- a/src/schemas/json/bxci.schema-2.0.0.json
+++ b/src/schemas/json/bxci.schema-2.0.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/bxci.schema-2.0.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "branchPattern": {

--- a/src/schemas/json/content-security-policy-report-2.json
+++ b/src/schemas/json/content-security-policy-report-2.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
   "description": "https://www.w3.org/TR/CSP2/#violation-reports",
+  "id": "https://json.schemastore.org/content-security-policy-report-2.json",
   "properties": {
     "csp-report": {
       "type": "object",

--- a/src/schemas/json/datalogic-scan2deploy-android.json
+++ b/src/schemas/json/datalogic-scan2deploy-android.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://example.com/root.json",
+  "$id": "https://json.schemastore.org/datalogic-scan2deploy-android.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {},
   "description": "Schema to validate Android JSON files given as input to DL-Config to generate Scan2Deploy barcodes",

--- a/src/schemas/json/datalogic-scan2deploy-ce.json
+++ b/src/schemas/json/datalogic-scan2deploy-ce.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://example.com/root.json",
+  "$id": "https://json.schemastore.org/datalogic-scan2deploy-ce.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {},
   "description": "Schema to validate Windows CE JSON files given as input to DL-Config to generate Scan2Deploy barcodes",

--- a/src/schemas/json/detekt-1.14.1.json
+++ b/src/schemas/json/detekt-1.14.1.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/detekt-1.14.1.json",
   "properties": {
     "build": {
       "type": "object",

--- a/src/schemas/json/devinit.schema-1.0.json
+++ b/src/schemas/json/devinit.schema-1.0.json
@@ -80,6 +80,7 @@
       "additionalProperties": false
     }
   },
+  "id": "https://json.schemastore.org/devinit.schema-1.0.json",
   "properties": {
     "$schema": {
       "type": "string"

--- a/src/schemas/json/devinit.schema-2.0.json
+++ b/src/schemas/json/devinit.schema-2.0.json
@@ -81,6 +81,7 @@
       "additionalProperties": false
     }
   },
+  "id": "https://json.schemastore.org/devinit.schema-2.0.json",
   "properties": {
     "$schema": {
       "type": "string"

--- a/src/schemas/json/devinit.schema-3.0.json
+++ b/src/schemas/json/devinit.schema-3.0.json
@@ -82,6 +82,7 @@
       "additionalProperties": false
     }
   },
+  "id": "https://json.schemastore.org/devinit.schema-3.0.json",
   "properties": {
     "$schema": {
       "type": "string"

--- a/src/schemas/json/devinit.schema-4.0.json
+++ b/src/schemas/json/devinit.schema-4.0.json
@@ -84,6 +84,7 @@
       "additionalProperties": false
     }
   },
+  "id": "https://json.schemastore.org/devinit.schema-4.0.json",
   "properties": {
     "$schema": {
       "type": "string"

--- a/src/schemas/json/devinit.schema-5.0.json
+++ b/src/schemas/json/devinit.schema-5.0.json
@@ -82,6 +82,7 @@
       "additionalProperties": false
     }
   },
+  "id": "https://json.schemastore.org/devinit.schema-5.0.json",
   "properties": {
     "$schema": {
       "type": "string"

--- a/src/schemas/json/expo-37.0.0.json
+++ b/src/schemas/json/expo-37.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "id": "https://json.schemastore.org/expo-37.0.0.json",
   "properties": {
     "expo": {
       "type": "object",

--- a/src/schemas/json/expo-38.0.0.json
+++ b/src/schemas/json/expo-38.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "id": "https://json.schemastore.org/expo-38.0.0.json",
   "properties": {
     "expo": {
       "type": "object",

--- a/src/schemas/json/expo-39.0.0.json
+++ b/src/schemas/json/expo-39.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "id": "https://json.schemastore.org/expo-39.0.0.json",
   "properties": {
     "expo": {
       "definitions": {

--- a/src/schemas/json/expo-40.0.0.json
+++ b/src/schemas/json/expo-40.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "id": "https://json.schemastore.org/expo-40.0.0.json",
   "properties": {
     "expo": {
       "definitions": {

--- a/src/schemas/json/expo-41.0.0.json
+++ b/src/schemas/json/expo-41.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "id": "https://json.schemastore.org/expo-41.0.0.json",
   "properties": {
     "expo": {
       "definitions": {

--- a/src/schemas/json/expo-42.0.0.json
+++ b/src/schemas/json/expo-42.0.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": false,
+  "id": "https://json.schemastore.org/expo-42.0.0.json",
   "properties": {
     "expo": {
       "definitions": {

--- a/src/schemas/json/install.json
+++ b/src/schemas/json/install.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/install.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "src": {

--- a/src/schemas/json/jasonette.json
+++ b/src/schemas/json/jasonette.json
@@ -166,6 +166,7 @@
       ]
     }
   },
+  "id": "https://json.schemastore.org/jasonette.json",
   "properties": {
     "head": {
       "type": "object",

--- a/src/schemas/json/jreleaser-1.6.0.json
+++ b/src/schemas/json/jreleaser-1.6.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/jreleaser-1.6.0.json",
   "$ref": "#/definitions/JReleaserModel",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {

--- a/src/schemas/json/json-api-1.0.json
+++ b/src/schemas/json/json-api-1.0.json
@@ -365,6 +365,7 @@
     }
   },
   "description": "This is a schema for responses in the JSON API format. For more, see http://jsonapi.org",
+  "id": "https://json.schemastore.org/json-api-1.0.json",
   "oneOf": [
     {
       "$ref": "#/definitions/success"

--- a/src/schemas/json/lazydocker.json
+++ b/src/schemas/json/lazydocker.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/lazydocker.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "color": {

--- a/src/schemas/json/liquibase.json
+++ b/src/schemas/json/liquibase.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/liquibase.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": true,
   "default": {},

--- a/src/schemas/json/mboats-config-0.1.json
+++ b/src/schemas/json/mboats-config-0.1.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/mboats-config-0.1.json",
   "$ref": "#/definitions/Main",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {

--- a/src/schemas/json/mta.json
+++ b/src/schemas/json/mta.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Based on https://github.wdf.sap.corp/mta/spec/blob/master/schemas/v3/v3.3/mta-schema.yaml",
-  "$id": "http://example.com/mta.schema.json",
+  "$id": "https://json.schemastore.org/mta.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "generic-memory": {

--- a/src/schemas/json/mtad.json
+++ b/src/schemas/json/mtad.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://example.com/MTA/mtad.yaml",
+  "$id": "https://json.schemastore.org/mtad.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "generic-memory": {

--- a/src/schemas/json/mtaext.json
+++ b/src/schemas/json/mtaext.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://example.com/MTA/.mtaext",
+  "$id": "https://json.schemastore.org/mtaext.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "hooks": {

--- a/src/schemas/json/npm-link-up.json
+++ b/src/schemas/json/npm-link-up.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/npm-link-up.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {

--- a/src/schemas/json/nuget-project-3.3.0.json
+++ b/src/schemas/json/nuget-project-3.3.0.json
@@ -30,6 +30,7 @@
       }
     }
   },
+  "id": "https://json.schemastore.org/nuget-project-3.3.0.json",
   "properties": {
     "dependencies": {
       "$ref": "#/definitions/dependencies"

--- a/src/schemas/json/package.manifest-7.0.0.json
+++ b/src/schemas/json/package.manifest-7.0.0.json
@@ -174,6 +174,7 @@
       }
     }
   },
+  "id": "https://json.schemastore.org/package.manifest-7.0.0.json",
   "properties": {
     "javascript": {
       "type": "array",

--- a/src/schemas/json/package.manifest-8.0.0.json
+++ b/src/schemas/json/package.manifest-8.0.0.json
@@ -290,6 +290,7 @@
       }
     }
   },
+  "id": "https://json.schemastore.org/package.manifest-8.0.0.json",
   "properties": {
     "javascript": {
       "type": "array",

--- a/src/schemas/json/pantsbuild-2.14.0.json
+++ b/src/schemas/json/pantsbuild-2.14.0.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": true,
   "description": "Pants configuration file schema: https://www.pantsbuild.org/",
+  "id": "https://json.schemastore.org/pantsbuild-2.14.0.json",
   "properties": {
     "GLOBAL": {
       "description": "Options to control the overall behavior of Pants.",

--- a/src/schemas/json/pantsbuild-2.15.0.json
+++ b/src/schemas/json/pantsbuild-2.15.0.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": true,
   "description": "Pants configuration file schema: https://www.pantsbuild.org/",
+  "id": "https://json.schemastore.org/pantsbuild-2.15.0.json",
   "properties": {
     "GLOBAL": {
       "description": "Options to control the overall behavior of Pants.",

--- a/src/schemas/json/prettierrc-1.8.2.json
+++ b/src/schemas/json/prettierrc-1.8.2.json
@@ -139,6 +139,7 @@
       }
     }
   },
+  "id": "https://json.schemastore.org/prettierrc-1.8.2.json",
   "title": "Schema for .prettierrc",
   "type": "object"
 }

--- a/src/schemas/json/sarif-2.0.0-csd.2.beta.2018-10-10.json
+++ b/src/schemas/json/sarif-2.0.0-csd.2.beta.2018-10-10.json
@@ -1542,6 +1542,7 @@
     }
   },
   "description": "Static Analysis Results Format (SARIF) Version 2.0.0.csd.2.beta-2018-10-10 JSON Schema: a standard format for the output of static analysis tools.",
+  "id": "https://json.schemastore.org/sarif-2.0.0-csd.2.beta.2018-10-10.json",
   "properties": {
     "$schema": {
       "description": "The URI of the JSON schema corresponding to the version.",

--- a/src/schemas/json/sarif-2.0.0-csd.2.beta.2019-01-09.json
+++ b/src/schemas/json/sarif-2.0.0-csd.2.beta.2019-01-09.json
@@ -1756,6 +1756,7 @@
     }
   },
   "description": "Static Analysis Results Format (SARIF) Version 2.0.0-csd.2.beta-2019-01-09 JSON Schema: a standard format for the output of static analysis tools.",
+  "id": "https://json.schemastore.org/sarif-2.0.0-csd.2.beta.2019-01-09.json",
   "properties": {
     "$schema": {
       "description": "The URI of the JSON schema corresponding to the version.",

--- a/src/schemas/json/sarif-2.0.0-csd.2.beta.2019-01-24.json
+++ b/src/schemas/json/sarif-2.0.0-csd.2.beta.2019-01-24.json
@@ -1853,6 +1853,7 @@
     }
   },
   "description": "Static Analysis Results Format (SARIF) Version 2.0.0-csd.2.beta-2019-01-24 JSON Schema: a standard format for the output of static analysis tools.",
+  "id": "https://json.schemastore.org/sarif-2.0.0-csd.2.beta.2019-01-24.json",
   "properties": {
     "$schema": {
       "description": "The URI of the JSON schema corresponding to the version.",

--- a/src/schemas/json/schema-draft-v4.json
+++ b/src/schemas/json/schema-draft-v4.json
@@ -48,6 +48,7 @@
     "exclusiveMinimum": ["minimum"]
   },
   "description": "Modified JSON Schema draft v4 that includes the optional '$ref' and 'format'",
+  "id": "https://json.schemastore.org/schema-draft-v4.json",
   "properties": {
     "id": {
       "type": "string",

--- a/src/schemas/json/sourcehut-build-0.41.2.json
+++ b/src/schemas/json/sourcehut-build-0.41.2.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "A recipe for Sourcehut CI service",
+  "id": "https://json.schemastore.org/sourcehut-build-0.41.2.json",
   "properties": {
     "image": {
       "description": "Which OS image to build in",

--- a/src/schemas/json/stylintrc.json
+++ b/src/schemas/json/stylintrc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/stylintrc.json",
   "properties": {
     "blocks": {
       "type": ["string", "boolean"],

--- a/src/schemas/json/winget-pkgs-singleton-0.1.json
+++ b/src/schemas/json/winget-pkgs-singleton-0.1.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/winget-pkgs-singleton-0.1.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "Id": {

--- a/src/schemas/json/xs-app.json
+++ b/src/schemas/json/xs-app.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Based on https://github.wdf.sap.corp/xs2/approuter.js/blob/master/lib/configuration/schemas/xs-app-schema.json",
-  "$id": "http://example.com/xsapp.schema.json",
+  "$id": "https://json.schemastore.org/xs-app.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "sourceSchema": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

In the same spirit as #3133, adds top-level id fields. For some reason, the automated script I used previously did not catch all cases.

This fixes all remaining cases in which:
- `$id`/`id` is missing
- `$id`/`id` begins with `https?://example.com/**` (this **_IS_** a breaking change, but because this value is _very_ semantically incorrect, the people that set it are therefore unlikely to use the value for its designated purpose. I argue this decreases the risk of fixing the value, and allows us to more confidentaly make the change)

Lastly, I improved the `local_lint_schema_has_correct_metadata` task to print more useful information:

```sh
$ npm run grunt local_lint_schema_has_correct_metadata 
...
>> Incorrect property '$id' for schema 'src/schemas/json/winget-pkgs-locale-1.0.0.json'
     expected value: https://json.schemastore.org/winget-pkgs-locale-1.0.0.json
     found value   : https://aka.ms/winget-manifest.locale.1.0.0.schema.json
>> Incorrect property '$id' for schema 'src/schemas/json/winget-pkgs-singleton-1.0.0.json'
     expected value: https://json.schemastore.org/winget-pkgs-singleton-1.0.0.json
     found value   : https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
>> Total missing ids: 0
>> Total mismatched ids: 0
>> Total incorrect ids: 67
>> Total files scan: 501