### PR TITLE
Allow node10 in tsconfig.json moduleResolution

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -639,7 +639,7 @@
     },
     {
       "tsconfig.json": {
-        "unknownKeywords": ["markdownDescription"]
+        "unknownKeywords": ["markdownDescription", "markdownEnumDescriptions"]
       }
     },
     {
@@ -650,7 +650,7 @@
     {
       "tsoa.json": {
         "externalSchema": ["tsconfig.json"],
-        "unknownKeywords": ["markdownDescription"]
+        "unknownKeywords": ["markdownDescription", "markdownEnumDescriptions"]
       }
     },
     {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -382,13 +382,27 @@
               "type": "string",
               "anyOf": [
                 {
-                  "enum": ["Classic", "Node", "Node16", "NodeNext", "Bundler"]
+                  "enum": [
+                    "Classic",
+                    "Node",
+                    "Node10",
+                    "Node16",
+                    "NodeNext",
+                    "Bundler"
+                  ],
+                  "markdownEnumDescriptions": [
+                    "It’s recommended to use `\"Node16\"` instead",
+                    "Deprecated, use `\"Node10\"` instead",
+                    "It’s recommended to use `\"Node16\"` instead",
+                    "This is the recommended setting for libraries and Node.js applications",
+                    "This is the recommended setting for libraries and Node.js applications",
+                    "This is the recommended setting for applications that use a bundler"
+                  ]
                 },
                 {
-                  "pattern": "^(([Nn]ode)|([Nn]ode16)|([Nn]ode[Nn]ext)|([Cc]lassic)|([Bb]undler))$"
+                  "pattern": "^(([Nn]ode)|([Nn]ode1[06])|([Nn]ode[Nn]ext)|([Cc]lassic)|([Bb]undler))$"
                 }
               ],
-              "default": "classic",
               "markdownDescription": "Specify how TypeScript looks up a file from a given module specifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleResolution"
             },
             "newLine": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -392,11 +392,11 @@
                   ],
                   "markdownEnumDescriptions": [
                     "It’s recommended to use `\"Node16\"` instead",
-                    "Deprecated, use `\"Node10\"` instead",
+                    "Deprecated, use `\"Node10\"` in TypeScript 5.0+ instead",
                     "It’s recommended to use `\"Node16\"` instead",
                     "This is the recommended setting for libraries and Node.js applications",
                     "This is the recommended setting for libraries and Node.js applications",
-                    "This is the recommended setting for applications that use a bundler"
+                    "This is the recommended setting in TypeScript 5.0+ for applications that use a bundler"
                   ]
                 },
                 {


### PR DESCRIPTION
`node` was renamed to `node10`, but `node` is still a deprecated alias.

Also the default value was removed because the default value depends on the value of `module`. Also a description was added for each possible value.

Possibly @andrewbranch has an opinion on this.