### PR TITLE
Fix: Added "WSL2" to commandName in Launchsettings schema

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -80,7 +80,8 @@
             "DebugRoslynComponent",
             "Docker",
             "DockerCompose",
-            "MsixPackage"
+            "MsixPackage",
+            "WSL2"
           ],
           "default": "",
           "minLength": 1


### PR DESCRIPTION
Should allow WSL2 which is an option Visual Studio 2022 provides to launch apps with WSL2 as per the documentation https://learn.microsoft.com/en-us/visualstudio/debugger/debug-dotnet-core-in-wsl-2?view=vs-2022

Closes #3189