### PR TITLE
Update file matching pattern for AsyncAPI

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -305,11 +305,11 @@
       "description": "A JSON Schema for validating AsyncAPI documentation files",
       "fileMatch": [
         "asyncapi.json",
-        "*asyncapi.json",
+        "*asyncapi*.json",
         "asyncapi.yml",
-        "*asyncapi.yml",
+        "*asyncapi*.yml",
         "asyncapi.yaml",
-        "*asyncapi.yaml"
+        "*asyncapi*.yaml"
       ],
       "url": "https://www.asyncapi.com/schema-store/all.schema-store.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -304,11 +304,8 @@
       "name": "AsyncAPI",
       "description": "A JSON Schema for validating AsyncAPI documentation files",
       "fileMatch": [
-        "asyncapi.json",
         "*asyncapi*.json",
-        "asyncapi.yml",
         "*asyncapi*.yml",
-        "asyncapi.yaml",
         "*asyncapi*.yaml"
       ],
       "url": "https://www.asyncapi.com/schema-store/all.schema-store.json"

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -303,11 +303,7 @@
     {
       "name": "AsyncAPI",
       "description": "A JSON Schema for validating AsyncAPI documentation files",
-      "fileMatch": [
-        "*asyncapi*.json",
-        "*asyncapi*.yml",
-        "*asyncapi*.yaml"
-      ],
+      "fileMatch": ["*asyncapi*.json", "*asyncapi*.yml", "*asyncapi*.yaml"],
       "url": "https://www.asyncapi.com/schema-store/all.schema-store.json"
     },
     {


### PR DESCRIPTION
Hey, I noticed people name their files also `asyncapi-cart.yaml` or similar, thus the change. I hope I got right how patterns work.

and just to clarify `"*asyncapi*.json` means any `json` file with `asyncapi` text in it, in root and nested folders? not just root?