### PR TITLE
feat: add volta to package.json schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -661,6 +661,21 @@
         "type": "string"
       }
     },
+    "volta": {
+      "description": "Defines which tools and versions are expected to be used when Volta is installed.",
+      "type": "object",
+      "properties": {
+        "extends": {
+          "description": "The value of that entry should be a path to another JSON file which also has a \"volta\" section",
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "(node|npm|pnpm|yarn)": {
+          "type": "string"
+        }
+      }
+    },
     "engineStrict": {
       "type": "boolean"
     },


### PR DESCRIPTION
Adds Volta to `package.json` based on https://docs.volta.sh/guide/understanding#managing-your-toolchain and https://docs.volta.sh/advanced/workspaces