### PR TITLE
Update minecraft-pack-mcmeta.json

### DIFF
--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -1,9 +1,8 @@
 {
-  "$comment": "https://minecraft.fandom.com/wiki/Data_Pack",
   "$id": "https://json.schemastore.org/minecraft-pack-mcmeta.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
-  "description": "A pack metadata\nhttps://minecraft.fandom.com/wiki/Data_pack",
+  "description": "Minecraft Resource/Data Pack Metadata\nhttps://minecraft.fandom.com/wiki/Resource_pack\nhttps://minecraft.fandom.com/wiki/Data_pack",
   "properties": {
     "pack": {
       "title": "pack options",
@@ -17,7 +16,7 @@
         "pack_format": {
           "description": "A version for the current pack\nhttps://minecraft.fandom.com/wiki/Data_pack#Contents",
           "type": "integer",
-          "minimum": 4,
+          "minimum": 1,
           "maximum": 15,
           "default": 4
         }


### PR DESCRIPTION
- Reference resource packs in addition to data packs
- Set minimum pack version to 1 (Minecraft 1.6.1-1.8.9)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
