### PR TITLE
fix: Use `https://json.schemastore.org` for JSON schema store link

### DIFF
--- a/src/schemas/json/sarif.json
+++ b/src/schemas/json/sarif.json
@@ -2842,7 +2842,7 @@
     }
   },
   "description": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.5 JSON Schema: a standard format for the output of static analysis tools.",
-  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-2.1.0-rtm.5.json",
+  "id": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
   "properties": {
     "$schema": {
       "description": "The URI of the JSON schema corresponding to the version.",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

This is the only instance of such an occurance.
