### PR TITLE
feat: add g2p mapping configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1729,6 +1729,18 @@
       "url": "https://json.schemastore.org/function.json"
     },
     {
+      "name": "G2P Mapping Configuration",
+      "description": "JSON Schema for defining mappings for Python-based grapheme-to-phoneme engine 'g2p'.",
+      "fileMatch": [
+        "config-g2p.yaml",
+        "config-g2p.json"
+      ],
+      "versions": {
+        "2.0": "https://raw.githubusercontent.com/roedoejet/g2p/main/g2p/mappings/.schema/g2p-config-schema-2.0.json"
+      },
+      "url": "https://raw.githubusercontent.com/roedoejet/g2p/main/g2p/mappings/.schema/g2p-config-schema-2.0.json"
+    },
+    {
       "name": "GatewayCore API Gateway",
       "description": "JSON schema for Cloudtoid GatewayCore API Gateway and Reverse Proxy",
       "fileMatch": [

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1731,10 +1731,7 @@
     {
       "name": "G2P Mapping Configuration",
       "description": "JSON Schema for defining mappings for Python-based grapheme-to-phoneme engine 'g2p'.",
-      "fileMatch": [
-        "config-g2p.yaml",
-        "config-g2p.json"
-      ],
+      "fileMatch": ["config-g2p.yaml", "config-g2p.json"],
       "versions": {
         "2.0": "https://raw.githubusercontent.com/roedoejet/g2p/main/g2p/mappings/.schema/g2p-config-schema-2.0.json"
       },


### PR DESCRIPTION
Hello there and thank you for this great project! 

We would like to submit a schema for [g2p](https://github.com/roedoejet/g2p). I followed [the guide for adding a self-hosted schema](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#how-to-add-a-json-schema-thats-self-hostedremoteexternal) and used [this PR](https://github.com/SchemaStore/schemastore/pull/1211/files) as the reference. As such, despite the PR default message I did not add test files. Please let me know if anything else needs addressing.

- [x] Adding a JSON schema file to the catalog is required.
- [ ] Add tests files. (.json, .yml, .yaml or .toml)
- [x] Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
- [x] JSON formatted according to the .editorconfig settings.
