### PR TITLE
add support for Goblet

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5293,6 +5293,12 @@
       "description": "Warp workflows",
       "url": "https://json.schemastore.org/warp-workflows.json",
       "fileMatch": ["**/.warp/workflows/*.yaml"]
+    },
+    {
+      "name": "goblet.schema.json",
+      "description": "Goblet serverless framework config",
+      "url": "https://raw.githubusercontent.com/goblet/goblet/main/goblet.schema.json",
+      "fileMatch": ["**/.goblet/config.json"]
     }
   ],
   "version": 1


### PR DESCRIPTION
I would like to add the schema for the configuration files for Goblet, a serverless framework for GCP. https://github.com/goblet/goblet