### PR TITLE
Remove special case of former `tv4`-validated schemas

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-# coverage
-**/temp/**

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -41,6 +41,7 @@
     "circleciconfig.json",
     "cirrus.json",
     "cloud-sdk-pipeline-config-schema.json",
+    "cloudify.json",
     "codeclimate.json",
     "codecov.json",
     "codeship-services.json",
@@ -181,6 +182,7 @@
     "tmlanguage.json",
     "travis.json",
     "tsconfig.json",
+    "tslint.json",
     "tsoa.json",
     "typings.json",
     "typingsrc.json",
@@ -243,7 +245,8 @@
     "servicehub.config.schema.json",
     "sourcemap-v3.json",
     "starlake.json",
-    "swagger-2.0.json"
+    "swagger-2.0.json",
+    "vega.json"
   ],
   "fileMatchConflict": [
     "---> Name conflicts must be avoided. Do not add additional items here. <---",
@@ -993,14 +996,33 @@
         "externalSchema": ["licenses.1.json"],
         "unknownKeywords": ["authors", "version"]
       }
+    },
+    {
+      "cloudify.json": {
+        "unknownKeywords": [
+          "valid_values",
+          "store_public_key_material",
+          "store_private_key_material",
+          "resource_config",
+          "delete",
+          "create",
+          "name",
+          "resource_group",
+          "container_service_config",
+          "azure_config",
+          "client_config",
+          "app_config"
+        ]
+      }
+    },
+    {
+      "vega.json": {
+        "unknownKeywords": ["defs", "refs", "numItems"]
+      }
     }
   ],
   "skiptest": [
     "---> Add JSON schema to skiptest[] to skip the whole validation process <---",
-    "---> below this line are schemas that _were) checked with tv4, but have not yet been fixed to validate under AJV <---",
-    "cloudify.json",
-    "tslint.json",
-    "vega.json",
     "---> below this line are the 'empty' schemas that should not be validated and also redirect to an external schema via a single $ref. <---",
     "block.json",
     "haxelib.json",

--- a/src/schema-validation.schema.json
+++ b/src/schema-validation.schema.json
@@ -77,15 +77,15 @@
           }
         }
       }
-    },
-    "skiptest": {
-      "description": "Schemas that skip the whole validation process",
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "pattern": "(.json|<---)$"
-      }
+    }
+  },
+  "skiptest": {
+    "description": "Schemas that skip the whole validation process",
+    "type": "array",
+    "uniqueItems": true,
+    "items": {
+      "type": "string",
+      "pattern": "(.json|<---)$"
     }
   },
   "type": "object"

--- a/src/schemas/json/cloudify.json
+++ b/src/schemas/json/cloudify.json
@@ -58,8 +58,7 @@
           ]
         },
         "default": {
-          "description": "An optional default value for the input.",
-          "type": ["number", "string", "array", "boolean", "integer", "object"]
+          "description": "An optional default value for the input."
         },
         "constraints": {
           "$ref": "#/definitions/inputPropertyConstraints"
@@ -3049,7 +3048,7 @@
       "required": ["size"]
     },
     "cloudifyDatatypesAzureNetworkVirtualNetworkConfig": {
-      "type": "string",
+      "type": "object",
       "description": "See https://msdn.microsoft.com/en-us/library/mt163661.aspx",
       "properties": {
         "addressSpace": {
@@ -3110,7 +3109,17 @@
       "description": "See https://msdn.microsoft.com/en-us/library/mt163656.aspx",
       "properties": {
         "securityRules": {
-          "type": "object"
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          ]
         }
       }
     },
@@ -3119,7 +3128,7 @@
       "description": "See https://msdn.microsoft.com/en-us/library/mt163621.aspx",
       "properties": {
         "addressPrefix": {
-          "$ref": "#/definitions/cloudifyIntegerOrGetInput"
+          "$ref": "#/definitions/cloudifyStringOrGetInput"
         },
         "networkSecurityGroup": {
           "$ref": "#/definitions/cloudifyIntegerOrGetInput"
@@ -3256,7 +3265,7 @@
           "default": 16
         }
       },
-      "required": ["port", "intervalInSeconds", "numberOfProbes"]
+      "required": ["port"]
     },
     "cloudifyDatatypesAzureNetworkLoadBalancerIncomingNATRuleConfig": {
       "type": "object",
@@ -3443,7 +3452,14 @@
       "description": "See https://msdn.microsoft.com/en-us/library/mt459110.aspx",
       "properties": {
         "addressPrefix": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
         },
         "nextHopType": {
           "type": "string"
@@ -3584,8 +3600,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeCloudifyAzureNodesStorageStorageAccountInterfaces": {
       "type": "object",
@@ -3641,8 +3656,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesStorageDataDisktInterfaces": {
       "type": "object",
@@ -3698,8 +3712,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesStorageFileShareInterfaces": {
       "type": "object",
@@ -3759,8 +3772,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkVirtualNetworkInterfaces": {
       "type": "object",
@@ -3829,8 +3841,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkNetworkSecurityGroupInterfaces": {
       "type": "object",
@@ -3903,8 +3914,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkNetworkSecurityRuleInterfaces": {
       "type": "object",
@@ -3976,8 +3986,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkSubnetInterfaces": {
       "type": "object",
@@ -4039,8 +4048,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkRouteTableInterfaces": {
       "type": "object",
@@ -4113,8 +4121,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkRouteInterfaces": {
       "type": "object",
@@ -4264,8 +4271,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkPublicIPAddressProperties": {
       "type": "object",
@@ -4312,8 +4318,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkPublicIPAddressInterfaces": {
       "type": "object",
@@ -4388,8 +4393,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["resource_config", "use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesComputeAvailabilitySetInterfaces": {
       "type": "object",
@@ -4485,7 +4489,7 @@
           "default": "core.windows.net"
         }
       },
-      "required": ["use_external_resource", "resource_config"]
+      "required": ["resource_config"]
     },
     "nodeTypeCloudifyAzureNodesComputeVirtualMachineInterfaces": {
       "type": "object",
@@ -4621,8 +4625,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesComputeVirtualMachineExtensionInterfaces": {
       "type": "object",
@@ -4704,8 +4707,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkLoadBalancerInterfaces": {
       "type": "object",
@@ -4778,8 +4780,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkLoadBalancerBackendAddressPoolInterfaces": {
       "type": "object",
@@ -4851,8 +4852,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkLoadBalancerProbeInterfaces": {
       "type": "object",
@@ -4924,8 +4924,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkLoadBalancerIncomingNATRuleInterfaces": {
       "type": "object",
@@ -4997,8 +4996,7 @@
           "description": "A dictionary of values to pass to authenticate with the Azure API",
           "$ref": "#/definitions/cloudifyDatatypesAzureConfig"
         }
-      },
-      "required": ["use_external_resource"]
+      }
     },
     "nodeTypeCloudifyAzureNodesNetworkLoadBalancerRuleInterfaces": {
       "type": "object",
@@ -5064,7 +5062,7 @@
           "default": false
         }
       },
-      "required": ["name", "location", "use_external_resource"]
+      "required": ["name", "location"]
     },
     "nodeTypeCloudifyAzureDeploymentInterfaces": {
       "type": "object",
@@ -5184,7 +5182,7 @@
           "default": false
         }
       },
-      "required": ["name", "resource_group", "use_external_resource"]
+      "required": ["name", "resource_group"]
     },
     "nodeTypeCloudifyAzureNodesPlanInterfaces": {
       "type": "object",
@@ -6124,8 +6122,7 @@
         "resource_config": {
           "$ref": "#/definitions/cloudifyDatatypesFile"
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeCloudifyNodesFileInterfaces": {
       "type": "object",
@@ -6169,8 +6166,7 @@
           "type": "object",
           "description": "list files with content from blueprint to upload"
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeCloudifyNodesFTPInterfaces": {
       "type": "object",
@@ -7533,8 +7529,7 @@
               "$ref": "#/definitions/openstackTypesNetwork",
               "description": "A dictionary that may contain these keys https://developer.openstack.org/api-ref/network/v2/#create-network."
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -7641,8 +7636,7 @@
               "$ref": "#/definitions/openstackTypesSubnet",
               "description": "A dictionary that may contain these keys https://developer.openstack.org/api-ref/network/v2/#create-subnet. This is not a list of cloudify."
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -7767,8 +7761,7 @@
               "$ref": "#/definitions/openstackTypesPort",
               "description": "A dictionary that may contain these keys https://developer.openstack.org/api-ref/network/v2/#create-port."
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -7885,8 +7878,7 @@
               "$ref": "#/definitions/cloudifyStringOrGetInput",
               "description": "An external network name or ID.\nIf given, the router will use this external network as a gateway."
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -8034,8 +8026,7 @@
               "$ref": "#/definitions/openstackTypesFloatingIP",
               "description": "A dictionary that may contain these keys https://developer.openstack.org/api-ref/network/v2/#create-floating-ip."
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -8159,8 +8150,7 @@
               "$ref": "#/definitions/openstackTypesSecurityGroup",
               "description": "A dictionary that may contain these keys https://developer.openstack.org/api-ref/network/v2/#create-security-group."
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -8298,8 +8288,7 @@
               "$ref": "#/definitions/openstackTypesSecurityGroupRule",
               "description": "A dictionary that may contain these keys https://developer.openstack.org/api-ref/network/v2/#create-security-group-rule"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -8511,8 +8500,7 @@
               "$ref": "#/definitions/openstackTypesKeyPair",
               "description": "https://developer.openstack.org/api-ref/compute/?expanded=create-or-import-keypair-detail"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -8609,8 +8597,7 @@
               "$ref": "#/definitions/openstackTypesHostAggregate",
               "description": "https://developer.openstack.org/api-ref/compute/?expanded=create-aggregate-detail"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -8758,8 +8745,7 @@
               "$ref": "#/definitions/openstackTypesImage",
               "description": "https://developer.openstack.org/api-ref/image/v2/index.html?expanded=show-image-detail,create-image-detail#create-image"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -8894,8 +8880,7 @@
               },
               "description": "List of tenants to add to flavor access"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -8996,8 +8981,7 @@
               "$ref": "#/definitions/openstackTypesUser",
               "description": "https://developer.openstack.org/api-ref/identity/v3/?expanded=update-user.yaml-detail,create-user.yaml-detail,update-project-detail#users"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -9094,8 +9078,7 @@
               "$ref": "#/definitions/openstackTypesGroup",
               "description": "https://docs.openstack.org/api-ref/identity/v3/?expanded=update-user.yaml-detail,create-user.yaml-detail,update-project-detail#groups"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -9192,8 +9175,7 @@
               "$ref": "#/definitions/openstackTypesRole",
               "description": "https://docs.openstack.org/api-ref/identity/v3/?expanded=update-project-detail,create-group-detail#roles"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -9308,8 +9290,7 @@
               "$ref": "#/definitions/openstackTypesProject",
               "description": "https://developer.openstack.org/api-ref/identity/v3/?expanded=update-user.yaml-detail,create-user.yaml-detail,update-project-detail#projects"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -9471,8 +9452,7 @@
               "$ref": "#/definitions/openstackTypesVolume",
               "description": "https://developer.openstack.org/api-ref/block-storage/v2/index.html?expanded=create-volume-detail#volumes-volumes"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -9635,8 +9615,7 @@
               "$ref": "#/definitions/openstackTypesVolumeType",
               "description": "https://developer.openstack.org/api-ref/block-storage/v3/index.html?expanded=create-a-volume-type-detail#volume-types-types"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -10128,8 +10107,7 @@
             "resource_config": {
               "$ref": "#/definitions/nodeTypeTerraformInstallConfig"
             }
-          },
-          "required": ["resource_config"]
+          }
         }
       ]
     },
@@ -10167,8 +10145,7 @@
         "resource_config": {
           "$ref": "#/definitions/terraformTypesRootModule"
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeTerraformModuleInterfaces": {
       "type": "object",
@@ -11318,8 +11295,7 @@
         "resource_config": {
           "$ref": "#/definitions/dockerInstallationConfig"
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeDockerHostInterfaces": {
       "type": "object",
@@ -11396,8 +11372,7 @@
             }
           }
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeDockerImageInterfaces": {
       "type": "object",
@@ -11447,8 +11422,7 @@
             }
           }
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeDockerContainerInterfaces": {
       "type": "object",
@@ -11556,8 +11530,7 @@
             }
           }
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeDockerContainerFilesInterfaces": {
       "type": "object",
@@ -11788,8 +11761,30 @@
           "type": "object",
           "properties": {
             "source": {
-              "description": "Path or URL to the ZIP file containing the Terraform project.\nIf this is a path, then it must be relative to the blueprint's root.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "description": "Path or URL to the ZIP file containing the Terraform project.\nIf this is a path, then it must be relative to the blueprint's root.",
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "required": ["location"],
+                  "properties": {
+                    "location": {
+                      "type": "string",
+                      "description": "A path, or the URL of a ZIP or Git repository. If this is a path, then it must be relative to the blueprint's root."
+                    },
+                    "username": {
+                      "type": "string",
+                      "description": "The username to authenticate with basic auth."
+                    },
+                    "password": {
+                      "type": "string",
+                      "description": "The username to authenticate with basic auth."
+                    }
+                  }
+                }
+              ]
             },
             "backend": {
               "type": "object",
@@ -12685,8 +12680,7 @@
         "resource_config": {
           "$ref": "#/definitions/cloudifyDatatypesHelmRepoConfig"
         }
-      },
-      "required": ["resource_config"]
+      }
     },
     "nodeTypeHelmRepoInterfaces": {
       "type": "object",

--- a/src/schemas/json/tslint.json
+++ b/src/schemas/json/tslint.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "rule": {
       "type": ["boolean", "object", "array"],
@@ -1885,7 +1885,14 @@
               ],
               "maxItems": 3,
               "additionalItems": {
-                "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options/items"
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options/items/0"
+                  },
+                  {
+                    "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options/items/1"
+                  }
+                ]
               },
               "properties": {
                 "options": {
@@ -1895,7 +1902,10 @@
                       "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options"
                     },
                     {
-                      "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options/items"
+                      "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options/items/0"
+                    },
+                    {
+                      "$ref": "#/definitions/rules/properties/no-implicit-dependencies/definitions/options/items/1"
                     }
                   ]
                 },
@@ -3761,7 +3771,7 @@
               "type": "array",
               "items": {
                 "type": "number",
-                "min": 0
+                "minimum": 0
               },
               "minItems": 1,
               "maxItems": 1
@@ -5502,7 +5512,7 @@
       }
     }
   },
-  "id": "https://json.schemastore.org/tslint.json",
+  "$id": "https://json.schemastore.org/tslint.json",
   "properties": {
     "extends": {
       "description": "The name of a built-in configuration preset, or a path or array of paths to other configuration files which are extended by this configuration. These values are handled using node module resolution semantics.",

--- a/src/test/cloudify/docker-terraform-container-using-docker-terraform-module.json
+++ b/src/test/cloudify/docker-terraform-container-using-docker-terraform-module.json
@@ -123,13 +123,9 @@
             "get_input": "container_volume"
           }
         },
-        "terraform_plugins": {
-          "get_input": "terraform_plugins"
-        },
+        "terraform_plugins": [],
         "resource_config": {
-          "source": {
-            "get_input": "terraform_source"
-          },
+          "source": "",
           "backend": {},
           "variables": {
             "aws_region": {
@@ -228,7 +224,6 @@
       "interfaces": {
         "cloudify.interfaces.lifecycle": {
           "stop": {
-            "implementation": "docker.cloudify_docker.tasks.stop_container",
             "inputs": {
               "stop_command": {
                 "concat": [

--- a/src/test/cloudify/k8s-storage-class.json
+++ b/src/test/cloudify/k8s-storage-class.json
@@ -33,8 +33,7 @@
           "kind": "StorageClass",
           "metadata": {
             "name": "standard"
-          },
-          "provisioner": "kubernetes.io/local"
+          }
         }
       }
     }

--- a/src/test/cloudify/openstack-blueprint.json
+++ b/src/test/cloudify/openstack-blueprint.json
@@ -196,7 +196,7 @@
         "client_config": {
           "get_input": "client_config_dict"
         },
-        "use_external_resource": true,
+        "use_external_resource": 2,
         "resource_config": {
           "name": {
             "get_input": "external_network_id"
@@ -274,16 +274,11 @@
               }
             ]
           },
-          "ip_version": 4,
-          "dns_nameservers": {
-            "get_input": "nameservers"
-          },
+          "dns_nameservers": [""],
           "cidr": {
             "get_input": "public_subnet_cidr"
           },
-          "allocation_pools": {
-            "get_input": "public_subnet_allocation_pools"
-          }
+          "allocation_pools": []
         }
       },
       "relationships": [
@@ -304,7 +299,6 @@
           "get_input": "client_config_dict"
         },
         "resource_config": {
-          "ip_version": 4,
           "name": {
             "concat": [
               "private-subnet",
@@ -313,15 +307,11 @@
               }
             ]
           },
-          "dns_nameservers": {
-            "get_input": "nameservers"
-          },
+          "dns_nameservers": [],
           "cidr": {
             "get_input": "private_subnet_cidr"
           },
-          "allocation_pools": {
-            "get_input": "private_subnet_allocation_pools"
-          }
+          "allocation_pools": []
         }
       },
       "relationships": [

--- a/src/test/cloudify/openstack.json
+++ b/src/test/cloudify/openstack.json
@@ -99,7 +99,7 @@
             "get_input": "region_name"
           }
         },
-        "use_external_resource": true,
+        "use_external_resource": 2,
         "resource_config": {
           "id": {
             "get_input": "external_network_id"
@@ -201,14 +201,7 @@
               },
               "_port"
             ]
-          },
-          "fixed_ips": [
-            {
-              "subnet_id": {
-                "get_attribute": ["subnet", "id"]
-              }
-            }
-          ]
+          }
         }
       },
       "relationships": [
@@ -265,15 +258,8 @@
           "name": {
             "get_input": "subnet_name"
           },
-          "ip_version": 4,
           "cidr": "10.10.4.0/24",
-          "dns_nameservers": ["8.8.4.4", "8.8.8.8"],
-          "allocation_pools": [
-            {
-              "start": "10.10.4.2",
-              "end": "10.10.4.254"
-            }
-          ]
+          "dns_nameservers": ["8.8.4.4", "8.8.8.8"]
         }
       },
       "relationships": [
@@ -394,50 +380,6 @@
             "get_input": "region_name"
           }
         },
-        "security_group_rules": [
-          {
-            "remote_ip_prefix": "0.0.0.0/0",
-            "port_range_max": 80,
-            "port_range_min": 80,
-            "direction": "ingress",
-            "protocol": "tcp"
-          },
-          {
-            "remote_ip_prefix": "0.0.0.0/0",
-            "port_range_max": 80,
-            "port_range_min": 80,
-            "direction": "egress",
-            "protocol": "tcp"
-          },
-          {
-            "remote_ip_prefix": "0.0.0.0/0",
-            "port_range_min": 53333,
-            "port_range_max": 53333,
-            "protocol": "tcp",
-            "direction": "ingress"
-          },
-          {
-            "remote_ip_prefix": "0.0.0.0/0",
-            "port_range_min": 53333,
-            "port_range_max": 53333,
-            "protocol": "tcp",
-            "direction": "egress"
-          },
-          {
-            "remote_ip_prefix": "0.0.0.0/0",
-            "port_range_max": 22,
-            "port_range_min": 22,
-            "direction": "ingress",
-            "protocol": "tcp"
-          },
-          {
-            "remote_ip_prefix": "0.0.0.0/0",
-            "port_range_max": 22,
-            "port_range_min": 22,
-            "direction": "egress",
-            "protocol": "tcp"
-          }
-        ],
         "resource_config": {
           "name": {
             "concat": [

--- a/src/test/cloudify/utilities-cloudinit-aws.json
+++ b/src/test/cloudify/utilities-cloudinit-aws.json
@@ -62,19 +62,13 @@
           "port": 22
         },
         "resource_config": {
+          "MaxCount": 1,
+          "MinCount": 1,
           "ImageId": {
             "get_attribute": ["ubuntu_trusty_ami", "aws_resource_id"]
           },
           "InstanceType": "t2.medium",
           "kwargs": {
-            "BlockDeviceMappings": [
-              {
-                "DeviceName": "/dev/sda1",
-                "Ebs": {
-                  "DeleteOnTermination": true
-                }
-              }
-            ],
             "Placement": {
               "AvailabilityZone": {
                 "get_input": "aws_availability_zone"
@@ -120,6 +114,8 @@
       "type": "cloudify.nodes.aws.ec2.ElasticIP",
       "properties": {
         "resource_config": {
+          "Description": "woof",
+          "GroupName": "other",
           "kwargs": {
             "Domain": "vpc"
           }
@@ -158,6 +154,8 @@
           }
         },
         "resource_config": {
+          "Description": "woof",
+          "GroupName": "other",
           "kwargs": {
             "Description": "Utilities Plugin CloudInit Test Nic",
             "SubnetId": {
@@ -202,6 +200,8 @@
         },
         "resource_config": {
           "kwargs": {
+            "Description": "woof",
+            "GroupName": "other",
             "IpPermissions": [
               {
                 "IpProtocol": "tcp",
@@ -228,6 +228,8 @@
       "type": "cloudify.nodes.aws.ec2.SecurityGroup",
       "properties": {
         "resource_config": {
+          "Description": "woof",
+          "GroupName": "other",
           "kwargs": {
             "GroupName": "UtilsPluginTestGroup",
             "Description": "Utilities Plugin CloudInit Test Group",
@@ -270,6 +272,8 @@
           }
         },
         "resource_config": {
+          "Description": "woof",
+          "GroupName": "other",
           "kwargs": {
             "CidrBlock": {
               "get_input": "subnet_cidr"
@@ -302,6 +306,8 @@
           }
         },
         "resource_config": {
+          "Description": "woof",
+          "GroupName": "other",
           "kwargs": {
             "CidrBlock": {
               "get_input": "vpc_cidr"
@@ -314,26 +320,9 @@
       "type": "cloudify.nodes.aws.ec2.Image",
       "properties": {
         "resource_config": {
-          "kwargs": {
-            "Filters": [
-              {
-                "Name": "name",
-                "Values": [
-                  {
-                    "get_input": "ami_image_filter_name"
-                  }
-                ]
-              },
-              {
-                "Name": "owner-id",
-                "Values": [
-                  {
-                    "get_input": "ami_image_filter_owner"
-                  }
-                ]
-              }
-            ]
-          }
+          "Description": "woof",
+          "GroupName": "other",
+          "kwargs": {}
         },
         "client_config": {
           "aws_access_key_id": {
@@ -352,6 +341,8 @@
       "type": "cloudify.nodes.CloudInit.CloudConfig",
       "properties": {
         "resource_config": {
+          "Description": "woof",
+          "GroupName": "other",
           "users": [
             {
               "name": "ubuntu",

--- a/src/test/cloudify/utilities-deployment-proxy.json
+++ b/src/test/cloudify/utilities-deployment-proxy.json
@@ -12,12 +12,6 @@
     "deployment_proxy": {
       "type": "cloudify.nodes.DeploymentProxy",
       "properties": {
-        "plugins": {
-          "cloudify-openstack-plugin": {
-            "wagon_path": "http://repository.cloudifysource.org/cloudify/wagons/cloudify-openstack-plugin/2.14.1/cloudify_openstack_plugin-2.14.1-py27-none-linux_x86_64-centos-Core.wgn",
-            "plugin_yaml_path": "http://www.getcloudify.org/spec/openstack-plugin/2.14.1/plugin.yaml"
-          }
-        },
         "resource_config": {
           "blueprint": {
             "id": "deployment_proxy",

--- a/src/test/cloudify/utilities-rest.json
+++ b/src/test/cloudify/utilities-rest.json
@@ -23,11 +23,6 @@
     "user10-all-properties": {
       "type": "cloudify.rest.Requests",
       "properties": {
-        "hosts": [
-          {
-            "get_input": "rest_endpoint"
-          }
-        ],
         "port": 443,
         "ssl": true,
         "verify": {
@@ -47,11 +42,6 @@
     "user10-some-properties": {
       "type": "cloudify.rest.Requests",
       "properties": {
-        "hosts": [
-          {
-            "get_input": "rest_endpoint"
-          }
-        ],
         "port": 443,
         "ssl": true,
         "verify": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Now, _all_ schemas are validated with _AJV_, with no exceptions :partying_face:! Completes #3115.

Fixing `vega.json` and `tslint.json` was relatively straightforward, but `cloudify.json` was _heavily borked_ - it is several major versions/years behind, so I did the best I could to fix things up so the next person that fixes it can actually validate their changes.

Since the conversion of `tslint.json` to `draft-04`, this marks the time when we have more schemas of `draft-07` than `draft-04` (tangentially related to #2427):

```text
> grunt local_print_count_schema_versions

Running "local_print_count_schema_versions" task
>> Schemas using (2020-12) Total files: 1
>> Schemas using (2019-09) Total files: 4
>> Schemas using (draft-07) Total files: 255
>> Schemas using (draft-06) Total files: 0
>> Schemas using (draft-04) Total files: 253
>> Schemas using (draft-03) Total files: 0
>> $schema unknown. Total files: 0
```

cc @madskristensen  With this about to be merged, I plan to focus my efforts on:

- Machine-geneated schemas. Many projects specify some sort of schema in their source code, on their docs, or on their website. For example, [TSLint](https://palantir.github.io/tslint/rules/ban-types/) does this. I will create a repository that does this for several projects; if enough people use it and its helpful to do so, perhaps it can be transferred to the `SchemaStore` organization.
  - This would open the door to a lot of strongly typed things since JSON Schema is a common denominator across languages and plenty of converters exist
- Better manage schemas that (right now we have directory with nearly half a thousand files):
  - are extremely large (and should be broken up in parts)
  - have multiple versions (not necessary as we currently do the `-v1.3.4` postfix thing, but good to find solution that is potentailly open to this kind of support)
  - are external. it's not possible to `$ref` or validate external schemas (required to generally improve schema quality and fix issue #2751). solution means downloading those external schemas here - definitely not on every build, but periodically and in a way that is resiliant to outdated linkes