### PR TITLE
add EnableGenerateFields to Serenity Code Generator (sergen) schema

### DIFF
--- a/src/schemas/json/sergen.json
+++ b/src/schemas/json/sergen.json
@@ -116,6 +116,10 @@
       "type": "boolean",
       "description": "If true, generated code will declare and use jFKTable type of constants for expressions in entities"
     },
+    "EnableGenerateFields": {
+      "type": "boolean",
+      "description": "If this is true, it allows the use of [GenerateFields] attributes on rows, which automatically generates the fields using a source generator. This should only be used when Serenity.Pro.Coder is enabled in the project"
+    },
     "EnableRowTemplates": {
       "type": "boolean",
       "description": "If true, enables RowTemplate class generation. This should only be used when Serenity.Pro.Coder is enabled in the project"

--- a/src/test/sergen/extends-file.json
+++ b/src/test/sergen/extends-file.json
@@ -38,6 +38,7 @@
   },
   "CustomTemplates": "abc/def",
   "DeclareJoinConstants": true,
+  "EnableGenerateFields": true,
   "EnableRowTemplates": false,
   "EndOfLine": "CRLF",
   "ExcludeGlobalUsings": [],

--- a/src/test/sergen/extends-version.json
+++ b/src/test/sergen/extends-version.json
@@ -38,6 +38,7 @@
   },
   "CustomTemplates": "abc/def",
   "DeclareJoinConstants": true,
+  "EnableGenerateFields": false,
   "EnableRowTemplates": false,
   "EndOfLine": "CRLF",
   "ExcludeGlobalUsings": [],


### PR DESCRIPTION
add EnableGenerateFields to sergen schema

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
