### PR TITLE
add new Hugo theme JSON schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4757,7 +4757,7 @@
     {
       "name": "Hugo Theme",
       "description": "Hugo theme config file schema",
-      "fileMatch": ["theme.toml"],
+      "fileMatch": [],
       "url": "https://json.schemastore.org/hugo-theme.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4756,7 +4756,7 @@
     },
     {
       "name": "Hugo Theme",
-      "description": "Hugo theme config file schema",
+      "description": "Hugo theme config file",
       "fileMatch": [],
       "url": "https://json.schemastore.org/hugo-theme.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4755,6 +4755,12 @@
       "url": "https://json.schemastore.org/unist.json"
     },
     {
+      "name": "Hugo Theme",
+      "description": "Hugo theme config file schema",
+      "fileMatch": ["theme.toml"],
+      "url": "https://json.schemastore.org/hugo-theme.json"
+    },
+    {
       "name": "Hugo",
       "description": "Hugo static site generator config file schema",
       "fileMatch": ["hugo.toml", "hugo.json", "hugo.yaml"],

--- a/src/negative_test/hugo-theme/basic-requirement.toml
+++ b/src/negative_test/hugo-theme/basic-requirement.toml
@@ -1,0 +1,16 @@
+license     = "MIT"
+licenselink = "https://example.com/mit"
+description = "Theme description"
+homepage    = "https://example.com/theme"
+tags        = ["blog", "company"]
+features    = ["some", "awesome", "features"]
+
+[author]
+    name     = "awesomeness"
+    homepage = "https://example.com/awesomeness"
+
+# If porting an existing theme
+[original]
+    author   = "Name of original author"
+    homepage = "https://example.com/origin-author"
+    repo     = "https://example.com/origin-theme"

--- a/src/negative_test/hugo-theme/incorrect-values.toml
+++ b/src/negative_test/hugo-theme/incorrect-values.toml
@@ -1,0 +1,23 @@
+name        = 100
+license     = false
+licenselink = "Link to theme's license"
+description = ["Theme description"]
+homepage    = "Website of your theme"
+tags        = ["blog", 29082023]
+features    = ["some", 9999, "features"]
+min_version = "0.59"
+
+authors = [
+    "awesomeness<https://example.com/awesomeness>",
+    { name = "awesomeless", homepage = "Website of author" },
+]
+
+[author]
+    name     = 2023
+    homepage = "Your website"
+
+# If porting an existing theme
+[original]
+    author   = 2022
+    homepage = "His/Her website"
+    repo     = "Link to source code of original theme"

--- a/src/negative_test/hugo-theme/mistake-author-s.toml
+++ b/src/negative_test/hugo-theme/mistake-author-s.toml
@@ -1,0 +1,17 @@
+name        = "Theme Name"
+license     = "MIT"
+licenselink = "https://example.com/mit"
+description = "Theme description"
+homepage    = "https://example.com/theme"
+tags        = ["blog", "company"]
+features    = ["some", "awesome", "features"]
+min_version = "0.59.1"
+
+author = [
+    { name = "awesomeness", homepage = "https://example.com/awesomeness" },
+    { name = "awesomeless", homepage = "https://example.com/awesomeless" },
+]
+
+[authors]
+    name     = "awesomeness"
+    homepage = "https://example.com/awesomeness"

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -564,9 +564,7 @@
     },
     {
       "hugo-theme.json": {
-        "unknownKeywords": [
-          "x-taplo-info"
-        ]
+        "unknownKeywords": ["x-taplo-info"]
       }
     },
     {

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -563,6 +563,13 @@
       }
     },
     {
+      "hugo-theme.json": {
+        "unknownKeywords": [
+          "x-taplo-info"
+        ]
+      }
+    },
+    {
       "huskyrc.json": {
         "unknownKeywords": [
           "x-intellij-html-description",

--- a/src/schemas/json/hugo-theme.json
+++ b/src/schemas/json/hugo-theme.json
@@ -1,146 +1,134 @@
 {
-    "$comment": "https://github.com/gohugoio/hugoThemes#themetoml",
-    "$id": "https://json.schemastore.org/hugo-theme.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "additionalProperties": false,
-    "definitions": {
-        "author-data": {
-            "additionalProperties": false,
-            "default": {
-                "name": ""
-            },
-            "properties": {
-                "homepage": {
-                    "format": "uri",
-                    "title": "author website",
-                    "type": "string"
-                },
-                "name": {
-                    "title": "author name",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        }
-    },
-    "description": "This file contains metadata about the theme and its creator or creators. Hugo only recognizes theme.toml file, any other files are not accepted. Learn more at https://github.com/gohugoio/hugoThemes#themetoml",
-    "properties": {
-        "$schema": {
-            "$comment": "Because the theme config file (`theme.toml`) only works with TOML format, so we don't need to support this property.",
-            "description": "Hugo will not recognize the theme config file if it is JSON or YAML format. Please use theme.toml file.",
-            "type": "null"
-        },
-        "authors": {
-            "description": "For themes that have multiple authors",
-            "items": {
-                "$ref": "#/definitions/author-data"
-            },
-            "minItems": 2,
-            "type": "array",
-            "title": "theme authors"
-        },
-        "author": {
-            "description": "For themes that have single author",
-            "$ref": "#/definitions/author-data",
-            "title": "theme author"
-        },
-        "description": {
-            "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
-            "title": "theme description",
-            "type": "string"
-        },
-        "features": {
-            "items": {
-                "type": "string"
-            },
-            "title": "theme features",
-            "type": "array"
-        },
+  "$comment": "https://github.com/gohugoio/hugoThemes#themetoml",
+  "$id": "https://json.schemastore.org/hugo-theme.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "author-data": {
+      "additionalProperties": false,
+      "default": {
+        "name": ""
+      },
+      "properties": {
         "homepage": {
-            "default": "https://",
-            "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
-            "format": "uri",
-            "title": "website of the theme",
-            "type": "string"
-        },
-        "license": {
-            "description": "Reference: https://choosealicense.com",
-            "title": "Theme License",
-            "type": "string"
-        },
-        "licenselink": {
-            "default": "https://",
-            "format": "uri",
-            "title": "Link to theme's license",
-            "type": "string"
-        },
-        "min_version": {
-            "description": "Since the version **0.54.0**, Hugo started using full semver. Therefore, it is required to be `X.Y.Z` format. For instance: `0.54` is incorrect, `0.54.0` is correct.",
-            "minLength": 5,
-            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
-            "title": "Minimum Hugo Version",
-            "type": "string"
+          "format": "uri",
+          "title": "author website",
+          "type": "string"
         },
         "name": {
-            "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
-            "title": "Theme Name",
-            "type": "string"
-        },
-        "original": {
-            "additionalProperties": false,
-            "default": {
-                "author": "",
-                "repo": "https://"
-            },
-            "description": "For themes that port an existing theme",
-            "properties": {
-                "author": {
-                    "title": "name of original author",
-                    "type": "string"
-                },
-                "homepage": {
-                    "format": "uri",
-                    "title": "his/her website",
-                    "type": "string"
-                },
-                "repo": {
-                    "description": "Link to source code of original theme",
-                    "format": "uri",
-                    "title": "author website",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "author",
-                "repo"
-            ],
-            "title": "original theme",
-            "type": "object"
-        },
-        "tags": {
-            "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
-            "items": {
-                "type": "string"
-            },
-            "title": "theme tags",
-            "type": "array"
+          "title": "author name",
+          "type": "string"
         }
-    },
-    "required": [
-        "name",
-        "min_version"
-    ],
-    "title": "Hugo theme config file schema",
-    "type": "object",
-    "x-taplo-info": {
-        "authors": [
-            "ngdangtu (https://gitlab.com/ngdangtu)"
-        ],
-        "patterns": [
-            "^(theme.toml)$"
-        ]
+      },
+      "required": ["name"],
+      "type": "object"
     }
+  },
+  "description": "This file contains metadata about the theme and its creator or creators. Hugo only recognizes theme.toml file, any other files are not accepted. Learn more at https://github.com/gohugoio/hugoThemes#themetoml",
+  "properties": {
+    "$schema": {
+      "$comment": "Because the theme config file (`theme.toml`) only works with TOML format, so we don't need to support this property.",
+      "description": "Hugo will not recognize the theme config file if it is JSON or YAML format. Please use theme.toml file.",
+      "type": "null"
+    },
+    "authors": {
+      "description": "For themes that have multiple authors",
+      "items": {
+        "$ref": "#/definitions/author-data"
+      },
+      "minItems": 2,
+      "type": "array",
+      "title": "theme authors"
+    },
+    "author": {
+      "description": "For themes that have single author",
+      "$ref": "#/definitions/author-data",
+      "title": "theme author"
+    },
+    "description": {
+      "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
+      "title": "theme description",
+      "type": "string"
+    },
+    "features": {
+      "items": {
+        "type": "string"
+      },
+      "title": "theme features",
+      "type": "array"
+    },
+    "homepage": {
+      "default": "https://",
+      "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
+      "format": "uri",
+      "title": "website of the theme",
+      "type": "string"
+    },
+    "license": {
+      "description": "Reference: https://choosealicense.com",
+      "title": "Theme License",
+      "type": "string"
+    },
+    "licenselink": {
+      "default": "https://",
+      "format": "uri",
+      "title": "Link to theme's license",
+      "type": "string"
+    },
+    "min_version": {
+      "description": "Since the version **0.54.0**, Hugo started using full semver. Therefore, it is required to be `X.Y.Z` format. For instance: `0.54` is incorrect, `0.54.0` is correct.",
+      "minLength": 5,
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "title": "Minimum Hugo Version",
+      "type": "string"
+    },
+    "name": {
+      "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
+      "title": "Theme Name",
+      "type": "string"
+    },
+    "original": {
+      "additionalProperties": false,
+      "default": {
+        "author": "",
+        "repo": "https://"
+      },
+      "description": "For themes that port an existing theme",
+      "properties": {
+        "author": {
+          "title": "name of original author",
+          "type": "string"
+        },
+        "homepage": {
+          "format": "uri",
+          "title": "his/her website",
+          "type": "string"
+        },
+        "repo": {
+          "description": "Link to source code of original theme",
+          "format": "uri",
+          "title": "author website",
+          "type": "string"
+        }
+      },
+      "required": ["author", "repo"],
+      "title": "original theme",
+      "type": "object"
+    },
+    "tags": {
+      "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
+      "items": {
+        "type": "string"
+      },
+      "title": "theme tags",
+      "type": "array"
+    }
+  },
+  "required": ["name", "min_version"],
+  "title": "Hugo theme config file schema",
+  "type": "object",
+  "x-taplo-info": {
+    "authors": ["ngdangtu (https://gitlab.com/ngdangtu)"],
+    "patterns": ["^(theme.toml)$"]
+  }
 }

--- a/src/schemas/json/hugo-theme.json
+++ b/src/schemas/json/hugo-theme.json
@@ -1,0 +1,146 @@
+{
+    "$comment": "https://github.com/gohugoio/hugoThemes#themetoml",
+    "$id": "https://json.schemastore.org/hugo-theme.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "definitions": {
+        "author-data": {
+            "additionalProperties": false,
+            "default": {
+                "name": ""
+            },
+            "properties": {
+                "homepage": {
+                    "format": "uri",
+                    "title": "author website",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "author name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        }
+    },
+    "description": "This file contains metadata about the theme and its creator or creators. Hugo only recognizes theme.toml file, any other files are not accepted. Learn more at https://github.com/gohugoio/hugoThemes#themetoml",
+    "properties": {
+        "$schema": {
+            "$comment": "Because the theme config file (`theme.toml`) only works with TOML format, so we don't need to support this property.",
+            "description": "Hugo will not recognize the theme config file if it is JSON or YAML format. Please use theme.toml file.",
+            "type": "null"
+        },
+        "authors": {
+            "description": "For themes that have multiple authors",
+            "items": {
+                "$ref": "#/definitions/author-data"
+            },
+            "minItems": 2,
+            "type": "array",
+            "title": "theme authors"
+        },
+        "author": {
+            "description": "For themes that have single author",
+            "$ref": "#/definitions/author-data",
+            "title": "theme author"
+        },
+        "description": {
+            "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
+            "title": "theme description",
+            "type": "string"
+        },
+        "features": {
+            "items": {
+                "type": "string"
+            },
+            "title": "theme features",
+            "type": "array"
+        },
+        "homepage": {
+            "default": "https://",
+            "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
+            "format": "uri",
+            "title": "website of the theme",
+            "type": "string"
+        },
+        "license": {
+            "description": "Reference: https://choosealicense.com",
+            "title": "Theme License",
+            "type": "string"
+        },
+        "licenselink": {
+            "default": "https://",
+            "format": "uri",
+            "title": "Link to theme's license",
+            "type": "string"
+        },
+        "min_version": {
+            "description": "Since the version **0.54.0**, Hugo started using full semver. Therefore, it is required to be `X.Y.Z` format. For instance: `0.54` is incorrect, `0.54.0` is correct.",
+            "minLength": 5,
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+            "title": "Minimum Hugo Version",
+            "type": "string"
+        },
+        "name": {
+            "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
+            "title": "Theme Name",
+            "type": "string"
+        },
+        "original": {
+            "additionalProperties": false,
+            "default": {
+                "author": "",
+                "repo": "https://"
+            },
+            "description": "For themes that port an existing theme",
+            "properties": {
+                "author": {
+                    "title": "name of original author",
+                    "type": "string"
+                },
+                "homepage": {
+                    "format": "uri",
+                    "title": "his/her website",
+                    "type": "string"
+                },
+                "repo": {
+                    "description": "Link to source code of original theme",
+                    "format": "uri",
+                    "title": "author website",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "author",
+                "repo"
+            ],
+            "title": "original theme",
+            "type": "object"
+        },
+        "tags": {
+            "description": "This info is used by Hugo theme store: https://themes.gohugo.io",
+            "items": {
+                "type": "string"
+            },
+            "title": "theme tags",
+            "type": "array"
+        }
+    },
+    "required": [
+        "name",
+        "min_version"
+    ],
+    "title": "Hugo theme config file schema",
+    "type": "object",
+    "x-taplo-info": {
+        "authors": [
+            "ngdangtu (https://gitlab.com/ngdangtu)"
+        ],
+        "patterns": [
+            "^(theme.toml)$"
+        ]
+    }
+}

--- a/src/test/hugo-theme/multiple-authors.toml
+++ b/src/test/hugo-theme/multiple-authors.toml
@@ -1,0 +1,19 @@
+name        = "Theme Name"
+license     = "MIT"
+licenselink = "https://example.com/mit"
+description = "Theme description"
+homepage    = "https://example.com/theme"
+tags        = ["blog", "company"]
+features    = ["some", "awesome", "features"]
+min_version = "0.59.1"
+
+authors = [
+    { name = "awesomeness", homepage = "https://example.com/awesomeness" },
+    { name = "awesomeless", homepage = "https://example.com/awesomeless" },
+]
+
+# If porting an existing theme
+[original]
+    author   = "Name of original author"
+    homepage = "https://example.com/origin-author"
+    repo     = "https://example.com/origin-theme"

--- a/src/test/hugo-theme/single-author.toml
+++ b/src/test/hugo-theme/single-author.toml
@@ -1,0 +1,18 @@
+name        = "Theme Name"
+license     = "MIT"
+licenselink = "https://example.com/mit"
+description = "Theme description"
+homepage    = "https://example.com/theme"
+tags        = ["blog", "company"]
+features    = ["some", "awesome", "features"]
+min_version = "0.59.1"
+
+[author]
+    name     = "awesomeness"
+    homepage = "https://example.com/awesomeness"
+
+# If porting an existing theme
+[original]
+    author   = "Name of original author"
+    homepage = "https://example.com/origin-author"
+    repo     = "https://example.com/origin-theme"


### PR DESCRIPTION
- add a JSON schema for `theme.toml`
- add a catalog
- add test cases: 2-positive, 3-negative
- add an unknown keyword (Taplo extension)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
