### PR TITLE
GitHub workflow's `fail-fast` also supports expressions (string)

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -522,7 +522,7 @@
             "fail-fast": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast",
               "description": "When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true",
-              "type": "boolean",
+              "type": ["boolean", "string"],
               "default": true
             },
             "max-parallel": {
@@ -904,7 +904,7 @@
             "fail-fast": {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast",
               "description": "When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true",
-              "type": "boolean",
+              "type": ["boolean", "string"],
               "default": true
             },
             "max-parallel": {

--- a/src/test/github-workflow/fail-fast.yaml
+++ b/src/test/github-workflow/fail-fast.yaml
@@ -1,0 +1,7 @@
+jobs:
+  boolean:
+    strategy:
+      fail-fast: true
+  non-boolean:
+    strategy:
+      fail-fast: ${{ github.ref == 'refs/heads/main' }}

--- a/src/test/github-workflow/fail-fast.yaml
+++ b/src/test/github-workflow/fail-fast.yaml
@@ -1,7 +1,19 @@
+on:
+  pull_request:
+  push:
 jobs:
   boolean:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
+      matrix:
+        version: [10, 12, 14]
+        os: [ubuntu-latest, windows-latest]
+
   non-boolean:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ github.ref == 'refs/heads/main' }}
+      matrix:
+        version: [10, 12, 14]
+        os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Add support for [expressions](https://docs.github.com/en/actions/learn-github-actions/expressions) to the [`fail-fast` field](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast).

A quick GitHub search shows various examples in the wild: https://github.com/search?q=path%3A.github%2Fworkflows+%22fail-fast%3A+%24%7B%7B%22&type=code