### PR TITLE
feat: update prettier schema to 3.x major version

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2993,7 +2993,9 @@
       ],
       "url": "https://json.schemastore.org/prettierrc.json",
       "versions": {
-        "1.8.2": "https://json.schemastore.org/prettierrc-1.8.2.json"
+        "1.8.2": "https://json.schemastore.org/prettierrc-1.8.2.json",
+        "2.8.8": "https://json.schemastore.org/prettierrc-2.8.8.json",
+        "3.0.0": "https://json.schemastore.org/prettierrc.json"
       }
     },
     {

--- a/src/schemas/json/prettierrc-2.8.8.json
+++ b/src/schemas/json/prettierrc-2.8.8.json
@@ -309,12 +309,8 @@
         },
         "trailingComma": {
           "description": "Print trailing commas wherever possible when multi-line.",
-          "default": "all",
+          "default": "es5",
           "oneOf": [
-            {
-              "enum": ["all"],
-              "description": "Trailing commas wherever possible (including function arguments)."
-            },
             {
               "enum": ["es5"],
               "description": "Trailing commas where valid in ES5 (objects, arrays, etc.)"
@@ -322,6 +318,10 @@
             {
               "enum": ["none"],
               "description": "No trailing commas."
+            },
+            {
+              "enum": ["all"],
+              "description": "Trailing commas wherever possible (including function arguments)."
             }
           ]
         },

--- a/src/test/prettierrc/.prettierrc.yml
+++ b/src/test/prettierrc/.prettierrc.yml
@@ -5,11 +5,11 @@ tabWidth: 4
 semi: false
 singleQuote: true
 overrides:
-    - files: '*.test.js'
-      options:
-          semi: true
-    - files:
-          - '*.html'
-          - 'legacy/**/*.js'
-      options:
-          tabWidth: 4
+  - files: '*.test.js'
+    options:
+      semi: true
+  - files:
+      - '*.html'
+      - 'legacy/**/*.js'
+    options:
+      tabWidth: 4

--- a/src/test/prettierrc/.prettierrc.yml
+++ b/src/test/prettierrc/.prettierrc.yml
@@ -5,11 +5,11 @@ tabWidth: 4
 semi: false
 singleQuote: true
 overrides:
-  - files: '*.test.js'
-    options:
-      semi: true
-  - files:
-      - '*.html'
-      - 'legacy/**/*.js'
-    options:
-      tabWidth: 4
+    - files: '*.test.js'
+      options:
+          semi: true
+    - files:
+          - '*.html'
+          - 'legacy/**/*.js'
+      options:
+          tabWidth: 4

--- a/src/test/prettierrc/.prettierrc.yml
+++ b/src/test/prettierrc/.prettierrc.yml
@@ -1,6 +1,6 @@
 # .prettierrc or .prettierrc.yaml
 # https://prettier.io/docs/en/configuration.html
-trailingComma: 'es5'
+trailingComma: 'all'
 tabWidth: 4
 semi: false
 singleQuote: true

--- a/src/test/prettierrc/prettierrc.json
+++ b/src/test/prettierrc/prettierrc.json
@@ -26,6 +26,6 @@
     "semi": true,
     "singleQuote": false,
     "tabWidth": 2,
-    "trailingComma": "es5",
+    "trailingComma": "all",
     "useTabs": false
 }

--- a/src/test/prettierrc/prettierrc.json
+++ b/src/test/prettierrc/prettierrc.json
@@ -1,31 +1,31 @@
 {
-    "arrowParens": "always",
-    "bracketSpacing": true,
-    "htmlWhitespaceSensitivity": "css",
-    "insertPragma": false,
-    "jsxBracketSameLine": false,
-    "jsxSingleQuote": false,
-    "overrides": [
-        {
-            "files": ["*/*.Rmd"],
-            "options": {
-                "parser": "markdown"
-            }
-        },
-        {
-            "files": ["*/*.type"],
-            "options": {
-                "parser": "custom"
-            }
-        }
-    ],
-    "printWidth": 80,
-    "proseWrap": "preserve",
-    "quoteProps": "as-needed",
-    "requirePragma": false,
-    "semi": true,
-    "singleQuote": false,
-    "tabWidth": 2,
-    "trailingComma": "all",
-    "useTabs": false
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "overrides": [
+    {
+      "files": ["*/*.Rmd"],
+      "options": {
+        "parser": "markdown"
+      }
+    },
+    {
+      "files": ["*/*.type"],
+      "options": {
+        "parser": "custom"
+      }
+    }
+  ],
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
 }

--- a/src/test/prettierrc/prettierrc.json
+++ b/src/test/prettierrc/prettierrc.json
@@ -1,31 +1,31 @@
 {
-  "arrowParens": "always",
-  "bracketSpacing": true,
-  "htmlWhitespaceSensitivity": "css",
-  "insertPragma": false,
-  "jsxBracketSameLine": false,
-  "jsxSingleQuote": false,
-  "overrides": [
-    {
-      "files": ["*/*.Rmd"],
-      "options": {
-        "parser": "markdown"
-      }
-    },
-    {
-      "files": ["*/*.type"],
-      "options": {
-        "parser": "custom"
-      }
-    }
-  ],
-  "printWidth": 80,
-  "proseWrap": "preserve",
-  "quoteProps": "as-needed",
-  "requirePragma": false,
-  "semi": true,
-  "singleQuote": false,
-  "tabWidth": 2,
-  "trailingComma": "all",
-  "useTabs": false
+    "arrowParens": "always",
+    "bracketSpacing": true,
+    "htmlWhitespaceSensitivity": "css",
+    "insertPragma": false,
+    "jsxBracketSameLine": false,
+    "jsxSingleQuote": false,
+    "overrides": [
+        {
+            "files": ["*/*.Rmd"],
+            "options": {
+                "parser": "markdown"
+            }
+        },
+        {
+            "files": ["*/*.type"],
+            "options": {
+                "parser": "custom"
+            }
+        }
+    ],
+    "printWidth": 80,
+    "proseWrap": "preserve",
+    "quoteProps": "as-needed",
+    "requirePragma": false,
+    "semi": true,
+    "singleQuote": false,
+    "tabWidth": 2,
+    "trailingComma": "all",
+    "useTabs": false
 }


### PR DESCRIPTION
According to Prettier 3.0.0 [Release Note](https://prettier.io/blog/2023/07/05/3.0.0.html) `trailingComma` changed default behavior from `es5` to `all`. It could be nice to handle this case.

I made a copy of schema valid with the newest Prettier 2.x for backward compatibility.