### PR TITLE
feat: Require `$id` or `id` on all schemas

### DIFF
--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -722,7 +722,6 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
     function () {
       let countScan = 0
       let totalMismatchIds = 0
-      let totalMissingIds = 0
       let totalIncorrectIds = 0
       localSchemaFileAndTestFile(
         {
@@ -734,29 +733,17 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
              * identifiers, rather than "$id". See for details:
              * https://json-schema.org/understanding-json-schema/basics.html#declaring-a-unique-identifier
              */
-            const dollarlessIdSchemas = [
+            const schemasWithDollarlessId = [
               'http://json-schema.org/draft-03/schema#',
               'http://json-schema.org/draft-04/schema#',
             ]
 
-            const schemaVersion = schema.jsonObj.$schema
-            if (dollarlessIdSchemas.includes(schemaVersion)) {
+            if (schemasWithDollarlessId.includes(schema.jsonObj.$schema)) {
               if (schema.jsonObj.$id) {
                 grunt.log.warn(
                   `Bad property of '$id'; expected 'id' for this schema version`,
                 )
                 ++totalMismatchIds
-                return
-              }
-
-              if (!schema.jsonObj.id) {
-                grunt.log.warn(
-                  `Missing property 'id' for schema 'src/schemas/json/${schema.jsonName}'`,
-                )
-                console.warn(
-                  `     expected value: https://json.schemastore.org/${schema.jsonName}`,
-                )
-                ++totalMissingIds
                 return
               }
 
@@ -782,17 +769,6 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
                 return
               }
 
-              if (!schema.jsonObj.$id) {
-                grunt.log.warn(
-                  `Missing property '$id' for schema 'src/schemas/json/${schema.jsonName}'`,
-                )
-                console.warn(
-                  `     expected value: https://json.schemastore.org/${schema.jsonName}`,
-                )
-                ++totalMissingIds
-                return
-              }
-
               if (
                 schema.jsonObj.$id !==
                 `https://json.schemastore.org/${schema.jsonName}`
@@ -814,7 +790,6 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
           skipReadFile: false,
         },
       )
-      grunt.log.ok(`Total missing ids: ${totalMissingIds}`)
       grunt.log.ok(`Total mismatched ids: ${totalMismatchIds}`)
       grunt.log.ok(`Total incorrect ids: ${totalIncorrectIds}`)
       grunt.log.ok(`Total files scan: ${countScan}`)
@@ -1495,7 +1470,47 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
   )
 
   grunt.registerTask(
-    'local_assert_schema_version_is_valid',
+    'local_assert_schema_has_valid_$id_field',
+    'Check that the $id field exists',
+    function () {
+      let countScan = 0
+
+      localSchemaFileAndTestFile(
+        {
+          schemaOnlyScan(schema) {
+            countScan++
+
+            const schemasWithDollarlessId = [
+              'http://json-schema.org/draft-03/schema#',
+              'http://json-schema.org/draft-04/schema#',
+            ]
+            if (schemasWithDollarlessId.includes(schema.jsonObj.$schema)) {
+              if (!schema.jsonObj.id) {
+                throwWithErrorText([
+                  `Missing property 'id' for schema 'src/schemas/json/${schema.jsonName}'`,
+                ])
+              }
+            } else {
+              if (!schema.jsonObj.$id) {
+                throwWithErrorText([
+                  `Missing property '$id' for schema 'src/schemas/json/${schema.jsonName}'`,
+                ])
+              }
+            }
+          },
+        },
+        {
+          fullScanAllFiles: true,
+          skipReadFile: false,
+        },
+      )
+
+      grunt.log.ok(`Total files scan: ${countScan}`)
+    },
+  )
+
+  grunt.registerTask(
+    'local_assert_schema_has_valid_$schema_field',
     'Check that the $schema version string is a correct and standard value',
     function () {
       let countScan = 0
@@ -2104,7 +2119,8 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
   grunt.registerTask('local_test_schema', [
     'local_assert_schema_no_bom',
     'local_assert_schema_no_duplicated_property_keys',
-    'local_assert_schema_version_is_valid',
+    'local_assert_schema_has_valid_$schema_field',
+    'local_assert_schema_has_valid_$id_field',
     'local_assert_schema_passes_schemasafe_lint',
   ])
   grunt.registerTask('local_test', [

--- a/src/Gruntfile.cjs
+++ b/src/Gruntfile.cjs
@@ -1480,22 +1480,35 @@ module.exports = function (/** @type {import('grunt')} */ grunt) {
           schemaOnlyScan(schema) {
             countScan++
 
+            let schemaId = ''
             const schemasWithDollarlessId = [
               'http://json-schema.org/draft-03/schema#',
               'http://json-schema.org/draft-04/schema#',
             ]
             if (schemasWithDollarlessId.includes(schema.jsonObj.$schema)) {
-              if (!schema.jsonObj.id) {
+              if (schema.jsonObj.id === undefined) {
                 throwWithErrorText([
                   `Missing property 'id' for schema 'src/schemas/json/${schema.jsonName}'`,
                 ])
               }
+              schemaId = schema.jsonObj.id
             } else {
-              if (!schema.jsonObj.$id) {
+              if (schema.jsonObj.$id === undefined) {
                 throwWithErrorText([
                   `Missing property '$id' for schema 'src/schemas/json/${schema.jsonName}'`,
                 ])
               }
+              schemaId = schema.jsonObj.$id
+            }
+
+            if (
+              !schemaId.startsWith('https://') &&
+              !schemaId.startsWith('http://')
+            ) {
+              throwWithErrorText([
+                schemaId,
+                `Schema id/$id must begin with 'https://' or 'http://' for schema 'src/schemas/json/${schema.jsonName}'`,
+              ])
             }
           },
         },

--- a/src/schemas/json/bxci.schema-1.0.1.json
+++ b/src/schemas/json/bxci.schema-1.0.1.json
@@ -1,5 +1,5 @@
 {
-  "$id": " https://json.schemastore.org/bxci.schema-1.0.1.json",
+  "$id": "https://json.schemastore.org/bxci.schema-1.0.1.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "branchPattern": {

--- a/src/schemas/json/jreleaser-1.8.0.json
+++ b/src/schemas/json/jreleaser-1.8.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/jreleaser-1.8.0.json",
   "$ref": "#/definitions/JReleaserModel",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {

--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -1,6 +1,6 @@
 {
   "$comment": "https://docs.nestjs.com/cli/monorepo#cli-properties",
-  "$id": "#Configuration",
+  "$id": "https://json.schemastore.org/nest-cli.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "CompilerOptions": {

--- a/src/schemas/json/pantsbuild-2.17.0.json
+++ b/src/schemas/json/pantsbuild-2.17.0.json
@@ -1,4 +1,5 @@
 {
+  "id": "https://json.schemastore.org/pantsbuild-2.17.0.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "additionalProperties": true,
   "description": "Pants configuration file schema: https://www.pantsbuild.org/",

--- a/src/schemas/json/sqlc-2.0.json
+++ b/src/schemas/json/sqlc-2.0.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/sqlc-2.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "version": {

--- a/src/schemas/json/warp-keysets.json
+++ b/src/schemas/json/warp-keysets.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/warp-keysets.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "key": {

--- a/src/schemas/json/warp-themes.json
+++ b/src/schemas/json/warp-themes.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/warp-themes.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "color": {

--- a/src/schemas/json/warp-workflows.json
+++ b/src/schemas/json/warp-workflows.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://json.schemastore.org/warp-workflows.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "url": {

--- a/src/schemas/json/web-types.json
+++ b/src/schemas/json/web-types.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/web-types.json",
   "title": "JSON schema for Web-Types",
   "type": "object",
   "properties": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Previous PRs #3169 and #3133 added the `$id` or `id` field on all schemas. Now, this ensures that standard for all new schemas. CI build will fail if the property is absent (`id` for draft-04 or below; `$id` for newer schemas).

Closes #1526