### PR TITLE
Problem package generators: add interaction key, negative test

### DIFF
--- a/src/negative_test/problem_package_generators/bad-argument.generators.yaml
+++ b/src/negative_test/problem_package_generators/bad-argument.generators.yaml
@@ -1,0 +1,14 @@
+data:
+  sample:
+    data:
+      "1":
+        in: "1"
+  secret:
+    data:
+      "2":
+        interaction: |
+          >Oh look, this isn't an argument!
+          <Yes it is!
+          >No it isn't!
+          It's just contradiction!
+          >No it isn't!

--- a/src/negative_test/problem_package_generators/bad-argument.generators.yaml
+++ b/src/negative_test/problem_package_generators/bad-argument.generators.yaml
@@ -1,11 +1,11 @@
 data:
   sample:
     data:
-      "1":
-        in: "1"
+      '1':
+        in: '1'
   secret:
     data:
-      "2":
+      '2':
         interaction: |
           >Oh look, this isn't an argument!
           <Yes it is!

--- a/src/schemas/json/problem_package_generators.json
+++ b/src/schemas/json/problem_package_generators.json
@@ -137,9 +137,7 @@
             "interaction": {
               "title": "Sample interaction",
               "description": "Input is prefixed with `<`, output is prefixed with `>`.",
-              "examples": [
-                "<1 2\n>3\n<4 5\n>9\n<6 7\n>13\n"
-              ],
+              "examples": ["<1 2\n>3\n<4 5\n>9\n<6 7\n>13\n"],
               "type": "string",
               "pattern": "^([<>][^\\n]*\\n)+$"
             },
@@ -168,10 +166,10 @@
       "title": "Visualizer",
       "description": "Absolute path to and arguments for a visualizer",
       "examples": [
-         "/visualizer",
-         "/visualizers/asy.py",
-         "/visualizers/vis --large"
-        ],
+        "/visualizer",
+        "/visualizers/asy.py",
+        "/visualizers/vis --large"
+      ],
       "type": "string",
       "pattern": "^/[^{}]*(\\{seed(:[0-9]+)?\\}[^{}]*)*$"
     },

--- a/src/schemas/json/problem_package_generators.json
+++ b/src/schemas/json/problem_package_generators.json
@@ -134,6 +134,15 @@
               "title": "Hint",
               "description": "Feedback shown to the solver about this test case given as a string"
             },
+            "interaction": {
+              "title": "Sample interaction",
+              "description": "Input is prefixed with `<`, output is prefixed with `>`.",
+              "examples": [
+                "<1 2\n>3\n<4 5\n>9\n<6 7\n>13\n"
+              ],
+              "type": "string",
+              "pattern": "^([<>][^\\n]*\\n)+$"
+            },
             "visualizer": {
               "oneOf": [
                 {
@@ -157,9 +166,14 @@
     },
     "visualizer": {
       "title": "Visualizer",
-      "description": "Absolute path to a visualizer",
-      "examples": ["/visualizers/asy.py"],
-      "$ref": "#/$defs/slashedfilepath"
+      "description": "Absolute path to and arguments for a visualizer",
+      "examples": [
+         "/visualizer",
+         "/visualizers/asy.py",
+         "/visualizers/vis --large"
+        ],
+      "type": "string",
+      "pattern": "^/[^{}]*(\\{seed(:[0-9]+)?\\}[^{}]*)*$"
     },
     "random_salt": {
       "title": "Random Salt",
@@ -178,7 +192,7 @@
       "description": "Invocation of a generator to create this testcase",
       "examples": ["forest --n 40 --connected", "path.cpp 20", "random {seed}"],
       "type": "string",
-      "pattern": "^[^{}]*(\\{(name|seed(:[0-9]+)?)\\}[^{}]*)*$"
+      "pattern": "^[^{}]*(\\{seed(:[0-9]+)?\\}[^{}]*)*$"
     },
     "slashedfilepath": {
       "type": "string",


### PR DESCRIPTION
I’ve added an extra negative test for these extensions, and run

> npm run grunt -- --SchemaName=problem_package_generators.json

successfully.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
