### PR TITLE
Add prefect deployment schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2961,6 +2961,12 @@
       "url": "https://json.schemastore.org/phraseapp.json"
     },
     {
+      "name": "prefect-deploy.json",
+      "description": "prefect.yaml configuration file",
+      "fileMatch": ["prefect.yaml"],
+      "url": "https://json.schemastore.org/prefect-deploy.json"
+    },
+    {
       "name": "prettierrc.json",
       "description": ".prettierrc configuration file",
       "fileMatch": [

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -764,7 +764,7 @@
           {
             "type": "object",
             "description": "A custom step created by the user",
-            "additionalProperties": true,
+            "additionalProperties": true
           }
         ]
       }
@@ -849,7 +849,7 @@
           {
             "type": "object",
             "description": "A custom step created by the user",
-            "additionalProperties": true,
+            "additionalProperties": true
           }
         ]
       },
@@ -903,7 +903,7 @@
           {
             "type": "object",
             "description": "A custom step created by the user",
-            "additionalProperties": true,
+            "additionalProperties": true
           }
         ]
       },

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -397,7 +397,6 @@
           "title": "Repository",
           "type": "string",
           "description": "The URL of the repository to clone",
-          "pattern": "https?://.*",
           "examples": ["https://www.github.com/prefecthq/prefect.git"],
           "default": "https://www.github.com/prefecthq/prefect.git"
         },
@@ -944,6 +943,7 @@
     },
     "deployments": {
       "type": "array",
+      "description": "The deployments section of prefect.yaml is where you define the deployments that will be created when this file is run.",
       "items": {
         "type": "object",
         "title": "Deployment Object",

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -26,7 +26,7 @@
           "default": "defaultFolder"
         },
         "credentials": {
-          "type": ["object", "string"],
+          "type": ["object", "string", "null"],
           "title": "Credentials",
           "description": "A dictionary of credentials with keys 'connection_string' or 'account_url' and values of the corresponding connection string or account URL. If both are provided, 'connection_string' will be used. If not provided, the application default credentials will be used. Alternatively, a templated string representing a credentials block can be used.",
           "properties": {
@@ -48,14 +48,14 @@
           "pattern": "^\\{\\{\\s*prefect\\.blocks\\.azure\\-blob\\-storage\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$"
         },
         "ignore_file": {
-          "type": "string",
+          "type": ["string", "null"],
           "title": "Ignore File",
           "description": "The path to a file containing patterns of files to ignore when pushing to Azure Blob Storage.",
           "default": ".prefectignore",
           "examples": [".gitignore", ".myignorefile"]
         }
       },
-      "required": ["requires", "container", "folder", "credentials"],
+      "required": ["requires", "container", "folder"],
       "title": "Push to Azure Blob Storage",
       "description": "Pushes to an Azure Blob Storage container."
     },
@@ -90,7 +90,7 @@
           "default": "latest"
         },
         "credentials": {
-          "type": ["object", "string"],
+          "type": ["object", "string", "null"],
           "title": "Credentials",
           "description": "A dictionary containing the username, password, and URL for the registry to push the image to.",
           "properties": {
@@ -144,14 +144,14 @@
           "examples": ["myFolder"]
         },
         "project": {
-          "type": ["string"],
+          "type": ["string", "null"],
           "title": "Project",
           "description": "The GCP project the bucket belongs to. If not provided, the project will be inferred from the credentials or the local environment.",
           "default": "my-gcp-project",
           "examples": ["my-gcp-project"]
         },
         "credentials": {
-          "type": ["object", "string"],
+          "type": ["object", "string", "null"],
           "title": "Credentials",
           "description": "A dictionary containing the service account information and project used for authentication. Alternatively, a templated string representing a credentials block can be used.",
           "default": null,
@@ -184,7 +184,7 @@
           ]
         },
         "ignore_file": {
-          "type": "string",
+          "type": ["string", "null"],
           "title": "Ignore File",
           "description": "The name of the file containing ignore patterns.",
           "default": ".prefectignore",
@@ -221,7 +221,7 @@
           "default": "myFolder"
         },
         "credentials": {
-          "type": ["object", "string"],
+          "type": ["object", "string", "null"],
           "title": "Credentials",
           "description": "A dictionary of AWS credentials (aws_access_key_id, aws_secret_access_key, aws_session_token).",
           "properties": {
@@ -258,7 +258,7 @@
           ]
         },
         "ignore_file": {
-          "type": "string",
+          "type": ["string", "null"],
           "title": "Ignore File",
           "description": "The name of the file containing ignore patterns.",
           "default": ".prefectignore",
@@ -318,7 +318,7 @@
           "default": "{{ prefect.blocks.azure-blob-storage-credentials.my-credentials }}"
         }
       },
-      "required": ["requires", "container", "folder", "credentials"]
+      "required": ["requires", "container", "folder"]
     },
     "prefect_gcp.deployments.steps.pull_from_gcs": {
       "type": "object",
@@ -346,14 +346,14 @@
           "examples": ["myFolder"]
         },
         "project": {
-          "type": "string",
+          "type": ["string", "null"],
           "title": "Project",
           "description": "The GCP project the bucket belongs to. If not provided, the project will be inferred from the credentials or the local environment.",
           "default": "my-gcp-project",
           "examples": ["my-gcp-project"]
         },
         "credentials": {
-          "type": ["object", "string"],
+          "type": ["object", "string", "null"],
           "title": "Credentials",
           "description": "A dictionary containing the service account information and project used for authentication. Alternatively, a templated string representing a credentials block can be used.",
           "default": null,
@@ -403,19 +403,19 @@
         },
         "branch": {
           "title": "Branch",
-          "type": "string",
+          "type": ["string", "null"],
           "description": "The branch to clone; if not provided, the default branch will be used",
           "default": "main"
         },
         "include_submodules": {
           "title": "Include Submodules",
-          "type": "boolean",
+          "type": ["boolean", "null"],
           "description": "Whether to include git submodules when cloning the repository",
           "default": false
         },
         "access_token": {
           "title": "Access Token",
-          "type": "string",
+          "type": ["string", "null"],
           "description": "An access token to use for cloning the repository; if not provided the repository will be cloned using the default git credentials",
           "default": null,
           "examples": [
@@ -426,7 +426,7 @@
         },
         "credentials": {
           "title": "Credentials",
-          "type": ["object", "string"],
+          "type": ["object", "string", "null"],
           "description": "A templated string representing GitHubCredentials, GitLabCredentials, or BitBucketCredentials block can be used to specify the credentials to use for cloning the repository.",
           "default": "{{ prefect.blocks.github-credentials.my-credentials }}",
           "pattern": "^\\{\\{\\s*prefect\\.blocks\\.(github|gitlab|bitbucket)\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
@@ -465,7 +465,7 @@
           "default": "myFolder"
         },
         "credentials": {
-          "type": ["object", "string"],
+          "type": ["object", "string", "null"],
           "title": "Credentials",
           "description": "A dictionary of AWS credentials (aws_access_key_id, aws_secret_access_key, aws_session_token).",
           "properties": {
@@ -541,13 +541,13 @@
           "examples": ["echo $USER"]
         },
         "directory": {
-          "type": "string",
+          "type": ["string", "null"],
           "title": "Working Directory",
           "description": "The directory to run the script in. Defaults to the current working directory.",
           "default": "my-directory"
         },
         "env": {
-          "type": "object",
+          "type": ["object", "null"],
           "title": "Environment Variables",
           "description": "A dictionary of environment variables to set for the script.",
           "default": {
@@ -555,13 +555,13 @@
           }
         },
         "stream_output": {
-          "type": "boolean",
+          "type": ["boolean", "null"],
           "title": "Stream Output",
           "description": "Whether to stream the output of the script to stdout/stderr.",
           "default": true
         },
         "expand_env_vars": {
-          "type": "boolean",
+          "type": ["boolean", "null"],
           "title": "Expand Environment Variables",
           "description": "Whether to expand environment variables in the script before running it.",
           "default": false
@@ -597,14 +597,14 @@
           "examples": ["requirements.txt", "path/to/requirements.txt"]
         },
         "directory": {
-          "type": "string",
+          "type": ["string", "null"],
           "title": "Directory",
           "description": "The directory the requirements.txt file is in. Defaults to the current working directory.",
           "default": "my-directory",
           "examples": ["/path/to/directory", "./relative/path"]
         },
         "stream_output": {
-          "type": "boolean",
+          "type": ["boolean", "null"],
           "title": "Stream Output",
           "description": "Whether to stream the output from pip install should be streamed to the console.",
           "default": true,
@@ -648,13 +648,13 @@
         },
         "push": {
           "title": "Deprecated: Push to Registry",
-          "type": "boolean",
+          "type": ["boolean", "null"],
           "description": "Whether or not to push the image after building.",
           "default": false
         },
         "credentials": {
           "title": "Credentials",
-          "type": ["object", "string"],
+          "type": ["object", "string", "null"],
           "description": "A dictionary containing the username, password, and URL for the registry to push the image to.",
           "default": "{{ prefect.blocks.docker-registry-credentials.dev-registry }}",
           "pattern": "^\\{\\{\\s*prefect\\.blocks\\.docker\\-registry\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
@@ -664,7 +664,7 @@
         },
         "build_kwargs": {
           "title": "Build Keyword Arguments",
-          "type": "object",
+          "type": ["object", "null"],
           "description": "Additional keyword arguments to pass to Docker when building the image. Available options can be found in the docker-py documentation.",
           "default": {}
         }
@@ -762,9 +762,21 @@
             "required": ["prefect.deployments.steps.pip_install_requirements"]
           },
           {
+            "title": "Custom Step",
             "type": "object",
             "description": "A custom step created by the user",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "not": {
+              "anyOf": [
+                { "required": ["prefect_docker.deployments.steps.push_docker_image"] },
+                { "required": ["prefect_azure.deployments.steps.push_to_azure_blob_storage"] },
+                { "required": ["prefect_gcp.deployments.steps.push_to_gcs"] },
+                { "required": ["prefect_aws.deployments.steps.push_to_s3"] },
+                { "required": ["prefect.deployments.steps.set_working_directory"] },
+                { "required": ["prefect.deployments.steps.run_shell_script"] },
+                { "required": ["prefect.deployments.steps.pip_install_requirements"] }
+              ]
+            }
           }
         ]
       }
@@ -847,9 +859,21 @@
             "required": ["prefect.deployments.steps.pip_install_requirements"]
           },
           {
+            "title": "Custom Step",
             "type": "object",
             "description": "A custom step created by the user",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "not": {
+              "anyOf": [
+                { "required": ["prefect.deployments.steps.git_clone"] },
+                { "required": ["prefect_azure.deployments.steps.pull_from_azure_blob_storage"] },
+                { "required": ["prefect_gcp.deployments.steps.pull_from_gcs"] },
+                { "required": ["prefect_aws.deployments.steps.pull_from_s3"] },
+                { "required": ["prefect.deployments.steps.set_working_directory"] },
+                { "required": ["prefect.deployments.steps.run_shell_script"] },
+                { "required": ["prefect.deployments.steps.pip_install_requirements"] }
+              ]
+            }
           }
         ]
       },
@@ -901,9 +925,18 @@
             "required": ["prefect.deployments.steps.pip_install_requirements"]
           },
           {
+            "title": "Custom Step",
             "type": "object",
             "description": "A custom step created by the user",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "not": {
+              "anyOf": [
+                { "required": ["prefect_docker.deployments.steps.build_docker_image"] },
+                { "required": ["prefect.deployments.steps.set_working_directory"] },
+                { "required": ["prefect.deployments.steps.run_shell_script"] },
+                { "required": ["prefect.deployments.steps.pip_install_requirements"] }
+              ]
+            }
           }
         ]
       },
@@ -917,20 +950,20 @@
         "description": "Configuration details for each deployment.",
         "properties": {
           "name": {
-            "type": "string",
+            "type": ["string", "null"],
             "title": "Deployment Name",
             "description": "The unique name of the deployment.",
             "examples": ["my_first_deployment"]
           },
           "version": {
-            "type": "string",
+            "type": ["string", "null"],
             "title": "Deployment Version",
             "description": "The version of the deployment.",
             "examples": ["v1.0"],
             "default": "v1.0"
           },
           "tags": {
-            "type": "array",
+            "type": ["array", "null"],
             "items": {
               "type": "string"
             },
@@ -939,7 +972,7 @@
             "examples": [["tag1", "tag2"]]
           },
           "description": {
-            "type": "string",
+            "type": ["string", "null"],
             "title": "Description",
             "description": "A brief description of the deployment.",
             "examples": ["This is my first deployment"],
@@ -951,7 +984,7 @@
                 "type": "null"
               },
               {
-                "type": "object",
+                "type": ["object", "null"],
                 "title": "Schedule Settings",
                 "description": "Configuration for scheduling the deployment.",
                 "properties": {
@@ -963,34 +996,34 @@
                     "default": null
                   },
                   "anchor_date": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "title": "Anchor Date",
                     "description": "The anchor date to start the scheduling.",
                     "examples": ["2023-01-01T12:00:00Z"],
                     "default": null
                   },
                   "timezone": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "title": "Timezone",
                     "description": "The timezone for the scheduling.",
                     "examples": ["UTC"],
                     "default": "UTC"
                   },
                   "cron": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "title": "CRON Expression",
                     "description": "The CRON expression for complex scheduling.",
                     "examples": ["0 0 * * *"],
                     "default": null
                   },
                   "day_or": {
-                    "type": "boolean",
+                    "type": ["boolean", "null"],
                     "title": "Daylight Saving Time Adjustment",
                     "description": "Whether to adjust for daylight saving time.",
                     "default": false
                   },
                   "rrule": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "title": "RRULE",
                     "description": "The RRULE string for complex recurring schedules.",
                     "examples": ["FREQ=DAILY;COUNT=10"],
@@ -1004,7 +1037,7 @@
             }
           },
           "triggers": {
-            "type": "array",
+            "type": ["array", "null"],
             "title": "Triggers",
             "description": "An array of triggers that initiate the deployment.",
             "examples": [["trigger1", "trigger2"]],
@@ -1018,7 +1051,7 @@
             "default": "main.py"
           },
           "parameters": {
-            "type": "object",
+            "type": ["object", "null"],
             "title": "Parameters",
             "description": "The parameters passed to the deployment script or application.",
             "examples": [
@@ -1048,7 +1081,7 @@
                 "default": "default_work_queue"
               },
               "job_variables": {
-                "type": "object",
+                "type": ["object", "null"],
                 "title": "Job Variables",
                 "additionalProperties": true,
                 "description": "Additional variables required for the jobs in this work pool.",

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -4,6 +4,13 @@
     "prefect_azure.deployments.steps.push_to_azure_blob_storage": {
       "type": "object",
       "properties": {
+        "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requires": {
           "type": "string",
           "title": "Required Packages",
@@ -64,6 +71,13 @@
       "title": "Push Docker Image",
       "description": "Push a Docker image to a remote registry.",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requires": {
           "type": "string",
           "title": "Required Packages",
@@ -121,6 +135,13 @@
     "prefect_gcp.deployments.steps.push_to_gcs": {
       "type": "object",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requires": {
           "type": "string",
           "title": "Required Packages",
@@ -198,6 +219,13 @@
     "prefect_aws.deployments.steps.push_to_s3": {
       "type": "object",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requires": {
           "type": "string",
           "title": "Required Packages",
@@ -274,6 +302,13 @@
       "title": "Pull from Azure Blob Storage",
       "description": "Pulls from an Azure Blob Storage container.",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requires": {
           "type": "string",
           "title": "Required Packages",
@@ -323,6 +358,13 @@
     "prefect_gcp.deployments.steps.pull_from_gcs": {
       "type": "object",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requires": {
           "type": "string",
           "title": "Required Packages",
@@ -393,6 +435,13 @@
     "prefect.deployments.steps.git_clone": {
       "type": "object",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "repository": {
           "title": "Repository",
           "type": "string",
@@ -441,6 +490,13 @@
     "prefect_aws.deployments.steps.pull_from_s3": {
       "type": "object",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requires": {
           "type": "string",
           "title": "Required Packages",
@@ -510,6 +566,13 @@
       "title": "Set Working Directory",
       "description": "Sets the working directory; works with both absolute and relative paths.",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "directory": {
           "title": "Directory",
           "type": "string",
@@ -532,6 +595,13 @@
       "title": "Run Shell Script",
       "description": "Runs one or more shell commands in a subprocess. Returns the standard output and standard error of the script.",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "script": {
           "type": "string",
           "title": "Script",
@@ -588,6 +658,13 @@
       "title": "Pip Install Requirements",
       "description": "Installs dependencies from a requirements.txt file.",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requirements_file": {
           "type": "string",
           "title": "Requirements File",
@@ -617,6 +694,13 @@
       "type": "object",
       "description": "Builds a Docker image for a Prefect deployment. Can be used within a prefect.yaml file to build a Docker image prior to creating or updating a deployment.",
       "properties": {
+          "id": {
+          "type": "string",
+          "title": "Step ID",
+          "description": "The ID of the step to pass to a downstream step.",
+          "default": "my-step",
+          "examples": ["my-step"]
+        },
         "requires": {
           "title": "Required Packages",
           "type": "string",

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -1,0 +1,1102 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "JSON Schema for Prefect deployments",
+	"description": "This schema defines the structure of a Prefect deployment file.",
+	"type": "object",
+	"properties": {
+		"name": {
+			"type": "string"
+		},
+		"prefect-version": {
+			"type": "string",
+			"pattern": "^(\\d+\\.\\d+\\.\\d+)(?:[-+][a-zA-Z0-9\\.]+)?$"
+		},
+		"push": {
+			"title": "Push Steps",
+			"description": "The push section allows users to specify and customize the logic for pushing this code to remote locations.",
+			"type": ["array", "null"],
+			"items": {
+				"type": "object",
+				"oneOf": [{
+						"properties": {
+							"prefect_docker.deployments.steps.push_docker_image": {
+								"$ref": "#/definitions/prefect_docker.deployments.steps.push_docker_image",
+								"title": "Push Docker Image"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect_docker.deployments.steps.push_docker_image"]
+					},
+					{
+						"properties": {
+							"prefect_azure.deployments.steps.push_to_azure_blob_storage": {
+								"title": "Push to Azure Blob Storage",
+								"$ref": "#/definitions/prefect_azure.deployments.steps.push_to_azure_blob_storage"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect_azure.deployments.steps.push_to_azure_blob_storage"]
+					},
+					{
+						"properties": {
+							"prefect_gcp.deployments.steps.push_to_gcs": {
+								"title": "Push to GCS",
+								"$ref": "#/definitions/prefect_gcp.deployments.steps.push_to_gcs"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect_gcp.deployments.steps.push_to_gcs"]
+					},
+					{
+						"properties": {
+							"prefect_aws.deployments.steps.push_to_s3": {
+								"title": "Push to S3",
+								"$ref": "#/definitions/prefect_aws.deployments.steps.push_to_s3"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect_aws.deployments.steps.push_to_s3"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.set_working_directory": {
+								"title": "Set Working Directory",
+								"$ref": "#/definitions/prefect.deployments.steps.set_working_directory"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.set_working_directory"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.run_shell_script": {
+								"title": "Run Shell Script",
+								"$ref": "#/definitions/prefect.deployments.steps.run_shell_script"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.run_shell_script"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.pip_install_requirements": {
+								"title": "Pip Install Requirements",
+								"$ref": "#/definitions/prefect.deployments.steps.pip_install_requirements"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.pip_install_requirements"]
+					}
+				]
+			}
+		},
+		"pull": {
+			"type": ["array", "null"],
+			"items": {
+				"type": "object",
+				"oneOf": [{
+						"properties": {
+							"prefect.deployments.steps.git_clone": {
+								"title": "Git Clone",
+								"$ref": "#/definitions/prefect.deployments.steps.git_clone"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.git_clone"]
+					},
+					{
+						"properties": {
+							"prefect_azure.deployments.steps.pull_from_azure_blob_storage": {
+								"title": "Pull from Azure Blob Storage",
+								"$ref": "#/definitions/prefect_azure.deployments.steps.pull_from_azure_blob_storage"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect_azure.deployments.steps.pull_from_azure_blob_storage"]
+					},
+					{
+						"properties": {
+							"prefect_gcp.deployments.steps.pull_from_gcs": {
+								"title": "Pull from GCS",
+								"$ref": "#/definitions/prefect_gcp.deployments.steps.pull_from_gcs"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect_gcp.deployments.steps.pull_from_gcs"]
+					},
+					{
+						"properties": {
+							"prefect_aws.deployments.steps.pull_from_s3": {
+								"title": "Pull from S3",
+								"$ref": "#/definitions/prefect_aws.deployments.steps.pull_from_s3"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect_aws.deployments.steps.pull_from_s3"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.set_working_directory": {
+								"title": "Set Working Directory",
+								"$ref": "#/definitions/prefect.deployments.steps.set_working_directory"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.set_working_directory"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.run_shell_script": {
+								"title": "Run Shell Script",
+								"$ref": "#/definitions/prefect.deployments.steps.run_shell_script"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.run_shell_script"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.pip_install_requirements": {
+								"title": "Pip Install Requirements",
+								"$ref": "#/definitions/prefect.deployments.steps.pip_install_requirements"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.pip_install_requirements"]
+					}
+				]
+			},
+			"description": "tbd"
+		},
+		"build": {
+			"type": ["array", "null"],
+			"items": {
+				"type": "object",
+				"oneOf": [{
+						"properties": {
+							"prefect_docker.deployments.steps.build_docker_image": {
+								"$ref": "#/definitions/prefect_docker.deployments.steps.build_docker_image",
+								"title": "Build Docker Image"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect_docker.deployments.steps.build_docker_image"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.set_working_directory": {
+								"title": "Set Working Directory",
+								"$ref": "#/definitions/prefect.deployments.steps.set_working_directory"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.set_working_directory"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.run_shell_script": {
+								"title": "Run Shell Script",
+								"$ref": "#/definitions/prefect.deployments.steps.run_shell_script"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.run_shell_script"]
+					},
+					{
+						"properties": {
+							"prefect.deployments.steps.pip_install_requirements": {
+								"title": "Pip Install Requirements",
+								"$ref": "#/definitions/prefect.deployments.steps.pip_install_requirements"
+							}
+						},
+						"additionalProperties": false,
+						"required": ["prefect.deployments.steps.pip_install_requirements"]
+					}
+				]
+			},
+			"description": "tbd"
+		},
+		"deployments": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"title": "Deployment Object",
+				"description": "Configuration details for each deployment.",
+				"properties": {
+					"name": {
+						"type": "string",
+						"title": "Deployment Name",
+						"description": "The unique name of the deployment.",
+						"examples": ["my_first_deployment"]
+					},
+					"version": {
+						"type": "string",
+						"title": "Deployment Version",
+						"description": "The version of the deployment.",
+						"examples": ["v1.0"],
+						"default": "v1.0"
+					},
+					"tags": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"title": "Tags",
+						"description": "List of tags to apply to the deployment.",
+						"examples": [
+							["tag1", "tag2"]
+						]
+					},
+					"description": {
+						"type": "string",
+						"title": "Description",
+						"description": "A brief description of the deployment.",
+						"examples": ["This is my first deployment"],
+						"default": "No description provided."
+					},
+					"schedule": {
+						"oneOf": [{
+								"type": "null"
+							},
+							{
+								"type": "object",
+								"title": "Schedule Settings",
+								"description": "Configuration for scheduling the deployment.",
+								"properties": {
+									"interval": {
+										"type": "number",
+										"title": "Interval",
+										"description": "The time interval between runs, in seconds.",
+										"examples": [3600],
+										"default": null
+									},
+									"anchor_date": {
+										"type": "string",
+										"title": "Anchor Date",
+										"description": "The anchor date to start the scheduling.",
+										"examples": ["2023-01-01T12:00:00Z"],
+										"default": null
+									},
+									"timezone": {
+										"type": "string",
+										"title": "Timezone",
+										"description": "The timezone for the scheduling.",
+										"examples": ["UTC"],
+										"default": "UTC"
+									},
+									"cron": {
+										"type": "string",
+										"title": "CRON Expression",
+										"description": "The CRON expression for complex scheduling.",
+										"examples": ["0 0 * * *"],
+										"default": null
+									},
+									"day_or": {
+										"type": "boolean",
+										"title": "Daylight Saving Time Adjustment",
+										"description": "Whether to adjust for daylight saving time.",
+										"default": false
+									},
+									"rrule": {
+										"type": "string",
+										"title": "RRULE",
+										"description": "The RRULE string for complex recurring schedules.",
+										"examples": ["FREQ=DAILY;COUNT=10"],
+										"default": null
+									}
+								}
+							}
+						],
+						"default": {
+							"cron": "0 0 * * *"
+						}
+					},
+					"triggers": {
+						"type": "array",
+						"title": "Triggers",
+						"description": "An array of triggers that initiate the deployment.",
+						"examples": [
+							["trigger1", "trigger2"]
+						],
+						"default": []
+					},
+					"entrypoint": {
+						"type": "string",
+						"title": "Entry Point",
+						"description": "The entry point script or command for the deployment.",
+						"examples": ["main.py"],
+						"default": "main.py"
+					},
+					"parameters": {
+						"type": "object",
+						"title": "Parameters",
+						"description": "The parameters passed to the deployment script or application.",
+						"examples": [{
+							"param1": "value1"
+						}],
+						"default": {}
+					},
+					"work_pool": {
+						"type": "object",
+						"title": "Work Pool Settings",
+						"description": "Configuration settings for the work pool.",
+						"properties": {
+							"name": {
+								"type": "string",
+								"title": "Work Pool Name",
+								"description": "The unique name for the work pool.",
+								"examples": ["my_work_pool"],
+								"default": "default_work_pool"
+							},
+							"work_queue_name": {
+								"type": "string",
+								"title": "Work Queue Name",
+								"description": "The name of the work queue associated with this work pool.",
+								"examples": ["my_work_queue"],
+								"default": "default_work_queue"
+							},
+							"job_variables": {
+								"type": "object",
+								"title": "Job Variables",
+								"additionalProperties": true,
+								"description": "Additional variables required for the jobs in this work pool.",
+								"examples": [{
+									"image": "{{ build-image.image }}",
+									"cluster_config": "{{ prefect.blocks.kubernetes-cluster-config.my-config }}",
+									"env": {
+										"FOO": "bar"
+									}
+								}]
+							}
+						},
+						"required": ["name", "work_queue_name"]
+					}
+				},
+				"required": ["name", "entrypoint"]
+			}
+		}
+	},
+	"definitions": {
+		"prefect_azure.deployments.steps.push_to_azure_blob_storage": {
+			"type": "object",
+			"properties": {
+				"requires": {
+					"type": "string",
+					"title": "Required Packages",
+					"description": "A list of dependencies that must be built before this step.",
+					"default": "prefect-azure[blob_storage]",
+					"pattern": "prefect-azure\\[blob_storage\\].*"
+				},
+				"container": {
+					"type": "string",
+					"title": "Container",
+					"description": "The name of the container to push files to.",
+					"examples": [
+						"myContainer"
+					],
+					"default": "defaultContainer"
+				},
+				"folder": {
+					"type": "string",
+					"title": "Folder",
+					"description": "The folder within the container to push to.",
+					"examples": [
+						"myFolder"
+					],
+					"default": "defaultFolder"
+				},
+				"credentials": {
+					"type": ["object", "string"],
+					"title": "Credentials",
+					"description": "A dictionary of credentials with keys 'connection_string' or 'account_url' and values of the corresponding connection string or account URL. If both are provided, 'connection_string' will be used. If not provided, the application default credentials will be used. Alternatively, a templated string representing a credentials block can be used.",
+					"properties": {
+						"connection_string": {
+							"type": "string"
+						},
+						"account_url": {
+							"type": "string"
+						}
+					},
+					"examples": [{
+							"connection_string": "myConnectionString",
+							"account_url": "https://myAccount.blob.core.windows.net"
+						},
+						"{{ prefect.blocks.azure-blob-storage-credentials.my-credentials }}"
+					],
+					"default": null,
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.azure\\-blob\\-storage\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$"
+				},
+				"ignore_file": {
+					"type": "string",
+					"title": "Ignore File",
+					"description": "The path to a file containing patterns of files to ignore when pushing to Azure Blob Storage.",
+					"default": ".prefectignore",
+					"examples": [
+						".gitignore",
+						".myignorefile"
+					]
+				}
+			},
+			"required": ["requires", "container", "folder", "credentials"],
+			"title": "Push to Azure Blob Storage",
+			"description": "Pushes to an Azure Blob Storage container."
+		},
+		"prefect_docker.deployments.steps.push_docker_image": {
+			"type": "object",
+			"title": "Push Docker Image",
+			"description": "Push a Docker image to a remote registry.",
+			"properties": {
+				"requires": 
+					{
+						"type": "string",
+						"title": "Required Packages",
+						"description": "A list of dependencies that must be built before this step.",
+						"default": "prefect-docker",
+						"examples": [
+							"prefect-docker"
+						],
+						"pattern": "prefect-docker.*"
+					},
+				"image_name": {
+					"type": "string",
+					"title": "Image Name",
+					"description": "The name of the Docker image to push, including the registry and repository.",
+					"examples": [
+						"registry.example.com/repository/image",
+						"repository/image"
+					],
+					"default": "my-registry/my-repo"
+				},
+				"tag": {
+					"type": "string",
+					"title": "Tag",
+					"description": "The tag of the Docker image to push.",
+					"examples": [
+						"latest",
+						"v1.0.0"
+					],
+					"default": "latest"
+				},
+				"credentials": {
+					"type": ["object", "string"],
+					"title": "Credentials",
+					"description": "A dictionary containing the username, password, and URL for the registry to push the image to.",
+					"properties": {
+						"username": {
+							"type": "string"
+						},
+						"password": {
+							"type": "string"
+						},
+						"url": {
+							"type": "string"
+						}
+					},
+					"examples": [
+						"{{ prefect.blocks.docker-registry-credentials.dev-registry }}",
+						{
+							"username": "myUsername",
+							"password": "myPassword",
+							"url": "registry.example.com"
+						}
+					],
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.docker\\-registry\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
+					"default": "{{ prefect.blocks.docker-registry-credentials.dev-registry }}"
+				}
+			},
+			"required": ["requires", "image_name"]
+		},
+		"prefect_gcp.deployments.steps.push_to_gcs": {
+			"type": "object",
+			"properties": {
+				"requires": {
+					"type": "string",
+					"title": "Required Packages",
+					"description": "A list of dependencies that must be built before this step.",
+					"default": "prefect-gcp",
+					"examples": [
+						"prefect-gcp"
+					],
+					"pattern": "prefect-gcp.*"
+				},
+				"bucket": {
+					"type": "string",
+					"title": "Bucket",
+					"description": "The name of the GCS bucket where files will be uploaded.",
+					"default": "myBucket",
+					"examples": [
+						"myBucket"
+					]
+				},
+				"folder": {
+					"type": "string",
+					"title": "Folder",
+					"description": "The folder in the GCS bucket where files will be uploaded.",
+					"default": "myFolder",
+					"examples": [
+						"myFolder"
+					]
+				},
+				"project": {
+					"type": ["string"],
+					"title": "Project",
+					"description": "The GCP project the bucket belongs to. If not provided, the project will be inferred from the credentials or the local environment.",
+					"default": "my-gcp-project",
+					"examples": [
+						"my-gcp-project"
+					]
+				},
+				"credentials": {
+					"type": ["object", "string"],
+					"title": "Credentials",
+					"description": "A dictionary containing the service account information and project used for authentication. Alternatively, a templated string representing a credentials block can be used.",
+					"default": null,
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.gcp\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
+					"properties": {
+						"service_account_info": {
+							"type": "object"
+						},
+						"project": {
+							"type": "string"
+						}
+					},
+					"examples": [
+						"{{ prefect.blocks.gcp-credentials.dev-credentials }}",
+						{
+							"service_account_info": {
+								"type": "service_account",
+								"project_id": "my-gcp-project",
+								"private_key_id": "my-private-key-id",
+								"private_key": "my-private-key",
+								"client_email": "my-email",
+								"client_id": "my-client-id",
+								"auth_uri": "my-auth-uri",
+								"token_uri": "my-token-uri",
+								"auth_provider_x509_cert_url": "my-cert-url",
+								"client_x509_cert_url": "my-client-cert-url"
+							},
+							"project": "my-gcp-project"
+						}
+					]
+				},
+				"ignore_file": {
+					"type": "string",
+					"title": "Ignore File",
+					"description": "The name of the file containing ignore patterns.",
+					"default": ".prefectignore",
+					"examples": [
+						".gitignore",
+						".myignorefile"
+					]
+				}
+			},
+			"required": ["requires", "bucket", "folder"],
+			"title": "Push to GCS",
+			"description": "Pushes the contents of the current working directory to a GCS bucket, excluding files and folders specified in the ignore_file."
+		},
+		"prefect_aws.deployments.steps.push_to_s3": {
+			"type": "object",
+			"properties": {
+				"requires": {
+					"type": "string",
+					"title": "Required Packages",
+					"description": "A list of dependencies that must be built before this step.",
+					"default": "prefect-aws",
+					"examples": [
+						"prefect-aws"
+					],
+					"pattern": "prefect-aws.*"
+				},
+				"bucket": {
+					"type": "string",
+					"title": "Bucket",
+					"default": "myBucket",
+					"description": "The name of the S3 bucket where files will be uploaded.",
+					"examples": [
+						"myS3Bucket"
+					]
+				},
+				"folder": {
+					"type": "string",
+					"title": "Folder",
+					"description": "The folder in the S3 bucket where files will be uploaded.",
+					"examples": [
+						"myFolder"
+					],
+					"default": "myFolder"
+				},
+				"credentials": {
+					"type": ["object", "string"],
+					"title": "Credentials",
+					"description": "A dictionary of AWS credentials (aws_access_key_id, aws_secret_access_key, aws_session_token).",
+					"properties": {
+						"aws_access_key_id": {
+							"type": "string"
+						},
+						"aws_secret_access_key": {
+							"type": "string"
+						},
+						"aws_session_token": {
+							"type": "string"
+						}
+					},
+					"default": null,
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.aws\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
+					"examples": [
+						"{{ prefect.blocks.aws-credentials.dev-credentials }}",
+						{
+							"aws_access_key_id": "myAccessKey",
+							"aws_secret_access_key": "mySecretAccessKey",
+							"aws_session_token": "mySessionToken"
+						}
+					]
+				},
+				"client_parameters": {
+					"type": ["object", "null"],
+					"title": "Client Parameters",
+					"description": "A dictionary of additional parameters to pass to the boto3 client.",
+					"default": null,
+					"examples": [{
+						"region_name": "us-east-1"
+					}]
+				},
+				"ignore_file": {
+					"type": "string",
+					"title": "Ignore File",
+					"description": "The name of the file containing ignore patterns.",
+					"default": ".prefectignore",
+					"examples": [
+						".gitignore",
+						".myignorefile"
+					]
+				}
+			},
+			"required": ["requires", "bucket", "folder"],
+			"title": "Push to S3",
+			"description": "Pushes the contents of the current working directory to an S3 bucket, excluding files and folders specified in the ignore_file."
+		},
+		"prefect_azure.deployments.steps.pull_from_azure_blob_storage": {
+			"type": "object",
+			"title": "Pull from Azure Blob Storage",
+			"description": "Pulls from an Azure Blob Storage container.",
+			"properties": {
+				"requires": {
+					"type": "string",
+					"title": "Required Packages",
+					"description": "A list of dependencies that must be built before this step.",
+					"default": "prefect-azure[blob_storage]",
+					"pattern": "prefect-azure\\[blob_storage\\].*"
+				},
+				"container": {
+					"type": "string",
+					"title": "Container",
+					"description": "The name of the container to pull files from.",
+					"examples": [
+						"myContainer",
+						"backupContainer"
+					],
+					"default": "defaultContainer"
+				},
+				"folder": {
+					"type": "string",
+					"title": "Folder",
+					"description": "The folder within the container to pull from.",
+					"examples": [
+						"myFolder",
+						"subFolder"
+					],
+					"default": "defaultFolder"
+				},
+				"credentials": {
+					"type": ["string", "object", "null"],
+					"title": "Credentials",
+					"description": "A dictionary of credentials with keys 'connection_string' or 'account_url' and values of the corresponding connection string or account URL. If both are provided, 'connection_string' will be used. If not provided, the application default credentials will be used. Alternatively, a templated string representing a credentials block can be used.",
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.azure\\-blob\\-storage\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
+					"properties": {
+						"connection_string": {
+							"type": "string"
+						},
+						"account_url": {
+							"type": "string"
+						}
+					},
+					"examples": [
+						"{{ prefect.blocks.azure-blob-storage-credentials.my-credentials }}",
+						{
+							"connection_string": "myConnectionString",
+							"account_url": "https://myAccount.blob.core.windows.net"
+						}
+					],
+					"default": "{{ prefect.blocks.azure-blob-storage-credentials.my-credentials }}"
+				}
+			},
+			"required": ["requires", "container", "folder", "credentials"]
+		},
+		"prefect_gcp.deployments.steps.pull_from_gcs": {
+			"type": "object",
+			"properties": {
+				"requires": {
+					"type": "string",
+					"title": "Required Packages",
+					"description": "A list of dependencies that must be built before this step.",
+					"default": "prefect-gcp",
+					"examples": [
+						"prefect-gcp"
+					],
+					"pattern": "prefect-gcp.*"
+				},
+				"bucket": {
+					"type": "string",
+					"title": "Bucket",
+					"default": "myBucket",
+					"description": "The name of the GCS bucket where files are stored.",
+					"examples": [
+						"myBucket"
+					]
+				},
+				"folder": {
+					"type": "string",
+					"title": "Folder",
+					"default": "myFolder",
+					"description": "The folder in the GCS bucket where files are stored.",
+					"examples": [
+						"myFolder"
+					]
+				},
+				"project": {
+					"type": "string",
+					"title": "Project",
+					"description": "The GCP project the bucket belongs to. If not provided, the project will be inferred from the credentials or the local environment.",
+					"default": "my-gcp-project",
+					"examples": [
+						"my-gcp-project"
+					]
+				},
+				"credentials": {
+					"type": ["object", "string"],
+					"title": "Credentials",
+					"description": "A dictionary containing the service account information and project used for authentication. Alternatively, a templated string representing a credentials block can be used.",
+					"default": null,
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.gcp\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
+					"properties": {
+						"service_account_info": {
+							"type": "object"
+						},
+						"project": {
+							"type": "string"
+						}
+					},
+					"examples": [
+						"{{ prefect.blocks.azure-blob-storage-credentials.my-credentials }}",
+						{
+							"service_account_info": {
+								"type": "service_account",
+								"project_id": "my-gcp-project",
+								"private_key_id": "my-private-key-id",
+								"private_key": "my-private-key",
+								"client_email": "my-email",
+								"client_id": "my-client-id",
+								"auth_uri": "my-auth-uri",
+								"token_uri": "my-token-uri",
+								"auth_provider_x509_cert_url": "my-cert-url",
+								"client_x509_cert_url": "my-client-cert-url"
+							},
+							"project": "my-gcp-project"
+						}
+					]
+				}
+			},
+			"required": ["requires", "bucket", "folder"],
+			"title": "Pull from GCS",
+			"description": "Pulls the contents of a project from a GCS bucket to the current working directory."
+		},
+		"prefect.deployments.steps.git_clone": {
+			"type": "object",
+			"properties": {
+				"repository": {
+					"title": "Repository",
+					"type": "string",
+					"description": "The URL of the repository to clone",
+					"pattern": "https?://.*",
+					"examples": ["https://www.github.com/prefecthq/prefect.git"],
+					"default": "https://www.github.com/prefecthq/prefect.git"
+				},
+				"branch": {
+					"title": "Branch",
+					"type": "string",
+					"description": "The branch to clone; if not provided, the default branch will be used",
+					"default": "main"
+				},
+				"include_submodules": {
+					"title": "Include Submodules",
+					"type": "boolean",
+					"description": "Whether to include git submodules when cloning the repository",
+					"default": false
+				},
+				"access_token": {
+					"title": "Access Token",
+					"type": "string",
+					"description": "An access token to use for cloning the repository; if not provided the repository will be cloned using the default git credentials",
+					"default": null,
+					"examples": ["oauth2:myAccessToken", "x-token-auth:myAccessToken", "myAccessToken"]
+				},
+				"credentials": {
+					"title": "Credentials",
+					"type": ["object", "string"],
+					"description": "A templated string representing GitHubCredentials, GitLabCredentials, or BitBucketCredentials block can be used to specify the credentials to use for cloning the repository.",
+					"default": "{{ prefect.blocks.github-credentials.my-credentials }}",
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.(github|gitlab|bitbucket)\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
+					"examples": [
+						"{{ prefect.blocks.github-credentials.my-credentials }}",
+						"{{ prefect.blocks.gitlab-credentials.my-credentials }}",
+						"{{ prefect.blocks.bitbucket-credentials.my-credentials }}"
+					]
+				}
+			},
+			"required": ["repository"]
+		},
+		"prefect_aws.deployments.steps.pull_from_s3": {
+			"type": "object",
+			"properties": {
+				"requires": {
+					"type": "string",
+					"title": "Required Packages",
+					"description": "A list of dependencies that must be built before this step.",
+					"default": "prefect-aws",
+					"examples": [
+						"prefect-aws", "prefect-aws>=0.3.0"
+					],
+					"pattern": "prefect-aws.*"
+				},
+				"bucket": {
+					"type": "string",
+					"title": "Bucket",
+					"description": "The name of the S3 bucket where files are stored.",
+					"examples": [
+						"myS3Bucket"
+					],
+					"default": "myS3Bucket"
+				},
+				"folder": {
+					"type": "string",
+					"title": "Folder",
+					"description": "The folder in the S3 bucket where files are stored.",
+					"examples": [
+						"myFolder"
+					],
+					"default": "myFolder"
+				},
+				"credentials": {
+					"type": ["object", "string"],
+					"title": "Credentials",
+					"description": "A dictionary of AWS credentials (aws_access_key_id, aws_secret_access_key, aws_session_token).",
+					"properties": {
+						"aws_access_key_id": {
+							"type": "string"
+						},
+						"aws_secret_access_key": {
+							"type": "string"
+						},
+						"aws_session_token": {
+							"type": "string"
+						}
+					},
+					"default": null,
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.aws\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
+					"examples": [
+						"{{ prefect.blocks.aws-credentials.default }}",
+						{
+							"aws_access_key_id": "myAccessKey",
+							"aws_secret_access_key": "mySecretAccessKey",
+							"aws_session_token": "mySessionToken"
+						}
+					]
+				},
+				"client_parameters": {
+					"type": ["object", "null"],
+					"title": "Client Parameters",
+					"description": "A dictionary of additional parameters to pass to the boto3 client.",
+					"default": null,
+					"examples": [{
+						"region_name": "us-east-1"
+					}]
+				}
+			},
+			"required": ["requires", "bucket", "folder"],
+			"title": "Pull from S3",
+			"description": "Pulls the contents of an S3 bucket folder to the current working directory."
+		},
+		"prefect.deployments.steps.set_working_directory": {
+			"type": "object",
+			"title": "Set Working Directory",
+			"description": "Sets the working directory; works with both absolute and relative paths.",
+			"properties": {
+				"directory": {
+					"title": "Directory",
+					"type": "string",
+					"description": "The directory to set as the working directory.",
+					"default": "my-directory"
+				}
+			},
+			"required": ["directory"],
+			"examples": [{
+					"directory": "/path/to/working/directory"
+				},
+				{
+					"directory": "./relative/path/to/working/directory"
+				}
+			]
+		},
+		"prefect.deployments.steps.run_shell_script": {
+			"type": "object",
+			"title": "Run Shell Script",
+			"description": "Runs one or more shell commands in a subprocess. Returns the standard output and standard error of the script.",
+			"properties": {
+				"script": {
+					"type": "string",
+					"title": "Script",
+					"description": "The script to run.",
+					"default": "git rev-parse --short HEAD",
+					"examples": ["echo $USER"]
+				},
+				"directory": {
+					"type": "string",
+					"title": "Working Directory",
+					"description": "The directory to run the script in. Defaults to the current working directory.",
+					"default": "my-directory"
+				},
+				"env": {
+					"type": "object",
+					"title": "Environment Variables",
+					"description": "A dictionary of environment variables to set for the script.",
+					"default": {
+						"DEV_VAR": "devValue"
+					}
+				},
+				"stream_output": {
+					"type": "boolean",
+					"title": "Stream Output",
+					"description": "Whether to stream the output of the script to stdout/stderr.",
+					"default": true
+				},
+				"expand_env_vars": {
+					"type": "boolean",
+					"title": "Expand Environment Variables",
+					"description": "Whether to expand environment variables in the script before running it.",
+					"default": false
+				}
+			},
+			"required": ["script"],
+			"examples": [{
+					"script": "echo 'Hello, world!'",
+					"directory": "/path/to/directory",
+					"env": {
+						"KEY": "VALUE"
+					},
+					"stream_output": true,
+					"expand_env_vars": false
+				},
+				{
+					"script": "ls -l",
+					"stream_output": true
+				}
+			]
+		},
+		"prefect.deployments.steps.pip_install_requirements": {
+			"type": "object",
+			"title": "Pip Install Requirements",
+			"description": "Installs dependencies from a requirements.txt file.",
+			"properties": {
+				"requirements_file": {
+					"type": "string",
+					"title": "Requirements File",
+					"description": "The requirements.txt file to use for installation.",
+					"default": "requirements.txt",
+					"examples": [
+						"requirements.txt",
+						"path/to/requirements.txt"
+					]
+				},
+				"directory": {
+					"type": "string",
+					"title": "Directory",
+					"description": "The directory the requirements.txt file is in. Defaults to the current working directory.",
+					"default": "my-directory",
+					"examples": [
+						"/path/to/directory",
+						"./relative/path"
+					]
+				},
+				"stream_output": {
+					"type": "boolean",
+					"title": "Stream Output",
+					"description": "Whether to stream the output from pip install should be streamed to the console.",
+					"default": true,
+					"examples": [
+						true,
+						false
+					]
+				}
+			},
+			"required": ["requirements_file"]
+		},
+		"prefect_docker.deployments.steps.build_docker_image": {
+			"title": "Build Docker Image",
+			"type": "object",
+			"description": "Builds a Docker image for a Prefect deployment. Can be used within a prefect.yaml file to build a Docker image prior to creating or updating a deployment.",
+			"properties": {
+				"requires": {
+					"title": "Required Packages",
+					"type": "string",
+					"description": "A list of dependencies that must be built before this step.",
+					"default": "prefect-docker",
+					"examples": ["prefect-docker"],
+					"pattern": "prefect-docker.*"
+				},
+				"image_name": {
+					"title": "Image Name",
+					"type": "string",
+					"description": "The name of the Docker image to build, including the registry and repository.",
+					"default": "my-registry/my-repo",
+					"examples": ["my-registry/my-repo"]
+				},
+				"dockerfile": {
+					"title": "Dockerfile",
+					"type": "string",
+					"description": "The path to the Dockerfile used to build the image. If 'auto' is passed, a temporary Dockerfile will be created to build the image.",
+					"default": "Dockerfile"
+				},
+				"tag": {
+					"title": "Tag",
+					"type": ["string", "null"],
+					"description": "The tag to apply to the built image.",
+					"default": "latest",
+					"examples": ["latest"]
+				},
+				"push": {
+					"title": "Deprecated: Push to Registry",
+					"type": "boolean",
+					"description": "Whether or not to push the image after building.",
+					"default": false
+				},
+				"credentials": {
+					"title": "Credentials",
+					"type": ["object", "string"],
+					"description": "A dictionary containing the username, password, and URL for the registry to push the image to.",
+					"default": "{{ prefect.blocks.docker-registry-credentials.dev-registry }}",
+					"pattern": "^\\{\\{\\s*prefect\\.blocks\\.docker\\-registry\\-credentials\\.[a-zA-Z0-9_\\-]+\\s*\\}\\}$",
+					"examples": ["{{ prefect.blocks.docker-registry-credentials.dev-registry }}"]
+				},
+				"build_kwargs": {
+					"title": "Build Keyword Arguments",
+					"type": "object",
+					"description": "Additional keyword arguments to pass to Docker when building the image. Available options can be found in the docker-py documentation.",
+					"default": {}
+				}
+			},
+			"required": ["requires", "image_name", "dockerfile"],
+			"additionalProperties": false
+		}
+	},
+	"required": ["name", "prefect-version"]
+}

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -166,7 +166,7 @@
 					}
 				]
 			},
-			"description": "tbd"
+			"description": "The pull section contains instructions for preparing your flows for a deployment run. These instructions will be executed each time a deployment created within this folder is run via a worker."
 		},
 		"build": {
 			"type": ["array", "null"],
@@ -214,7 +214,7 @@
 					}
 				]
 			},
-			"description": "tbd"
+			"description": "The build section of prefect.yaml is where any necessary side effects for running your deployments are built - the most common type of side effect produced here is a Docker image. "
 		},
 		"deployments": {
 			"type": "array",
@@ -446,17 +446,16 @@
 			"title": "Push Docker Image",
 			"description": "Push a Docker image to a remote registry.",
 			"properties": {
-				"requires": 
-					{
-						"type": "string",
-						"title": "Required Packages",
-						"description": "A list of dependencies that must be built before this step.",
-						"default": "prefect-docker",
-						"examples": [
-							"prefect-docker"
-						],
-						"pattern": "prefect-docker.*"
-					},
+				"requires": {
+					"type": "string",
+					"title": "Required Packages",
+					"description": "A list of dependencies that must be built before this step.",
+					"default": "prefect-docker",
+					"examples": [
+						"prefect-docker"
+					],
+					"pattern": "prefect-docker.*"
+				},
 				"image_name": {
 					"type": "string",
 					"title": "Image Name",

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -760,6 +760,11 @@
             },
             "additionalProperties": false,
             "required": ["prefect.deployments.steps.pip_install_requirements"]
+          },
+          {
+            "type": "object",
+            "description": "A custom step created by the user",
+            "additionalProperties": true,
           }
         ]
       }
@@ -840,6 +845,11 @@
             },
             "additionalProperties": false,
             "required": ["prefect.deployments.steps.pip_install_requirements"]
+          },
+          {
+            "type": "object",
+            "description": "A custom step created by the user",
+            "additionalProperties": true,
           }
         ]
       },
@@ -889,6 +899,11 @@
             },
             "additionalProperties": false,
             "required": ["prefect.deployments.steps.pip_install_requirements"]
+          },
+          {
+            "type": "object",
+            "description": "A custom step created by the user",
+            "additionalProperties": true,
           }
         ]
       },

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -843,8 +843,8 @@
           }
         ]
       },
-      "description": "tbd"
-    },
+      "description": "The pull section contains instructions for preparing your flows for a deployment run. These instructions will be executed each time a deployment created within this folder is run via a worker."
+	},
     "build": {
       "type": ["array", "null"],
       "items": {
@@ -892,8 +892,8 @@
           }
         ]
       },
-      "description": "tbd"
-    },
+      "description": "The build section of prefect.yaml is where any necessary side effects for running your deployments are built - the most common type of side effect produced here is a Docker image. "
+	},
     "deployments": {
       "type": "array",
       "items": {

--- a/src/schemas/json/prefect-deploy.json
+++ b/src/schemas/json/prefect-deploy.json
@@ -71,7 +71,7 @@
       "title": "Push Docker Image",
       "description": "Push a Docker image to a remote registry.",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -135,7 +135,7 @@
     "prefect_gcp.deployments.steps.push_to_gcs": {
       "type": "object",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -219,7 +219,7 @@
     "prefect_aws.deployments.steps.push_to_s3": {
       "type": "object",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -302,7 +302,7 @@
       "title": "Pull from Azure Blob Storage",
       "description": "Pulls from an Azure Blob Storage container.",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -358,7 +358,7 @@
     "prefect_gcp.deployments.steps.pull_from_gcs": {
       "type": "object",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -435,7 +435,7 @@
     "prefect.deployments.steps.git_clone": {
       "type": "object",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -490,7 +490,7 @@
     "prefect_aws.deployments.steps.pull_from_s3": {
       "type": "object",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -566,7 +566,7 @@
       "title": "Set Working Directory",
       "description": "Sets the working directory; works with both absolute and relative paths.",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -595,7 +595,7 @@
       "title": "Run Shell Script",
       "description": "Runs one or more shell commands in a subprocess. Returns the standard output and standard error of the script.",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -658,7 +658,7 @@
       "title": "Pip Install Requirements",
       "description": "Installs dependencies from a requirements.txt file.",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",
@@ -694,7 +694,7 @@
       "type": "object",
       "description": "Builds a Docker image for a Prefect deployment. Can be used within a prefect.yaml file to build a Docker image prior to creating or updating a deployment.",
       "properties": {
-          "id": {
+        "id": {
           "type": "string",
           "title": "Step ID",
           "description": "The ID of the step to pass to a downstream step.",

--- a/src/test/prefect-deploy/prefect.yaml
+++ b/src/test/prefect-deploy/prefect.yaml
@@ -1,0 +1,9 @@
+# Welcome to your prefect.yaml file! You can use this file for storing and managing
+# configuration for deploying your flows. We recommend committing this file to source
+# control along with your flow code.
+
+# Generic metadata about this project
+name: flows
+prefect-version: 2.11.4
+
+# WIP


### PR DESCRIPTION
## Description
This PR adds a new JSON schema for Prefect deployments. The schema aims to provide a structured way to define the various steps and configurations involved in deploying Prefect flows via `prefect deploy`. However, please note that this schema still needs tests.

## Key Points
- Introduces a `prefect-deploy.json` schema file.
- Attempts to cover all major elements of a Prefect deployment.

## Pending Issues
- Schema might not pass strict validation due to use of union types in certain fields and may require additional settings such as `allowUnionTypes`: true).
