### PR TITLE
feat(swcrc): add `resolveFully` option

### DIFF
--- a/src/schemas/json/swcrc.json
+++ b/src/schemas/json/swcrc.json
@@ -287,6 +287,10 @@
               "type": "string",
               "description": "If emitting amd-modules and specified, swc emits a named amd module"
             },
+            "resolveFully": {
+              "type": "boolean",
+              "description": "Make resolver fully resolve index.js"
+            },
             "globals": {
               "$ref": "#/definitions/stringStringMap"
             }

--- a/src/test/swcrc/swcrc-test.json
+++ b/src/test/swcrc/swcrc-test.json
@@ -34,7 +34,8 @@
   },
   "minify": false,
   "module": {
-    "type": "commonjs"
+    "type": "commonjs",
+    "resolveFully": true
   },
   "test": "a"
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

According to the [swcrc changelog v1.3.85](https://blog.swc.rs/changelog-v1-3-85#heading-an-option-to-configure-module-resolver) `resolveFully` option has been added to support resolving dependencies with /index.js included.
