### PR TITLE
Add Databricks Asset Bundles schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5305,6 +5305,12 @@
       "description": "Goblet serverless framework config",
       "url": "https://raw.githubusercontent.com/goblet/goblet/main/goblet.schema.json",
       "fileMatch": ["**/.goblet/config.json"]
+    },
+    {
+      "name": "Databricks Asset Bundles",
+      "description": "Databricks Asset Bundles config",
+      "url": "https://json.schemastore.org/databricks-asset-bundles.json",
+      "fileMatch": ["**/.databricks.yml"]
     }
   ],
   "version": 1

--- a/src/schemas/json/databricks-asset-bundles.json
+++ b/src/schemas/json/databricks-asset-bundles.json
@@ -1,0 +1,7645 @@
+{
+  "$id": "https://json.schemastore.org/databricks-asset-bundles.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Root of the bundle config",
+  "properties": {
+    "artifacts": {
+      "type": "object",
+      "description": "A description of all code artifacts in this bundle.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "build": {
+            "type": "string"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "source"
+              ]
+            }
+          },
+          "path": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "path",
+          "files",
+          "build"
+        ]
+      }
+    },
+    "bundle": {
+      "type": "object",
+      "description": "The details for this bundle.",
+      "properties": {
+        "compute_id": {
+          "type": "string"
+        },
+        "git": {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "type": "string"
+            },
+            "origin_url": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the bundle."
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ]
+    },
+    "environments": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "artifacts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "build": {
+                  "type": "string"
+                },
+                "files": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "source"
+                    ]
+                  }
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "path",
+                "files",
+                "build"
+              ]
+            }
+          },
+          "bundle": {
+            "type": "object",
+            "properties": {
+              "compute_id": {
+                "type": "string"
+              },
+              "git": {
+                "type": "object",
+                "properties": {
+                  "branch": {
+                    "type": "string"
+                  },
+                  "origin_url": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ]
+          },
+          "compute_id": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "git": {
+            "type": "object",
+            "properties": {
+              "branch": {
+                "type": "string"
+              },
+              "origin_url": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "mode": {
+            "type": "string"
+          },
+          "resources": {
+            "type": "object",
+            "properties": {
+              "experiments": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "artifact_location": {
+                      "type": "string"
+                    },
+                    "creation_time": {
+                      "type": "number"
+                    },
+                    "experiment_id": {
+                      "type": "string"
+                    },
+                    "last_update_time": {
+                      "type": "number"
+                    },
+                    "lifecycle_stage": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "jobs": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "compute": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "compute_key": {
+                            "type": "string"
+                          },
+                          "spec": {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "compute_key",
+                          "spec"
+                        ]
+                      }
+                    },
+                    "continuous": {
+                      "type": "object",
+                      "properties": {
+                        "pause_status": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "email_notifications": {
+                      "type": "object",
+                      "properties": {
+                        "no_alert_for_skipped_runs": {
+                          "type": "boolean"
+                        },
+                        "on_duration_warning_threshold_exceeded": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_failure": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_start": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_success": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "format": {
+                      "type": "string"
+                    },
+                    "git_source": {
+                      "type": "object",
+                      "properties": {
+                        "git_branch": {
+                          "type": "string"
+                        },
+                        "git_commit": {
+                          "type": "string"
+                        },
+                        "git_provider": {
+                          "type": "string"
+                        },
+                        "git_snapshot": {
+                          "type": "object",
+                          "properties": {
+                            "used_commit": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "git_tag": {
+                          "type": "string"
+                        },
+                        "git_url": {
+                          "type": "string"
+                        },
+                        "job_source": {
+                          "type": "object",
+                          "properties": {
+                            "dirty_state": {
+                              "type": "string"
+                            },
+                            "import_from_git_branch": {
+                              "type": "string"
+                            },
+                            "job_config_path": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "import_from_git_branch",
+                            "job_config_path"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "git_provider",
+                        "git_url"
+                      ]
+                    },
+                    "health": {
+                      "type": "object",
+                      "properties": {
+                        "rules": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "metric": {
+                                "type": "string"
+                              },
+                              "op": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "job_clusters": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "job_cluster_key": {
+                            "type": "string"
+                          },
+                          "new_cluster": {
+                            "type": "object",
+                            "properties": {
+                              "autoscale": {
+                                "type": "object",
+                                "properties": {
+                                  "max_workers": {
+                                    "type": "number"
+                                  },
+                                  "min_workers": {
+                                    "type": "number"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "max_workers",
+                                  "min_workers"
+                                ]
+                              },
+                              "autotermination_minutes": {
+                                "type": "number"
+                              },
+                              "aws_attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "ebs_volume_count": {
+                                    "type": "number"
+                                  },
+                                  "ebs_volume_iops": {
+                                    "type": "number"
+                                  },
+                                  "ebs_volume_size": {
+                                    "type": "number"
+                                  },
+                                  "ebs_volume_throughput": {
+                                    "type": "number"
+                                  },
+                                  "ebs_volume_type": {
+                                    "type": "string"
+                                  },
+                                  "first_on_demand": {
+                                    "type": "number"
+                                  },
+                                  "instance_profile_arn": {
+                                    "type": "string"
+                                  },
+                                  "spot_bid_price_percent": {
+                                    "type": "number"
+                                  },
+                                  "zone_id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "azure_attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "first_on_demand": {
+                                    "type": "number"
+                                  },
+                                  "log_analytics_info": {
+                                    "type": "object",
+                                    "properties": {
+                                      "log_analytics_primary_key": {
+                                        "type": "string"
+                                      },
+                                      "log_analytics_workspace_id": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "spot_bid_max_price": {
+                                    "type": "number"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "cluster_log_conf": {
+                                "type": "object",
+                                "properties": {
+                                  "dbfs": {
+                                    "type": "object",
+                                    "properties": {
+                                      "destination": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "s3": {
+                                    "type": "object",
+                                    "properties": {
+                                      "canned_acl": {
+                                        "type": "string"
+                                      },
+                                      "destination": {
+                                        "type": "string"
+                                      },
+                                      "enable_encryption": {
+                                        "type": "boolean"
+                                      },
+                                      "encryption_type": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "kms_key": {
+                                        "type": "string"
+                                      },
+                                      "region": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "cluster_name": {
+                                "type": "string"
+                              },
+                              "cluster_source": {
+                                "type": "string"
+                              },
+                              "custom_tags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "data_security_mode": {
+                                "type": "string"
+                              },
+                              "docker_image": {
+                                "type": "object",
+                                "properties": {
+                                  "basic_auth": {
+                                    "type": "object",
+                                    "properties": {
+                                      "password": {
+                                        "type": "string"
+                                      },
+                                      "username": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "driver_instance_pool_id": {
+                                "type": "string"
+                              },
+                              "driver_node_type_id": {
+                                "type": "string"
+                              },
+                              "enable_elastic_disk": {
+                                "type": "boolean"
+                              },
+                              "enable_local_disk_encryption": {
+                                "type": "boolean"
+                              },
+                              "gcp_attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "boot_disk_size": {
+                                    "type": "number"
+                                  },
+                                  "google_service_account": {
+                                    "type": "string"
+                                  },
+                                  "local_ssd_count": {
+                                    "type": "number"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "init_scripts": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "dbfs": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "s3": {
+                                      "type": "object",
+                                      "properties": {
+                                        "canned_acl": {
+                                          "type": "string"
+                                        },
+                                        "destination": {
+                                          "type": "string"
+                                        },
+                                        "enable_encryption": {
+                                          "type": "boolean"
+                                        },
+                                        "encryption_type": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "kms_key": {
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "volumes": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "workspace": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "instance_pool_id": {
+                                "type": "string"
+                              },
+                              "node_type_id": {
+                                "type": "string"
+                              },
+                              "num_workers": {
+                                "type": "number"
+                              },
+                              "policy_id": {
+                                "type": "string"
+                              },
+                              "runtime_engine": {
+                                "type": "string"
+                              },
+                              "single_user_name": {
+                                "type": "string"
+                              },
+                              "spark_conf": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "spark_env_vars": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "spark_version": {
+                                "type": "string"
+                              },
+                              "ssh_public_keys": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "workload_type": {
+                                "type": "object",
+                                "properties": {
+                                  "clients": {
+                                    "type": "object",
+                                    "properties": {
+                                      "jobs": {
+                                        "type": "boolean"
+                                      },
+                                      "notebooks": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "job_cluster_key"
+                        ]
+                      }
+                    },
+                    "max_concurrent_runs": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "notification_settings": {
+                      "type": "object",
+                      "properties": {
+                        "no_alert_for_canceled_runs": {
+                          "type": "boolean"
+                        },
+                        "no_alert_for_skipped_runs": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "parameters": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "default": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "default",
+                          "name"
+                        ]
+                      }
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    },
+                    "run_as": {
+                      "type": "object",
+                      "properties": {
+                        "service_principal_name": {
+                          "type": "string"
+                        },
+                        "user_name": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "schedule": {
+                      "type": "object",
+                      "properties": {
+                        "pause_status": {
+                          "type": "string"
+                        },
+                        "quartz_cron_expression": {
+                          "type": "string"
+                        },
+                        "timezone_id": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "quartz_cron_expression",
+                        "timezone_id"
+                      ]
+                    },
+                    "tags": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "tasks": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "compute_key": {
+                            "type": "string"
+                          },
+                          "condition_task": {
+                            "type": "object",
+                            "properties": {
+                              "left": {
+                                "type": "string"
+                              },
+                              "op": {
+                                "type": "string"
+                              },
+                              "right": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "dbt_task": {
+                            "type": "object",
+                            "properties": {
+                              "catalog": {
+                                "type": "string"
+                              },
+                              "commands": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "profiles_directory": {
+                                "type": "string"
+                              },
+                              "project_directory": {
+                                "type": "string"
+                              },
+                              "schema": {
+                                "type": "string"
+                              },
+                              "warehouse_id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "commands"
+                            ]
+                          },
+                          "depends_on": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "outcome": {
+                                  "type": "string"
+                                },
+                                "task_key": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "task_key"
+                              ]
+                            }
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "email_notifications": {
+                            "type": "object",
+                            "properties": {
+                              "on_duration_warning_threshold_exceeded": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "on_failure": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "on_start": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "on_success": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "existing_cluster_id": {
+                            "type": "string"
+                          },
+                          "health": {
+                            "type": "object",
+                            "properties": {
+                              "rules": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "metric": {
+                                      "type": "string"
+                                    },
+                                    "op": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "job_cluster_key": {
+                            "type": "string"
+                          },
+                          "libraries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "cran": {
+                                  "type": "object",
+                                  "properties": {
+                                    "package": {
+                                      "type": "string"
+                                    },
+                                    "repo": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "package"
+                                  ]
+                                },
+                                "egg": {
+                                  "type": "string"
+                                },
+                                "jar": {
+                                  "type": "string"
+                                },
+                                "maven": {
+                                  "type": "object",
+                                  "properties": {
+                                    "coordinates": {
+                                      "type": "string"
+                                    },
+                                    "exclusions": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "repo": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "coordinates"
+                                  ]
+                                },
+                                "pypi": {
+                                  "type": "object",
+                                  "properties": {
+                                    "package": {
+                                      "type": "string"
+                                    },
+                                    "repo": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "package"
+                                  ]
+                                },
+                                "whl": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "max_retries": {
+                            "type": "number"
+                          },
+                          "min_retry_interval_millis": {
+                            "type": "number"
+                          },
+                          "new_cluster": {
+                            "type": "object",
+                            "properties": {
+                              "autoscale": {
+                                "type": "object",
+                                "properties": {
+                                  "max_workers": {
+                                    "type": "number"
+                                  },
+                                  "min_workers": {
+                                    "type": "number"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "max_workers",
+                                  "min_workers"
+                                ]
+                              },
+                              "autotermination_minutes": {
+                                "type": "number"
+                              },
+                              "aws_attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "ebs_volume_count": {
+                                    "type": "number"
+                                  },
+                                  "ebs_volume_iops": {
+                                    "type": "number"
+                                  },
+                                  "ebs_volume_size": {
+                                    "type": "number"
+                                  },
+                                  "ebs_volume_throughput": {
+                                    "type": "number"
+                                  },
+                                  "ebs_volume_type": {
+                                    "type": "string"
+                                  },
+                                  "first_on_demand": {
+                                    "type": "number"
+                                  },
+                                  "instance_profile_arn": {
+                                    "type": "string"
+                                  },
+                                  "spot_bid_price_percent": {
+                                    "type": "number"
+                                  },
+                                  "zone_id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "azure_attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "first_on_demand": {
+                                    "type": "number"
+                                  },
+                                  "log_analytics_info": {
+                                    "type": "object",
+                                    "properties": {
+                                      "log_analytics_primary_key": {
+                                        "type": "string"
+                                      },
+                                      "log_analytics_workspace_id": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "spot_bid_max_price": {
+                                    "type": "number"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "cluster_log_conf": {
+                                "type": "object",
+                                "properties": {
+                                  "dbfs": {
+                                    "type": "object",
+                                    "properties": {
+                                      "destination": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "s3": {
+                                    "type": "object",
+                                    "properties": {
+                                      "canned_acl": {
+                                        "type": "string"
+                                      },
+                                      "destination": {
+                                        "type": "string"
+                                      },
+                                      "enable_encryption": {
+                                        "type": "boolean"
+                                      },
+                                      "encryption_type": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "kms_key": {
+                                        "type": "string"
+                                      },
+                                      "region": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "cluster_name": {
+                                "type": "string"
+                              },
+                              "cluster_source": {
+                                "type": "string"
+                              },
+                              "custom_tags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "data_security_mode": {
+                                "type": "string"
+                              },
+                              "docker_image": {
+                                "type": "object",
+                                "properties": {
+                                  "basic_auth": {
+                                    "type": "object",
+                                    "properties": {
+                                      "password": {
+                                        "type": "string"
+                                      },
+                                      "username": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "driver_instance_pool_id": {
+                                "type": "string"
+                              },
+                              "driver_node_type_id": {
+                                "type": "string"
+                              },
+                              "enable_elastic_disk": {
+                                "type": "boolean"
+                              },
+                              "enable_local_disk_encryption": {
+                                "type": "boolean"
+                              },
+                              "gcp_attributes": {
+                                "type": "object",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "boot_disk_size": {
+                                    "type": "number"
+                                  },
+                                  "google_service_account": {
+                                    "type": "string"
+                                  },
+                                  "local_ssd_count": {
+                                    "type": "number"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "init_scripts": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "dbfs": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "s3": {
+                                      "type": "object",
+                                      "properties": {
+                                        "canned_acl": {
+                                          "type": "string"
+                                        },
+                                        "destination": {
+                                          "type": "string"
+                                        },
+                                        "enable_encryption": {
+                                          "type": "boolean"
+                                        },
+                                        "encryption_type": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "kms_key": {
+                                          "type": "string"
+                                        },
+                                        "region": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "volumes": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "workspace": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "instance_pool_id": {
+                                "type": "string"
+                              },
+                              "node_type_id": {
+                                "type": "string"
+                              },
+                              "num_workers": {
+                                "type": "number"
+                              },
+                              "policy_id": {
+                                "type": "string"
+                              },
+                              "runtime_engine": {
+                                "type": "string"
+                              },
+                              "single_user_name": {
+                                "type": "string"
+                              },
+                              "spark_conf": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "spark_env_vars": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "spark_version": {
+                                "type": "string"
+                              },
+                              "ssh_public_keys": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "workload_type": {
+                                "type": "object",
+                                "properties": {
+                                  "clients": {
+                                    "type": "object",
+                                    "properties": {
+                                      "jobs": {
+                                        "type": "boolean"
+                                      },
+                                      "notebooks": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "notebook_task": {
+                            "type": "object",
+                            "properties": {
+                              "base_parameters": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "notebook_path": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "notebook_path"
+                            ]
+                          },
+                          "notification_settings": {
+                            "type": "object",
+                            "properties": {
+                              "alert_on_last_attempt": {
+                                "type": "boolean"
+                              },
+                              "no_alert_for_canceled_runs": {
+                                "type": "boolean"
+                              },
+                              "no_alert_for_skipped_runs": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "pipeline_task": {
+                            "type": "object",
+                            "properties": {
+                              "full_refresh": {
+                                "type": "boolean"
+                              },
+                              "pipeline_id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "python_wheel_task": {
+                            "type": "object",
+                            "properties": {
+                              "entry_point": {
+                                "type": "string"
+                              },
+                              "named_parameters": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "package_name": {
+                                "type": "string"
+                              },
+                              "parameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "retry_on_timeout": {
+                            "type": "boolean"
+                          },
+                          "run_if": {
+                            "type": "string"
+                          },
+                          "run_job_task": {
+                            "type": "object",
+                            "properties": {
+                              "job_id": {
+                                "type": "number"
+                              },
+                              "job_parameters": {}
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "job_id"
+                            ]
+                          },
+                          "spark_jar_task": {
+                            "type": "object",
+                            "properties": {
+                              "jar_uri": {
+                                "type": "string"
+                              },
+                              "main_class_name": {
+                                "type": "string"
+                              },
+                              "parameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "spark_python_task": {
+                            "type": "object",
+                            "properties": {
+                              "parameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "python_file": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "python_file"
+                            ]
+                          },
+                          "spark_submit_task": {
+                            "type": "object",
+                            "properties": {
+                              "parameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "sql_task": {
+                            "type": "object",
+                            "properties": {
+                              "alert": {
+                                "type": "object",
+                                "properties": {
+                                  "alert_id": {
+                                    "type": "string"
+                                  },
+                                  "pause_subscriptions": {
+                                    "type": "boolean"
+                                  },
+                                  "subscriptions": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination_id": {
+                                          "type": "string"
+                                        },
+                                        "user_name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "alert_id"
+                                ]
+                              },
+                              "dashboard": {
+                                "type": "object",
+                                "properties": {
+                                  "custom_subject": {
+                                    "type": "string"
+                                  },
+                                  "dashboard_id": {
+                                    "type": "string"
+                                  },
+                                  "pause_subscriptions": {
+                                    "type": "boolean"
+                                  },
+                                  "subscriptions": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination_id": {
+                                          "type": "string"
+                                        },
+                                        "user_name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "dashboard_id"
+                                ]
+                              },
+                              "file": {
+                                "type": "object",
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "path"
+                                ]
+                              },
+                              "parameters": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "query": {
+                                "type": "object",
+                                "properties": {
+                                  "query_id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "query_id"
+                                ]
+                              },
+                              "warehouse_id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "warehouse_id"
+                            ]
+                          },
+                          "task_key": {
+                            "type": "string"
+                          },
+                          "timeout_seconds": {
+                            "type": "number"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "task_key"
+                        ]
+                      }
+                    },
+                    "timeout_seconds": {
+                      "type": "number"
+                    },
+                    "trigger": {
+                      "type": "object",
+                      "properties": {
+                        "file_arrival": {
+                          "type": "object",
+                          "properties": {
+                            "min_time_between_triggers_seconds": {
+                              "type": "number"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "wait_after_last_change_seconds": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "pause_status": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "webhook_notifications": {
+                      "type": "object",
+                      "properties": {
+                        "on_duration_warning_threshold_exceeded": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "on_failure": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "on_start": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "on_success": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "model_serving_endpoints": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "served_models": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "environment_vars": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "instance_profile_arn": {
+                                "type": "string"
+                              },
+                              "model_name": {
+                                "type": "string"
+                              },
+                              "model_version": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "scale_to_zero_enabled": {
+                                "type": "boolean"
+                              },
+                              "workload_size": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "model_name",
+                              "model_version",
+                              "scale_to_zero_enabled",
+                              "workload_size"
+                            ]
+                          }
+                        },
+                        "traffic_config": {
+                          "type": "object",
+                          "properties": {
+                            "routes": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "served_model_name": {
+                                    "type": "string"
+                                  },
+                                  "traffic_percentage": {
+                                    "type": "number"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "served_model_name",
+                                  "traffic_percentage"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "served_models"
+                      ]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "config",
+                    "name"
+                  ]
+                }
+              },
+              "models": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "creation_timestamp": {
+                      "type": "number"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "last_updated_timestamp": {
+                      "type": "number"
+                    },
+                    "latest_versions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "creation_timestamp": {
+                            "type": "number"
+                          },
+                          "current_stage": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "last_updated_timestamp": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "run_id": {
+                            "type": "string"
+                          },
+                          "run_link": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "status_message": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "user_id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "user_id": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "pipelines": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "catalog": {
+                      "type": "string"
+                    },
+                    "channel": {
+                      "type": "string"
+                    },
+                    "clusters": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "apply_policy_default_values": {
+                            "type": "boolean"
+                          },
+                          "autoscale": {
+                            "type": "object",
+                            "properties": {
+                              "max_workers": {
+                                "type": "number"
+                              },
+                              "min_workers": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "max_workers",
+                              "min_workers"
+                            ]
+                          },
+                          "aws_attributes": {
+                            "type": "object",
+                            "properties": {
+                              "availability": {
+                                "type": "string"
+                              },
+                              "ebs_volume_count": {
+                                "type": "number"
+                              },
+                              "ebs_volume_iops": {
+                                "type": "number"
+                              },
+                              "ebs_volume_size": {
+                                "type": "number"
+                              },
+                              "ebs_volume_throughput": {
+                                "type": "number"
+                              },
+                              "ebs_volume_type": {
+                                "type": "string"
+                              },
+                              "first_on_demand": {
+                                "type": "number"
+                              },
+                              "instance_profile_arn": {
+                                "type": "string"
+                              },
+                              "spot_bid_price_percent": {
+                                "type": "number"
+                              },
+                              "zone_id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "azure_attributes": {
+                            "type": "object",
+                            "properties": {
+                              "availability": {
+                                "type": "string"
+                              },
+                              "first_on_demand": {
+                                "type": "number"
+                              },
+                              "log_analytics_info": {
+                                "type": "object",
+                                "properties": {
+                                  "log_analytics_primary_key": {
+                                    "type": "string"
+                                  },
+                                  "log_analytics_workspace_id": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "spot_bid_max_price": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "cluster_log_conf": {
+                            "type": "object",
+                            "properties": {
+                              "dbfs": {
+                                "type": "object",
+                                "properties": {
+                                  "destination": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "s3": {
+                                "type": "object",
+                                "properties": {
+                                  "canned_acl": {
+                                    "type": "string"
+                                  },
+                                  "destination": {
+                                    "type": "string"
+                                  },
+                                  "enable_encryption": {
+                                    "type": "boolean"
+                                  },
+                                  "encryption_type": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "kms_key": {
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "custom_tags": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "driver_instance_pool_id": {
+                            "type": "string"
+                          },
+                          "driver_node_type_id": {
+                            "type": "string"
+                          },
+                          "gcp_attributes": {
+                            "type": "object",
+                            "properties": {
+                              "availability": {
+                                "type": "string"
+                              },
+                              "boot_disk_size": {
+                                "type": "number"
+                              },
+                              "google_service_account": {
+                                "type": "string"
+                              },
+                              "local_ssd_count": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "instance_pool_id": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "type": "string"
+                          },
+                          "node_type_id": {
+                            "type": "string"
+                          },
+                          "num_workers": {
+                            "type": "number"
+                          },
+                          "policy_id": {
+                            "type": "string"
+                          },
+                          "spark_conf": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "spark_env_vars": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "ssh_public_keys": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "configuration": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "continuous": {
+                      "type": "boolean"
+                    },
+                    "development": {
+                      "type": "boolean"
+                    },
+                    "edition": {
+                      "type": "string"
+                    },
+                    "filters": {
+                      "type": "object",
+                      "properties": {
+                        "exclude": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "include": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "libraries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "file": {
+                            "type": "object",
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "jar": {
+                            "type": "string"
+                          },
+                          "maven": {
+                            "type": "object",
+                            "properties": {
+                              "coordinates": {
+                                "type": "string"
+                              },
+                              "exclusions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "repo": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "coordinates"
+                            ]
+                          },
+                          "notebook": {
+                            "type": "object",
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    },
+                    "photon": {
+                      "type": "boolean"
+                    },
+                    "serverless": {
+                      "type": "boolean"
+                    },
+                    "storage": {
+                      "type": "string"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "trigger": {
+                      "type": "object",
+                      "properties": {
+                        "cron": {
+                          "type": "object",
+                          "properties": {
+                            "quartz_cron_schedule": {
+                              "type": "string"
+                            },
+                            "timezone_id": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "manual": {}
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "run_as": {
+            "type": "object",
+            "properties": {
+              "service_principal_name": {
+                "type": "string"
+              },
+              "user_name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "variables": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "workspace": {
+            "type": "object",
+            "properties": {
+              "artifact_path": {
+                "type": "string"
+              },
+              "auth_type": {
+                "type": "string"
+              },
+              "azure_client_id": {
+                "type": "string"
+              },
+              "azure_environment": {
+                "type": "string"
+              },
+              "azure_login_app_id": {
+                "type": "string"
+              },
+              "azure_tenant_id": {
+                "type": "string"
+              },
+              "azure_use_msi": {
+                "type": "boolean"
+              },
+              "azure_workspace_resource_id": {
+                "type": "string"
+              },
+              "client_id": {
+                "type": "string"
+              },
+              "file_path": {
+                "type": "string"
+              },
+              "google_service_account": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "profile": {
+                "type": "string"
+              },
+              "root_path": {
+                "type": "string"
+              },
+              "state_path": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "include": {
+      "type": "array",
+      "description": "A list of glob patterns of files to load and merge into the this configuration. Defaults to no files being included.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Collection of Databricks resources to deploy.",
+      "properties": {
+        "experiments": {
+          "type": "object",
+          "description": "List of MLflow experiments",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "artifact_location": {
+                "type": "string",
+                "description": "Location where artifacts for the experiment are stored."
+              },
+              "creation_time": {
+                "type": "number",
+                "description": "Creation time"
+              },
+              "experiment_id": {
+                "type": "string",
+                "description": "Unique identifier for the experiment."
+              },
+              "last_update_time": {
+                "type": "number",
+                "description": "Last update time"
+              },
+              "lifecycle_stage": {
+                "type": "string",
+                "description": "Current life cycle stage of the experiment: \"active\" or \"deleted\".\nDeleted experiments are not returned by APIs."
+              },
+              "name": {
+                "type": "string",
+                "description": "Human readable name that identifies the experiment."
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group_name": {
+                      "type": "string"
+                    },
+                    "level": {
+                      "type": "string"
+                    },
+                    "service_principal_name": {
+                      "type": "string"
+                    },
+                    "user_name": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "level"
+                  ]
+                }
+              },
+              "tags": {
+                "type": "array",
+                "description": "Tags: Additional metadata key-value pairs.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string",
+                      "description": "The tag key."
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The tag value."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "jobs": {
+          "type": "object",
+          "description": "List of Databricks jobs",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "compute": {
+                "type": "array",
+                "description": "A list of compute requirements that can be referenced by tasks of this job.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "compute_key": {
+                      "type": "string",
+                      "description": "A unique name for the compute requirement. This field is required and must be unique within the job.\n`JobTaskSettings` may refer to this field to determine the compute requirements for the task execution."
+                    },
+                    "spec": {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "description": "The kind of compute described by this compute specification."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "compute_key",
+                    "spec"
+                  ]
+                }
+              },
+              "continuous": {
+                "type": "object",
+                "description": "An optional continuous property for this job. The continuous property will ensure that there is always one run executing. Only one of `schedule` and `continuous` can be used.",
+                "properties": {
+                  "pause_status": {
+                    "type": "string",
+                    "description": "Whether this trigger is paused or not."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "email_notifications": {
+                "type": "object",
+                "description": "An optional set of email addresses that is notified when runs of this job begin or complete as well as when this job is deleted. The default behavior is to not send any emails.",
+                "properties": {
+                  "no_alert_for_skipped_runs": {
+                    "type": "boolean",
+                    "description": "If true, do not send email to recipients specified in `on_failure` if the run is skipped."
+                  },
+                  "on_duration_warning_threshold_exceeded": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "on_failure": {
+                    "type": "array",
+                    "description": "A list of email addresses to be notified when a run unsuccessfully completes. A run is considered to have completed unsuccessfully if it ends with an `INTERNAL_ERROR` `life_cycle_state` or a `FAILED`, or `TIMED_OUT` result_state. If this is not specified on job creation, reset, or update the list is empty, and notifications are not sent.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "on_start": {
+                    "type": "array",
+                    "description": "A list of email addresses to be notified when a run begins. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "on_success": {
+                    "type": "array",
+                    "description": "A list of email addresses to be notified when a run successfully completes. A run is considered to have completed successfully if it ends with a `TERMINATED` `life_cycle_state` and a `SUCCESS` result_state. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "format": {
+                "type": "string",
+                "description": "Used to tell what is the format of the job. This field is ignored in Create/Update/Reset calls. When using the Jobs API 2.1 this value is always set to `\"MULTI_TASK\"`."
+              },
+              "git_source": {
+                "type": "object",
+                "description": "An optional specification for a remote repository containing the notebooks used by this job's notebook tasks.",
+                "properties": {
+                  "git_branch": {
+                    "type": "string",
+                    "description": "Name of the branch to be checked out and used by this job.\nThis field cannot be specified in conjunction with git_tag or git_commit.\n\nThe maximum length is 255 characters.\n"
+                  },
+                  "git_commit": {
+                    "type": "string",
+                    "description": "Commit to be checked out and used by this job. This field cannot be specified in conjunction with git_branch or git_tag.\nThe maximum length is 64 characters."
+                  },
+                  "git_provider": {
+                    "type": "string",
+                    "description": "Unique identifier of the service used to host the Git repository. The value is case insensitive."
+                  },
+                  "git_snapshot": {
+                    "type": "object",
+                    "properties": {
+                      "used_commit": {
+                        "type": "string",
+                        "description": "Commit that was used to execute the run. If git_branch was specified, this points to the HEAD of the branch at the time of the run; if git_tag was specified, this points to the commit the tag points to."
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "git_tag": {
+                    "type": "string",
+                    "description": "Name of the tag to be checked out and used by this job.\nThis field cannot be specified in conjunction with git_branch or git_commit.\n\nThe maximum length is 255 characters.\n"
+                  },
+                  "git_url": {
+                    "type": "string",
+                    "description": "URL of the repository to be cloned by this job.\nThe maximum length is 300 characters."
+                  },
+                  "job_source": {
+                    "type": "object",
+                    "properties": {
+                      "dirty_state": {
+                        "type": "string"
+                      },
+                      "import_from_git_branch": {
+                        "type": "string"
+                      },
+                      "job_config_path": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "import_from_git_branch",
+                      "job_config_path"
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "git_provider",
+                  "git_url"
+                ]
+              },
+              "health": {
+                "type": "object",
+                "properties": {
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "metric": {
+                          "type": "string"
+                        },
+                        "op": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "job_clusters": {
+                "type": "array",
+                "description": "A list of job cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "job_cluster_key": {
+                      "type": "string",
+                      "description": "A unique name for the job cluster. This field is required and must be unique within the job.\n`JobTaskSettings` may refer to this field to determine which cluster to launch for the task execution."
+                    },
+                    "new_cluster": {
+                      "type": "object",
+                      "description": "If new_cluster, a description of a cluster that is created for only for this task.",
+                      "properties": {
+                        "autoscale": {
+                          "type": "object",
+                          "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                          "properties": {
+                            "max_workers": {
+                              "type": "number",
+                              "description": "The maximum number of workers to which the cluster can scale up when overloaded.\nNote that `max_workers` must be strictly greater than `min_workers`."
+                            },
+                            "min_workers": {
+                              "type": "number",
+                              "description": "The minimum number of workers to which the cluster can scale down when underutilized.\nIt is also the initial number of workers the cluster will have after creation."
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "max_workers",
+                            "min_workers"
+                          ]
+                        },
+                        "autotermination_minutes": {
+                          "type": "number",
+                          "description": "Automatically terminates the cluster after it is inactive for this time in minutes. If not set,\nthis cluster will not be automatically terminated. If specified, the threshold must be between\n10 and 10000 minutes.\nUsers can also set this value to 0 to explicitly disable automatic termination."
+                        },
+                        "aws_attributes": {
+                          "type": "object",
+                          "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                          "properties": {
+                            "availability": {
+                              "type": "string"
+                            },
+                            "ebs_volume_count": {
+                              "type": "number",
+                              "description": "The number of volumes launched for each instance. Users can choose up to 10 volumes.\nThis feature is only enabled for supported node types. Legacy node types cannot specify\ncustom EBS volumes.\nFor node types with no instance store, at least one EBS volume needs to be specified;\notherwise, cluster creation will fail.\n\nThese EBS volumes will be mounted at `/ebs0`, `/ebs1`, and etc.\nInstance store volumes will be mounted at `/local_disk0`, `/local_disk1`, and etc.\n\nIf EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for\nscratch storage because heterogenously sized scratch devices can lead to inefficient disk\nutilization. If no EBS volumes are attached, Databricks will configure Spark to use instance\nstore volumes.\n\nPlease note that if EBS volumes are specified, then the Spark configuration `spark.local.dir`\nwill be overridden."
+                            },
+                            "ebs_volume_iops": {
+                              "type": "number",
+                              "description": "\u003cneeds content added\u003e"
+                            },
+                            "ebs_volume_size": {
+                              "type": "number",
+                              "description": "The size of each EBS volume (in GiB) launched for each instance. For general purpose\nSSD, this value must be within the range 100 - 4096. For throughput optimized HDD,\nthis value must be within the range 500 - 4096."
+                            },
+                            "ebs_volume_throughput": {
+                              "type": "number",
+                              "description": "\u003cneeds content added\u003e"
+                            },
+                            "ebs_volume_type": {
+                              "type": "string"
+                            },
+                            "first_on_demand": {
+                              "type": "number",
+                              "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nIf this value is greater than 0, the cluster driver node in particular will be placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                            },
+                            "instance_profile_arn": {
+                              "type": "string",
+                              "description": "Nodes for this cluster will only be placed on AWS instances with this instance profile. If\nommitted, nodes will be placed on instances without an IAM instance profile. The instance\nprofile must have previously been added to the Databricks environment by an account\nadministrator.\n\nThis feature may only be available to certain customer plans.\n\nIf this field is ommitted, we will pull in the default from the conf if it exists."
+                            },
+                            "spot_bid_price_percent": {
+                              "type": "number",
+                              "description": "The bid price for AWS spot instances, as a percentage of the corresponding instance type's\non-demand price.\nFor example, if this field is set to 50, and the cluster needs a new `r3.xlarge` spot\ninstance, then the bid price is half of the price of\non-demand `r3.xlarge` instances. Similarly, if this field is set to 200, the bid price is twice\nthe price of on-demand `r3.xlarge` instances. If not specified, the default value is 100.\nWhen spot instances are requested for this cluster, only spot instances whose bid price\npercentage matches this field will be considered.\nNote that, for safety, we enforce this field to be no more than 10000.\n\nThe default value and documentation here should be kept consistent with\nCommonConf.defaultSpotBidPricePercent and CommonConf.maxSpotBidPricePercent."
+                            },
+                            "zone_id": {
+                              "type": "string",
+                              "description": "Identifier for the availability zone/datacenter in which the cluster resides.\nThis string will be of a form like \"us-west-2a\". The provided availability\nzone must be in the same region as the Databricks deployment. For example, \"us-west-2a\"\nis not a valid zone id if the Databricks deployment resides in the \"us-east-1\" region.\nThis is an optional field at cluster creation, and if not specified, a default zone will be used.\nIf the zone specified is \"auto\", will try to place cluster in a zone with high availability,\nand will retry placement in a different AZ if there is not enough capacity.\nSee [[AutoAZHelper.scala]] for more details.\nThe list of available zones as well as the default value can be found by using the\n`List Zones`_ method."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "azure_attributes": {
+                          "type": "object",
+                          "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                          "properties": {
+                            "availability": {
+                              "type": "string"
+                            },
+                            "first_on_demand": {
+                              "type": "number",
+                              "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nThis value should be greater than 0, to make sure the cluster driver node is placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                            },
+                            "log_analytics_info": {
+                              "type": "object",
+                              "description": "Defines values necessary to configure and run Azure Log Analytics agent",
+                              "properties": {
+                                "log_analytics_primary_key": {
+                                  "type": "string",
+                                  "description": "\u003cneeds content added\u003e"
+                                },
+                                "log_analytics_workspace_id": {
+                                  "type": "string",
+                                  "description": "\u003cneeds content added\u003e"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "spot_bid_max_price": {
+                              "type": "number",
+                              "description": "The max bid price to be used for Azure spot instances.\nThe Max price for the bid cannot be higher than the on-demand price of the instance.\nIf not specified, the default value is -1, which specifies that the instance cannot be evicted\non the basis of price, and only on the basis of availability. Further, the value should \u003e 0 or -1."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "cluster_log_conf": {
+                          "type": "object",
+                          "description": "The configuration for delivering spark logs to a long-term storage destination.\nTwo kinds of destinations (dbfs and s3) are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.",
+                          "properties": {
+                            "dbfs": {
+                              "type": "object",
+                              "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                              "properties": {
+                                "destination": {
+                                  "type": "string",
+                                  "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "s3": {
+                              "type": "object",
+                              "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                              "properties": {
+                                "canned_acl": {
+                                  "type": "string",
+                                  "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                },
+                                "destination": {
+                                  "type": "string",
+                                  "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                },
+                                "enable_encryption": {
+                                  "type": "boolean",
+                                  "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                },
+                                "encryption_type": {
+                                  "type": "string",
+                                  "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                },
+                                "endpoint": {
+                                  "type": "string",
+                                  "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                },
+                                "kms_key": {
+                                  "type": "string",
+                                  "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                },
+                                "region": {
+                                  "type": "string",
+                                  "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "cluster_name": {
+                          "type": "string",
+                          "description": "Cluster name requested by the user. This doesn't have to be unique.\nIf not specified at creation, the cluster name will be an empty string.\n"
+                        },
+                        "cluster_source": {
+                          "type": "string"
+                        },
+                        "custom_tags": {
+                          "type": "object",
+                          "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "data_security_mode": {
+                          "type": "string"
+                        },
+                        "docker_image": {
+                          "type": "object",
+                          "properties": {
+                            "basic_auth": {
+                              "type": "object",
+                              "properties": {
+                                "password": {
+                                  "type": "string",
+                                  "description": "Password of the user"
+                                },
+                                "username": {
+                                  "type": "string",
+                                  "description": "Name of the user"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "url": {
+                              "type": "string",
+                              "description": "URL of the docker image."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "driver_instance_pool_id": {
+                          "type": "string",
+                          "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                        },
+                        "driver_node_type_id": {
+                          "type": "string",
+                          "description": "The node type of the Spark driver. Note that this field is optional;\nif unset, the driver node type will be set as the same value\nas `node_type_id` defined above.\n"
+                        },
+                        "enable_elastic_disk": {
+                          "type": "boolean",
+                          "description": "Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk\nspace when its Spark workers are running low on disk space. This feature requires specific AWS\npermissions to function correctly - refer to the User Guide for more details."
+                        },
+                        "enable_local_disk_encryption": {
+                          "type": "boolean",
+                          "description": "Whether to enable LUKS on cluster VMs' local disks"
+                        },
+                        "gcp_attributes": {
+                          "type": "object",
+                          "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                          "properties": {
+                            "availability": {
+                              "type": "string"
+                            },
+                            "boot_disk_size": {
+                              "type": "number",
+                              "description": "boot disk size in GB"
+                            },
+                            "google_service_account": {
+                              "type": "string",
+                              "description": "If provided, the cluster will impersonate the google service account when accessing\ngcloud services (like GCS). The google service account\nmust have previously been added to the Databricks environment by an account\nadministrator."
+                            },
+                            "local_ssd_count": {
+                              "type": "number",
+                              "description": "If provided, each node (workers and driver) in the cluster will have this number of local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP documentation](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) for the supported number of local SSDs for each instance type."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "init_scripts": {
+                          "type": "array",
+                          "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "dbfs": {
+                                "type": "object",
+                                "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                                "properties": {
+                                  "destination": {
+                                    "type": "string",
+                                    "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "s3": {
+                                "type": "object",
+                                "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                                "properties": {
+                                  "canned_acl": {
+                                    "type": "string",
+                                    "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                  },
+                                  "destination": {
+                                    "type": "string",
+                                    "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                  },
+                                  "enable_encryption": {
+                                    "type": "boolean",
+                                    "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                  },
+                                  "encryption_type": {
+                                    "type": "string",
+                                    "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                  },
+                                  "endpoint": {
+                                    "type": "string",
+                                    "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                  },
+                                  "kms_key": {
+                                    "type": "string",
+                                    "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "volumes": {
+                                "type": "object",
+                                "properties": {
+                                  "destination": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "workspace": {
+                                "type": "object",
+                                "description": "destination needs to be provided. e.g.\n`{ \"workspace\" : { \"destination\" : \"/Users/user1@databricks.com/my-init.sh\" } }`",
+                                "properties": {
+                                  "destination": {
+                                    "type": "string",
+                                    "description": "workspace files destination, e.g. `/Users/user1@databricks.com/my-init.sh`"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "instance_pool_id": {
+                          "type": "string",
+                          "description": "The optional ID of the instance pool to which the cluster belongs."
+                        },
+                        "node_type_id": {
+                          "type": "string",
+                          "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                        },
+                        "num_workers": {
+                          "type": "number",
+                          "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                        },
+                        "policy_id": {
+                          "type": "string",
+                          "description": "The ID of the cluster policy used to create the cluster if applicable."
+                        },
+                        "runtime_engine": {
+                          "type": "string"
+                        },
+                        "single_user_name": {
+                          "type": "string",
+                          "description": "Single user name if data_security_mode is `SINGLE_USER`"
+                        },
+                        "spark_conf": {
+                          "type": "object",
+                          "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nUsers can also pass in a string of extra JVM options to the driver and the executors via\n`spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` respectively.\n",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "spark_env_vars": {
+                          "type": "object",
+                          "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "spark_version": {
+                          "type": "string",
+                          "description": "The Spark version of the cluster, e.g. `3.3.x-scala2.11`.\nA list of available Spark versions can be retrieved by using\nthe :method:clusters/sparkVersions API call.\n"
+                        },
+                        "ssh_public_keys": {
+                          "type": "array",
+                          "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "workload_type": {
+                          "type": "object",
+                          "properties": {
+                            "clients": {
+                              "type": "object",
+                              "description": " defined what type of clients can use the cluster. E.g. Notebooks, Jobs",
+                              "properties": {
+                                "jobs": {
+                                  "type": "boolean",
+                                  "description": "With jobs set, the cluster can be used for jobs"
+                                },
+                                "notebooks": {
+                                  "type": "boolean",
+                                  "description": "With notebooks set, this cluster can be used for notebooks"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "job_cluster_key"
+                  ]
+                }
+              },
+              "max_concurrent_runs": {
+                "type": "number",
+                "description": "An optional maximum allowed number of concurrent runs of the job.\n\nSet this value if you want to be able to execute multiple runs of the same job concurrently. This is useful for example if you trigger your job on a frequent schedule and want to allow consecutive runs to overlap with each other, or if you want to trigger multiple runs which differ by their input parameters.\n\nThis setting affects only new runs. For example, suppose the job’s concurrency is 4 and there are 4 concurrent active runs. Then setting the concurrency to 3 won’t kill any of the active runs. However, from then on, new runs are skipped unless there are fewer than 3 active runs.\n\nThis value cannot exceed 1000\\. Setting this value to 0 causes all new runs to be skipped. The default behavior is to allow only 1 concurrent run."
+              },
+              "name": {
+                "type": "string",
+                "description": "An optional name for the job."
+              },
+              "notification_settings": {
+                "type": "object",
+                "description": "Optional notification settings that are used when sending notifications to each of the `email_notifications` and `webhook_notifications` for this job.",
+                "properties": {
+                  "no_alert_for_canceled_runs": {
+                    "type": "boolean",
+                    "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is canceled."
+                  },
+                  "no_alert_for_skipped_runs": {
+                    "type": "boolean",
+                    "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is skipped."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "parameters": {
+                "type": "array",
+                "description": "Job-level parameter definitions",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "default": {
+                      "type": "string",
+                      "description": "Default value of the parameter."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the defined parameter. May only contain alphanumeric characters, `_`, `-`, and `.`"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "default",
+                    "name"
+                  ]
+                }
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group_name": {
+                      "type": "string"
+                    },
+                    "level": {
+                      "type": "string"
+                    },
+                    "service_principal_name": {
+                      "type": "string"
+                    },
+                    "user_name": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "level"
+                  ]
+                }
+              },
+              "run_as": {
+                "type": "object",
+                "properties": {
+                  "service_principal_name": {
+                    "type": "string",
+                    "description": "Application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role."
+                  },
+                  "user_name": {
+                    "type": "string",
+                    "description": "The email of an active workspace user. Non-admin users can only set this field to their own email."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "schedule": {
+                "type": "object",
+                "description": "An optional periodic schedule for this job. The default behavior is that the job only runs when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`.",
+                "properties": {
+                  "pause_status": {
+                    "type": "string",
+                    "description": "Whether this trigger is paused or not."
+                  },
+                  "quartz_cron_expression": {
+                    "type": "string",
+                    "description": "A Cron expression using Quartz syntax that describes the schedule for a job.\nSee [Cron Trigger](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html)\nfor details. This field is required.\"\n"
+                  },
+                  "timezone_id": {
+                    "type": "string",
+                    "description": "A Java timezone ID. The schedule for a job is resolved with respect to this timezone.\nSee [Java TimeZone](https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html) for details.\nThis field is required.\n"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "quartz_cron_expression",
+                  "timezone_id"
+                ]
+              },
+              "tags": {
+                "type": "object",
+                "description": "A map of tags associated with the job. These are forwarded to the cluster as cluster tags for jobs clusters, and are subject to the same limitations as cluster tags. A maximum of 25 tags can be added to the job.",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "tasks": {
+                "type": "array",
+                "description": "A list of task specifications to be executed by this job.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "compute_key": {
+                      "type": "string",
+                      "description": "The key of the compute requirement, specified in `job.settings.compute`, to use for execution of this task."
+                    },
+                    "condition_task": {
+                      "type": "object",
+                      "description": "If condition_task, specifies a condition with an outcome that can be used to control the execution of other tasks. Does not require a cluster to execute and does not support retries or notifications.",
+                      "properties": {
+                        "left": {
+                          "type": "string",
+                          "description": "The left operand of the condition task. Can be either a string value or a job state or parameter reference."
+                        },
+                        "op": {
+                          "type": "string",
+                          "description": "* `EQUAL_TO`, `NOT_EQUAL` operators perform string comparison of their operands. This means that `“12.0” == “12”` will evaluate to `false`.\n* `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL` operators perform numeric comparison of their operands. `“12.0” \u003e= “12”` will evaluate to `true`, `“10.0” \u003e= “12”` will evaluate to `false`.\n\nThe boolean comparison to task values can be implemented with operators `EQUAL_TO`, `NOT_EQUAL`. If a task value was set to a boolean value, it will be serialized to `“true”` or `“false”` for the comparison.\n"
+                        },
+                        "right": {
+                          "type": "string",
+                          "description": "The right operand of the condition task. Can be either a string value or a job state or parameter reference."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "dbt_task": {
+                      "type": "object",
+                      "description": "If dbt_task, indicates that this must execute a dbt task. It requires both Databricks SQL and the ability to use a serverless or a pro SQL warehouse.",
+                      "properties": {
+                        "catalog": {
+                          "type": "string",
+                          "description": "Optional name of the catalog to use. The value is the top level in the 3-level namespace of Unity Catalog (catalog / schema / relation). The catalog value can only be specified if a warehouse_id is specified. Requires dbt-databricks \u003e= 1.1.1."
+                        },
+                        "commands": {
+                          "type": "array",
+                          "description": "A list of dbt commands to execute. All commands must start with `dbt`. This parameter must not be empty. A maximum of up to 10 commands can be provided.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "profiles_directory": {
+                          "type": "string",
+                          "description": "Optional (relative) path to the profiles directory. Can only be specified if no warehouse_id is specified. If no warehouse_id is specified and this folder is unset, the root directory is used."
+                        },
+                        "project_directory": {
+                          "type": "string",
+                          "description": "Optional (relative) path to the project directory, if no value is provided, the root of the git repository is used."
+                        },
+                        "schema": {
+                          "type": "string",
+                          "description": "Optional schema to write to. This parameter is only used when a warehouse_id is also provided. If not provided, the `default` schema is used."
+                        },
+                        "warehouse_id": {
+                          "type": "string",
+                          "description": "ID of the SQL warehouse to connect to. If provided, we automatically generate and provide the profile and connection details to dbt. It can be overridden on a per-command basis by using the `--profiles-dir` command line argument."
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "commands"
+                      ]
+                    },
+                    "depends_on": {
+                      "type": "array",
+                      "description": "An optional array of objects specifying the dependency graph of the task. All tasks specified in this field must complete successfully before executing this task.\nThe key is `task_key`, and the value is the name assigned to the dependent task.\n",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "outcome": {
+                            "type": "string",
+                            "description": "Can only be specified on condition task dependencies. The outcome of the dependent task that must be met for this task to run."
+                          },
+                          "task_key": {
+                            "type": "string",
+                            "description": "The name of the task this task depends on."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "task_key"
+                        ]
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "An optional description for this task.\nThe maximum length is 4096 bytes."
+                    },
+                    "email_notifications": {
+                      "type": "object",
+                      "description": "An optional set of email addresses that is notified when runs of this task begin or complete as well as when this task is deleted. The default behavior is to not send any emails.",
+                      "properties": {
+                        "on_duration_warning_threshold_exceeded": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_failure": {
+                          "type": "array",
+                          "description": "A list of email addresses to be notified when a run unsuccessfully completes. A run is considered to have completed unsuccessfully if it ends with an `INTERNAL_ERROR` `life_cycle_state` or a `FAILED`, or `TIMED_OUT` result_state. If this is not specified on job creation, reset, or update the list is empty, and notifications are not sent.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_start": {
+                          "type": "array",
+                          "description": "A list of email addresses to be notified when a run begins. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_success": {
+                          "type": "array",
+                          "description": "A list of email addresses to be notified when a run successfully completes. A run is considered to have completed successfully if it ends with a `TERMINATED` `life_cycle_state` and a `SUCCESS` result_state. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "existing_cluster_id": {
+                      "type": "string",
+                      "description": "If existing_cluster_id, the ID of an existing cluster that is used for all runs of this task. When running tasks on an existing cluster, you may need to manually restart the cluster if it stops responding. We suggest running jobs on new clusters for greater reliability."
+                    },
+                    "health": {
+                      "type": "object",
+                      "properties": {
+                        "rules": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "metric": {
+                                "type": "string"
+                              },
+                              "op": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "job_cluster_key": {
+                      "type": "string",
+                      "description": "If job_cluster_key, this task is executed reusing the cluster specified in `job.settings.job_clusters`."
+                    },
+                    "libraries": {
+                      "type": "array",
+                      "description": "An optional list of libraries to be installed on the cluster that executes the task. The default value is an empty list.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "cran": {
+                            "type": "object",
+                            "description": "Specification of a CRAN library to be installed as part of the library",
+                            "properties": {
+                              "package": {
+                                "type": "string",
+                                "description": "The name of the CRAN package to install."
+                              },
+                              "repo": {
+                                "type": "string",
+                                "description": "The repository where the package can be found. If not specified, the default CRAN repo is used."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "package"
+                            ]
+                          },
+                          "egg": {
+                            "type": "string",
+                            "description": "URI of the egg to be installed. Currently only DBFS and S3 URIs are supported.\nFor example: `{ \"egg\": \"dbfs:/my/egg\" }` or\n`{ \"egg\": \"s3://my-bucket/egg\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI."
+                          },
+                          "jar": {
+                            "type": "string",
+                            "description": "URI of the jar to be installed. Currently only DBFS and S3 URIs are supported.\nFor example: `{ \"jar\": \"dbfs:/mnt/databricks/library.jar\" }` or\n`{ \"jar\": \"s3://my-bucket/library.jar\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI."
+                          },
+                          "maven": {
+                            "type": "object",
+                            "description": "Specification of a maven library to be installed. For example:\n`{ \"coordinates\": \"org.jsoup:jsoup:1.7.2\" }`",
+                            "properties": {
+                              "coordinates": {
+                                "type": "string",
+                                "description": "Gradle-style maven coordinates. For example: \"org.jsoup:jsoup:1.7.2\"."
+                              },
+                              "exclusions": {
+                                "type": "array",
+                                "description": "List of dependences to exclude. For example: `[\"slf4j:slf4j\", \"*:hadoop-client\"]`.\n\nMaven dependency exclusions:\nhttps://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "repo": {
+                                "type": "string",
+                                "description": "Maven repo to install the Maven package from. If omitted, both Maven Central Repository\nand Spark Packages are searched."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "coordinates"
+                            ]
+                          },
+                          "pypi": {
+                            "type": "object",
+                            "description": "Specification of a PyPi library to be installed. For example:\n`{ \"package\": \"simplejson\" }`",
+                            "properties": {
+                              "package": {
+                                "type": "string",
+                                "description": "The name of the pypi package to install. An optional exact version specification is also\nsupported. Examples: \"simplejson\" and \"simplejson==3.8.0\"."
+                              },
+                              "repo": {
+                                "type": "string",
+                                "description": "The repository where the package can be found. If not specified, the default pip index is\nused."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "package"
+                            ]
+                          },
+                          "whl": {
+                            "type": "string",
+                            "description": "URI of the wheel to be installed.\nFor example: `{ \"whl\": \"dbfs:/my/whl\" }` or `{ \"whl\": \"s3://my-bucket/whl\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI."
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "max_retries": {
+                      "type": "number",
+                      "description": "An optional maximum number of times to retry an unsuccessful run. A run is considered to be unsuccessful if it completes with the `FAILED` result_state or `INTERNAL_ERROR` `life_cycle_state`. The value -1 means to retry indefinitely and the value 0 means to never retry. The default behavior is to never retry."
+                    },
+                    "min_retry_interval_millis": {
+                      "type": "number",
+                      "description": "An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried."
+                    },
+                    "new_cluster": {
+                      "type": "object",
+                      "description": "If new_cluster, a description of a cluster that is created for only for this task.",
+                      "properties": {
+                        "autoscale": {
+                          "type": "object",
+                          "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                          "properties": {
+                            "max_workers": {
+                              "type": "number",
+                              "description": "The maximum number of workers to which the cluster can scale up when overloaded.\nNote that `max_workers` must be strictly greater than `min_workers`."
+                            },
+                            "min_workers": {
+                              "type": "number",
+                              "description": "The minimum number of workers to which the cluster can scale down when underutilized.\nIt is also the initial number of workers the cluster will have after creation."
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "max_workers",
+                            "min_workers"
+                          ]
+                        },
+                        "autotermination_minutes": {
+                          "type": "number",
+                          "description": "Automatically terminates the cluster after it is inactive for this time in minutes. If not set,\nthis cluster will not be automatically terminated. If specified, the threshold must be between\n10 and 10000 minutes.\nUsers can also set this value to 0 to explicitly disable automatic termination."
+                        },
+                        "aws_attributes": {
+                          "type": "object",
+                          "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                          "properties": {
+                            "availability": {
+                              "type": "string"
+                            },
+                            "ebs_volume_count": {
+                              "type": "number",
+                              "description": "The number of volumes launched for each instance. Users can choose up to 10 volumes.\nThis feature is only enabled for supported node types. Legacy node types cannot specify\ncustom EBS volumes.\nFor node types with no instance store, at least one EBS volume needs to be specified;\notherwise, cluster creation will fail.\n\nThese EBS volumes will be mounted at `/ebs0`, `/ebs1`, and etc.\nInstance store volumes will be mounted at `/local_disk0`, `/local_disk1`, and etc.\n\nIf EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for\nscratch storage because heterogenously sized scratch devices can lead to inefficient disk\nutilization. If no EBS volumes are attached, Databricks will configure Spark to use instance\nstore volumes.\n\nPlease note that if EBS volumes are specified, then the Spark configuration `spark.local.dir`\nwill be overridden."
+                            },
+                            "ebs_volume_iops": {
+                              "type": "number",
+                              "description": "\u003cneeds content added\u003e"
+                            },
+                            "ebs_volume_size": {
+                              "type": "number",
+                              "description": "The size of each EBS volume (in GiB) launched for each instance. For general purpose\nSSD, this value must be within the range 100 - 4096. For throughput optimized HDD,\nthis value must be within the range 500 - 4096."
+                            },
+                            "ebs_volume_throughput": {
+                              "type": "number",
+                              "description": "\u003cneeds content added\u003e"
+                            },
+                            "ebs_volume_type": {
+                              "type": "string"
+                            },
+                            "first_on_demand": {
+                              "type": "number",
+                              "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nIf this value is greater than 0, the cluster driver node in particular will be placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                            },
+                            "instance_profile_arn": {
+                              "type": "string",
+                              "description": "Nodes for this cluster will only be placed on AWS instances with this instance profile. If\nommitted, nodes will be placed on instances without an IAM instance profile. The instance\nprofile must have previously been added to the Databricks environment by an account\nadministrator.\n\nThis feature may only be available to certain customer plans.\n\nIf this field is ommitted, we will pull in the default from the conf if it exists."
+                            },
+                            "spot_bid_price_percent": {
+                              "type": "number",
+                              "description": "The bid price for AWS spot instances, as a percentage of the corresponding instance type's\non-demand price.\nFor example, if this field is set to 50, and the cluster needs a new `r3.xlarge` spot\ninstance, then the bid price is half of the price of\non-demand `r3.xlarge` instances. Similarly, if this field is set to 200, the bid price is twice\nthe price of on-demand `r3.xlarge` instances. If not specified, the default value is 100.\nWhen spot instances are requested for this cluster, only spot instances whose bid price\npercentage matches this field will be considered.\nNote that, for safety, we enforce this field to be no more than 10000.\n\nThe default value and documentation here should be kept consistent with\nCommonConf.defaultSpotBidPricePercent and CommonConf.maxSpotBidPricePercent."
+                            },
+                            "zone_id": {
+                              "type": "string",
+                              "description": "Identifier for the availability zone/datacenter in which the cluster resides.\nThis string will be of a form like \"us-west-2a\". The provided availability\nzone must be in the same region as the Databricks deployment. For example, \"us-west-2a\"\nis not a valid zone id if the Databricks deployment resides in the \"us-east-1\" region.\nThis is an optional field at cluster creation, and if not specified, a default zone will be used.\nIf the zone specified is \"auto\", will try to place cluster in a zone with high availability,\nand will retry placement in a different AZ if there is not enough capacity.\nSee [[AutoAZHelper.scala]] for more details.\nThe list of available zones as well as the default value can be found by using the\n`List Zones`_ method."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "azure_attributes": {
+                          "type": "object",
+                          "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                          "properties": {
+                            "availability": {
+                              "type": "string"
+                            },
+                            "first_on_demand": {
+                              "type": "number",
+                              "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nThis value should be greater than 0, to make sure the cluster driver node is placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                            },
+                            "log_analytics_info": {
+                              "type": "object",
+                              "description": "Defines values necessary to configure and run Azure Log Analytics agent",
+                              "properties": {
+                                "log_analytics_primary_key": {
+                                  "type": "string",
+                                  "description": "\u003cneeds content added\u003e"
+                                },
+                                "log_analytics_workspace_id": {
+                                  "type": "string",
+                                  "description": "\u003cneeds content added\u003e"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "spot_bid_max_price": {
+                              "type": "number",
+                              "description": "The max bid price to be used for Azure spot instances.\nThe Max price for the bid cannot be higher than the on-demand price of the instance.\nIf not specified, the default value is -1, which specifies that the instance cannot be evicted\non the basis of price, and only on the basis of availability. Further, the value should \u003e 0 or -1."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "cluster_log_conf": {
+                          "type": "object",
+                          "description": "The configuration for delivering spark logs to a long-term storage destination.\nTwo kinds of destinations (dbfs and s3) are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.",
+                          "properties": {
+                            "dbfs": {
+                              "type": "object",
+                              "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                              "properties": {
+                                "destination": {
+                                  "type": "string",
+                                  "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "s3": {
+                              "type": "object",
+                              "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                              "properties": {
+                                "canned_acl": {
+                                  "type": "string",
+                                  "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                },
+                                "destination": {
+                                  "type": "string",
+                                  "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                },
+                                "enable_encryption": {
+                                  "type": "boolean",
+                                  "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                },
+                                "encryption_type": {
+                                  "type": "string",
+                                  "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                },
+                                "endpoint": {
+                                  "type": "string",
+                                  "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                },
+                                "kms_key": {
+                                  "type": "string",
+                                  "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                },
+                                "region": {
+                                  "type": "string",
+                                  "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "cluster_name": {
+                          "type": "string",
+                          "description": "Cluster name requested by the user. This doesn't have to be unique.\nIf not specified at creation, the cluster name will be an empty string.\n"
+                        },
+                        "cluster_source": {
+                          "type": "string"
+                        },
+                        "custom_tags": {
+                          "type": "object",
+                          "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "data_security_mode": {
+                          "type": "string"
+                        },
+                        "docker_image": {
+                          "type": "object",
+                          "properties": {
+                            "basic_auth": {
+                              "type": "object",
+                              "properties": {
+                                "password": {
+                                  "type": "string",
+                                  "description": "Password of the user"
+                                },
+                                "username": {
+                                  "type": "string",
+                                  "description": "Name of the user"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "url": {
+                              "type": "string",
+                              "description": "URL of the docker image."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "driver_instance_pool_id": {
+                          "type": "string",
+                          "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                        },
+                        "driver_node_type_id": {
+                          "type": "string",
+                          "description": "The node type of the Spark driver. Note that this field is optional;\nif unset, the driver node type will be set as the same value\nas `node_type_id` defined above.\n"
+                        },
+                        "enable_elastic_disk": {
+                          "type": "boolean",
+                          "description": "Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk\nspace when its Spark workers are running low on disk space. This feature requires specific AWS\npermissions to function correctly - refer to the User Guide for more details."
+                        },
+                        "enable_local_disk_encryption": {
+                          "type": "boolean",
+                          "description": "Whether to enable LUKS on cluster VMs' local disks"
+                        },
+                        "gcp_attributes": {
+                          "type": "object",
+                          "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                          "properties": {
+                            "availability": {
+                              "type": "string"
+                            },
+                            "boot_disk_size": {
+                              "type": "number",
+                              "description": "boot disk size in GB"
+                            },
+                            "google_service_account": {
+                              "type": "string",
+                              "description": "If provided, the cluster will impersonate the google service account when accessing\ngcloud services (like GCS). The google service account\nmust have previously been added to the Databricks environment by an account\nadministrator."
+                            },
+                            "local_ssd_count": {
+                              "type": "number",
+                              "description": "If provided, each node (workers and driver) in the cluster will have this number of local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP documentation](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) for the supported number of local SSDs for each instance type."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "init_scripts": {
+                          "type": "array",
+                          "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "dbfs": {
+                                "type": "object",
+                                "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                                "properties": {
+                                  "destination": {
+                                    "type": "string",
+                                    "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "s3": {
+                                "type": "object",
+                                "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                                "properties": {
+                                  "canned_acl": {
+                                    "type": "string",
+                                    "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                  },
+                                  "destination": {
+                                    "type": "string",
+                                    "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                  },
+                                  "enable_encryption": {
+                                    "type": "boolean",
+                                    "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                  },
+                                  "encryption_type": {
+                                    "type": "string",
+                                    "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                  },
+                                  "endpoint": {
+                                    "type": "string",
+                                    "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                  },
+                                  "kms_key": {
+                                    "type": "string",
+                                    "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "volumes": {
+                                "type": "object",
+                                "properties": {
+                                  "destination": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "workspace": {
+                                "type": "object",
+                                "description": "destination needs to be provided. e.g.\n`{ \"workspace\" : { \"destination\" : \"/Users/user1@databricks.com/my-init.sh\" } }`",
+                                "properties": {
+                                  "destination": {
+                                    "type": "string",
+                                    "description": "workspace files destination, e.g. `/Users/user1@databricks.com/my-init.sh`"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "instance_pool_id": {
+                          "type": "string",
+                          "description": "The optional ID of the instance pool to which the cluster belongs."
+                        },
+                        "node_type_id": {
+                          "type": "string",
+                          "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                        },
+                        "num_workers": {
+                          "type": "number",
+                          "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                        },
+                        "policy_id": {
+                          "type": "string",
+                          "description": "The ID of the cluster policy used to create the cluster if applicable."
+                        },
+                        "runtime_engine": {
+                          "type": "string"
+                        },
+                        "single_user_name": {
+                          "type": "string",
+                          "description": "Single user name if data_security_mode is `SINGLE_USER`"
+                        },
+                        "spark_conf": {
+                          "type": "object",
+                          "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nUsers can also pass in a string of extra JVM options to the driver and the executors via\n`spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` respectively.\n",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "spark_env_vars": {
+                          "type": "object",
+                          "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "spark_version": {
+                          "type": "string",
+                          "description": "The Spark version of the cluster, e.g. `3.3.x-scala2.11`.\nA list of available Spark versions can be retrieved by using\nthe :method:clusters/sparkVersions API call.\n"
+                        },
+                        "ssh_public_keys": {
+                          "type": "array",
+                          "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "workload_type": {
+                          "type": "object",
+                          "properties": {
+                            "clients": {
+                              "type": "object",
+                              "description": " defined what type of clients can use the cluster. E.g. Notebooks, Jobs",
+                              "properties": {
+                                "jobs": {
+                                  "type": "boolean",
+                                  "description": "With jobs set, the cluster can be used for jobs"
+                                },
+                                "notebooks": {
+                                  "type": "boolean",
+                                  "description": "With notebooks set, this cluster can be used for notebooks"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "notebook_task": {
+                      "type": "object",
+                      "description": "If notebook_task, indicates that this task must run a notebook. This field may not be specified in conjunction with spark_jar_task.",
+                      "properties": {
+                        "base_parameters": {
+                          "type": "object",
+                          "description": "Base parameters to be used for each run of this job. If the run is initiated by a call to\n:method:jobs/runNow with parameters specified, the two parameters maps are merged. If the same key is specified in\n`base_parameters` and in `run-now`, the value from `run-now` is used.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n\nIf the notebook takes a parameter that is not specified in the job’s `base_parameters` or the `run-now` override parameters,\nthe default value from the notebook is used.\n\nRetrieve these parameters in a notebook using [dbutils.widgets.get](https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-widgets).\n",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "notebook_path": {
+                          "type": "string",
+                          "description": "The path of the notebook to be run in the Databricks workspace or remote repository.\nFor notebooks stored in the Databricks workspace, the path must be absolute and begin with a slash.\nFor notebooks stored in a remote repository, the path must be relative. This field is required.\n"
+                        },
+                        "source": {
+                          "type": "string",
+                          "description": "Optional location type of the Python file. When set to `WORKSPACE` or not specified, the file will be retrieved\nfrom the local \u003cDatabricks\u003e workspace or cloud location (if the `python_file` has a URI format). When set to `GIT`,\nthe Python file will be retrieved from a Git repository defined in `git_source`.\n\n* `WORKSPACE`: The Python file is located in a \u003cDatabricks\u003e workspace or at a cloud filesystem URI.\n* `GIT`: The Python file is located in a remote Git repository.\n"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "notebook_path"
+                      ]
+                    },
+                    "notification_settings": {
+                      "type": "object",
+                      "description": "Optional notification settings that are used when sending notifications to each of the `email_notifications` for this task.",
+                      "properties": {
+                        "alert_on_last_attempt": {
+                          "type": "boolean",
+                          "description": "If true, do not send notifications to recipients specified in `on_start` for the retried runs and do not send notifications to recipients specified in `on_failure` until the last retry of the run."
+                        },
+                        "no_alert_for_canceled_runs": {
+                          "type": "boolean",
+                          "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is canceled."
+                        },
+                        "no_alert_for_skipped_runs": {
+                          "type": "boolean",
+                          "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is skipped."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "pipeline_task": {
+                      "type": "object",
+                      "description": "If pipeline_task, indicates that this task must execute a Pipeline.",
+                      "properties": {
+                        "full_refresh": {
+                          "type": "boolean",
+                          "description": "If true, a full refresh will be triggered on the delta live table."
+                        },
+                        "pipeline_id": {
+                          "type": "string",
+                          "description": "The full name of the pipeline task to execute."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "python_wheel_task": {
+                      "type": "object",
+                      "description": "If python_wheel_task, indicates that this job must execute a PythonWheel.",
+                      "properties": {
+                        "entry_point": {
+                          "type": "string",
+                          "description": "Named entry point to use, if it does not exist in the metadata of the package it executes the function from the package directly using `$packageName.$entryPoint()`"
+                        },
+                        "named_parameters": {
+                          "type": "object",
+                          "description": "Command-line parameters passed to Python wheel task in the form of `[\"--name=task\", \"--data=dbfs:/path/to/data.json\"]`. Leave it empty if `parameters` is not null.",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "package_name": {
+                          "type": "string",
+                          "description": "Name of the package to execute"
+                        },
+                        "parameters": {
+                          "type": "array",
+                          "description": "Command-line parameters passed to Python wheel task. Leave it empty if `named_parameters` is not null.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "retry_on_timeout": {
+                      "type": "boolean",
+                      "description": "An optional policy to specify whether to retry a task when it times out. The default behavior is to not retry on timeout."
+                    },
+                    "run_if": {
+                      "type": "string",
+                      "description": "An optional value specifying the condition determining whether the task is run once its dependencies have been completed. When omitted, defaults to `ALL_SUCCESS`.\n\n* `ALL_SUCCESS`: All dependencies have executed and succeeded\n* `AT_LEAST_ONE_SUCCESS`: At least one dependency has succeeded\n* `NONE_FAILED`: None of the dependencies have failed and at least one was executed\n* `ALL_DONE`: All dependencies completed and at least one was executed\n* `AT_LEAST_ONE_FAILED`: At least one dependency failed\n* `ALL_FAILED`: ALl dependencies have failed\n"
+                    },
+                    "run_job_task": {
+                      "type": "object",
+                      "properties": {
+                        "job_id": {
+                          "type": "number"
+                        },
+                        "job_parameters": {}
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "job_id"
+                      ]
+                    },
+                    "spark_jar_task": {
+                      "type": "object",
+                      "description": "If spark_jar_task, indicates that this task must run a JAR.",
+                      "properties": {
+                        "jar_uri": {
+                          "type": "string",
+                          "description": "Deprecated since 04/2016. Provide a `jar` through the `libraries` field instead. For an example, see :method:jobs/create.\n"
+                        },
+                        "main_class_name": {
+                          "type": "string",
+                          "description": "The full name of the class containing the main method to be executed. This class must be contained in a JAR provided as a library.\n\nThe code must use `SparkContext.getOrCreate` to obtain a Spark context; otherwise, runs of the job fail."
+                        },
+                        "parameters": {
+                          "type": "array",
+                          "description": "Parameters passed to the main method.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "spark_python_task": {
+                      "type": "object",
+                      "description": "If spark_python_task, indicates that this task must run a Python file.",
+                      "properties": {
+                        "parameters": {
+                          "type": "array",
+                          "description": "Command line parameters passed to the Python file.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "python_file": {
+                          "type": "string",
+                          "description": "The Python file to be executed. Cloud file URIs (such as dbfs:/, s3:/, adls:/, gcs:/) and workspace paths are supported. For python files stored in the Databricks workspace, the path must be absolute and begin with `/`. For files stored in a remote repository, the path must be relative. This field is required."
+                        },
+                        "source": {
+                          "type": "string",
+                          "description": "Optional location type of the Python file. When set to `WORKSPACE` or not specified, the file will be retrieved\nfrom the local \u003cDatabricks\u003e workspace or cloud location (if the `python_file` has a URI format). When set to `GIT`,\nthe Python file will be retrieved from a Git repository defined in `git_source`.\n\n* `WORKSPACE`: The Python file is located in a \u003cDatabricks\u003e workspace or at a cloud filesystem URI.\n* `GIT`: The Python file is located in a remote Git repository.\n"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "python_file"
+                      ]
+                    },
+                    "spark_submit_task": {
+                      "type": "object",
+                      "description": "If spark_submit_task, indicates that this task must be launched by the spark submit script. This task can run only on new clusters.",
+                      "properties": {
+                        "parameters": {
+                          "type": "array",
+                          "description": "Command-line parameters passed to spark submit.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "sql_task": {
+                      "type": "object",
+                      "description": "If sql_task, indicates that this job must execute a SQL task.",
+                      "properties": {
+                        "alert": {
+                          "type": "object",
+                          "description": "If alert, indicates that this job must refresh a SQL alert.",
+                          "properties": {
+                            "alert_id": {
+                              "type": "string",
+                              "description": "The canonical identifier of the SQL alert."
+                            },
+                            "pause_subscriptions": {
+                              "type": "boolean",
+                              "description": "If true, the alert notifications are not sent to subscribers."
+                            },
+                            "subscriptions": {
+                              "type": "array",
+                              "description": "If specified, alert notifications are sent to subscribers.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "destination_id": {
+                                    "type": "string",
+                                    "description": "The canonical identifier of the destination to receive email notification."
+                                  },
+                                  "user_name": {
+                                    "type": "string",
+                                    "description": "The user name to receive the subscription email."
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "alert_id"
+                          ]
+                        },
+                        "dashboard": {
+                          "type": "object",
+                          "description": "If dashboard, indicates that this job must refresh a SQL dashboard.",
+                          "properties": {
+                            "custom_subject": {
+                              "type": "string",
+                              "description": "Subject of the email sent to subscribers of this task."
+                            },
+                            "dashboard_id": {
+                              "type": "string",
+                              "description": "The canonical identifier of the SQL dashboard."
+                            },
+                            "pause_subscriptions": {
+                              "type": "boolean",
+                              "description": "If true, the dashboard snapshot is not taken, and emails are not sent to subscribers."
+                            },
+                            "subscriptions": {
+                              "type": "array",
+                              "description": "If specified, dashboard snapshots are sent to subscriptions.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "destination_id": {
+                                    "type": "string",
+                                    "description": "The canonical identifier of the destination to receive email notification."
+                                  },
+                                  "user_name": {
+                                    "type": "string",
+                                    "description": "The user name to receive the subscription email."
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "dashboard_id"
+                          ]
+                        },
+                        "file": {
+                          "type": "object",
+                          "description": "If file, indicates that this job runs a SQL file in a remote Git repository. Only one SQL statement is supported in a file. Multiple SQL statements separated by semicolons (;) are not permitted.",
+                          "properties": {
+                            "path": {
+                              "type": "string",
+                              "description": "Relative path of the SQL file in the remote Git repository."
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "path"
+                          ]
+                        },
+                        "parameters": {
+                          "type": "object",
+                          "description": "Parameters to be used for each run of this job. The SQL alert task does not support custom parameters.",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "query": {
+                          "type": "object",
+                          "description": "If query, indicates that this job must execute a SQL query.",
+                          "properties": {
+                            "query_id": {
+                              "type": "string",
+                              "description": "The canonical identifier of the SQL query."
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "query_id"
+                          ]
+                        },
+                        "warehouse_id": {
+                          "type": "string",
+                          "description": "The canonical identifier of the SQL warehouse. Only serverless and pro SQL warehouses are supported."
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "warehouse_id"
+                      ]
+                    },
+                    "task_key": {
+                      "type": "string",
+                      "description": "A unique name for the task. This field is used to refer to this task from other tasks.\nThis field is required and must be unique within its parent job.\nOn Update or Reset, this field is used to reference the tasks to be updated or reset.\nThe maximum length is 100 characters."
+                    },
+                    "timeout_seconds": {
+                      "type": "number",
+                      "description": "An optional timeout applied to each run of this job task. The default behavior is to have no timeout."
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "task_key"
+                  ]
+                }
+              },
+              "timeout_seconds": {
+                "type": "number",
+                "description": "An optional timeout applied to each run of this job. The default behavior is to have no timeout."
+              },
+              "trigger": {
+                "type": "object",
+                "description": "Trigger settings for the job. Can be used to trigger a run when new files arrive in an external location. The default behavior is that the job runs only when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`.",
+                "properties": {
+                  "file_arrival": {
+                    "type": "object",
+                    "description": "File arrival trigger settings.",
+                    "properties": {
+                      "min_time_between_triggers_seconds": {
+                        "type": "number",
+                        "description": "If set, the trigger starts a run only after the specified amount of time passed since\nthe last time the trigger fired. The minimum allowed value is 60 seconds\n"
+                      },
+                      "url": {
+                        "type": "string",
+                        "description": "URL to be monitored for file arrivals. The path must point to the root or a subpath of the external location."
+                      },
+                      "wait_after_last_change_seconds": {
+                        "type": "number",
+                        "description": "If set, the trigger starts a run only after no file activity has occurred for the specified amount of time.\nThis makes it possible to wait for a batch of incoming files to arrive before triggering a run. The\nminimum allowed value is 60 seconds.\n"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "pause_status": {
+                    "type": "string",
+                    "description": "Whether this trigger is paused or not."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "webhook_notifications": {
+                "type": "object",
+                "description": "A collection of system notification IDs to notify when the run begins or completes. The default behavior is to not send any system notifications.",
+                "properties": {
+                  "on_duration_warning_threshold_exceeded": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "on_failure": {
+                    "type": "array",
+                    "description": "An optional list of system notification IDs to call when the run fails. A maximum of 3 destinations can be specified for the `on_failure` property.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "on_start": {
+                    "type": "array",
+                    "description": "An optional list of system notification IDs to call when the run starts. A maximum of 3 destinations can be specified for the `on_start` property.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "on_success": {
+                    "type": "array",
+                    "description": "An optional list of system notification IDs to call when the run completes successfully. A maximum of 3 destinations can be specified for the `on_success` property.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "model_serving_endpoints": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "config": {
+                "type": "object",
+                "properties": {
+                  "served_models": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "environment_vars": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "instance_profile_arn": {
+                          "type": "string"
+                        },
+                        "model_name": {
+                          "type": "string"
+                        },
+                        "model_version": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "scale_to_zero_enabled": {
+                          "type": "boolean"
+                        },
+                        "workload_size": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "model_name",
+                        "model_version",
+                        "scale_to_zero_enabled",
+                        "workload_size"
+                      ]
+                    }
+                  },
+                  "traffic_config": {
+                    "type": "object",
+                    "properties": {
+                      "routes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "served_model_name": {
+                              "type": "string"
+                            },
+                            "traffic_percentage": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "served_model_name",
+                            "traffic_percentage"
+                          ]
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "served_models"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group_name": {
+                      "type": "string"
+                    },
+                    "level": {
+                      "type": "string"
+                    },
+                    "service_principal_name": {
+                      "type": "string"
+                    },
+                    "user_name": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "level"
+                  ]
+                }
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "config",
+              "name"
+            ]
+          }
+        },
+        "models": {
+          "type": "object",
+          "description": "List of MLflow models",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "creation_timestamp": {
+                "type": "number",
+                "description": "Timestamp recorded when this `registered_model` was created."
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of this `registered_model`."
+              },
+              "last_updated_timestamp": {
+                "type": "number",
+                "description": "Timestamp recorded when metadata for this `registered_model` was last updated."
+              },
+              "latest_versions": {
+                "type": "array",
+                "description": "Collection of latest model versions for each stage.\nOnly contains models with current `READY` status.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "creation_timestamp": {
+                      "type": "number",
+                      "description": "Timestamp recorded when this `model_version` was created."
+                    },
+                    "current_stage": {
+                      "type": "string",
+                      "description": "Current stage for this `model_version`."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of this `model_version`."
+                    },
+                    "last_updated_timestamp": {
+                      "type": "number",
+                      "description": "Timestamp recorded when metadata for this `model_version` was last updated."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Unique name of the model"
+                    },
+                    "run_id": {
+                      "type": "string",
+                      "description": "MLflow run ID used when creating `model_version`, if `source` was generated by an\nexperiment run stored in MLflow tracking server."
+                    },
+                    "run_link": {
+                      "type": "string",
+                      "description": "Run Link: Direct link to the run that generated this version"
+                    },
+                    "source": {
+                      "type": "string",
+                      "description": "URI indicating the location of the source model artifacts, used when creating `model_version`"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Current status of `model_version`"
+                    },
+                    "status_message": {
+                      "type": "string",
+                      "description": "Details on current `status`, if it is pending or failed."
+                    },
+                    "tags": {
+                      "type": "array",
+                      "description": "Tags: Additional metadata key-value pairs for this `model_version`.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string",
+                            "description": "The tag key."
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "The tag value."
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "user_id": {
+                      "type": "string",
+                      "description": "User that created this `model_version`."
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "Model's version number."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "name": {
+                "type": "string",
+                "description": "Unique name for the model."
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group_name": {
+                      "type": "string"
+                    },
+                    "level": {
+                      "type": "string"
+                    },
+                    "service_principal_name": {
+                      "type": "string"
+                    },
+                    "user_name": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "level"
+                  ]
+                }
+              },
+              "tags": {
+                "type": "array",
+                "description": "Tags: Additional metadata key-value pairs for this `registered_model`.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string",
+                      "description": "The tag key."
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The tag value."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "user_id": {
+                "type": "string",
+                "description": "User that created this `registered_model`"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "pipelines": {
+          "type": "object",
+          "description": "List of DLT pipelines",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "catalog": {
+                "type": "string",
+                "description": "A catalog in Unity Catalog to publish data from this pipeline to. If `target` is specified, tables in this pipeline are published to a `target` schema inside `catalog` (for example, `catalog`.`target`.`table`). If `target` is not specified, no data is published to Unity Catalog."
+              },
+              "channel": {
+                "type": "string",
+                "description": "DLT Release Channel that specifies which version to use."
+              },
+              "clusters": {
+                "type": "array",
+                "description": "Cluster settings for this pipeline deployment.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "apply_policy_default_values": {
+                      "type": "boolean",
+                      "description": "Note: This field won't be persisted. Only API users will check this field."
+                    },
+                    "autoscale": {
+                      "type": "object",
+                      "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                      "properties": {
+                        "max_workers": {
+                          "type": "number",
+                          "description": "The maximum number of workers to which the cluster can scale up when overloaded.\nNote that `max_workers` must be strictly greater than `min_workers`."
+                        },
+                        "min_workers": {
+                          "type": "number",
+                          "description": "The minimum number of workers to which the cluster can scale down when underutilized.\nIt is also the initial number of workers the cluster will have after creation."
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "max_workers",
+                        "min_workers"
+                      ]
+                    },
+                    "aws_attributes": {
+                      "type": "object",
+                      "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "properties": {
+                        "availability": {
+                          "type": "string"
+                        },
+                        "ebs_volume_count": {
+                          "type": "number",
+                          "description": "The number of volumes launched for each instance. Users can choose up to 10 volumes.\nThis feature is only enabled for supported node types. Legacy node types cannot specify\ncustom EBS volumes.\nFor node types with no instance store, at least one EBS volume needs to be specified;\notherwise, cluster creation will fail.\n\nThese EBS volumes will be mounted at `/ebs0`, `/ebs1`, and etc.\nInstance store volumes will be mounted at `/local_disk0`, `/local_disk1`, and etc.\n\nIf EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for\nscratch storage because heterogenously sized scratch devices can lead to inefficient disk\nutilization. If no EBS volumes are attached, Databricks will configure Spark to use instance\nstore volumes.\n\nPlease note that if EBS volumes are specified, then the Spark configuration `spark.local.dir`\nwill be overridden."
+                        },
+                        "ebs_volume_iops": {
+                          "type": "number",
+                          "description": "\u003cneeds content added\u003e"
+                        },
+                        "ebs_volume_size": {
+                          "type": "number",
+                          "description": "The size of each EBS volume (in GiB) launched for each instance. For general purpose\nSSD, this value must be within the range 100 - 4096. For throughput optimized HDD,\nthis value must be within the range 500 - 4096."
+                        },
+                        "ebs_volume_throughput": {
+                          "type": "number",
+                          "description": "\u003cneeds content added\u003e"
+                        },
+                        "ebs_volume_type": {
+                          "type": "string"
+                        },
+                        "first_on_demand": {
+                          "type": "number",
+                          "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nIf this value is greater than 0, the cluster driver node in particular will be placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                        },
+                        "instance_profile_arn": {
+                          "type": "string",
+                          "description": "Nodes for this cluster will only be placed on AWS instances with this instance profile. If\nommitted, nodes will be placed on instances without an IAM instance profile. The instance\nprofile must have previously been added to the Databricks environment by an account\nadministrator.\n\nThis feature may only be available to certain customer plans.\n\nIf this field is ommitted, we will pull in the default from the conf if it exists."
+                        },
+                        "spot_bid_price_percent": {
+                          "type": "number",
+                          "description": "The bid price for AWS spot instances, as a percentage of the corresponding instance type's\non-demand price.\nFor example, if this field is set to 50, and the cluster needs a new `r3.xlarge` spot\ninstance, then the bid price is half of the price of\non-demand `r3.xlarge` instances. Similarly, if this field is set to 200, the bid price is twice\nthe price of on-demand `r3.xlarge` instances. If not specified, the default value is 100.\nWhen spot instances are requested for this cluster, only spot instances whose bid price\npercentage matches this field will be considered.\nNote that, for safety, we enforce this field to be no more than 10000.\n\nThe default value and documentation here should be kept consistent with\nCommonConf.defaultSpotBidPricePercent and CommonConf.maxSpotBidPricePercent."
+                        },
+                        "zone_id": {
+                          "type": "string",
+                          "description": "Identifier for the availability zone/datacenter in which the cluster resides.\nThis string will be of a form like \"us-west-2a\". The provided availability\nzone must be in the same region as the Databricks deployment. For example, \"us-west-2a\"\nis not a valid zone id if the Databricks deployment resides in the \"us-east-1\" region.\nThis is an optional field at cluster creation, and if not specified, a default zone will be used.\nIf the zone specified is \"auto\", will try to place cluster in a zone with high availability,\nand will retry placement in a different AZ if there is not enough capacity.\nSee [[AutoAZHelper.scala]] for more details.\nThe list of available zones as well as the default value can be found by using the\n`List Zones`_ method."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "azure_attributes": {
+                      "type": "object",
+                      "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "properties": {
+                        "availability": {
+                          "type": "string"
+                        },
+                        "first_on_demand": {
+                          "type": "number",
+                          "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nThis value should be greater than 0, to make sure the cluster driver node is placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                        },
+                        "log_analytics_info": {
+                          "type": "object",
+                          "description": "Defines values necessary to configure and run Azure Log Analytics agent",
+                          "properties": {
+                            "log_analytics_primary_key": {
+                              "type": "string",
+                              "description": "\u003cneeds content added\u003e"
+                            },
+                            "log_analytics_workspace_id": {
+                              "type": "string",
+                              "description": "\u003cneeds content added\u003e"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "spot_bid_max_price": {
+                          "type": "number",
+                          "description": "The max bid price to be used for Azure spot instances.\nThe Max price for the bid cannot be higher than the on-demand price of the instance.\nIf not specified, the default value is -1, which specifies that the instance cannot be evicted\non the basis of price, and only on the basis of availability. Further, the value should \u003e 0 or -1."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "cluster_log_conf": {
+                      "type": "object",
+                      "description": "The configuration for delivering spark logs to a long-term storage destination.\nOnly dbfs destinations are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.\n",
+                      "properties": {
+                        "dbfs": {
+                          "type": "object",
+                          "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                          "properties": {
+                            "destination": {
+                              "type": "string",
+                              "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "s3": {
+                          "type": "object",
+                          "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                          "properties": {
+                            "canned_acl": {
+                              "type": "string",
+                              "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                            },
+                            "destination": {
+                              "type": "string",
+                              "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                            },
+                            "enable_encryption": {
+                              "type": "boolean",
+                              "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                            },
+                            "encryption_type": {
+                              "type": "string",
+                              "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                            },
+                            "endpoint": {
+                              "type": "string",
+                              "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                            },
+                            "kms_key": {
+                              "type": "string",
+                              "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                            },
+                            "region": {
+                              "type": "string",
+                              "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "custom_tags": {
+                      "type": "object",
+                      "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "driver_instance_pool_id": {
+                      "type": "string",
+                      "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                    },
+                    "driver_node_type_id": {
+                      "type": "string",
+                      "description": "The node type of the Spark driver.\nNote that this field is optional; if unset, the driver node type will be set as the same value\nas `node_type_id` defined above."
+                    },
+                    "gcp_attributes": {
+                      "type": "object",
+                      "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "properties": {
+                        "availability": {
+                          "type": "string"
+                        },
+                        "boot_disk_size": {
+                          "type": "number",
+                          "description": "boot disk size in GB"
+                        },
+                        "google_service_account": {
+                          "type": "string",
+                          "description": "If provided, the cluster will impersonate the google service account when accessing\ngcloud services (like GCS). The google service account\nmust have previously been added to the Databricks environment by an account\nadministrator."
+                        },
+                        "local_ssd_count": {
+                          "type": "number",
+                          "description": "If provided, each node (workers and driver) in the cluster will have this number of local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP documentation](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) for the supported number of local SSDs for each instance type."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "instance_pool_id": {
+                      "type": "string",
+                      "description": "The optional ID of the instance pool to which the cluster belongs."
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "A label for the cluster specification, either `default` to configure the default cluster, or `maintenance` to configure the maintenance cluster. This field is optional. The default value is `default`."
+                    },
+                    "node_type_id": {
+                      "type": "string",
+                      "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                    },
+                    "num_workers": {
+                      "type": "number",
+                      "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                    },
+                    "policy_id": {
+                      "type": "string",
+                      "description": "The ID of the cluster policy used to create the cluster if applicable."
+                    },
+                    "spark_conf": {
+                      "type": "object",
+                      "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nSee :method:clusters/create for more details.\n",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "spark_env_vars": {
+                      "type": "object",
+                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "ssh_public_keys": {
+                      "type": "array",
+                      "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "configuration": {
+                "type": "object",
+                "description": "String-String configuration for this pipeline execution.",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "continuous": {
+                "type": "boolean",
+                "description": "Whether the pipeline is continuous or triggered. This replaces `trigger`."
+              },
+              "development": {
+                "type": "boolean",
+                "description": "Whether the pipeline is in Development mode. Defaults to false."
+              },
+              "edition": {
+                "type": "string",
+                "description": "Pipeline product edition."
+              },
+              "filters": {
+                "type": "object",
+                "description": "Filters on which Pipeline packages to include in the deployed graph.",
+                "properties": {
+                  "exclude": {
+                    "type": "array",
+                    "description": "Paths to exclude.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "include": {
+                    "type": "array",
+                    "description": "Paths to include.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "id": {
+                "type": "string",
+                "description": "Unique identifier for this pipeline."
+              },
+              "libraries": {
+                "type": "array",
+                "description": "Libraries or code needed by this deployment.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "file": {
+                      "type": "object",
+                      "description": "The path to a file that defines a pipeline and is stored in the Databricks Repos.\n",
+                      "properties": {
+                        "path": {
+                          "type": "string",
+                          "description": "The absolute path of the file."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "jar": {
+                      "type": "string",
+                      "description": "URI of the jar to be installed. Currently only DBFS is supported.\n"
+                    },
+                    "maven": {
+                      "type": "object",
+                      "description": "Specification of a maven library to be installed.\n",
+                      "properties": {
+                        "coordinates": {
+                          "type": "string",
+                          "description": "Gradle-style maven coordinates. For example: \"org.jsoup:jsoup:1.7.2\"."
+                        },
+                        "exclusions": {
+                          "type": "array",
+                          "description": "List of dependences to exclude. For example: `[\"slf4j:slf4j\", \"*:hadoop-client\"]`.\n\nMaven dependency exclusions:\nhttps://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "repo": {
+                          "type": "string",
+                          "description": "Maven repo to install the Maven package from. If omitted, both Maven Central Repository\nand Spark Packages are searched."
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "coordinates"
+                      ]
+                    },
+                    "notebook": {
+                      "type": "object",
+                      "description": "The path to a notebook that defines a pipeline and is stored in the \u003cDatabricks\u003e workspace.\n",
+                      "properties": {
+                        "path": {
+                          "type": "string",
+                          "description": "The absolute path of the notebook."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "name": {
+                "type": "string",
+                "description": "Friendly identifier for this pipeline."
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group_name": {
+                      "type": "string"
+                    },
+                    "level": {
+                      "type": "string"
+                    },
+                    "service_principal_name": {
+                      "type": "string"
+                    },
+                    "user_name": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "level"
+                  ]
+                }
+              },
+              "photon": {
+                "type": "boolean",
+                "description": "Whether Photon is enabled for this pipeline."
+              },
+              "serverless": {
+                "type": "boolean",
+                "description": "Whether serverless compute is enabled for this pipeline."
+              },
+              "storage": {
+                "type": "string",
+                "description": "DBFS root directory for storing checkpoints and tables."
+              },
+              "target": {
+                "type": "string",
+                "description": "Target schema (database) to add tables in this pipeline to. If not specified, no data is published to the Hive metastore or Unity Catalog. To publish to Unity Catalog, also specify `catalog`."
+              },
+              "trigger": {
+                "type": "object",
+                "description": "Which pipeline trigger to use. Deprecated: Use `continuous` instead.",
+                "properties": {
+                  "cron": {
+                    "type": "object",
+                    "properties": {
+                      "quartz_cron_schedule": {
+                        "type": "string"
+                      },
+                      "timezone_id": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "manual": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "run_as": {
+      "type": "object",
+      "properties": {
+        "service_principal_name": {
+          "type": "string"
+        },
+        "user_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sync": {
+      "type": "object",
+      "properties": {
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "targets": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "artifacts": {
+            "type": "object",
+            "description": "A description of all code artifacts in this bundle.",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "build": {
+                  "type": "string"
+                },
+                "files": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "source"
+                    ]
+                  }
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "path",
+                "files",
+                "build"
+              ]
+            }
+          },
+          "bundle": {
+            "type": "object",
+            "description": "The details for this bundle.",
+            "properties": {
+              "compute_id": {
+                "type": "string"
+              },
+              "git": {
+                "type": "object",
+                "properties": {
+                  "branch": {
+                    "type": "string"
+                  },
+                  "origin_url": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string",
+                "description": "The name of the bundle."
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ]
+          },
+          "compute_id": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "git": {
+            "type": "object",
+            "properties": {
+              "branch": {
+                "type": "string"
+              },
+              "origin_url": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "mode": {
+            "type": "string"
+          },
+          "resources": {
+            "type": "object",
+            "description": "Collection of Databricks resources to deploy.",
+            "properties": {
+              "experiments": {
+                "type": "object",
+                "description": "List of MLflow experiments",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "artifact_location": {
+                      "type": "string",
+                      "description": "Location where artifacts for the experiment are stored."
+                    },
+                    "creation_time": {
+                      "type": "number",
+                      "description": "Creation time"
+                    },
+                    "experiment_id": {
+                      "type": "string",
+                      "description": "Unique identifier for the experiment."
+                    },
+                    "last_update_time": {
+                      "type": "number",
+                      "description": "Last update time"
+                    },
+                    "lifecycle_stage": {
+                      "type": "string",
+                      "description": "Current life cycle stage of the experiment: \"active\" or \"deleted\".\nDeleted experiments are not returned by APIs."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Human readable name that identifies the experiment."
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "description": "Tags: Additional metadata key-value pairs.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string",
+                            "description": "The tag key."
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "The tag value."
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "jobs": {
+                "type": "object",
+                "description": "List of Databricks jobs",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "compute": {
+                      "type": "array",
+                      "description": "A list of compute requirements that can be referenced by tasks of this job.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "compute_key": {
+                            "type": "string",
+                            "description": "A unique name for the compute requirement. This field is required and must be unique within the job.\n`JobTaskSettings` may refer to this field to determine the compute requirements for the task execution."
+                          },
+                          "spec": {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "description": "The kind of compute described by this compute specification."
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "compute_key",
+                          "spec"
+                        ]
+                      }
+                    },
+                    "continuous": {
+                      "type": "object",
+                      "description": "An optional continuous property for this job. The continuous property will ensure that there is always one run executing. Only one of `schedule` and `continuous` can be used.",
+                      "properties": {
+                        "pause_status": {
+                          "type": "string",
+                          "description": "Whether this trigger is paused or not."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "email_notifications": {
+                      "type": "object",
+                      "description": "An optional set of email addresses that is notified when runs of this job begin or complete as well as when this job is deleted. The default behavior is to not send any emails.",
+                      "properties": {
+                        "no_alert_for_skipped_runs": {
+                          "type": "boolean",
+                          "description": "If true, do not send email to recipients specified in `on_failure` if the run is skipped."
+                        },
+                        "on_duration_warning_threshold_exceeded": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_failure": {
+                          "type": "array",
+                          "description": "A list of email addresses to be notified when a run unsuccessfully completes. A run is considered to have completed unsuccessfully if it ends with an `INTERNAL_ERROR` `life_cycle_state` or a `FAILED`, or `TIMED_OUT` result_state. If this is not specified on job creation, reset, or update the list is empty, and notifications are not sent.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_start": {
+                          "type": "array",
+                          "description": "A list of email addresses to be notified when a run begins. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "on_success": {
+                          "type": "array",
+                          "description": "A list of email addresses to be notified when a run successfully completes. A run is considered to have completed successfully if it ends with a `TERMINATED` `life_cycle_state` and a `SUCCESS` result_state. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "format": {
+                      "type": "string",
+                      "description": "Used to tell what is the format of the job. This field is ignored in Create/Update/Reset calls. When using the Jobs API 2.1 this value is always set to `\"MULTI_TASK\"`."
+                    },
+                    "git_source": {
+                      "type": "object",
+                      "description": "An optional specification for a remote repository containing the notebooks used by this job's notebook tasks.",
+                      "properties": {
+                        "git_branch": {
+                          "type": "string",
+                          "description": "Name of the branch to be checked out and used by this job.\nThis field cannot be specified in conjunction with git_tag or git_commit.\n\nThe maximum length is 255 characters.\n"
+                        },
+                        "git_commit": {
+                          "type": "string",
+                          "description": "Commit to be checked out and used by this job. This field cannot be specified in conjunction with git_branch or git_tag.\nThe maximum length is 64 characters."
+                        },
+                        "git_provider": {
+                          "type": "string",
+                          "description": "Unique identifier of the service used to host the Git repository. The value is case insensitive."
+                        },
+                        "git_snapshot": {
+                          "type": "object",
+                          "properties": {
+                            "used_commit": {
+                              "type": "string",
+                              "description": "Commit that was used to execute the run. If git_branch was specified, this points to the HEAD of the branch at the time of the run; if git_tag was specified, this points to the commit the tag points to."
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "git_tag": {
+                          "type": "string",
+                          "description": "Name of the tag to be checked out and used by this job.\nThis field cannot be specified in conjunction with git_branch or git_commit.\n\nThe maximum length is 255 characters.\n"
+                        },
+                        "git_url": {
+                          "type": "string",
+                          "description": "URL of the repository to be cloned by this job.\nThe maximum length is 300 characters."
+                        },
+                        "job_source": {
+                          "type": "object",
+                          "properties": {
+                            "dirty_state": {
+                              "type": "string"
+                            },
+                            "import_from_git_branch": {
+                              "type": "string"
+                            },
+                            "job_config_path": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "import_from_git_branch",
+                            "job_config_path"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "git_provider",
+                        "git_url"
+                      ]
+                    },
+                    "health": {
+                      "type": "object",
+                      "properties": {
+                        "rules": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "metric": {
+                                "type": "string"
+                              },
+                              "op": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "job_clusters": {
+                      "type": "array",
+                      "description": "A list of job cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "job_cluster_key": {
+                            "type": "string",
+                            "description": "A unique name for the job cluster. This field is required and must be unique within the job.\n`JobTaskSettings` may refer to this field to determine which cluster to launch for the task execution."
+                          },
+                          "new_cluster": {
+                            "type": "object",
+                            "description": "If new_cluster, a description of a cluster that is created for only for this task.",
+                            "properties": {
+                              "autoscale": {
+                                "type": "object",
+                                "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                                "properties": {
+                                  "max_workers": {
+                                    "type": "number",
+                                    "description": "The maximum number of workers to which the cluster can scale up when overloaded.\nNote that `max_workers` must be strictly greater than `min_workers`."
+                                  },
+                                  "min_workers": {
+                                    "type": "number",
+                                    "description": "The minimum number of workers to which the cluster can scale down when underutilized.\nIt is also the initial number of workers the cluster will have after creation."
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "max_workers",
+                                  "min_workers"
+                                ]
+                              },
+                              "autotermination_minutes": {
+                                "type": "number",
+                                "description": "Automatically terminates the cluster after it is inactive for this time in minutes. If not set,\nthis cluster will not be automatically terminated. If specified, the threshold must be between\n10 and 10000 minutes.\nUsers can also set this value to 0 to explicitly disable automatic termination."
+                              },
+                              "aws_attributes": {
+                                "type": "object",
+                                "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "ebs_volume_count": {
+                                    "type": "number",
+                                    "description": "The number of volumes launched for each instance. Users can choose up to 10 volumes.\nThis feature is only enabled for supported node types. Legacy node types cannot specify\ncustom EBS volumes.\nFor node types with no instance store, at least one EBS volume needs to be specified;\notherwise, cluster creation will fail.\n\nThese EBS volumes will be mounted at `/ebs0`, `/ebs1`, and etc.\nInstance store volumes will be mounted at `/local_disk0`, `/local_disk1`, and etc.\n\nIf EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for\nscratch storage because heterogenously sized scratch devices can lead to inefficient disk\nutilization. If no EBS volumes are attached, Databricks will configure Spark to use instance\nstore volumes.\n\nPlease note that if EBS volumes are specified, then the Spark configuration `spark.local.dir`\nwill be overridden."
+                                  },
+                                  "ebs_volume_iops": {
+                                    "type": "number",
+                                    "description": "\u003cneeds content added\u003e"
+                                  },
+                                  "ebs_volume_size": {
+                                    "type": "number",
+                                    "description": "The size of each EBS volume (in GiB) launched for each instance. For general purpose\nSSD, this value must be within the range 100 - 4096. For throughput optimized HDD,\nthis value must be within the range 500 - 4096."
+                                  },
+                                  "ebs_volume_throughput": {
+                                    "type": "number",
+                                    "description": "\u003cneeds content added\u003e"
+                                  },
+                                  "ebs_volume_type": {
+                                    "type": "string"
+                                  },
+                                  "first_on_demand": {
+                                    "type": "number",
+                                    "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nIf this value is greater than 0, the cluster driver node in particular will be placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                                  },
+                                  "instance_profile_arn": {
+                                    "type": "string",
+                                    "description": "Nodes for this cluster will only be placed on AWS instances with this instance profile. If\nommitted, nodes will be placed on instances without an IAM instance profile. The instance\nprofile must have previously been added to the Databricks environment by an account\nadministrator.\n\nThis feature may only be available to certain customer plans.\n\nIf this field is ommitted, we will pull in the default from the conf if it exists."
+                                  },
+                                  "spot_bid_price_percent": {
+                                    "type": "number",
+                                    "description": "The bid price for AWS spot instances, as a percentage of the corresponding instance type's\non-demand price.\nFor example, if this field is set to 50, and the cluster needs a new `r3.xlarge` spot\ninstance, then the bid price is half of the price of\non-demand `r3.xlarge` instances. Similarly, if this field is set to 200, the bid price is twice\nthe price of on-demand `r3.xlarge` instances. If not specified, the default value is 100.\nWhen spot instances are requested for this cluster, only spot instances whose bid price\npercentage matches this field will be considered.\nNote that, for safety, we enforce this field to be no more than 10000.\n\nThe default value and documentation here should be kept consistent with\nCommonConf.defaultSpotBidPricePercent and CommonConf.maxSpotBidPricePercent."
+                                  },
+                                  "zone_id": {
+                                    "type": "string",
+                                    "description": "Identifier for the availability zone/datacenter in which the cluster resides.\nThis string will be of a form like \"us-west-2a\". The provided availability\nzone must be in the same region as the Databricks deployment. For example, \"us-west-2a\"\nis not a valid zone id if the Databricks deployment resides in the \"us-east-1\" region.\nThis is an optional field at cluster creation, and if not specified, a default zone will be used.\nIf the zone specified is \"auto\", will try to place cluster in a zone with high availability,\nand will retry placement in a different AZ if there is not enough capacity.\nSee [[AutoAZHelper.scala]] for more details.\nThe list of available zones as well as the default value can be found by using the\n`List Zones`_ method."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "azure_attributes": {
+                                "type": "object",
+                                "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "first_on_demand": {
+                                    "type": "number",
+                                    "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nThis value should be greater than 0, to make sure the cluster driver node is placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                                  },
+                                  "log_analytics_info": {
+                                    "type": "object",
+                                    "description": "Defines values necessary to configure and run Azure Log Analytics agent",
+                                    "properties": {
+                                      "log_analytics_primary_key": {
+                                        "type": "string",
+                                        "description": "\u003cneeds content added\u003e"
+                                      },
+                                      "log_analytics_workspace_id": {
+                                        "type": "string",
+                                        "description": "\u003cneeds content added\u003e"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "spot_bid_max_price": {
+                                    "type": "number",
+                                    "description": "The max bid price to be used for Azure spot instances.\nThe Max price for the bid cannot be higher than the on-demand price of the instance.\nIf not specified, the default value is -1, which specifies that the instance cannot be evicted\non the basis of price, and only on the basis of availability. Further, the value should \u003e 0 or -1."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "cluster_log_conf": {
+                                "type": "object",
+                                "description": "The configuration for delivering spark logs to a long-term storage destination.\nTwo kinds of destinations (dbfs and s3) are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.",
+                                "properties": {
+                                  "dbfs": {
+                                    "type": "object",
+                                    "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                                    "properties": {
+                                      "destination": {
+                                        "type": "string",
+                                        "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "s3": {
+                                    "type": "object",
+                                    "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                                    "properties": {
+                                      "canned_acl": {
+                                        "type": "string",
+                                        "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                      },
+                                      "destination": {
+                                        "type": "string",
+                                        "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                      },
+                                      "enable_encryption": {
+                                        "type": "boolean",
+                                        "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                      },
+                                      "encryption_type": {
+                                        "type": "string",
+                                        "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                      },
+                                      "endpoint": {
+                                        "type": "string",
+                                        "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                      },
+                                      "kms_key": {
+                                        "type": "string",
+                                        "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                      },
+                                      "region": {
+                                        "type": "string",
+                                        "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "cluster_name": {
+                                "type": "string",
+                                "description": "Cluster name requested by the user. This doesn't have to be unique.\nIf not specified at creation, the cluster name will be an empty string.\n"
+                              },
+                              "cluster_source": {
+                                "type": "string"
+                              },
+                              "custom_tags": {
+                                "type": "object",
+                                "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "data_security_mode": {
+                                "type": "string"
+                              },
+                              "docker_image": {
+                                "type": "object",
+                                "properties": {
+                                  "basic_auth": {
+                                    "type": "object",
+                                    "properties": {
+                                      "password": {
+                                        "type": "string",
+                                        "description": "Password of the user"
+                                      },
+                                      "username": {
+                                        "type": "string",
+                                        "description": "Name of the user"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string",
+                                    "description": "URL of the docker image."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "driver_instance_pool_id": {
+                                "type": "string",
+                                "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                              },
+                              "driver_node_type_id": {
+                                "type": "string",
+                                "description": "The node type of the Spark driver. Note that this field is optional;\nif unset, the driver node type will be set as the same value\nas `node_type_id` defined above.\n"
+                              },
+                              "enable_elastic_disk": {
+                                "type": "boolean",
+                                "description": "Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk\nspace when its Spark workers are running low on disk space. This feature requires specific AWS\npermissions to function correctly - refer to the User Guide for more details."
+                              },
+                              "enable_local_disk_encryption": {
+                                "type": "boolean",
+                                "description": "Whether to enable LUKS on cluster VMs' local disks"
+                              },
+                              "gcp_attributes": {
+                                "type": "object",
+                                "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "boot_disk_size": {
+                                    "type": "number",
+                                    "description": "boot disk size in GB"
+                                  },
+                                  "google_service_account": {
+                                    "type": "string",
+                                    "description": "If provided, the cluster will impersonate the google service account when accessing\ngcloud services (like GCS). The google service account\nmust have previously been added to the Databricks environment by an account\nadministrator."
+                                  },
+                                  "local_ssd_count": {
+                                    "type": "number",
+                                    "description": "If provided, each node (workers and driver) in the cluster will have this number of local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP documentation](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) for the supported number of local SSDs for each instance type."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "init_scripts": {
+                                "type": "array",
+                                "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`.",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "dbfs": {
+                                      "type": "object",
+                                      "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string",
+                                          "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "s3": {
+                                      "type": "object",
+                                      "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                                      "properties": {
+                                        "canned_acl": {
+                                          "type": "string",
+                                          "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                        },
+                                        "destination": {
+                                          "type": "string",
+                                          "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                        },
+                                        "enable_encryption": {
+                                          "type": "boolean",
+                                          "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                        },
+                                        "encryption_type": {
+                                          "type": "string",
+                                          "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                        },
+                                        "endpoint": {
+                                          "type": "string",
+                                          "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                        },
+                                        "kms_key": {
+                                          "type": "string",
+                                          "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                        },
+                                        "region": {
+                                          "type": "string",
+                                          "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "volumes": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "workspace": {
+                                      "type": "object",
+                                      "description": "destination needs to be provided. e.g.\n`{ \"workspace\" : { \"destination\" : \"/Users/user1@databricks.com/my-init.sh\" } }`",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string",
+                                          "description": "workspace files destination, e.g. `/Users/user1@databricks.com/my-init.sh`"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "instance_pool_id": {
+                                "type": "string",
+                                "description": "The optional ID of the instance pool to which the cluster belongs."
+                              },
+                              "node_type_id": {
+                                "type": "string",
+                                "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                              },
+                              "num_workers": {
+                                "type": "number",
+                                "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                              },
+                              "policy_id": {
+                                "type": "string",
+                                "description": "The ID of the cluster policy used to create the cluster if applicable."
+                              },
+                              "runtime_engine": {
+                                "type": "string"
+                              },
+                              "single_user_name": {
+                                "type": "string",
+                                "description": "Single user name if data_security_mode is `SINGLE_USER`"
+                              },
+                              "spark_conf": {
+                                "type": "object",
+                                "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nUsers can also pass in a string of extra JVM options to the driver and the executors via\n`spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` respectively.\n",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "spark_env_vars": {
+                                "type": "object",
+                                "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "spark_version": {
+                                "type": "string",
+                                "description": "The Spark version of the cluster, e.g. `3.3.x-scala2.11`.\nA list of available Spark versions can be retrieved by using\nthe :method:clusters/sparkVersions API call.\n"
+                              },
+                              "ssh_public_keys": {
+                                "type": "array",
+                                "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "workload_type": {
+                                "type": "object",
+                                "properties": {
+                                  "clients": {
+                                    "type": "object",
+                                    "description": " defined what type of clients can use the cluster. E.g. Notebooks, Jobs",
+                                    "properties": {
+                                      "jobs": {
+                                        "type": "boolean",
+                                        "description": "With jobs set, the cluster can be used for jobs"
+                                      },
+                                      "notebooks": {
+                                        "type": "boolean",
+                                        "description": "With notebooks set, this cluster can be used for notebooks"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "job_cluster_key"
+                        ]
+                      }
+                    },
+                    "max_concurrent_runs": {
+                      "type": "number",
+                      "description": "An optional maximum allowed number of concurrent runs of the job.\n\nSet this value if you want to be able to execute multiple runs of the same job concurrently. This is useful for example if you trigger your job on a frequent schedule and want to allow consecutive runs to overlap with each other, or if you want to trigger multiple runs which differ by their input parameters.\n\nThis setting affects only new runs. For example, suppose the job’s concurrency is 4 and there are 4 concurrent active runs. Then setting the concurrency to 3 won’t kill any of the active runs. However, from then on, new runs are skipped unless there are fewer than 3 active runs.\n\nThis value cannot exceed 1000\\. Setting this value to 0 causes all new runs to be skipped. The default behavior is to allow only 1 concurrent run."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "An optional name for the job."
+                    },
+                    "notification_settings": {
+                      "type": "object",
+                      "description": "Optional notification settings that are used when sending notifications to each of the `email_notifications` and `webhook_notifications` for this job.",
+                      "properties": {
+                        "no_alert_for_canceled_runs": {
+                          "type": "boolean",
+                          "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is canceled."
+                        },
+                        "no_alert_for_skipped_runs": {
+                          "type": "boolean",
+                          "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is skipped."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "parameters": {
+                      "type": "array",
+                      "description": "Job-level parameter definitions",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "default": {
+                            "type": "string",
+                            "description": "Default value of the parameter."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the defined parameter. May only contain alphanumeric characters, `_`, `-`, and `.`"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "default",
+                          "name"
+                        ]
+                      }
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    },
+                    "run_as": {
+                      "type": "object",
+                      "properties": {
+                        "service_principal_name": {
+                          "type": "string",
+                          "description": "Application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role."
+                        },
+                        "user_name": {
+                          "type": "string",
+                          "description": "The email of an active workspace user. Non-admin users can only set this field to their own email."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "schedule": {
+                      "type": "object",
+                      "description": "An optional periodic schedule for this job. The default behavior is that the job only runs when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`.",
+                      "properties": {
+                        "pause_status": {
+                          "type": "string",
+                          "description": "Whether this trigger is paused or not."
+                        },
+                        "quartz_cron_expression": {
+                          "type": "string",
+                          "description": "A Cron expression using Quartz syntax that describes the schedule for a job.\nSee [Cron Trigger](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html)\nfor details. This field is required.\"\n"
+                        },
+                        "timezone_id": {
+                          "type": "string",
+                          "description": "A Java timezone ID. The schedule for a job is resolved with respect to this timezone.\nSee [Java TimeZone](https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html) for details.\nThis field is required.\n"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "quartz_cron_expression",
+                        "timezone_id"
+                      ]
+                    },
+                    "tags": {
+                      "type": "object",
+                      "description": "A map of tags associated with the job. These are forwarded to the cluster as cluster tags for jobs clusters, and are subject to the same limitations as cluster tags. A maximum of 25 tags can be added to the job.",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "tasks": {
+                      "type": "array",
+                      "description": "A list of task specifications to be executed by this job.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "compute_key": {
+                            "type": "string",
+                            "description": "The key of the compute requirement, specified in `job.settings.compute`, to use for execution of this task."
+                          },
+                          "condition_task": {
+                            "type": "object",
+                            "description": "If condition_task, specifies a condition with an outcome that can be used to control the execution of other tasks. Does not require a cluster to execute and does not support retries or notifications.",
+                            "properties": {
+                              "left": {
+                                "type": "string",
+                                "description": "The left operand of the condition task. Can be either a string value or a job state or parameter reference."
+                              },
+                              "op": {
+                                "type": "string",
+                                "description": "* `EQUAL_TO`, `NOT_EQUAL` operators perform string comparison of their operands. This means that `“12.0” == “12”` will evaluate to `false`.\n* `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL` operators perform numeric comparison of their operands. `“12.0” \u003e= “12”` will evaluate to `true`, `“10.0” \u003e= “12”` will evaluate to `false`.\n\nThe boolean comparison to task values can be implemented with operators `EQUAL_TO`, `NOT_EQUAL`. If a task value was set to a boolean value, it will be serialized to `“true”` or `“false”` for the comparison.\n"
+                              },
+                              "right": {
+                                "type": "string",
+                                "description": "The right operand of the condition task. Can be either a string value or a job state or parameter reference."
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "dbt_task": {
+                            "type": "object",
+                            "description": "If dbt_task, indicates that this must execute a dbt task. It requires both Databricks SQL and the ability to use a serverless or a pro SQL warehouse.",
+                            "properties": {
+                              "catalog": {
+                                "type": "string",
+                                "description": "Optional name of the catalog to use. The value is the top level in the 3-level namespace of Unity Catalog (catalog / schema / relation). The catalog value can only be specified if a warehouse_id is specified. Requires dbt-databricks \u003e= 1.1.1."
+                              },
+                              "commands": {
+                                "type": "array",
+                                "description": "A list of dbt commands to execute. All commands must start with `dbt`. This parameter must not be empty. A maximum of up to 10 commands can be provided.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "profiles_directory": {
+                                "type": "string",
+                                "description": "Optional (relative) path to the profiles directory. Can only be specified if no warehouse_id is specified. If no warehouse_id is specified and this folder is unset, the root directory is used."
+                              },
+                              "project_directory": {
+                                "type": "string",
+                                "description": "Optional (relative) path to the project directory, if no value is provided, the root of the git repository is used."
+                              },
+                              "schema": {
+                                "type": "string",
+                                "description": "Optional schema to write to. This parameter is only used when a warehouse_id is also provided. If not provided, the `default` schema is used."
+                              },
+                              "warehouse_id": {
+                                "type": "string",
+                                "description": "ID of the SQL warehouse to connect to. If provided, we automatically generate and provide the profile and connection details to dbt. It can be overridden on a per-command basis by using the `--profiles-dir` command line argument."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "commands"
+                            ]
+                          },
+                          "depends_on": {
+                            "type": "array",
+                            "description": "An optional array of objects specifying the dependency graph of the task. All tasks specified in this field must complete successfully before executing this task.\nThe key is `task_key`, and the value is the name assigned to the dependent task.\n",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "outcome": {
+                                  "type": "string",
+                                  "description": "Can only be specified on condition task dependencies. The outcome of the dependent task that must be met for this task to run."
+                                },
+                                "task_key": {
+                                  "type": "string",
+                                  "description": "The name of the task this task depends on."
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "task_key"
+                              ]
+                            }
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "An optional description for this task.\nThe maximum length is 4096 bytes."
+                          },
+                          "email_notifications": {
+                            "type": "object",
+                            "description": "An optional set of email addresses that is notified when runs of this task begin or complete as well as when this task is deleted. The default behavior is to not send any emails.",
+                            "properties": {
+                              "on_duration_warning_threshold_exceeded": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "on_failure": {
+                                "type": "array",
+                                "description": "A list of email addresses to be notified when a run unsuccessfully completes. A run is considered to have completed unsuccessfully if it ends with an `INTERNAL_ERROR` `life_cycle_state` or a `FAILED`, or `TIMED_OUT` result_state. If this is not specified on job creation, reset, or update the list is empty, and notifications are not sent.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "on_start": {
+                                "type": "array",
+                                "description": "A list of email addresses to be notified when a run begins. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "on_success": {
+                                "type": "array",
+                                "description": "A list of email addresses to be notified when a run successfully completes. A run is considered to have completed successfully if it ends with a `TERMINATED` `life_cycle_state` and a `SUCCESS` result_state. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "existing_cluster_id": {
+                            "type": "string",
+                            "description": "If existing_cluster_id, the ID of an existing cluster that is used for all runs of this task. When running tasks on an existing cluster, you may need to manually restart the cluster if it stops responding. We suggest running jobs on new clusters for greater reliability."
+                          },
+                          "health": {
+                            "type": "object",
+                            "properties": {
+                              "rules": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "metric": {
+                                      "type": "string"
+                                    },
+                                    "op": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "job_cluster_key": {
+                            "type": "string",
+                            "description": "If job_cluster_key, this task is executed reusing the cluster specified in `job.settings.job_clusters`."
+                          },
+                          "libraries": {
+                            "type": "array",
+                            "description": "An optional list of libraries to be installed on the cluster that executes the task. The default value is an empty list.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "cran": {
+                                  "type": "object",
+                                  "description": "Specification of a CRAN library to be installed as part of the library",
+                                  "properties": {
+                                    "package": {
+                                      "type": "string",
+                                      "description": "The name of the CRAN package to install."
+                                    },
+                                    "repo": {
+                                      "type": "string",
+                                      "description": "The repository where the package can be found. If not specified, the default CRAN repo is used."
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "package"
+                                  ]
+                                },
+                                "egg": {
+                                  "type": "string",
+                                  "description": "URI of the egg to be installed. Currently only DBFS and S3 URIs are supported.\nFor example: `{ \"egg\": \"dbfs:/my/egg\" }` or\n`{ \"egg\": \"s3://my-bucket/egg\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI."
+                                },
+                                "jar": {
+                                  "type": "string",
+                                  "description": "URI of the jar to be installed. Currently only DBFS and S3 URIs are supported.\nFor example: `{ \"jar\": \"dbfs:/mnt/databricks/library.jar\" }` or\n`{ \"jar\": \"s3://my-bucket/library.jar\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI."
+                                },
+                                "maven": {
+                                  "type": "object",
+                                  "description": "Specification of a maven library to be installed. For example:\n`{ \"coordinates\": \"org.jsoup:jsoup:1.7.2\" }`",
+                                  "properties": {
+                                    "coordinates": {
+                                      "type": "string",
+                                      "description": "Gradle-style maven coordinates. For example: \"org.jsoup:jsoup:1.7.2\"."
+                                    },
+                                    "exclusions": {
+                                      "type": "array",
+                                      "description": "List of dependences to exclude. For example: `[\"slf4j:slf4j\", \"*:hadoop-client\"]`.\n\nMaven dependency exclusions:\nhttps://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html.",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "repo": {
+                                      "type": "string",
+                                      "description": "Maven repo to install the Maven package from. If omitted, both Maven Central Repository\nand Spark Packages are searched."
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "coordinates"
+                                  ]
+                                },
+                                "pypi": {
+                                  "type": "object",
+                                  "description": "Specification of a PyPi library to be installed. For example:\n`{ \"package\": \"simplejson\" }`",
+                                  "properties": {
+                                    "package": {
+                                      "type": "string",
+                                      "description": "The name of the pypi package to install. An optional exact version specification is also\nsupported. Examples: \"simplejson\" and \"simplejson==3.8.0\"."
+                                    },
+                                    "repo": {
+                                      "type": "string",
+                                      "description": "The repository where the package can be found. If not specified, the default pip index is\nused."
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "package"
+                                  ]
+                                },
+                                "whl": {
+                                  "type": "string",
+                                  "description": "URI of the wheel to be installed.\nFor example: `{ \"whl\": \"dbfs:/my/whl\" }` or `{ \"whl\": \"s3://my-bucket/whl\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI."
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "max_retries": {
+                            "type": "number",
+                            "description": "An optional maximum number of times to retry an unsuccessful run. A run is considered to be unsuccessful if it completes with the `FAILED` result_state or `INTERNAL_ERROR` `life_cycle_state`. The value -1 means to retry indefinitely and the value 0 means to never retry. The default behavior is to never retry."
+                          },
+                          "min_retry_interval_millis": {
+                            "type": "number",
+                            "description": "An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried."
+                          },
+                          "new_cluster": {
+                            "type": "object",
+                            "description": "If new_cluster, a description of a cluster that is created for only for this task.",
+                            "properties": {
+                              "autoscale": {
+                                "type": "object",
+                                "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                                "properties": {
+                                  "max_workers": {
+                                    "type": "number",
+                                    "description": "The maximum number of workers to which the cluster can scale up when overloaded.\nNote that `max_workers` must be strictly greater than `min_workers`."
+                                  },
+                                  "min_workers": {
+                                    "type": "number",
+                                    "description": "The minimum number of workers to which the cluster can scale down when underutilized.\nIt is also the initial number of workers the cluster will have after creation."
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "max_workers",
+                                  "min_workers"
+                                ]
+                              },
+                              "autotermination_minutes": {
+                                "type": "number",
+                                "description": "Automatically terminates the cluster after it is inactive for this time in minutes. If not set,\nthis cluster will not be automatically terminated. If specified, the threshold must be between\n10 and 10000 minutes.\nUsers can also set this value to 0 to explicitly disable automatic termination."
+                              },
+                              "aws_attributes": {
+                                "type": "object",
+                                "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "ebs_volume_count": {
+                                    "type": "number",
+                                    "description": "The number of volumes launched for each instance. Users can choose up to 10 volumes.\nThis feature is only enabled for supported node types. Legacy node types cannot specify\ncustom EBS volumes.\nFor node types with no instance store, at least one EBS volume needs to be specified;\notherwise, cluster creation will fail.\n\nThese EBS volumes will be mounted at `/ebs0`, `/ebs1`, and etc.\nInstance store volumes will be mounted at `/local_disk0`, `/local_disk1`, and etc.\n\nIf EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for\nscratch storage because heterogenously sized scratch devices can lead to inefficient disk\nutilization. If no EBS volumes are attached, Databricks will configure Spark to use instance\nstore volumes.\n\nPlease note that if EBS volumes are specified, then the Spark configuration `spark.local.dir`\nwill be overridden."
+                                  },
+                                  "ebs_volume_iops": {
+                                    "type": "number",
+                                    "description": "\u003cneeds content added\u003e"
+                                  },
+                                  "ebs_volume_size": {
+                                    "type": "number",
+                                    "description": "The size of each EBS volume (in GiB) launched for each instance. For general purpose\nSSD, this value must be within the range 100 - 4096. For throughput optimized HDD,\nthis value must be within the range 500 - 4096."
+                                  },
+                                  "ebs_volume_throughput": {
+                                    "type": "number",
+                                    "description": "\u003cneeds content added\u003e"
+                                  },
+                                  "ebs_volume_type": {
+                                    "type": "string"
+                                  },
+                                  "first_on_demand": {
+                                    "type": "number",
+                                    "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nIf this value is greater than 0, the cluster driver node in particular will be placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                                  },
+                                  "instance_profile_arn": {
+                                    "type": "string",
+                                    "description": "Nodes for this cluster will only be placed on AWS instances with this instance profile. If\nommitted, nodes will be placed on instances without an IAM instance profile. The instance\nprofile must have previously been added to the Databricks environment by an account\nadministrator.\n\nThis feature may only be available to certain customer plans.\n\nIf this field is ommitted, we will pull in the default from the conf if it exists."
+                                  },
+                                  "spot_bid_price_percent": {
+                                    "type": "number",
+                                    "description": "The bid price for AWS spot instances, as a percentage of the corresponding instance type's\non-demand price.\nFor example, if this field is set to 50, and the cluster needs a new `r3.xlarge` spot\ninstance, then the bid price is half of the price of\non-demand `r3.xlarge` instances. Similarly, if this field is set to 200, the bid price is twice\nthe price of on-demand `r3.xlarge` instances. If not specified, the default value is 100.\nWhen spot instances are requested for this cluster, only spot instances whose bid price\npercentage matches this field will be considered.\nNote that, for safety, we enforce this field to be no more than 10000.\n\nThe default value and documentation here should be kept consistent with\nCommonConf.defaultSpotBidPricePercent and CommonConf.maxSpotBidPricePercent."
+                                  },
+                                  "zone_id": {
+                                    "type": "string",
+                                    "description": "Identifier for the availability zone/datacenter in which the cluster resides.\nThis string will be of a form like \"us-west-2a\". The provided availability\nzone must be in the same region as the Databricks deployment. For example, \"us-west-2a\"\nis not a valid zone id if the Databricks deployment resides in the \"us-east-1\" region.\nThis is an optional field at cluster creation, and if not specified, a default zone will be used.\nIf the zone specified is \"auto\", will try to place cluster in a zone with high availability,\nand will retry placement in a different AZ if there is not enough capacity.\nSee [[AutoAZHelper.scala]] for more details.\nThe list of available zones as well as the default value can be found by using the\n`List Zones`_ method."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "azure_attributes": {
+                                "type": "object",
+                                "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "first_on_demand": {
+                                    "type": "number",
+                                    "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nThis value should be greater than 0, to make sure the cluster driver node is placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                                  },
+                                  "log_analytics_info": {
+                                    "type": "object",
+                                    "description": "Defines values necessary to configure and run Azure Log Analytics agent",
+                                    "properties": {
+                                      "log_analytics_primary_key": {
+                                        "type": "string",
+                                        "description": "\u003cneeds content added\u003e"
+                                      },
+                                      "log_analytics_workspace_id": {
+                                        "type": "string",
+                                        "description": "\u003cneeds content added\u003e"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "spot_bid_max_price": {
+                                    "type": "number",
+                                    "description": "The max bid price to be used for Azure spot instances.\nThe Max price for the bid cannot be higher than the on-demand price of the instance.\nIf not specified, the default value is -1, which specifies that the instance cannot be evicted\non the basis of price, and only on the basis of availability. Further, the value should \u003e 0 or -1."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "cluster_log_conf": {
+                                "type": "object",
+                                "description": "The configuration for delivering spark logs to a long-term storage destination.\nTwo kinds of destinations (dbfs and s3) are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.",
+                                "properties": {
+                                  "dbfs": {
+                                    "type": "object",
+                                    "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                                    "properties": {
+                                      "destination": {
+                                        "type": "string",
+                                        "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "s3": {
+                                    "type": "object",
+                                    "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                                    "properties": {
+                                      "canned_acl": {
+                                        "type": "string",
+                                        "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                      },
+                                      "destination": {
+                                        "type": "string",
+                                        "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                      },
+                                      "enable_encryption": {
+                                        "type": "boolean",
+                                        "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                      },
+                                      "encryption_type": {
+                                        "type": "string",
+                                        "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                      },
+                                      "endpoint": {
+                                        "type": "string",
+                                        "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                      },
+                                      "kms_key": {
+                                        "type": "string",
+                                        "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                      },
+                                      "region": {
+                                        "type": "string",
+                                        "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "cluster_name": {
+                                "type": "string",
+                                "description": "Cluster name requested by the user. This doesn't have to be unique.\nIf not specified at creation, the cluster name will be an empty string.\n"
+                              },
+                              "cluster_source": {
+                                "type": "string"
+                              },
+                              "custom_tags": {
+                                "type": "object",
+                                "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "data_security_mode": {
+                                "type": "string"
+                              },
+                              "docker_image": {
+                                "type": "object",
+                                "properties": {
+                                  "basic_auth": {
+                                    "type": "object",
+                                    "properties": {
+                                      "password": {
+                                        "type": "string",
+                                        "description": "Password of the user"
+                                      },
+                                      "username": {
+                                        "type": "string",
+                                        "description": "Name of the user"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string",
+                                    "description": "URL of the docker image."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "driver_instance_pool_id": {
+                                "type": "string",
+                                "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                              },
+                              "driver_node_type_id": {
+                                "type": "string",
+                                "description": "The node type of the Spark driver. Note that this field is optional;\nif unset, the driver node type will be set as the same value\nas `node_type_id` defined above.\n"
+                              },
+                              "enable_elastic_disk": {
+                                "type": "boolean",
+                                "description": "Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk\nspace when its Spark workers are running low on disk space. This feature requires specific AWS\npermissions to function correctly - refer to the User Guide for more details."
+                              },
+                              "enable_local_disk_encryption": {
+                                "type": "boolean",
+                                "description": "Whether to enable LUKS on cluster VMs' local disks"
+                              },
+                              "gcp_attributes": {
+                                "type": "object",
+                                "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                                "properties": {
+                                  "availability": {
+                                    "type": "string"
+                                  },
+                                  "boot_disk_size": {
+                                    "type": "number",
+                                    "description": "boot disk size in GB"
+                                  },
+                                  "google_service_account": {
+                                    "type": "string",
+                                    "description": "If provided, the cluster will impersonate the google service account when accessing\ngcloud services (like GCS). The google service account\nmust have previously been added to the Databricks environment by an account\nadministrator."
+                                  },
+                                  "local_ssd_count": {
+                                    "type": "number",
+                                    "description": "If provided, each node (workers and driver) in the cluster will have this number of local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP documentation](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) for the supported number of local SSDs for each instance type."
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "init_scripts": {
+                                "type": "array",
+                                "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`.",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "dbfs": {
+                                      "type": "object",
+                                      "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string",
+                                          "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "s3": {
+                                      "type": "object",
+                                      "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                                      "properties": {
+                                        "canned_acl": {
+                                          "type": "string",
+                                          "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                        },
+                                        "destination": {
+                                          "type": "string",
+                                          "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                        },
+                                        "enable_encryption": {
+                                          "type": "boolean",
+                                          "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                        },
+                                        "encryption_type": {
+                                          "type": "string",
+                                          "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                        },
+                                        "endpoint": {
+                                          "type": "string",
+                                          "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                        },
+                                        "kms_key": {
+                                          "type": "string",
+                                          "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                        },
+                                        "region": {
+                                          "type": "string",
+                                          "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "volumes": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "workspace": {
+                                      "type": "object",
+                                      "description": "destination needs to be provided. e.g.\n`{ \"workspace\" : { \"destination\" : \"/Users/user1@databricks.com/my-init.sh\" } }`",
+                                      "properties": {
+                                        "destination": {
+                                          "type": "string",
+                                          "description": "workspace files destination, e.g. `/Users/user1@databricks.com/my-init.sh`"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "instance_pool_id": {
+                                "type": "string",
+                                "description": "The optional ID of the instance pool to which the cluster belongs."
+                              },
+                              "node_type_id": {
+                                "type": "string",
+                                "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                              },
+                              "num_workers": {
+                                "type": "number",
+                                "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                              },
+                              "policy_id": {
+                                "type": "string",
+                                "description": "The ID of the cluster policy used to create the cluster if applicable."
+                              },
+                              "runtime_engine": {
+                                "type": "string"
+                              },
+                              "single_user_name": {
+                                "type": "string",
+                                "description": "Single user name if data_security_mode is `SINGLE_USER`"
+                              },
+                              "spark_conf": {
+                                "type": "object",
+                                "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nUsers can also pass in a string of extra JVM options to the driver and the executors via\n`spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` respectively.\n",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "spark_env_vars": {
+                                "type": "object",
+                                "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "spark_version": {
+                                "type": "string",
+                                "description": "The Spark version of the cluster, e.g. `3.3.x-scala2.11`.\nA list of available Spark versions can be retrieved by using\nthe :method:clusters/sparkVersions API call.\n"
+                              },
+                              "ssh_public_keys": {
+                                "type": "array",
+                                "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "workload_type": {
+                                "type": "object",
+                                "properties": {
+                                  "clients": {
+                                    "type": "object",
+                                    "description": " defined what type of clients can use the cluster. E.g. Notebooks, Jobs",
+                                    "properties": {
+                                      "jobs": {
+                                        "type": "boolean",
+                                        "description": "With jobs set, the cluster can be used for jobs"
+                                      },
+                                      "notebooks": {
+                                        "type": "boolean",
+                                        "description": "With notebooks set, this cluster can be used for notebooks"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "notebook_task": {
+                            "type": "object",
+                            "description": "If notebook_task, indicates that this task must run a notebook. This field may not be specified in conjunction with spark_jar_task.",
+                            "properties": {
+                              "base_parameters": {
+                                "type": "object",
+                                "description": "Base parameters to be used for each run of this job. If the run is initiated by a call to\n:method:jobs/runNow with parameters specified, the two parameters maps are merged. If the same key is specified in\n`base_parameters` and in `run-now`, the value from `run-now` is used.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n\nIf the notebook takes a parameter that is not specified in the job’s `base_parameters` or the `run-now` override parameters,\nthe default value from the notebook is used.\n\nRetrieve these parameters in a notebook using [dbutils.widgets.get](https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-widgets).\n",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "notebook_path": {
+                                "type": "string",
+                                "description": "The path of the notebook to be run in the Databricks workspace or remote repository.\nFor notebooks stored in the Databricks workspace, the path must be absolute and begin with a slash.\nFor notebooks stored in a remote repository, the path must be relative. This field is required.\n"
+                              },
+                              "source": {
+                                "type": "string",
+                                "description": "Optional location type of the Python file. When set to `WORKSPACE` or not specified, the file will be retrieved\nfrom the local \u003cDatabricks\u003e workspace or cloud location (if the `python_file` has a URI format). When set to `GIT`,\nthe Python file will be retrieved from a Git repository defined in `git_source`.\n\n* `WORKSPACE`: The Python file is located in a \u003cDatabricks\u003e workspace or at a cloud filesystem URI.\n* `GIT`: The Python file is located in a remote Git repository.\n"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "notebook_path"
+                            ]
+                          },
+                          "notification_settings": {
+                            "type": "object",
+                            "description": "Optional notification settings that are used when sending notifications to each of the `email_notifications` for this task.",
+                            "properties": {
+                              "alert_on_last_attempt": {
+                                "type": "boolean",
+                                "description": "If true, do not send notifications to recipients specified in `on_start` for the retried runs and do not send notifications to recipients specified in `on_failure` until the last retry of the run."
+                              },
+                              "no_alert_for_canceled_runs": {
+                                "type": "boolean",
+                                "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is canceled."
+                              },
+                              "no_alert_for_skipped_runs": {
+                                "type": "boolean",
+                                "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is skipped."
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "pipeline_task": {
+                            "type": "object",
+                            "description": "If pipeline_task, indicates that this task must execute a Pipeline.",
+                            "properties": {
+                              "full_refresh": {
+                                "type": "boolean",
+                                "description": "If true, a full refresh will be triggered on the delta live table."
+                              },
+                              "pipeline_id": {
+                                "type": "string",
+                                "description": "The full name of the pipeline task to execute."
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "python_wheel_task": {
+                            "type": "object",
+                            "description": "If python_wheel_task, indicates that this job must execute a PythonWheel.",
+                            "properties": {
+                              "entry_point": {
+                                "type": "string",
+                                "description": "Named entry point to use, if it does not exist in the metadata of the package it executes the function from the package directly using `$packageName.$entryPoint()`"
+                              },
+                              "named_parameters": {
+                                "type": "object",
+                                "description": "Command-line parameters passed to Python wheel task in the form of `[\"--name=task\", \"--data=dbfs:/path/to/data.json\"]`. Leave it empty if `parameters` is not null.",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "package_name": {
+                                "type": "string",
+                                "description": "Name of the package to execute"
+                              },
+                              "parameters": {
+                                "type": "array",
+                                "description": "Command-line parameters passed to Python wheel task. Leave it empty if `named_parameters` is not null.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "retry_on_timeout": {
+                            "type": "boolean",
+                            "description": "An optional policy to specify whether to retry a task when it times out. The default behavior is to not retry on timeout."
+                          },
+                          "run_if": {
+                            "type": "string",
+                            "description": "An optional value specifying the condition determining whether the task is run once its dependencies have been completed. When omitted, defaults to `ALL_SUCCESS`.\n\n* `ALL_SUCCESS`: All dependencies have executed and succeeded\n* `AT_LEAST_ONE_SUCCESS`: At least one dependency has succeeded\n* `NONE_FAILED`: None of the dependencies have failed and at least one was executed\n* `ALL_DONE`: All dependencies completed and at least one was executed\n* `AT_LEAST_ONE_FAILED`: At least one dependency failed\n* `ALL_FAILED`: ALl dependencies have failed\n"
+                          },
+                          "run_job_task": {
+                            "type": "object",
+                            "properties": {
+                              "job_id": {
+                                "type": "number"
+                              },
+                              "job_parameters": {}
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "job_id"
+                            ]
+                          },
+                          "spark_jar_task": {
+                            "type": "object",
+                            "description": "If spark_jar_task, indicates that this task must run a JAR.",
+                            "properties": {
+                              "jar_uri": {
+                                "type": "string",
+                                "description": "Deprecated since 04/2016. Provide a `jar` through the `libraries` field instead. For an example, see :method:jobs/create.\n"
+                              },
+                              "main_class_name": {
+                                "type": "string",
+                                "description": "The full name of the class containing the main method to be executed. This class must be contained in a JAR provided as a library.\n\nThe code must use `SparkContext.getOrCreate` to obtain a Spark context; otherwise, runs of the job fail."
+                              },
+                              "parameters": {
+                                "type": "array",
+                                "description": "Parameters passed to the main method.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "spark_python_task": {
+                            "type": "object",
+                            "description": "If spark_python_task, indicates that this task must run a Python file.",
+                            "properties": {
+                              "parameters": {
+                                "type": "array",
+                                "description": "Command line parameters passed to the Python file.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "python_file": {
+                                "type": "string",
+                                "description": "The Python file to be executed. Cloud file URIs (such as dbfs:/, s3:/, adls:/, gcs:/) and workspace paths are supported. For python files stored in the Databricks workspace, the path must be absolute and begin with `/`. For files stored in a remote repository, the path must be relative. This field is required."
+                              },
+                              "source": {
+                                "type": "string",
+                                "description": "Optional location type of the Python file. When set to `WORKSPACE` or not specified, the file will be retrieved\nfrom the local \u003cDatabricks\u003e workspace or cloud location (if the `python_file` has a URI format). When set to `GIT`,\nthe Python file will be retrieved from a Git repository defined in `git_source`.\n\n* `WORKSPACE`: The Python file is located in a \u003cDatabricks\u003e workspace or at a cloud filesystem URI.\n* `GIT`: The Python file is located in a remote Git repository.\n"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "python_file"
+                            ]
+                          },
+                          "spark_submit_task": {
+                            "type": "object",
+                            "description": "If spark_submit_task, indicates that this task must be launched by the spark submit script. This task can run only on new clusters.",
+                            "properties": {
+                              "parameters": {
+                                "type": "array",
+                                "description": "Command-line parameters passed to spark submit.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "sql_task": {
+                            "type": "object",
+                            "description": "If sql_task, indicates that this job must execute a SQL task.",
+                            "properties": {
+                              "alert": {
+                                "type": "object",
+                                "description": "If alert, indicates that this job must refresh a SQL alert.",
+                                "properties": {
+                                  "alert_id": {
+                                    "type": "string",
+                                    "description": "The canonical identifier of the SQL alert."
+                                  },
+                                  "pause_subscriptions": {
+                                    "type": "boolean",
+                                    "description": "If true, the alert notifications are not sent to subscribers."
+                                  },
+                                  "subscriptions": {
+                                    "type": "array",
+                                    "description": "If specified, alert notifications are sent to subscribers.",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination_id": {
+                                          "type": "string",
+                                          "description": "The canonical identifier of the destination to receive email notification."
+                                        },
+                                        "user_name": {
+                                          "type": "string",
+                                          "description": "The user name to receive the subscription email."
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "alert_id"
+                                ]
+                              },
+                              "dashboard": {
+                                "type": "object",
+                                "description": "If dashboard, indicates that this job must refresh a SQL dashboard.",
+                                "properties": {
+                                  "custom_subject": {
+                                    "type": "string",
+                                    "description": "Subject of the email sent to subscribers of this task."
+                                  },
+                                  "dashboard_id": {
+                                    "type": "string",
+                                    "description": "The canonical identifier of the SQL dashboard."
+                                  },
+                                  "pause_subscriptions": {
+                                    "type": "boolean",
+                                    "description": "If true, the dashboard snapshot is not taken, and emails are not sent to subscribers."
+                                  },
+                                  "subscriptions": {
+                                    "type": "array",
+                                    "description": "If specified, dashboard snapshots are sent to subscriptions.",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "destination_id": {
+                                          "type": "string",
+                                          "description": "The canonical identifier of the destination to receive email notification."
+                                        },
+                                        "user_name": {
+                                          "type": "string",
+                                          "description": "The user name to receive the subscription email."
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "dashboard_id"
+                                ]
+                              },
+                              "file": {
+                                "type": "object",
+                                "description": "If file, indicates that this job runs a SQL file in a remote Git repository. Only one SQL statement is supported in a file. Multiple SQL statements separated by semicolons (;) are not permitted.",
+                                "properties": {
+                                  "path": {
+                                    "type": "string",
+                                    "description": "Relative path of the SQL file in the remote Git repository."
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "path"
+                                ]
+                              },
+                              "parameters": {
+                                "type": "object",
+                                "description": "Parameters to be used for each run of this job. The SQL alert task does not support custom parameters.",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "query": {
+                                "type": "object",
+                                "description": "If query, indicates that this job must execute a SQL query.",
+                                "properties": {
+                                  "query_id": {
+                                    "type": "string",
+                                    "description": "The canonical identifier of the SQL query."
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "query_id"
+                                ]
+                              },
+                              "warehouse_id": {
+                                "type": "string",
+                                "description": "The canonical identifier of the SQL warehouse. Only serverless and pro SQL warehouses are supported."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "warehouse_id"
+                            ]
+                          },
+                          "task_key": {
+                            "type": "string",
+                            "description": "A unique name for the task. This field is used to refer to this task from other tasks.\nThis field is required and must be unique within its parent job.\nOn Update or Reset, this field is used to reference the tasks to be updated or reset.\nThe maximum length is 100 characters."
+                          },
+                          "timeout_seconds": {
+                            "type": "number",
+                            "description": "An optional timeout applied to each run of this job task. The default behavior is to have no timeout."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "task_key"
+                        ]
+                      }
+                    },
+                    "timeout_seconds": {
+                      "type": "number",
+                      "description": "An optional timeout applied to each run of this job. The default behavior is to have no timeout."
+                    },
+                    "trigger": {
+                      "type": "object",
+                      "description": "Trigger settings for the job. Can be used to trigger a run when new files arrive in an external location. The default behavior is that the job runs only when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`.",
+                      "properties": {
+                        "file_arrival": {
+                          "type": "object",
+                          "description": "File arrival trigger settings.",
+                          "properties": {
+                            "min_time_between_triggers_seconds": {
+                              "type": "number",
+                              "description": "If set, the trigger starts a run only after the specified amount of time passed since\nthe last time the trigger fired. The minimum allowed value is 60 seconds\n"
+                            },
+                            "url": {
+                              "type": "string",
+                              "description": "URL to be monitored for file arrivals. The path must point to the root or a subpath of the external location."
+                            },
+                            "wait_after_last_change_seconds": {
+                              "type": "number",
+                              "description": "If set, the trigger starts a run only after no file activity has occurred for the specified amount of time.\nThis makes it possible to wait for a batch of incoming files to arrive before triggering a run. The\nminimum allowed value is 60 seconds.\n"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "pause_status": {
+                          "type": "string",
+                          "description": "Whether this trigger is paused or not."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "webhook_notifications": {
+                      "type": "object",
+                      "description": "A collection of system notification IDs to notify when the run begins or completes. The default behavior is to not send any system notifications.",
+                      "properties": {
+                        "on_duration_warning_threshold_exceeded": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "on_failure": {
+                          "type": "array",
+                          "description": "An optional list of system notification IDs to call when the run fails. A maximum of 3 destinations can be specified for the `on_failure` property.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "on_start": {
+                          "type": "array",
+                          "description": "An optional list of system notification IDs to call when the run starts. A maximum of 3 destinations can be specified for the `on_start` property.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "on_success": {
+                          "type": "array",
+                          "description": "An optional list of system notification IDs to call when the run completes successfully. A maximum of 3 destinations can be specified for the `on_success` property.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "model_serving_endpoints": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "served_models": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "environment_vars": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "instance_profile_arn": {
+                                "type": "string"
+                              },
+                              "model_name": {
+                                "type": "string"
+                              },
+                              "model_version": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "scale_to_zero_enabled": {
+                                "type": "boolean"
+                              },
+                              "workload_size": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "model_name",
+                              "model_version",
+                              "scale_to_zero_enabled",
+                              "workload_size"
+                            ]
+                          }
+                        },
+                        "traffic_config": {
+                          "type": "object",
+                          "properties": {
+                            "routes": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "served_model_name": {
+                                    "type": "string"
+                                  },
+                                  "traffic_percentage": {
+                                    "type": "number"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                  "served_model_name",
+                                  "traffic_percentage"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "served_models"
+                      ]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "config",
+                    "name"
+                  ]
+                }
+              },
+              "models": {
+                "type": "object",
+                "description": "List of MLflow models",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "creation_timestamp": {
+                      "type": "number",
+                      "description": "Timestamp recorded when this `registered_model` was created."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of this `registered_model`."
+                    },
+                    "last_updated_timestamp": {
+                      "type": "number",
+                      "description": "Timestamp recorded when metadata for this `registered_model` was last updated."
+                    },
+                    "latest_versions": {
+                      "type": "array",
+                      "description": "Collection of latest model versions for each stage.\nOnly contains models with current `READY` status.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "creation_timestamp": {
+                            "type": "number",
+                            "description": "Timestamp recorded when this `model_version` was created."
+                          },
+                          "current_stage": {
+                            "type": "string",
+                            "description": "Current stage for this `model_version`."
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Description of this `model_version`."
+                          },
+                          "last_updated_timestamp": {
+                            "type": "number",
+                            "description": "Timestamp recorded when metadata for this `model_version` was last updated."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Unique name of the model"
+                          },
+                          "run_id": {
+                            "type": "string",
+                            "description": "MLflow run ID used when creating `model_version`, if `source` was generated by an\nexperiment run stored in MLflow tracking server."
+                          },
+                          "run_link": {
+                            "type": "string",
+                            "description": "Run Link: Direct link to the run that generated this version"
+                          },
+                          "source": {
+                            "type": "string",
+                            "description": "URI indicating the location of the source model artifacts, used when creating `model_version`"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current status of `model_version`"
+                          },
+                          "status_message": {
+                            "type": "string",
+                            "description": "Details on current `status`, if it is pending or failed."
+                          },
+                          "tags": {
+                            "type": "array",
+                            "description": "Tags: Additional metadata key-value pairs for this `model_version`.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string",
+                                  "description": "The tag key."
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "description": "The tag value."
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "user_id": {
+                            "type": "string",
+                            "description": "User that created this `model_version`."
+                          },
+                          "version": {
+                            "type": "string",
+                            "description": "Model's version number."
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Unique name for the model."
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "description": "Tags: Additional metadata key-value pairs for this `registered_model`.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string",
+                            "description": "The tag key."
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "The tag value."
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "user_id": {
+                      "type": "string",
+                      "description": "User that created this `registered_model`"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "pipelines": {
+                "type": "object",
+                "description": "List of DLT pipelines",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "catalog": {
+                      "type": "string",
+                      "description": "A catalog in Unity Catalog to publish data from this pipeline to. If `target` is specified, tables in this pipeline are published to a `target` schema inside `catalog` (for example, `catalog`.`target`.`table`). If `target` is not specified, no data is published to Unity Catalog."
+                    },
+                    "channel": {
+                      "type": "string",
+                      "description": "DLT Release Channel that specifies which version to use."
+                    },
+                    "clusters": {
+                      "type": "array",
+                      "description": "Cluster settings for this pipeline deployment.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "apply_policy_default_values": {
+                            "type": "boolean",
+                            "description": "Note: This field won't be persisted. Only API users will check this field."
+                          },
+                          "autoscale": {
+                            "type": "object",
+                            "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                            "properties": {
+                              "max_workers": {
+                                "type": "number",
+                                "description": "The maximum number of workers to which the cluster can scale up when overloaded.\nNote that `max_workers` must be strictly greater than `min_workers`."
+                              },
+                              "min_workers": {
+                                "type": "number",
+                                "description": "The minimum number of workers to which the cluster can scale down when underutilized.\nIt is also the initial number of workers the cluster will have after creation."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "max_workers",
+                              "min_workers"
+                            ]
+                          },
+                          "aws_attributes": {
+                            "type": "object",
+                            "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                            "properties": {
+                              "availability": {
+                                "type": "string"
+                              },
+                              "ebs_volume_count": {
+                                "type": "number",
+                                "description": "The number of volumes launched for each instance. Users can choose up to 10 volumes.\nThis feature is only enabled for supported node types. Legacy node types cannot specify\ncustom EBS volumes.\nFor node types with no instance store, at least one EBS volume needs to be specified;\notherwise, cluster creation will fail.\n\nThese EBS volumes will be mounted at `/ebs0`, `/ebs1`, and etc.\nInstance store volumes will be mounted at `/local_disk0`, `/local_disk1`, and etc.\n\nIf EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for\nscratch storage because heterogenously sized scratch devices can lead to inefficient disk\nutilization. If no EBS volumes are attached, Databricks will configure Spark to use instance\nstore volumes.\n\nPlease note that if EBS volumes are specified, then the Spark configuration `spark.local.dir`\nwill be overridden."
+                              },
+                              "ebs_volume_iops": {
+                                "type": "number",
+                                "description": "\u003cneeds content added\u003e"
+                              },
+                              "ebs_volume_size": {
+                                "type": "number",
+                                "description": "The size of each EBS volume (in GiB) launched for each instance. For general purpose\nSSD, this value must be within the range 100 - 4096. For throughput optimized HDD,\nthis value must be within the range 500 - 4096."
+                              },
+                              "ebs_volume_throughput": {
+                                "type": "number",
+                                "description": "\u003cneeds content added\u003e"
+                              },
+                              "ebs_volume_type": {
+                                "type": "string"
+                              },
+                              "first_on_demand": {
+                                "type": "number",
+                                "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nIf this value is greater than 0, the cluster driver node in particular will be placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                              },
+                              "instance_profile_arn": {
+                                "type": "string",
+                                "description": "Nodes for this cluster will only be placed on AWS instances with this instance profile. If\nommitted, nodes will be placed on instances without an IAM instance profile. The instance\nprofile must have previously been added to the Databricks environment by an account\nadministrator.\n\nThis feature may only be available to certain customer plans.\n\nIf this field is ommitted, we will pull in the default from the conf if it exists."
+                              },
+                              "spot_bid_price_percent": {
+                                "type": "number",
+                                "description": "The bid price for AWS spot instances, as a percentage of the corresponding instance type's\non-demand price.\nFor example, if this field is set to 50, and the cluster needs a new `r3.xlarge` spot\ninstance, then the bid price is half of the price of\non-demand `r3.xlarge` instances. Similarly, if this field is set to 200, the bid price is twice\nthe price of on-demand `r3.xlarge` instances. If not specified, the default value is 100.\nWhen spot instances are requested for this cluster, only spot instances whose bid price\npercentage matches this field will be considered.\nNote that, for safety, we enforce this field to be no more than 10000.\n\nThe default value and documentation here should be kept consistent with\nCommonConf.defaultSpotBidPricePercent and CommonConf.maxSpotBidPricePercent."
+                              },
+                              "zone_id": {
+                                "type": "string",
+                                "description": "Identifier for the availability zone/datacenter in which the cluster resides.\nThis string will be of a form like \"us-west-2a\". The provided availability\nzone must be in the same region as the Databricks deployment. For example, \"us-west-2a\"\nis not a valid zone id if the Databricks deployment resides in the \"us-east-1\" region.\nThis is an optional field at cluster creation, and if not specified, a default zone will be used.\nIf the zone specified is \"auto\", will try to place cluster in a zone with high availability,\nand will retry placement in a different AZ if there is not enough capacity.\nSee [[AutoAZHelper.scala]] for more details.\nThe list of available zones as well as the default value can be found by using the\n`List Zones`_ method."
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "azure_attributes": {
+                            "type": "object",
+                            "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                            "properties": {
+                              "availability": {
+                                "type": "string"
+                              },
+                              "first_on_demand": {
+                                "type": "number",
+                                "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nThis value should be greater than 0, to make sure the cluster driver node is placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                              },
+                              "log_analytics_info": {
+                                "type": "object",
+                                "description": "Defines values necessary to configure and run Azure Log Analytics agent",
+                                "properties": {
+                                  "log_analytics_primary_key": {
+                                    "type": "string",
+                                    "description": "\u003cneeds content added\u003e"
+                                  },
+                                  "log_analytics_workspace_id": {
+                                    "type": "string",
+                                    "description": "\u003cneeds content added\u003e"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "spot_bid_max_price": {
+                                "type": "number",
+                                "description": "The max bid price to be used for Azure spot instances.\nThe Max price for the bid cannot be higher than the on-demand price of the instance.\nIf not specified, the default value is -1, which specifies that the instance cannot be evicted\non the basis of price, and only on the basis of availability. Further, the value should \u003e 0 or -1."
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "cluster_log_conf": {
+                            "type": "object",
+                            "description": "The configuration for delivering spark logs to a long-term storage destination.\nOnly dbfs destinations are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.\n",
+                            "properties": {
+                              "dbfs": {
+                                "type": "object",
+                                "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                                "properties": {
+                                  "destination": {
+                                    "type": "string",
+                                    "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "s3": {
+                                "type": "object",
+                                "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                                "properties": {
+                                  "canned_acl": {
+                                    "type": "string",
+                                    "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                                  },
+                                  "destination": {
+                                    "type": "string",
+                                    "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                                  },
+                                  "enable_encryption": {
+                                    "type": "boolean",
+                                    "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                                  },
+                                  "encryption_type": {
+                                    "type": "string",
+                                    "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                                  },
+                                  "endpoint": {
+                                    "type": "string",
+                                    "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                                  },
+                                  "kms_key": {
+                                    "type": "string",
+                                    "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "custom_tags": {
+                            "type": "object",
+                            "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "driver_instance_pool_id": {
+                            "type": "string",
+                            "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                          },
+                          "driver_node_type_id": {
+                            "type": "string",
+                            "description": "The node type of the Spark driver.\nNote that this field is optional; if unset, the driver node type will be set as the same value\nas `node_type_id` defined above."
+                          },
+                          "gcp_attributes": {
+                            "type": "object",
+                            "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                            "properties": {
+                              "availability": {
+                                "type": "string"
+                              },
+                              "boot_disk_size": {
+                                "type": "number",
+                                "description": "boot disk size in GB"
+                              },
+                              "google_service_account": {
+                                "type": "string",
+                                "description": "If provided, the cluster will impersonate the google service account when accessing\ngcloud services (like GCS). The google service account\nmust have previously been added to the Databricks environment by an account\nadministrator."
+                              },
+                              "local_ssd_count": {
+                                "type": "number",
+                                "description": "If provided, each node (workers and driver) in the cluster will have this number of local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP documentation](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) for the supported number of local SSDs for each instance type."
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "instance_pool_id": {
+                            "type": "string",
+                            "description": "The optional ID of the instance pool to which the cluster belongs."
+                          },
+                          "label": {
+                            "type": "string",
+                            "description": "A label for the cluster specification, either `default` to configure the default cluster, or `maintenance` to configure the maintenance cluster. This field is optional. The default value is `default`."
+                          },
+                          "node_type_id": {
+                            "type": "string",
+                            "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                          },
+                          "num_workers": {
+                            "type": "number",
+                            "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                          },
+                          "policy_id": {
+                            "type": "string",
+                            "description": "The ID of the cluster policy used to create the cluster if applicable."
+                          },
+                          "spark_conf": {
+                            "type": "object",
+                            "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nSee :method:clusters/create for more details.\n",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "spark_env_vars": {
+                            "type": "object",
+                            "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "ssh_public_keys": {
+                            "type": "array",
+                            "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "configuration": {
+                      "type": "object",
+                      "description": "String-String configuration for this pipeline execution.",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "continuous": {
+                      "type": "boolean",
+                      "description": "Whether the pipeline is continuous or triggered. This replaces `trigger`."
+                    },
+                    "development": {
+                      "type": "boolean",
+                      "description": "Whether the pipeline is in Development mode. Defaults to false."
+                    },
+                    "edition": {
+                      "type": "string",
+                      "description": "Pipeline product edition."
+                    },
+                    "filters": {
+                      "type": "object",
+                      "description": "Filters on which Pipeline packages to include in the deployed graph.",
+                      "properties": {
+                        "exclude": {
+                          "type": "array",
+                          "description": "Paths to exclude.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "include": {
+                          "type": "array",
+                          "description": "Paths to include.",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier for this pipeline."
+                    },
+                    "libraries": {
+                      "type": "array",
+                      "description": "Libraries or code needed by this deployment.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "file": {
+                            "type": "object",
+                            "description": "The path to a file that defines a pipeline and is stored in the Databricks Repos.\n",
+                            "properties": {
+                              "path": {
+                                "type": "string",
+                                "description": "The absolute path of the file."
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "jar": {
+                            "type": "string",
+                            "description": "URI of the jar to be installed. Currently only DBFS is supported.\n"
+                          },
+                          "maven": {
+                            "type": "object",
+                            "description": "Specification of a maven library to be installed.\n",
+                            "properties": {
+                              "coordinates": {
+                                "type": "string",
+                                "description": "Gradle-style maven coordinates. For example: \"org.jsoup:jsoup:1.7.2\"."
+                              },
+                              "exclusions": {
+                                "type": "array",
+                                "description": "List of dependences to exclude. For example: `[\"slf4j:slf4j\", \"*:hadoop-client\"]`.\n\nMaven dependency exclusions:\nhttps://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "repo": {
+                                "type": "string",
+                                "description": "Maven repo to install the Maven package from. If omitted, both Maven Central Repository\nand Spark Packages are searched."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "coordinates"
+                            ]
+                          },
+                          "notebook": {
+                            "type": "object",
+                            "description": "The path to a notebook that defines a pipeline and is stored in the \u003cDatabricks\u003e workspace.\n",
+                            "properties": {
+                              "path": {
+                                "type": "string",
+                                "description": "The absolute path of the notebook."
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Friendly identifier for this pipeline."
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "group_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "service_principal_name": {
+                            "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "level"
+                        ]
+                      }
+                    },
+                    "photon": {
+                      "type": "boolean",
+                      "description": "Whether Photon is enabled for this pipeline."
+                    },
+                    "serverless": {
+                      "type": "boolean",
+                      "description": "Whether serverless compute is enabled for this pipeline."
+                    },
+                    "storage": {
+                      "type": "string",
+                      "description": "DBFS root directory for storing checkpoints and tables."
+                    },
+                    "target": {
+                      "type": "string",
+                      "description": "Target schema (database) to add tables in this pipeline to. If not specified, no data is published to the Hive metastore or Unity Catalog. To publish to Unity Catalog, also specify `catalog`."
+                    },
+                    "trigger": {
+                      "type": "object",
+                      "description": "Which pipeline trigger to use. Deprecated: Use `continuous` instead.",
+                      "properties": {
+                        "cron": {
+                          "type": "object",
+                          "properties": {
+                            "quartz_cron_schedule": {
+                              "type": "string"
+                            },
+                            "timezone_id": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "manual": {}
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "run_as": {
+            "type": "object",
+            "properties": {
+              "service_principal_name": {
+                "type": "string"
+              },
+              "user_name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "variables": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "workspace": {
+            "type": "object",
+            "description": "Configures which workspace to connect to and locations for files, state, and similar locations within the workspace file tree.",
+            "properties": {
+              "artifact_path": {
+                "type": "string",
+                "description": "The remote path to synchronize build artifacts to. This defaults to `${workspace.root}/artifacts`"
+              },
+              "auth_type": {
+                "type": "string"
+              },
+              "azure_client_id": {
+                "type": "string"
+              },
+              "azure_environment": {
+                "type": "string",
+                "description": "Azure environment, one of (Public, UsGov, China, Germany)."
+              },
+              "azure_login_app_id": {
+                "type": "string",
+                "description": "Azure Login Application ID."
+              },
+              "azure_tenant_id": {
+                "type": "string"
+              },
+              "azure_use_msi": {
+                "type": "boolean"
+              },
+              "azure_workspace_resource_id": {
+                "type": "string",
+                "description": "Azure Resource Manager ID for Azure Databricks workspace."
+              },
+              "client_id": {
+                "type": "string"
+              },
+              "file_path": {
+                "type": "string",
+                "description": "The remote path to synchronize local files artifacts to. This defaults to `${workspace.root}/files`"
+              },
+              "google_service_account": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string",
+                "description": "Host url of the workspace."
+              },
+              "profile": {
+                "type": "string",
+                "description": "Connection profile to use. By default profiles are specified in ~/.databrickscfg."
+              },
+              "root_path": {
+                "type": "string",
+                "description": "The base location for synchronizing files, artifacts and state. Defaults to `/Users/jane@doe.com/.bundle/${bundle.name}/${bundle.target}`"
+              },
+              "state_path": {
+                "type": "string",
+                "description": "The remote path to synchronize bundle state to. This defaults to `${workspace.root}/state`"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "variables": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "workspace": {
+      "type": "object",
+      "description": "Configures which workspace to connect to and locations for files, state, and similar locations within the workspace file tree.",
+      "properties": {
+        "artifact_path": {
+          "type": "string",
+          "description": "The remote path to synchronize build artifacts to. This defaults to `${workspace.root}/artifacts`"
+        },
+        "auth_type": {
+          "type": "string"
+        },
+        "azure_client_id": {
+          "type": "string"
+        },
+        "azure_environment": {
+          "type": "string",
+          "description": "Azure environment, one of (Public, UsGov, China, Germany)."
+        },
+        "azure_login_app_id": {
+          "type": "string",
+          "description": "Azure Login Application ID."
+        },
+        "azure_tenant_id": {
+          "type": "string"
+        },
+        "azure_use_msi": {
+          "type": "boolean"
+        },
+        "azure_workspace_resource_id": {
+          "type": "string",
+          "description": "Azure Resource Manager ID for Azure Databricks workspace."
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "file_path": {
+          "type": "string",
+          "description": "The remote path to synchronize local files artifacts to. This defaults to `${workspace.root}/files`"
+        },
+        "google_service_account": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string",
+          "description": "Host url of the workspace."
+        },
+        "profile": {
+          "type": "string",
+          "description": "Connection profile to use. By default profiles are specified in ~/.databrickscfg."
+        },
+        "root_path": {
+          "type": "string",
+          "description": "The base location for synchronizing files, artifacts and state. Defaults to `/Users/jane@doe.com/.bundle/${bundle.name}/${bundle.target}`"
+        },
+        "state_path": {
+          "type": "string",
+          "description": "The remote path to synchronize bundle state to. This defaults to `${workspace.root}/state`"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/databricks-asset-bundles/databricks.yml
+++ b/src/test/databricks-asset-bundles/databricks.yml
@@ -1,0 +1,43 @@
+# This is a Databricks asset bundle definition for default_python.
+# See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
+bundle:
+  name: default_python
+
+include:
+  - resources/*.yml
+
+targets:
+  # The 'dev' target, used for development purposes.
+  # Whenever a developer deploys using 'dev', they get their own copy.
+  dev:
+    # We use 'mode: development' to make sure everything deployed to this target gets a prefix
+    # like '[dev my_user_name]'. Setting this mode also disables any schedules and
+    # automatic triggers for jobs and enables the 'development' mode for Delta Live Tables pipelines.
+    mode: development
+    default: true
+    workspace:
+      host: https://myworkspace.databricks.com
+
+  # Optionally, there could be a 'staging' target here.
+  # (See Databricks docs on CI/CD at https://docs.databricks.com/dev-tools/bundles/index.html.)
+  #
+  # staging:
+  #  workspace:
+  #    host: https://myworkspace.databricks.com
+
+  # The 'prod' target, used for production deployment.
+  prod:
+    # For production deployments, we only have a single copy, so we override the
+    # workspace.root_path default of
+    # /Users/${workspace.current_user.userName}/.bundle/${bundle.target}/${bundle.name}
+    # to a path that is not specific to the current user.
+    mode: production
+    workspace:
+      host: https://myworkspace.databricks.com
+      root_path: /Shared/.bundle/prod/${bundle.name}
+    run_as:
+      # This runs as username@company.com in production. Alternatively,
+      # a service principal could be used here using service_principal_name
+      # (see Databricks documentation).
+      user_name: lennart.kats@databricks.com
+    


### PR DESCRIPTION
Adds schemas for [Databricks Asset Bundles](https://docs.databricks.com/en/dev-tools/bundles/index.html). These can be generated using the Databricks CLI (`databricks bundle schema`) and are not statically available anywhere.