### PR TITLE
Adept author regex from poetry project

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -36,7 +36,7 @@
     "poetry-author-pattern": {
       "description": "Pattern that matches `Name <email>` like 'King Arthur' or 'Miss Islington &lt;miss-islington@python.org&gt;'.",
       "type": "string",
-      "pattern": "^(?:\\S+?\\s)+?(?:<(?:[a-z\\d!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z\\d!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z\\d](?:[a-z\\d-]*[a-z\\d])?\\.)+[a-z\\d](?:[a-z\\d-]*[a-z\\d])?|\\[(?:(?:25[0-5]|2[0-4][\\d]|[01]?[\\d][\\d]?)\\.){3}(?:25[0-5]|2[0-4][\\d]|[01]?[\\d][\\d]?|[a-z\\d-]*[a-z\\d]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])>)?$"
+      "pattern": "^(?:[- .,\\w\\d'’\\\"():&]+)(?: <(?:.+?)>)?"    
     },
     "poetry-authors": {
       "type": "array",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -36,7 +36,7 @@
     "poetry-author-pattern": {
       "description": "Pattern that matches `Name <email>` like 'King Arthur' or 'Miss Islington &lt;miss-islington@python.org&gt;'.",
       "type": "string",
-      "pattern": "^(?:[- .,\\w\\d'’\\\"():&]+)(?: <(?:.+?)>)?"    
+      "pattern": "^(?:[- .,\\w\\d'’\"():&]+)(?: <(?:.+?)>)?"
     },
     "poetry-authors": {
       "type": "array",

--- a/src/test/pyproject/poetry-author-no-email.toml
+++ b/src/test/pyproject/poetry-author-no-email.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "single-python"
+version = "0.1"
+description = "Some description."
+authors = ["Wagner Macedo <Fake.Mail@example.com>"]
+license = "MIT"
+
+readme = ["README-1.rst", "README-2.rst"]
+
+homepage = "https://python-poetry.org/"
+
+
+[tool.poetry.dependencies]
+python = "2.7.15"

--- a/src/test/pyproject/poetry-capital-in-author-email.toml
+++ b/src/test/pyproject/poetry-capital-in-author-email.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "single-python"
+version = "0.1"
+description = "Some description."
+authors = ["Wagner Macedo"]
+license = "MIT"
+
+readme = ["README-1.rst", "README-2.rst"]
+
+homepage = "https://python-poetry.org/"
+
+
+[tool.poetry.dependencies]
+python = "2.7.15"


### PR DESCRIPTION
This PR solves https://github.com/tamasfe/taplo/issues/360 and https://github.com/tamasfe/taplo/issues/384

We adept the Regex in use in the poetry project https://github.com/python-poetry/poetry-core/blob/main/src/poetry/core/packages/package.py in order to be just as permissive as the Poetry project, for which we are validating.


----
This PR is our first contribution. We are very open to suggestions and improvements.

This PR was a group effort by Ordina Pythoneers, they would like to thank Ordina for the time to do this.

@SanderBeekhuis
@RoelAdriaans
@Coen-Smulders

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
