### PR TITLE
circleci: add `macos.m1.medium.gen`

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -464,6 +464,7 @@
               "windows.gpu.nvidia.medium",
               "macos.x86.medium.gen2",
               "macos.x86.metal.gen1",
+              "macos.m1.medium.gen1",
               "macos.m1.large.gen1"
             ]
           },


### PR DESCRIPTION
Added (relatively) new medium Apple Silicon runner. https://circleci.com/docs/using-macos/#available-resource-classes

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
