### PR TITLE
chore: Upgrade Prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,5 +7,5 @@ repos:
         types_or: [yaml, json, javascript, css, markdown]
         always_run: true
         additional_dependencies:
-          - prettier@2.8.3
-          - prettier-plugin-sort-json@1.0.0
+          - 'prettier@3.0.3'
+          - 'prettier-plugin-sort-json@3.0.1'

--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -896,11 +896,9 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
     'local_assert_catalog.json_validates',
     'Check that the catalog.json file passes schema validation',
     function () {
-      const catalogSchema = require(path.resolve(
-        '.',
-        schemaDir,
-        'schema-catalog.json',
-      ))
+      const catalogSchema = require(
+        path.resolve('.', schemaDir, 'schema-catalog.json'),
+      )
       const ajvInstance = factoryAJV({ schemaName: 'draft-04' })
       if (ajvInstance.validate(catalogSchema, catalog)) {
         grunt.log.ok('catalog.json OK')

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -3,7 +3,12 @@
 }
 
 body {
-  font: 18px/1.5 'Segoe UI', 'Segoe WP Light', 'Segoe WP', Tahoma, Arial,
+  font:
+    18px/1.5 'Segoe UI',
+    'Segoe WP Light',
+    'Segoe WP',
+    Tahoma,
+    Arial,
     sans-serif;
   margin: 0;
   background: white;

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -25,8 +25,8 @@
         "eslint-plugin-promise": "^6.1.1",
         "find-duplicated-property-keys": "^1.2.9",
         "grunt": "^1.6.0",
-        "prettier": "^2.8.3",
-        "prettier-plugin-sort-json": "^1.0.0",
+        "prettier": "^3.0.3",
+        "prettier-plugin-sort-json": "^3.0.1",
         "yaml": "^2.2.1"
       },
       "engines": {
@@ -208,12 +208,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "node_modules/@types/prettier": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -3166,33 +3160,30 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-plugin-sort-json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-json/-/prettier-plugin-sort-json-1.0.0.tgz",
-      "integrity": "sha512-XgcaF/Sojax1vD6j53wNIByx0rp7ecang+A8W0eM+Ks3yBFu/qXjJNvUtC1lEWeYbNfmRs/d8FyYJCYozAVENw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-json/-/prettier-plugin-sort-json-3.0.1.tgz",
+      "integrity": "sha512-YwBxM8FxhnTW/Y6oovigLOSvqdNdkyIAi9JdDK2SS5T+Nws6MDhr+xEuiPf83TSPDfWjRc71riMYMfmMHtj05w==",
       "dev": true,
-      "dependencies": {
-        "@types/prettier": "^2.7.2"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "prettier": "^2.3.2"
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/proxy-from-env": {

--- a/src/package.json
+++ b/src/package.json
@@ -47,8 +47,8 @@
     "eslint-plugin-promise": "^6.1.1",
     "find-duplicated-property-keys": "^1.2.9",
     "grunt": "^1.6.0",
-    "prettier": "^2.8.3",
-    "prettier-plugin-sort-json": "^1.0.0",
+    "prettier": "^3.0.3",
+    "prettier-plugin-sort-json": "^3.0.1",
     "yaml": "^2.2.1"
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

A few weeks ago [prettier-plugin-sort-json](https://github.com/Gudahtt/prettier-plugin-sort-json/releases/tag/v3.0.0) released v3.0.0, which made it compatable with `prettier@v3`.

Now, we can update to `prettier@v3` without breaking `prettier-plugins-sort-json`. This does that.