### PR TITLE
Better validation for our unofficial draft-07 meta schema

### DIFF
--- a/src/schemas/json/metaschema-draft-07-unofficial-strict.json
+++ b/src/schemas/json/metaschema-draft-07-unofficial-strict.json
@@ -115,7 +115,7 @@
       "not": {
         "$ref": "#/definitions/space-string"
       },
-      "pattern": "\\n",
+      "pattern": "\\nhttps?://.",
       "examples": ["An image\nurl", "An image type\nurl"]
     },
     "type-property": {

--- a/src/schemas/json/metaschema-draft-07-unofficial-strict.json
+++ b/src/schemas/json/metaschema-draft-07-unofficial-strict.json
@@ -2,934 +2,996 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json",
   "definitions": {
-    "space-string": {
-      "pattern": "^\\s+$|\\s{2,}"
-    },
-    "simple-type": {
-      "type": ["boolean", "integer", "null", "number", "string"]
-    },
-    "numeric-type-requirement": {
-      "oneOf": [
-        {
-          "properties": {
-            "type": {
-              "const": "integer"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "number"
-            }
-          }
-        }
-      ]
-    },
-    "string-type-requirement": {
-      "properties": {
-        "type": {
-          "const": "string"
-        }
-      }
-    },
-    "array-type-requirement": {
-      "properties": {
-        "type": {
-          "const": "array"
-        }
-      }
-    },
-    "object-type-requirement": {
-      "properties": {
-        "type": {
-          "const": "object"
-        }
-      }
-    },
-    "simple-type-requirement": {
-      "oneOf": [
-        {
-          "properties": {
-            "type": {
-              "const": "boolean"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "integer"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "null"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "number"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "string"
-            }
-          }
-        }
-      ]
-    },
-    "comment-property": {
-      "description": "A comment of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html#id3",
-      "type": "string",
-      "minLength": 1,
-      "examples": ["Don't remove until #issue is closed."]
-    },
-    "ref-property": {
-      "description": "A reference of the current property or definition\nhttps://json-schema.org/understanding-json-schema/structuring.html#ref",
-      "type": "string",
-      "minLength": 1,
-      "pattern": "^#/definitions/.",
-      "examples": ["#/definitions/reference"]
-    },
-    "title-property": {
-      "description": "A title of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
-      "type": "string",
-      "minLength": 1,
-      "not": {
-        "$ref": "#/definitions/space-string"
+      "space-string": {
+          "pattern": "^\\s+$|\\s{2,}"
       },
-      "examples": ["image", "image type"]
-    },
-    "description-property": {
-      "description": "A description of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
-      "type": "string",
-      "minLength": 1,
-      "not": {
-        "$ref": "#/definitions/space-string"
+      "simple-type": {
+          "type": [
+              "boolean",
+              "integer",
+              "null",
+              "number",
+              "string"
+          ]
       },
-      "examples": [
-        "An image",
-        "An image type",
-        "An image\nurl",
-        "An image type\nurl"
-      ]
-    },
-    "type-property": {
-      "description": "A type of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/type.html",
-      "type": "string",
-      "enum": [
-        "number",
-        "integer",
-        "null",
-        "array",
-        "object",
-        "boolean",
-        "string"
-      ],
-      "default": "string"
-    },
-    "minimum-property": {
-      "description": "A minimum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
-      "type": "number",
-      "default": 0
-    },
-    "maximum-property": {
-      "description": "A maximum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
-      "type": "number",
-      "default": 0
-    },
-    "exclusive-minimum-property": {
-      "description": "An exclusive minimum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
-      "type": "number",
-      "default": 0
-    },
-    "exclusive-maximum-property": {
-      "description": "An exclusive maximum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
-      "type": "number",
-      "default": 0
-    },
-    "multiple-of-property": {
-      "description": "A multiple of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#multiples",
-      "type": "number",
-      "exclusiveMinimum": 0,
-      "default": 1
-    },
-    "min-length-property": {
-      "description": "A minimum length of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#length",
-      "type": "integer",
-      "minimum": 0
-    },
-    "max-length-property": {
-      "description": "A maximum length of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#length",
-      "type": "integer",
-      "minimum": 0
-    },
-    "pattern-property": {
-      "description": "A pattern of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#regular-expressions",
-      "type": "string",
-      "format": "regex",
-      "examples": ["^.+=.*$", "^--?\\w+", "^#[0-9a-fA-F]{6}$"]
-    },
-    "enum-property": {
-      "description": "Valid values of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
-      "type": "array",
-      "uniqueItems": true,
-      "minItems": 1,
-      "items": {
-        "description": "A valid value of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
-        "$ref": "#/definitions/simple-type",
-        "examples": ["success", "failure"]
-      }
-    },
-    "items-property": {
-      "description": "Items of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#items",
-      "$ref": "#/definitions/entity"
-    },
-    "min-items-property": {
-      "description": "A minimum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",
-      "type": "integer",
-      "exclusiveMinimum": 0,
-      "default": 1
-    },
-    "max-items-property": {
-      "description": "A maximum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",
-      "type": "integer",
-      "exclusiveMinimum": 0,
-      "default": 1
-    },
-    "unique-items-property": {
-      "description": "Whether items of the current property or definition should be unique\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#uniqueness",
-      "type": "boolean",
-      "default": false
-    },
-    "required-property": {
-      "description": "Required sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "description": "A required sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
-        "type": "string",
-        "minLength": 1
+      "numeric-type-requirement": {
+          "oneOf": [
+              {
+                  "properties": {
+                      "type": {
+                          "const": "integer"
+                      }
+                  }
+              },
+              {
+                  "properties": {
+                      "type": {
+                          "const": "number"
+                      }
+                  }
+              }
+          ]
       },
-      "minLength": 1
-    },
-    "properties-property": {
-      "description": "Sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=properties#properties",
-      "type": "object",
-      "patternProperties": {
-        ".": {
-          "description": "A sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=properties#properties",
+      "string-type-requirement": {
+          "properties": {
+              "type": {
+                  "const": "string"
+              }
+          }
+      },
+      "array-type-requirement": {
+          "properties": {
+              "type": {
+                  "const": "array"
+              }
+          }
+      },
+      "object-type-requirement": {
+          "properties": {
+              "type": {
+                  "const": "object"
+              }
+          }
+      },
+      "simple-type-requirement": {
+          "oneOf": [
+              {
+                  "properties": {
+                      "type": {
+                          "const": "boolean"
+                      }
+                  }
+              },
+              {
+                  "properties": {
+                      "type": {
+                          "const": "integer"
+                      }
+                  }
+              },
+              {
+                  "properties": {
+                      "type": {
+                          "const": "null"
+                      }
+                  }
+              },
+              {
+                  "properties": {
+                      "type": {
+                          "const": "number"
+                      }
+                  }
+              },
+              {
+                  "properties": {
+                      "type": {
+                          "const": "string"
+                      }
+                  }
+              }
+          ]
+      },
+      "comment-property": {
+          "description": "A comment of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html#id3",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+              "Don't remove until #issue is closed."
+          ]
+      },
+      "ref-property": {
+          "description": "A reference of the current property or definition\nhttps://json-schema.org/understanding-json-schema/structuring.html#ref",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^#/definitions/.",
+          "examples": [
+              "#/definitions/reference"
+          ]
+      },
+      "title-property": {
+          "description": "A title of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
+          "type": "string",
+          "minLength": 1,
+          "not": {
+              "$ref": "#/definitions/space-string"
+          },
+          "examples": [
+              "image",
+              "image type"
+          ]
+      },
+      "description-property": {
+          "description": "A description of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
+          "type": "string",
+          "minLength": 1,
+          "not": {
+              "$ref": "#/definitions/space-string"
+          },
+          "pattern": "\\n",
+          "examples": [
+              "An image\nurl",
+              "An image type\nurl"
+          ]
+      },
+      "type-property": {
+          "description": "A type of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/type.html",
+          "type": "string",
+          "enum": [
+              "number",
+              "integer",
+              "null",
+              "array",
+              "object",
+              "boolean",
+              "string"
+          ],
+          "default": "string"
+      },
+      "minimum-property": {
+          "description": "A minimum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
+          "type": "number",
+          "default": 0
+      },
+      "maximum-property": {
+          "description": "A maximum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
+          "type": "number",
+          "default": 0
+      },
+      "exclusive-minimum-property": {
+          "description": "An exclusive minimum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
+          "type": "number",
+          "default": 0
+      },
+      "exclusive-maximum-property": {
+          "description": "An exclusive maximum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
+          "type": "number",
+          "default": 0
+      },
+      "multiple-of-property": {
+          "description": "A multiple of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#multiples",
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "default": 1
+      },
+      "min-length-property": {
+          "description": "A minimum length of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#length",
+          "type": "integer",
+          "minimum": 0
+      },
+      "max-length-property": {
+          "description": "A maximum length of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#length",
+          "type": "integer",
+          "minimum": 0
+      },
+      "pattern-property": {
+          "description": "A pattern of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#regular-expressions",
+          "type": "string",
+          "format": "regex",
+          "examples": [
+              "^.+=.*$",
+              "^--?\\w+",
+              "^#[0-9a-fA-F]{6}$"
+          ]
+      },
+      "enum-property": {
+          "description": "Valid values of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+              "description": "A valid value of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
+              "$ref": "#/definitions/simple-type",
+              "examples": [
+                  "success",
+                  "failure"
+              ]
+          }
+      },
+      "items-property": {
+          "description": "Items of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#items",
           "$ref": "#/definitions/entity"
-        }
       },
-      "additionalProperties": false
-    },
-    "pattern-properties-property": {
-      "description": "Pattern sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
-      "type": "object",
-      "properties": {
-        ".": {
-          "description": "A pattern sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
-          "$ref": "#/definitions/entity"
-        }
+      "min-items-property": {
+          "description": "A minimum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "default": 1
       },
-      "patternProperties": {
-        ".": {
-          "description": "A pattern sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
-          "$ref": "#/definitions/entity"
-        }
+      "max-items-property": {
+          "description": "A maximum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "default": 1
       },
-      "additionalProperties": false
-    },
-    "additional-properties-property": {
-      "description": "Additional sub-properties of the current property or definition or whether to allow them\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#additional-properties",
-      "$ref": "#/definitions/entity"
-    },
-    "min-properties-property": {
-      "description": "A minimum count of sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#size",
-      "type": "integer",
-      "minimum": 1,
-      "default": 1
-    },
-    "max-properties-property": {
-      "description": "A maximum count of sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#size",
-      "type": "integer",
-      "minimum": 1,
-      "default": 1
-    },
-    "const-property": {
-      "description": "A constant of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=const#constant-values",
-      "$ref": "#/definitions/simple-type"
-    },
-    "default-property": {
-      "description": "A default of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
-      "$ref": "#/definitions/simple-type"
-    },
-    "examples-property": {
-      "description": "Examples of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "description": "An example of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
-        "$ref": "#/definitions/simple-type"
+      "unique-items-property": {
+          "description": "Whether items of the current property or definition should be unique\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#uniqueness",
+          "type": "boolean",
+          "default": false
       },
-      "minLength": 1
-    },
-    "not-property": {
-      "description": "A sub-schema should not match of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#not",
-      "$ref": "#/definitions/sub-schema-entity",
-      "minProperties": 1
-    },
-    "any-of-property": {
-      "description": "A requirement to match at least one sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#anyof",
-      "type": "array",
-      "uniqueItems": true,
-      "minItems": 2,
-      "items": {
-        "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#anyof",
-        "$ref": "#/definitions/sub-schema-entity"
-      }
-    },
-    "one-of-property": {
-      "description": "A requirement to match at one sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#oneof",
-      "type": "array",
-      "uniqueItems": true,
-      "minItems": 2,
-      "items": {
-        "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#oneof",
-        "$ref": "#/definitions/sub-schema-entity"
-      }
-    },
-    "all-of-property": {
-      "description": "A requirement to match all sub-schemas of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#allof",
-      "type": "array",
-      "uniqueItems": true,
-      "minItems": 2,
-      "items": {
-        "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#allof",
-        "$ref": "#/definitions/sub-schema-entity"
-      }
-    },
-    "sub-schema-entity": {
-      "type": "object",
-      "properties": {
-        "$comment": {
-          "$ref": "#/definitions/comment-property"
-        },
-        "$ref": {
-          "$ref": "#/definitions/ref-property"
-        },
-        "minimum": {
-          "$ref": "#/definitions/minimum-property"
-        },
-        "maximum": {
-          "$ref": "#/definitions/maximum-property"
-        },
-        "exclusiveMinimum": {
-          "$ref": "#/definitions/exclusive-minimum-property"
-        },
-        "exclusiveMaximum": {
-          "$ref": "#/definitions/exclusive-maximum-property"
-        },
-        "multipleOf": {
-          "$ref": "#/definitions/multiple-of-property"
-        },
-        "minLength": {
-          "$ref": "#/definitions/min-length-property"
-        },
-        "maxLength": {
-          "$ref": "#/definitions/max-length-property"
-        },
-        "pattern": {
-          "$ref": "#/definitions/pattern-property"
-        },
-        "enum": {
-          "$ref": "#/definitions/enum-property"
-        },
-        "items": {
-          "$ref": "#/definitions/items-property"
-        },
-        "minItems": {
-          "$ref": "#/definitions/min-items-property"
-        },
-        "maxItems": {
-          "$ref": "#/definitions/max-items-property"
-        },
-        "uniqueItems": {
-          "$ref": "#/definitions/unique-items-property"
-        },
-        "required": {
-          "$ref": "#/definitions/required-property"
-        },
-        "properties": {
-          "$ref": "#/definitions/properties-property"
-        },
-        "patternProperties": {
-          "$ref": "#/definitions/pattern-properties-property"
-        },
-        "additionalProperties": {
-          "$ref": "#/definitions/additional-properties-property"
-        },
-        "minProperties": {
-          "$ref": "#/definitions/min-properties-property"
-        },
-        "maxProperties": {
-          "$ref": "#/definitions/max-properties-property"
-        },
-        "const": {
-          "$ref": "#/definitions/const-property"
-        },
-        "default": {
-          "$ref": "#/definitions/default-property"
-        },
-        "examples": {
-          "$ref": "#/definitions/examples-property"
-        },
-        "not": {
-          "$ref": "#/definitions/not-property"
-        },
-        "anyOf": {
-          "$ref": "#/definitions/any-of-property"
-        },
-        "oneOf": {
-          "$ref": "#/definitions/one-of-property"
-        },
-        "allOf": {
-          "$ref": "#/definitions/all-of-property"
-        },
-        "if": {
-          "$ref": "#/definitions/if-property"
-        },
-        "then": {
-          "$ref": "#/definitions/then-property"
-        },
-        "else": {
-          "$ref": "#/definitions/else-property"
-        }
+      "required-property": {
+          "description": "Required sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+              "description": "A required sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
+              "type": "string",
+              "minLength": 1
+          },
+          "minLength": 1
       },
-      "$ref": "#/definitions/entity-dependencies"
-    },
-    "condition-entity": {
-      "description": "A mapping from sub-property name to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-      "type": "object",
-      "properties": {
-        "$comment": {
-          "$ref": "#/definitions/comment-property"
-        },
-        "$ref": {
-          "$ref": "#/definitions/ref-property"
-        },
-        "type": {
-          "$ref": "#/definitions/type-property"
-        },
-        "minimum": {
-          "$ref": "#/definitions/minimum-property"
-        },
-        "maximum": {
-          "$ref": "#/definitions/maximum-property"
-        },
-        "exclusiveMinimum": {
-          "$ref": "#/definitions/exclusive-minimum-property"
-        },
-        "exclusiveMaximum": {
-          "$ref": "#/definitions/exclusive-maximum-property"
-        },
-        "multipleOf": {
-          "$ref": "#/definitions/multiple-of-property"
-        },
-        "minLength": {
-          "$ref": "#/definitions/min-length-property"
-        },
-        "maxLength": {
-          "$ref": "#/definitions/max-length-property"
-        },
-        "pattern": {
-          "$ref": "#/definitions/pattern-property"
-        },
-        "enum": {
-          "$ref": "#/definitions/enum-property"
-        },
-        "items": {
-          "$ref": "#/definitions/condition-entity"
-        },
-        "minItems": {
-          "$ref": "#/definitions/min-items-property"
-        },
-        "maxItems": {
-          "$ref": "#/definitions/max-items-property"
-        },
-        "uniqueItems": {
-          "$ref": "#/definitions/unique-items-property"
-        },
-        "required": {
-          "$ref": "#/definitions/required-property"
-        },
-        "properties": {
-          "$ref": "#/definitions/properties-property"
-        },
-        "patternProperties": {
-          "$ref": "#/definitions/pattern-properties-property"
-        },
-        "additionalProperties": {
-          "$ref": "#/definitions/additional-properties-property"
-        },
-        "minProperties": {
-          "$ref": "#/definitions/min-properties-property"
-        },
-        "maxProperties": {
-          "$ref": "#/definitions/max-properties-property"
-        },
-        "const": {
-          "$ref": "#/definitions/const-property"
-        },
-        "default": {
-          "$ref": "#/definitions/default-property"
-        }
-      },
-      "additionalProperties": false
-    },
-    "requirement-entity": {
-      "description": "A mapping from sub-property name to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-      "type": "object",
-      "properties": {
-        "$comment": {
-          "$ref": "#/definitions/comment-property"
-        },
-        "$ref": {
-          "$ref": "#/definitions/ref-property"
-        },
-        "title": {
-          "$ref": "#/definitions/title-property"
-        },
-        "description": {
-          "$ref": "#/definitions/description-property"
-        },
-        "type": {
-          "$ref": "#/definitions/type-property"
-        },
-        "minimum": {
-          "$ref": "#/definitions/minimum-property"
-        },
-        "maximum": {
-          "$ref": "#/definitions/maximum-property"
-        },
-        "exclusiveMinimum": {
-          "$ref": "#/definitions/exclusive-minimum-property"
-        },
-        "exclusiveMaximum": {
-          "$ref": "#/definitions/exclusive-maximum-property"
-        },
-        "multipleOf": {
-          "$ref": "#/definitions/multiple-of-property"
-        },
-        "minLength": {
-          "$ref": "#/definitions/min-length-property"
-        },
-        "maxLength": {
-          "$ref": "#/definitions/max-length-property"
-        },
-        "pattern": {
-          "$ref": "#/definitions/pattern-property"
-        },
-        "enum": {
-          "$ref": "#/definitions/enum-property"
-        },
-        "items": {
-          "$ref": "#/definitions/requirement-entity"
-        },
-        "minItems": {
-          "$ref": "#/definitions/min-items-property"
-        },
-        "maxItems": {
-          "$ref": "#/definitions/max-items-property"
-        },
-        "uniqueItems": {
-          "$ref": "#/definitions/unique-items-property"
-        },
-        "required": {
-          "$ref": "#/definitions/required-property"
-        },
-        "properties": {
-          "$ref": "#/definitions/properties-property"
-        },
-        "patternProperties": {
-          "$ref": "#/definitions/pattern-properties-property"
-        },
-        "additionalProperties": {
-          "$ref": "#/definitions/additional-properties-property"
-        },
-        "minProperties": {
-          "$ref": "#/definitions/min-properties-property"
-        },
-        "maxProperties": {
-          "$ref": "#/definitions/max-properties-property"
-        },
-        "default": {
-          "$ref": "#/definitions/default-property"
-        },
-        "examples": {
-          "$ref": "#/definitions/examples-property"
-        }
-      },
-      "additionalProperties": false
-    },
-    "requirements": {
-      "required": ["properties"],
-      "properties": {
-        "properties": {
-          "description": "A mapping from sub-property names to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "properties-property": {
+          "description": "Sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=properties#properties",
           "type": "object",
           "patternProperties": {
-            ".": {
-              "$ref": "#/definitions/requirement-entity"
-            }
+              ".": {
+                  "description": "A sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=properties#properties",
+                  "$ref": "#/definitions/entity"
+              }
           },
+          "additionalProperties": false
+      },
+      "pattern-properties-property": {
+          "description": "Pattern sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
+          "type": "object",
+          "properties": {
+              ".": {
+                  "description": "A pattern sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
+                  "$ref": "#/definitions/entity"
+              }
+          },
+          "patternProperties": {
+              ".": {
+                  "description": "A pattern sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
+                  "$ref": "#/definitions/entity"
+              }
+          },
+          "additionalProperties": false
+      },
+      "additional-properties-property": {
+          "description": "Additional sub-properties of the current property or definition or whether to allow them\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#additional-properties",
+          "oneOf": [
+              {
+                  "type": "boolean",
+                  "const": false
+              },
+              {
+                  "$ref": "#/definitions/entity"
+              }
+          ]
+      },
+      "min-properties-property": {
+          "description": "A minimum count of sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#size",
+          "type": "integer",
+          "minimum": 1,
+          "default": 1
+      },
+      "max-properties-property": {
+          "description": "A maximum count of sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#size",
+          "type": "integer",
+          "minimum": 1,
+          "default": 1
+      },
+      "const-property": {
+          "description": "A constant of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=const#constant-values",
+          "$ref": "#/definitions/simple-type"
+      },
+      "default-property": {
+          "description": "A default of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
+          "$ref": "#/definitions/simple-type"
+      },
+      "examples-property": {
+          "description": "Examples of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+              "description": "An example of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
+              "$ref": "#/definitions/simple-type"
+          },
+          "minLength": 1
+      },
+      "not-property": {
+          "description": "A sub-schema should not match of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#not",
+          "$ref": "#/definitions/sub-schema-entity",
+          "minProperties": 1
+      },
+      "any-of-property": {
+          "description": "A requirement to match at least one sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#anyof",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 2,
+          "items": {
+              "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#anyof",
+              "$ref": "#/definitions/sub-schema-entity"
+          }
+      },
+      "one-of-property": {
+          "description": "A requirement to match at one sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#oneof",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 2,
+          "items": {
+              "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#oneof",
+              "$ref": "#/definitions/sub-schema-entity"
+          }
+      },
+      "all-of-property": {
+          "description": "A requirement to match all sub-schemas of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#allof",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 2,
+          "items": {
+              "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#allof",
+              "$ref": "#/definitions/sub-schema-entity"
+          }
+      },
+      "sub-schema-entity": {
+          "type": "object",
+          "properties": {
+              "$comment": {
+                  "$ref": "#/definitions/comment-property"
+              },
+              "$ref": {
+                  "$ref": "#/definitions/ref-property"
+              },
+              "type": {
+                  "$ref": "#/definitions/type-property"
+              },
+              "minimum": {
+                  "$ref": "#/definitions/minimum-property"
+              },
+              "maximum": {
+                  "$ref": "#/definitions/maximum-property"
+              },
+              "exclusiveMinimum": {
+                  "$ref": "#/definitions/exclusive-minimum-property"
+              },
+              "exclusiveMaximum": {
+                  "$ref": "#/definitions/exclusive-maximum-property"
+              },
+              "multipleOf": {
+                  "$ref": "#/definitions/multiple-of-property"
+              },
+              "minLength": {
+                  "$ref": "#/definitions/min-length-property"
+              },
+              "maxLength": {
+                  "$ref": "#/definitions/max-length-property"
+              },
+              "pattern": {
+                  "$ref": "#/definitions/pattern-property"
+              },
+              "enum": {
+                  "$ref": "#/definitions/enum-property"
+              },
+              "items": {
+                  "$ref": "#/definitions/items-property"
+              },
+              "minItems": {
+                  "$ref": "#/definitions/min-items-property"
+              },
+              "maxItems": {
+                  "$ref": "#/definitions/max-items-property"
+              },
+              "uniqueItems": {
+                  "$ref": "#/definitions/unique-items-property"
+              },
+              "required": {
+                  "$ref": "#/definitions/required-property"
+              },
+              "properties": {
+                  "$ref": "#/definitions/properties-property"
+              },
+              "patternProperties": {
+                  "$ref": "#/definitions/pattern-properties-property"
+              },
+              "additionalProperties": {
+                  "$ref": "#/definitions/additional-properties-property"
+              },
+              "minProperties": {
+                  "$ref": "#/definitions/min-properties-property"
+              },
+              "maxProperties": {
+                  "$ref": "#/definitions/max-properties-property"
+              },
+              "const": {
+                  "$ref": "#/definitions/const-property"
+              },
+              "default": {
+                  "$ref": "#/definitions/default-property"
+              },
+              "examples": {
+                  "$ref": "#/definitions/examples-property"
+              },
+              "not": {
+                  "$ref": "#/definitions/not-property"
+              },
+              "anyOf": {
+                  "$ref": "#/definitions/any-of-property"
+              },
+              "oneOf": {
+                  "$ref": "#/definitions/one-of-property"
+              },
+              "allOf": {
+                  "$ref": "#/definitions/all-of-property"
+              },
+              "if": {
+                  "$ref": "#/definitions/if-property"
+              },
+              "then": {
+                  "$ref": "#/definitions/then-property"
+              },
+              "else": {
+                  "$ref": "#/definitions/else-property"
+              }
+          },
+          "$ref": "#/definitions/entity-dependencies",
           "minProperties": 1,
           "additionalProperties": false
-        },
-        "additionalProperties": {
-          "$ref": "#/definitions/additional-properties-property"
-        },
-        "minProperties": {
-          "$ref": "#/definitions/min-properties-property"
-        },
-        "maxProperties": {
-          "$ref": "#/definitions/max-properties-property"
-        }
       },
-      "additionalProperties": false
-    },
-    "entity-dependencies": {
-      "dependencies": {
-        "minimum": {
-          "$ref": "#/definitions/numeric-type-requirement"
-        },
-        "maximum": {
-          "$ref": "#/definitions/numeric-type-requirement"
-        },
-        "exclusiveMinimum": {
-          "$ref": "#/definitions/numeric-type-requirement"
-        },
-        "exclusiveMaximum": {
-          "$ref": "#/definitions/numeric-type-requirement"
-        },
-        "multipleOf": {
-          "$ref": "#/definitions/numeric-type-requirement"
-        },
-        "minLength": {
-          "$ref": "#/definitions/string-type-requirement"
-        },
-        "maxLength": {
-          "$ref": "#/definitions/string-type-requirement"
-        },
-        "pattern": {
-          "$ref": "#/definitions/string-type-requirement"
-        },
-        "enum": {
-          "$ref": "#/definitions/simple-type-requirement"
-        },
-        "items": {
-          "$ref": "#/definitions/array-type-requirement"
-        },
-        "minItems": {
-          "$ref": "#/definitions/array-type-requirement"
-        },
-        "maxItems": {
-          "$ref": "#/definitions/array-type-requirement"
-        },
-        "uniqueItems": {
-          "$ref": "#/definitions/array-type-requirement"
-        },
-        "required": {
-          "$ref": "#/definitions/object-type-requirement"
-        },
-        "properties": {
-          "$ref": "#/definitions/object-type-requirement"
-        },
-        "patternProperties": {
-          "$ref": "#/definitions/object-type-requirement"
-        },
-        "additionalProperties": {
-          "$ref": "#/definitions/object-type-requirement"
-        },
-        "minProperties": {
-          "$ref": "#/definitions/object-type-requirement"
-        },
-        "maxProperties": {
-          "$ref": "#/definitions/object-type-requirement"
-        },
-        "if": ["then"],
-        "then": ["if"],
-        "else": ["if", "then"]
+      "condition-entity": {
+          "description": "A mapping from sub-property name to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+          "type": "object",
+          "properties": {
+              "$comment": {
+                  "$ref": "#/definitions/comment-property"
+              },
+              "$ref": {
+                  "$ref": "#/definitions/ref-property"
+              },
+              "type": {
+                  "$ref": "#/definitions/type-property"
+              },
+              "minimum": {
+                  "$ref": "#/definitions/minimum-property"
+              },
+              "maximum": {
+                  "$ref": "#/definitions/maximum-property"
+              },
+              "exclusiveMinimum": {
+                  "$ref": "#/definitions/exclusive-minimum-property"
+              },
+              "exclusiveMaximum": {
+                  "$ref": "#/definitions/exclusive-maximum-property"
+              },
+              "multipleOf": {
+                  "$ref": "#/definitions/multiple-of-property"
+              },
+              "minLength": {
+                  "$ref": "#/definitions/min-length-property"
+              },
+              "maxLength": {
+                  "$ref": "#/definitions/max-length-property"
+              },
+              "pattern": {
+                  "$ref": "#/definitions/pattern-property"
+              },
+              "enum": {
+                  "$ref": "#/definitions/enum-property"
+              },
+              "items": {
+                  "$ref": "#/definitions/condition-entity"
+              },
+              "minItems": {
+                  "$ref": "#/definitions/min-items-property"
+              },
+              "maxItems": {
+                  "$ref": "#/definitions/max-items-property"
+              },
+              "uniqueItems": {
+                  "$ref": "#/definitions/unique-items-property"
+              },
+              "required": {
+                  "$ref": "#/definitions/required-property"
+              },
+              "properties": {
+                  "$ref": "#/definitions/properties-property"
+              },
+              "patternProperties": {
+                  "$ref": "#/definitions/pattern-properties-property"
+              },
+              "additionalProperties": {
+                  "$ref": "#/definitions/additional-properties-property"
+              },
+              "minProperties": {
+                  "$ref": "#/definitions/min-properties-property"
+              },
+              "maxProperties": {
+                  "$ref": "#/definitions/max-properties-property"
+              },
+              "const": {
+                  "$ref": "#/definitions/const-property"
+              },
+              "default": {
+                  "$ref": "#/definitions/default-property"
+              }
+          },
+          "additionalProperties": false
+      },
+      "requirement-entity": {
+          "description": "A mapping from sub-property name to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+          "type": "object",
+          "properties": {
+              "$comment": {
+                  "$ref": "#/definitions/comment-property"
+              },
+              "$ref": {
+                  "$ref": "#/definitions/ref-property"
+              },
+              "title": {
+                  "$ref": "#/definitions/title-property"
+              },
+              "description": {
+                  "$ref": "#/definitions/description-property"
+              },
+              "type": {
+                  "$ref": "#/definitions/type-property"
+              },
+              "minimum": {
+                  "$ref": "#/definitions/minimum-property"
+              },
+              "maximum": {
+                  "$ref": "#/definitions/maximum-property"
+              },
+              "exclusiveMinimum": {
+                  "$ref": "#/definitions/exclusive-minimum-property"
+              },
+              "exclusiveMaximum": {
+                  "$ref": "#/definitions/exclusive-maximum-property"
+              },
+              "multipleOf": {
+                  "$ref": "#/definitions/multiple-of-property"
+              },
+              "minLength": {
+                  "$ref": "#/definitions/min-length-property"
+              },
+              "maxLength": {
+                  "$ref": "#/definitions/max-length-property"
+              },
+              "pattern": {
+                  "$ref": "#/definitions/pattern-property"
+              },
+              "enum": {
+                  "$ref": "#/definitions/enum-property"
+              },
+              "items": {
+                  "$ref": "#/definitions/requirement-entity"
+              },
+              "minItems": {
+                  "$ref": "#/definitions/min-items-property"
+              },
+              "maxItems": {
+                  "$ref": "#/definitions/max-items-property"
+              },
+              "uniqueItems": {
+                  "$ref": "#/definitions/unique-items-property"
+              },
+              "required": {
+                  "$ref": "#/definitions/required-property"
+              },
+              "properties": {
+                  "$ref": "#/definitions/properties-property"
+              },
+              "patternProperties": {
+                  "$ref": "#/definitions/pattern-properties-property"
+              },
+              "additionalProperties": {
+                  "$ref": "#/definitions/additional-properties-property"
+              },
+              "minProperties": {
+                  "$ref": "#/definitions/min-properties-property"
+              },
+              "maxProperties": {
+                  "$ref": "#/definitions/max-properties-property"
+              },
+              "default": {
+                  "$ref": "#/definitions/default-property"
+              },
+              "examples": {
+                  "$ref": "#/definitions/examples-property"
+              }
+          },
+          "additionalProperties": false
+      },
+      "requirements": {
+          "required": [
+              "properties"
+          ],
+          "properties": {
+              "properties": {
+                  "description": "A mapping from sub-property names to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+                  "type": "object",
+                  "patternProperties": {
+                      ".": {
+                          "$ref": "#/definitions/requirement-entity"
+                      }
+                  },
+                  "minProperties": 1,
+                  "additionalProperties": false
+              },
+              "additionalProperties": {
+                  "$ref": "#/definitions/additional-properties-property"
+              },
+              "minProperties": {
+                  "$ref": "#/definitions/min-properties-property"
+              },
+              "maxProperties": {
+                  "$ref": "#/definitions/max-properties-property"
+              }
+          },
+          "additionalProperties": false
+      },
+      "entity-dependencies": {
+          "dependencies": {
+              "minimum": {
+                  "$ref": "#/definitions/numeric-type-requirement"
+              },
+              "maximum": {
+                  "$ref": "#/definitions/numeric-type-requirement"
+              },
+              "exclusiveMinimum": {
+                  "$ref": "#/definitions/numeric-type-requirement"
+              },
+              "exclusiveMaximum": {
+                  "$ref": "#/definitions/numeric-type-requirement"
+              },
+              "multipleOf": {
+                  "$ref": "#/definitions/numeric-type-requirement"
+              },
+              "minLength": {
+                  "$ref": "#/definitions/string-type-requirement"
+              },
+              "maxLength": {
+                  "$ref": "#/definitions/string-type-requirement"
+              },
+              "pattern": {
+                  "$ref": "#/definitions/string-type-requirement"
+              },
+              "enum": {
+                  "$ref": "#/definitions/simple-type-requirement"
+              },
+              "items": {
+                  "$ref": "#/definitions/array-type-requirement"
+              },
+              "minItems": {
+                  "$ref": "#/definitions/array-type-requirement"
+              },
+              "maxItems": {
+                  "$ref": "#/definitions/array-type-requirement"
+              },
+              "uniqueItems": {
+                  "$ref": "#/definitions/array-type-requirement"
+              },
+              "required": {
+                  "$ref": "#/definitions/object-type-requirement"
+              },
+              "properties": {
+                  "$ref": "#/definitions/object-type-requirement"
+              },
+              "patternProperties": {
+                  "$ref": "#/definitions/object-type-requirement"
+              },
+              "additionalProperties": {
+                  "$ref": "#/definitions/object-type-requirement"
+              },
+              "minProperties": {
+                  "$ref": "#/definitions/object-type-requirement"
+              },
+              "maxProperties": {
+                  "$ref": "#/definitions/object-type-requirement"
+              },
+              "if": [
+                  "then"
+              ],
+              "then": [
+                  "if"
+              ],
+              "else": [
+                  "if",
+                  "then"
+              ],
+              "$ref": {
+                  "required": []
+              }
+          }
+      },
+      "entity-requirements-and-dependencies": {
+          "required": [
+              "title",
+              "description",
+              "type"
+          ],
+          "$ref": "#/definitions/entity-dependencies"
+      },
+      "if-property": {
+          "description": "A conditional header of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+          "type": "object",
+          "required": [
+              "properties"
+          ],
+          "properties": {
+              "properties": {
+                  "description": "A mapping from sub-property names to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+                  "type": "object",
+                  "patternProperties": {
+                      ".": {
+                          "$ref": "#/definitions/condition-entity"
+                      }
+                  },
+                  "additionalProperties": false
+              }
+          },
+          "additionalProperties": false
+      },
+      "then-property": {
+          "description": "A conditional branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+          "type": "object",
+          "$ref": "#/definitions/requirements"
+      },
+      "else-property": {
+          "description": "A conditional else branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+          "type": "object",
+          "$ref": "#/definitions/requirements"
+      },
+      "entity": {
+          "type": "object",
+          "properties": {
+              "$comment": {
+                  "$ref": "#/definitions/comment-property"
+              },
+              "$ref": {
+                  "$ref": "#/definitions/ref-property"
+              },
+              "title": {
+                  "$ref": "#/definitions/title-property"
+              },
+              "description": {
+                  "$ref": "#/definitions/description-property"
+              },
+              "type": {
+                  "$ref": "#/definitions/type-property"
+              },
+              "minimum": {
+                  "$ref": "#/definitions/minimum-property"
+              },
+              "maximum": {
+                  "$ref": "#/definitions/maximum-property"
+              },
+              "exclusiveMinimum": {
+                  "$ref": "#/definitions/exclusive-minimum-property"
+              },
+              "exclusiveMaximum": {
+                  "$ref": "#/definitions/exclusive-maximum-property"
+              },
+              "multipleOf": {
+                  "$ref": "#/definitions/multiple-of-property"
+              },
+              "minLength": {
+                  "$ref": "#/definitions/min-length-property"
+              },
+              "maxLength": {
+                  "$ref": "#/definitions/max-length-property"
+              },
+              "pattern": {
+                  "$ref": "#/definitions/pattern-property"
+              },
+              "enum": {
+                  "$ref": "#/definitions/enum-property"
+              },
+              "items": {
+                  "$ref": "#/definitions/items-property"
+              },
+              "minItems": {
+                  "$ref": "#/definitions/min-items-property"
+              },
+              "maxItems": {
+                  "$ref": "#/definitions/max-items-property"
+              },
+              "uniqueItems": {
+                  "$ref": "#/definitions/unique-items-property"
+              },
+              "required": {
+                  "$ref": "#/definitions/required-property"
+              },
+              "properties": {
+                  "$ref": "#/definitions/properties-property"
+              },
+              "patternProperties": {
+                  "$ref": "#/definitions/pattern-properties-property"
+              },
+              "additionalProperties": {
+                  "$ref": "#/definitions/additional-properties-property"
+              },
+              "minProperties": {
+                  "$ref": "#/definitions/min-properties-property"
+              },
+              "maxProperties": {
+                  "$ref": "#/definitions/max-properties-property"
+              },
+              "const": {
+                  "$ref": "#/definitions/const-property"
+              },
+              "default": {
+                  "$ref": "#/definitions/default-property"
+              },
+              "examples": {
+                  "$ref": "#/definitions/examples-property"
+              },
+              "not": {
+                  "$ref": "#/definitions/not-property"
+              },
+              "anyOf": {
+                  "$ref": "#/definitions/any-of-property"
+              },
+              "oneOf": {
+                  "$ref": "#/definitions/one-of-property"
+              },
+              "allOf": {
+                  "$ref": "#/definitions/all-of-property"
+              },
+              "if": {
+                  "$ref": "#/definitions/if-property"
+              },
+              "then": {
+                  "$ref": "#/definitions/then-property"
+              },
+              "else": {
+                  "$ref": "#/definitions/else-property"
+              }
+          },
+          "$ref": "#/definitions/entity-requirements-and-dependencies",
+          "additionalProperties": false
+      },
+      "root-entity": {
+          "type": "object",
+          "properties": {
+              "$schema": {
+                  "description": "A schema used to validate this JSON schema",
+                  "type": "string",
+                  "minLength": 1,
+                  "examples": [
+                      "http://json-schema.org/draft-04/schema#",
+                      "http://json-schema.org/draft-07/schema#",
+                      "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json"
+                  ]
+              },
+              "definitions": {
+                  "description": "Definitions",
+                  "type": "object",
+                  "patternProperties": {
+                      ".": {
+                          "description": "A definition",
+                          "$ref": "#/definitions/entity"
+                      }
+                  },
+                  "additionalProperties": false
+              },
+              "$comment": {
+                  "$ref": "#/definitions/comment-property"
+              },
+              "$ref": {
+                  "$ref": "#/definitions/ref-property"
+              },
+              "title": {
+                  "$ref": "#/definitions/title-property"
+              },
+              "description": {
+                  "$ref": "#/definitions/description-property"
+              },
+              "type": {
+                  "$ref": "#/definitions/type-property"
+              },
+              "minimum": {
+                  "$ref": "#/definitions/minimum-property"
+              },
+              "maximum": {
+                  "$ref": "#/definitions/maximum-property"
+              },
+              "exclusiveMinimum": {
+                  "$ref": "#/definitions/exclusive-minimum-property"
+              },
+              "exclusiveMaximum": {
+                  "$ref": "#/definitions/exclusive-maximum-property"
+              },
+              "multipleOf": {
+                  "$ref": "#/definitions/multiple-of-property"
+              },
+              "minLength": {
+                  "$ref": "#/definitions/min-length-property"
+              },
+              "maxLength": {
+                  "$ref": "#/definitions/max-length-property"
+              },
+              "pattern": {
+                  "$ref": "#/definitions/pattern-property"
+              },
+              "enum": {
+                  "$ref": "#/definitions/enum-property"
+              },
+              "items": {
+                  "$ref": "#/definitions/items-property"
+              },
+              "minItems": {
+                  "$ref": "#/definitions/min-items-property"
+              },
+              "maxItems": {
+                  "$ref": "#/definitions/max-items-property"
+              },
+              "uniqueItems": {
+                  "$ref": "#/definitions/unique-items-property"
+              },
+              "required": {
+                  "$ref": "#/definitions/required-property"
+              },
+              "properties": {
+                  "$ref": "#/definitions/properties-property"
+              },
+              "patternProperties": {
+                  "$ref": "#/definitions/pattern-properties-property"
+              },
+              "additionalProperties": {
+                  "$ref": "#/definitions/additional-properties-property"
+              },
+              "minProperties": {
+                  "$ref": "#/definitions/min-properties-property"
+              },
+              "maxProperties": {
+                  "$ref": "#/definitions/max-properties-property"
+              },
+              "const": {
+                  "$ref": "#/definitions/const-property"
+              },
+              "default": {
+                  "$ref": "#/definitions/default-property"
+              },
+              "examples": {
+                  "$ref": "#/definitions/examples-property"
+              },
+              "not": {
+                  "$ref": "#/definitions/not-property"
+              },
+              "anyOf": {
+                  "$ref": "#/definitions/any-of-property"
+              },
+              "oneOf": {
+                  "$ref": "#/definitions/one-of-property"
+              },
+              "allOf": {
+                  "$ref": "#/definitions/all-of-property"
+              },
+              "if": {
+                  "$ref": "#/definitions/if-property"
+              },
+              "then": {
+                  "$ref": "#/definitions/then-property"
+              },
+              "else": {
+                  "$ref": "#/definitions/else-property"
+              }
+          },
+          "$ref": "#/definitions/entity-requirements-and-dependencies",
+          "additionalProperties": false
       }
-    },
-    "entity-requirements-and-dependencies": {
-      "required": ["title", "description", "type"],
-      "$ref": "#/definitions/entity-dependencies"
-    },
-    "if-property": {
-      "description": "A conditional header of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-      "type": "object",
-      "required": ["properties"],
-      "properties": {
-        "properties": {
-          "description": "A mapping from sub-property names to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-          "type": "object",
-          "patternProperties": {
-            ".": {
-              "$ref": "#/definitions/condition-entity"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "then-property": {
-      "description": "A conditional branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-      "type": "object",
-      "$ref": "#/definitions/requirements"
-    },
-    "else-property": {
-      "description": "A conditional else branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-      "type": "object",
-      "$ref": "#/definitions/requirements"
-    },
-    "entity": {
-      "type": "object",
-      "properties": {
-        "$comment": {
-          "$ref": "#/definitions/comment-property"
-        },
-        "$ref": {
-          "$ref": "#/definitions/ref-property"
-        },
-        "title": {
-          "$ref": "#/definitions/title-property"
-        },
-        "description": {
-          "$ref": "#/definitions/description-property"
-        },
-        "type": {
-          "$ref": "#/definitions/type-property"
-        },
-        "minimum": {
-          "$ref": "#/definitions/minimum-property"
-        },
-        "maximum": {
-          "$ref": "#/definitions/maximum-property"
-        },
-        "exclusiveMinimum": {
-          "$ref": "#/definitions/exclusive-minimum-property"
-        },
-        "exclusiveMaximum": {
-          "$ref": "#/definitions/exclusive-maximum-property"
-        },
-        "multipleOf": {
-          "$ref": "#/definitions/multiple-of-property"
-        },
-        "minLength": {
-          "$ref": "#/definitions/min-length-property"
-        },
-        "maxLength": {
-          "$ref": "#/definitions/max-length-property"
-        },
-        "pattern": {
-          "$ref": "#/definitions/pattern-property"
-        },
-        "enum": {
-          "$ref": "#/definitions/enum-property"
-        },
-        "items": {
-          "$ref": "#/definitions/items-property"
-        },
-        "minItems": {
-          "$ref": "#/definitions/min-items-property"
-        },
-        "maxItems": {
-          "$ref": "#/definitions/max-items-property"
-        },
-        "uniqueItems": {
-          "$ref": "#/definitions/unique-items-property"
-        },
-        "required": {
-          "$ref": "#/definitions/required-property"
-        },
-        "properties": {
-          "$ref": "#/definitions/properties-property"
-        },
-        "patternProperties": {
-          "$ref": "#/definitions/pattern-properties-property"
-        },
-        "additionalProperties": {
-          "$ref": "#/definitions/additional-properties-property"
-        },
-        "minProperties": {
-          "$ref": "#/definitions/min-properties-property"
-        },
-        "maxProperties": {
-          "$ref": "#/definitions/max-properties-property"
-        },
-        "const": {
-          "$ref": "#/definitions/const-property"
-        },
-        "default": {
-          "$ref": "#/definitions/default-property"
-        },
-        "examples": {
-          "$ref": "#/definitions/examples-property"
-        },
-        "not": {
-          "$ref": "#/definitions/not-property"
-        },
-        "anyOf": {
-          "$ref": "#/definitions/any-of-property"
-        },
-        "oneOf": {
-          "$ref": "#/definitions/one-of-property"
-        },
-        "allOf": {
-          "$ref": "#/definitions/all-of-property"
-        },
-        "if": {
-          "$ref": "#/definitions/if-property"
-        },
-        "then": {
-          "$ref": "#/definitions/then-property"
-        },
-        "else": {
-          "$ref": "#/definitions/else-property"
-        }
-      },
-      "$ref": "#/definitions/entity-requirements-and-dependencies"
-    },
-    "root-entity": {
-      "type": "object",
-      "properties": {
-        "definitions": {
-          "description": "Definitions",
-          "type": "object",
-          "patternProperties": {
-            ".": {
-              "description": "A definition",
-              "$ref": "#/definitions/entity"
-            }
-          },
-          "additionalProperties": false
-        },
-        "$comment": {
-          "$ref": "#/definitions/comment-property"
-        },
-        "$ref": {
-          "$ref": "#/definitions/ref-property"
-        },
-        "title": {
-          "$ref": "#/definitions/title-property"
-        },
-        "description": {
-          "$ref": "#/definitions/description-property"
-        },
-        "type": {
-          "$ref": "#/definitions/type-property"
-        },
-        "minimum": {
-          "$ref": "#/definitions/minimum-property"
-        },
-        "maximum": {
-          "$ref": "#/definitions/maximum-property"
-        },
-        "exclusiveMinimum": {
-          "$ref": "#/definitions/exclusive-minimum-property"
-        },
-        "exclusiveMaximum": {
-          "$ref": "#/definitions/exclusive-maximum-property"
-        },
-        "multipleOf": {
-          "$ref": "#/definitions/multiple-of-property"
-        },
-        "minLength": {
-          "$ref": "#/definitions/min-length-property"
-        },
-        "maxLength": {
-          "$ref": "#/definitions/max-length-property"
-        },
-        "pattern": {
-          "$ref": "#/definitions/pattern-property"
-        },
-        "enum": {
-          "$ref": "#/definitions/enum-property"
-        },
-        "items": {
-          "$ref": "#/definitions/items-property"
-        },
-        "minItems": {
-          "$ref": "#/definitions/min-items-property"
-        },
-        "maxItems": {
-          "$ref": "#/definitions/max-items-property"
-        },
-        "uniqueItems": {
-          "$ref": "#/definitions/unique-items-property"
-        },
-        "required": {
-          "$ref": "#/definitions/required-property"
-        },
-        "properties": {
-          "$ref": "#/definitions/properties-property"
-        },
-        "patternProperties": {
-          "$ref": "#/definitions/pattern-properties-property"
-        },
-        "additionalProperties": {
-          "$ref": "#/definitions/additional-properties-property"
-        },
-        "minProperties": {
-          "$ref": "#/definitions/min-properties-property"
-        },
-        "maxProperties": {
-          "$ref": "#/definitions/max-properties-property"
-        },
-        "const": {
-          "$ref": "#/definitions/const-property"
-        },
-        "default": {
-          "$ref": "#/definitions/default-property"
-        },
-        "examples": {
-          "$ref": "#/definitions/examples-property"
-        },
-        "not": {
-          "$ref": "#/definitions/not-property"
-        },
-        "anyOf": {
-          "$ref": "#/definitions/any-of-property"
-        },
-        "oneOf": {
-          "$ref": "#/definitions/one-of-property"
-        },
-        "allOf": {
-          "$ref": "#/definitions/all-of-property"
-        },
-        "if": {
-          "$ref": "#/definitions/if-property"
-        },
-        "then": {
-          "$ref": "#/definitions/then-property"
-        },
-        "else": {
-          "$ref": "#/definitions/else-property"
-        }
-      },
-      "$ref": "#/definitions/entity-requirements-and-dependencies"
-    }
   },
   "description": "A schema\nhttps://json-schema.org/understanding-json-schema/index.html",
   "$ref": "#/definitions/root-entity"

--- a/src/schemas/json/metaschema-draft-07-unofficial-strict.json
+++ b/src/schemas/json/metaschema-draft-07-unofficial-strict.json
@@ -2,996 +2,958 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json",
   "definitions": {
-      "space-string": {
-          "pattern": "^\\s+$|\\s{2,}"
-      },
-      "simple-type": {
-          "type": [
-              "boolean",
-              "integer",
-              "null",
-              "number",
-              "string"
-          ]
-      },
-      "numeric-type-requirement": {
-          "oneOf": [
-              {
-                  "properties": {
-                      "type": {
-                          "const": "integer"
-                      }
-                  }
-              },
-              {
-                  "properties": {
-                      "type": {
-                          "const": "number"
-                      }
-                  }
-              }
-          ]
-      },
-      "string-type-requirement": {
+    "space-string": {
+      "pattern": "^\\s+$|\\s{2,}"
+    },
+    "simple-type": {
+      "type": ["boolean", "integer", "null", "number", "string"]
+    },
+    "numeric-type-requirement": {
+      "oneOf": [
+        {
           "properties": {
-              "type": {
-                  "const": "string"
-              }
+            "type": {
+              "const": "integer"
+            }
           }
-      },
-      "array-type-requirement": {
+        },
+        {
           "properties": {
-              "type": {
-                  "const": "array"
-              }
+            "type": {
+              "const": "number"
+            }
           }
-      },
-      "object-type-requirement": {
+        }
+      ]
+    },
+    "string-type-requirement": {
+      "properties": {
+        "type": {
+          "const": "string"
+        }
+      }
+    },
+    "array-type-requirement": {
+      "properties": {
+        "type": {
+          "const": "array"
+        }
+      }
+    },
+    "object-type-requirement": {
+      "properties": {
+        "type": {
+          "const": "object"
+        }
+      }
+    },
+    "simple-type-requirement": {
+      "oneOf": [
+        {
           "properties": {
-              "type": {
-                  "const": "object"
-              }
+            "type": {
+              "const": "boolean"
+            }
           }
-      },
-      "simple-type-requirement": {
-          "oneOf": [
-              {
-                  "properties": {
-                      "type": {
-                          "const": "boolean"
-                      }
-                  }
-              },
-              {
-                  "properties": {
-                      "type": {
-                          "const": "integer"
-                      }
-                  }
-              },
-              {
-                  "properties": {
-                      "type": {
-                          "const": "null"
-                      }
-                  }
-              },
-              {
-                  "properties": {
-                      "type": {
-                          "const": "number"
-                      }
-                  }
-              },
-              {
-                  "properties": {
-                      "type": {
-                          "const": "string"
-                      }
-                  }
-              }
-          ]
-      },
-      "comment-property": {
-          "description": "A comment of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html#id3",
-          "type": "string",
-          "minLength": 1,
-          "examples": [
-              "Don't remove until #issue is closed."
-          ]
-      },
-      "ref-property": {
-          "description": "A reference of the current property or definition\nhttps://json-schema.org/understanding-json-schema/structuring.html#ref",
-          "type": "string",
-          "minLength": 1,
-          "pattern": "^#/definitions/.",
-          "examples": [
-              "#/definitions/reference"
-          ]
-      },
-      "title-property": {
-          "description": "A title of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
-          "type": "string",
-          "minLength": 1,
-          "not": {
-              "$ref": "#/definitions/space-string"
-          },
-          "examples": [
-              "image",
-              "image type"
-          ]
-      },
-      "description-property": {
-          "description": "A description of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
-          "type": "string",
-          "minLength": 1,
-          "not": {
-              "$ref": "#/definitions/space-string"
-          },
-          "pattern": "\\n",
-          "examples": [
-              "An image\nurl",
-              "An image type\nurl"
-          ]
-      },
-      "type-property": {
-          "description": "A type of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/type.html",
-          "type": "string",
-          "enum": [
-              "number",
-              "integer",
-              "null",
-              "array",
-              "object",
-              "boolean",
-              "string"
-          ],
-          "default": "string"
-      },
-      "minimum-property": {
-          "description": "A minimum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
-          "type": "number",
-          "default": 0
-      },
-      "maximum-property": {
-          "description": "A maximum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
-          "type": "number",
-          "default": 0
-      },
-      "exclusive-minimum-property": {
-          "description": "An exclusive minimum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
-          "type": "number",
-          "default": 0
-      },
-      "exclusive-maximum-property": {
-          "description": "An exclusive maximum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
-          "type": "number",
-          "default": 0
-      },
-      "multiple-of-property": {
-          "description": "A multiple of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#multiples",
-          "type": "number",
-          "exclusiveMinimum": 0,
-          "default": 1
-      },
-      "min-length-property": {
-          "description": "A minimum length of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#length",
-          "type": "integer",
-          "minimum": 0
-      },
-      "max-length-property": {
-          "description": "A maximum length of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#length",
-          "type": "integer",
-          "minimum": 0
-      },
-      "pattern-property": {
-          "description": "A pattern of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#regular-expressions",
-          "type": "string",
-          "format": "regex",
-          "examples": [
-              "^.+=.*$",
-              "^--?\\w+",
-              "^#[0-9a-fA-F]{6}$"
-          ]
-      },
-      "enum-property": {
-          "description": "Valid values of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 1,
-          "items": {
-              "description": "A valid value of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
-              "$ref": "#/definitions/simple-type",
-              "examples": [
-                  "success",
-                  "failure"
-              ]
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "integer"
+            }
           }
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "null"
+            }
+          }
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "number"
+            }
+          }
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "string"
+            }
+          }
+        }
+      ]
+    },
+    "comment-property": {
+      "description": "A comment of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html#id3",
+      "type": "string",
+      "minLength": 1,
+      "examples": ["Don't remove until #issue is closed."]
+    },
+    "ref-property": {
+      "description": "A reference of the current property or definition\nhttps://json-schema.org/understanding-json-schema/structuring.html#ref",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^#/definitions/.",
+      "examples": ["#/definitions/reference"]
+    },
+    "title-property": {
+      "description": "A title of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
+      "type": "string",
+      "minLength": 1,
+      "not": {
+        "$ref": "#/definitions/space-string"
       },
-      "items-property": {
-          "description": "Items of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#items",
+      "examples": ["image", "image type"]
+    },
+    "description-property": {
+      "description": "A description of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
+      "type": "string",
+      "minLength": 1,
+      "not": {
+        "$ref": "#/definitions/space-string"
+      },
+      "pattern": "\\n",
+      "examples": ["An image\nurl", "An image type\nurl"]
+    },
+    "type-property": {
+      "description": "A type of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/type.html",
+      "type": "string",
+      "enum": [
+        "number",
+        "integer",
+        "null",
+        "array",
+        "object",
+        "boolean",
+        "string"
+      ],
+      "default": "string"
+    },
+    "minimum-property": {
+      "description": "A minimum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
+      "type": "number",
+      "default": 0
+    },
+    "maximum-property": {
+      "description": "A maximum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
+      "type": "number",
+      "default": 0
+    },
+    "exclusive-minimum-property": {
+      "description": "An exclusive minimum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
+      "type": "number",
+      "default": 0
+    },
+    "exclusive-maximum-property": {
+      "description": "An exclusive maximum of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#range",
+      "type": "number",
+      "default": 0
+    },
+    "multiple-of-property": {
+      "description": "A multiple of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/numeric.html?highlight=minimum#multiples",
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "default": 1
+    },
+    "min-length-property": {
+      "description": "A minimum length of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#length",
+      "type": "integer",
+      "minimum": 0
+    },
+    "max-length-property": {
+      "description": "A maximum length of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#length",
+      "type": "integer",
+      "minimum": 0
+    },
+    "pattern-property": {
+      "description": "A pattern of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#regular-expressions",
+      "type": "string",
+      "format": "regex",
+      "examples": ["^.+=.*$", "^--?\\w+", "^#[0-9a-fA-F]{6}$"]
+    },
+    "enum-property": {
+      "description": "Valid values of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "description": "A valid value of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
+        "$ref": "#/definitions/simple-type",
+        "examples": ["success", "failure"]
+      }
+    },
+    "items-property": {
+      "description": "Items of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#items",
+      "$ref": "#/definitions/entity"
+    },
+    "min-items-property": {
+      "description": "A minimum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "default": 1
+    },
+    "max-items-property": {
+      "description": "A maximum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "default": 1
+    },
+    "unique-items-property": {
+      "description": "Whether items of the current property or definition should be unique\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#uniqueness",
+      "type": "boolean",
+      "default": false
+    },
+    "required-property": {
+      "description": "Required sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "description": "A required sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
+        "type": "string",
+        "minLength": 1
+      },
+      "minLength": 1
+    },
+    "properties-property": {
+      "description": "Sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=properties#properties",
+      "type": "object",
+      "patternProperties": {
+        ".": {
+          "description": "A sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=properties#properties",
           "$ref": "#/definitions/entity"
+        }
       },
-      "min-items-property": {
-          "description": "A minimum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",
-          "type": "integer",
-          "exclusiveMinimum": 0,
-          "default": 1
+      "additionalProperties": false
+    },
+    "pattern-properties-property": {
+      "description": "Pattern sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
+      "type": "object",
+      "properties": {
+        ".": {
+          "description": "A pattern sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
+          "$ref": "#/definitions/entity"
+        }
       },
-      "max-items-property": {
-          "description": "A maximum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",
-          "type": "integer",
-          "exclusiveMinimum": 0,
-          "default": 1
+      "patternProperties": {
+        ".": {
+          "description": "A pattern sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
+          "$ref": "#/definitions/entity"
+        }
       },
-      "unique-items-property": {
-          "description": "Whether items of the current property or definition should be unique\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#uniqueness",
+      "additionalProperties": false
+    },
+    "additional-properties-property": {
+      "description": "Additional sub-properties of the current property or definition or whether to allow them\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#additional-properties",
+      "oneOf": [
+        {
           "type": "boolean",
-          "default": false
+          "const": false
+        },
+        {
+          "$ref": "#/definitions/entity"
+        }
+      ]
+    },
+    "min-properties-property": {
+      "description": "A minimum count of sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#size",
+      "type": "integer",
+      "minimum": 1,
+      "default": 1
+    },
+    "max-properties-property": {
+      "description": "A maximum count of sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#size",
+      "type": "integer",
+      "minimum": 1,
+      "default": 1
+    },
+    "const-property": {
+      "description": "A constant of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=const#constant-values",
+      "$ref": "#/definitions/simple-type"
+    },
+    "default-property": {
+      "description": "A default of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
+      "$ref": "#/definitions/simple-type"
+    },
+    "examples-property": {
+      "description": "Examples of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "description": "An example of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
+        "$ref": "#/definitions/simple-type"
       },
-      "required-property": {
-          "description": "Required sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-              "description": "A required sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
-              "type": "string",
-              "minLength": 1
-          },
-          "minLength": 1
+      "minLength": 1
+    },
+    "not-property": {
+      "description": "A sub-schema should not match of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#not",
+      "$ref": "#/definitions/sub-schema-entity",
+      "minProperties": 1
+    },
+    "any-of-property": {
+      "description": "A requirement to match at least one sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#anyof",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 2,
+      "items": {
+        "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#anyof",
+        "$ref": "#/definitions/sub-schema-entity"
+      }
+    },
+    "one-of-property": {
+      "description": "A requirement to match at one sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#oneof",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 2,
+      "items": {
+        "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#oneof",
+        "$ref": "#/definitions/sub-schema-entity"
+      }
+    },
+    "all-of-property": {
+      "description": "A requirement to match all sub-schemas of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#allof",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 2,
+      "items": {
+        "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#allof",
+        "$ref": "#/definitions/sub-schema-entity"
+      }
+    },
+    "sub-schema-entity": {
+      "type": "object",
+      "properties": {
+        "$comment": {
+          "$ref": "#/definitions/comment-property"
+        },
+        "$ref": {
+          "$ref": "#/definitions/ref-property"
+        },
+        "type": {
+          "$ref": "#/definitions/type-property"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum-property"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum-property"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusive-minimum-property"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusive-maximum-property"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multiple-of-property"
+        },
+        "minLength": {
+          "$ref": "#/definitions/min-length-property"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/max-length-property"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern-property"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum-property"
+        },
+        "items": {
+          "$ref": "#/definitions/items-property"
+        },
+        "minItems": {
+          "$ref": "#/definitions/min-items-property"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/max-items-property"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/unique-items-property"
+        },
+        "required": {
+          "$ref": "#/definitions/required-property"
+        },
+        "properties": {
+          "$ref": "#/definitions/properties-property"
+        },
+        "patternProperties": {
+          "$ref": "#/definitions/pattern-properties-property"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/additional-properties-property"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/min-properties-property"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/max-properties-property"
+        },
+        "const": {
+          "$ref": "#/definitions/const-property"
+        },
+        "default": {
+          "$ref": "#/definitions/default-property"
+        },
+        "examples": {
+          "$ref": "#/definitions/examples-property"
+        },
+        "not": {
+          "$ref": "#/definitions/not-property"
+        },
+        "anyOf": {
+          "$ref": "#/definitions/any-of-property"
+        },
+        "oneOf": {
+          "$ref": "#/definitions/one-of-property"
+        },
+        "allOf": {
+          "$ref": "#/definitions/all-of-property"
+        },
+        "if": {
+          "$ref": "#/definitions/if-property"
+        },
+        "then": {
+          "$ref": "#/definitions/then-property"
+        },
+        "else": {
+          "$ref": "#/definitions/else-property"
+        }
       },
-      "properties-property": {
-          "description": "Sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=properties#properties",
+      "$ref": "#/definitions/entity-dependencies",
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "condition-entity": {
+      "description": "A mapping from sub-property name to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "type": "object",
+      "properties": {
+        "$comment": {
+          "$ref": "#/definitions/comment-property"
+        },
+        "$ref": {
+          "$ref": "#/definitions/ref-property"
+        },
+        "type": {
+          "$ref": "#/definitions/type-property"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum-property"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum-property"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusive-minimum-property"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusive-maximum-property"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multiple-of-property"
+        },
+        "minLength": {
+          "$ref": "#/definitions/min-length-property"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/max-length-property"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern-property"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum-property"
+        },
+        "items": {
+          "$ref": "#/definitions/condition-entity"
+        },
+        "minItems": {
+          "$ref": "#/definitions/min-items-property"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/max-items-property"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/unique-items-property"
+        },
+        "required": {
+          "$ref": "#/definitions/required-property"
+        },
+        "properties": {
+          "$ref": "#/definitions/properties-property"
+        },
+        "patternProperties": {
+          "$ref": "#/definitions/pattern-properties-property"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/additional-properties-property"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/min-properties-property"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/max-properties-property"
+        },
+        "const": {
+          "$ref": "#/definitions/const-property"
+        },
+        "default": {
+          "$ref": "#/definitions/default-property"
+        }
+      },
+      "additionalProperties": false
+    },
+    "requirement-entity": {
+      "description": "A mapping from sub-property name to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "type": "object",
+      "properties": {
+        "$comment": {
+          "$ref": "#/definitions/comment-property"
+        },
+        "$ref": {
+          "$ref": "#/definitions/ref-property"
+        },
+        "title": {
+          "$ref": "#/definitions/title-property"
+        },
+        "description": {
+          "$ref": "#/definitions/description-property"
+        },
+        "type": {
+          "$ref": "#/definitions/type-property"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum-property"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum-property"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusive-minimum-property"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusive-maximum-property"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multiple-of-property"
+        },
+        "minLength": {
+          "$ref": "#/definitions/min-length-property"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/max-length-property"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern-property"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum-property"
+        },
+        "items": {
+          "$ref": "#/definitions/requirement-entity"
+        },
+        "minItems": {
+          "$ref": "#/definitions/min-items-property"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/max-items-property"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/unique-items-property"
+        },
+        "required": {
+          "$ref": "#/definitions/required-property"
+        },
+        "properties": {
+          "$ref": "#/definitions/properties-property"
+        },
+        "patternProperties": {
+          "$ref": "#/definitions/pattern-properties-property"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/additional-properties-property"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/min-properties-property"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/max-properties-property"
+        },
+        "default": {
+          "$ref": "#/definitions/default-property"
+        },
+        "examples": {
+          "$ref": "#/definitions/examples-property"
+        }
+      },
+      "additionalProperties": false
+    },
+    "requirements": {
+      "required": ["properties"],
+      "properties": {
+        "properties": {
+          "description": "A mapping from sub-property names to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
           "type": "object",
           "patternProperties": {
-              ".": {
-                  "description": "A sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=properties#properties",
-                  "$ref": "#/definitions/entity"
-              }
+            ".": {
+              "$ref": "#/definitions/requirement-entity"
+            }
           },
-          "additionalProperties": false
-      },
-      "pattern-properties-property": {
-          "description": "Pattern sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
-          "type": "object",
-          "properties": {
-              ".": {
-                  "description": "A pattern sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
-                  "$ref": "#/definitions/entity"
-              }
-          },
-          "patternProperties": {
-              ".": {
-                  "description": "A pattern sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#pattern-properties",
-                  "$ref": "#/definitions/entity"
-              }
-          },
-          "additionalProperties": false
-      },
-      "additional-properties-property": {
-          "description": "Additional sub-properties of the current property or definition or whether to allow them\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#additional-properties",
-          "oneOf": [
-              {
-                  "type": "boolean",
-                  "const": false
-              },
-              {
-                  "$ref": "#/definitions/entity"
-              }
-          ]
-      },
-      "min-properties-property": {
-          "description": "A minimum count of sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#size",
-          "type": "integer",
-          "minimum": 1,
-          "default": 1
-      },
-      "max-properties-property": {
-          "description": "A maximum count of sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#size",
-          "type": "integer",
-          "minimum": 1,
-          "default": 1
-      },
-      "const-property": {
-          "description": "A constant of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=const#constant-values",
-          "$ref": "#/definitions/simple-type"
-      },
-      "default-property": {
-          "description": "A default of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
-          "$ref": "#/definitions/simple-type"
-      },
-      "examples-property": {
-          "description": "Examples of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-              "description": "An example of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=default#annotations",
-              "$ref": "#/definitions/simple-type"
-          },
-          "minLength": 1
-      },
-      "not-property": {
-          "description": "A sub-schema should not match of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#not",
-          "$ref": "#/definitions/sub-schema-entity",
-          "minProperties": 1
-      },
-      "any-of-property": {
-          "description": "A requirement to match at least one sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#anyof",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 2,
-          "items": {
-              "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#anyof",
-              "$ref": "#/definitions/sub-schema-entity"
-          }
-      },
-      "one-of-property": {
-          "description": "A requirement to match at one sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#oneof",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 2,
-          "items": {
-              "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#oneof",
-              "$ref": "#/definitions/sub-schema-entity"
-          }
-      },
-      "all-of-property": {
-          "description": "A requirement to match all sub-schemas of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#allof",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 2,
-          "items": {
-              "description": "A sub-schema of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/combining.html?highlight=anyof#allof",
-              "$ref": "#/definitions/sub-schema-entity"
-          }
-      },
-      "sub-schema-entity": {
-          "type": "object",
-          "properties": {
-              "$comment": {
-                  "$ref": "#/definitions/comment-property"
-              },
-              "$ref": {
-                  "$ref": "#/definitions/ref-property"
-              },
-              "type": {
-                  "$ref": "#/definitions/type-property"
-              },
-              "minimum": {
-                  "$ref": "#/definitions/minimum-property"
-              },
-              "maximum": {
-                  "$ref": "#/definitions/maximum-property"
-              },
-              "exclusiveMinimum": {
-                  "$ref": "#/definitions/exclusive-minimum-property"
-              },
-              "exclusiveMaximum": {
-                  "$ref": "#/definitions/exclusive-maximum-property"
-              },
-              "multipleOf": {
-                  "$ref": "#/definitions/multiple-of-property"
-              },
-              "minLength": {
-                  "$ref": "#/definitions/min-length-property"
-              },
-              "maxLength": {
-                  "$ref": "#/definitions/max-length-property"
-              },
-              "pattern": {
-                  "$ref": "#/definitions/pattern-property"
-              },
-              "enum": {
-                  "$ref": "#/definitions/enum-property"
-              },
-              "items": {
-                  "$ref": "#/definitions/items-property"
-              },
-              "minItems": {
-                  "$ref": "#/definitions/min-items-property"
-              },
-              "maxItems": {
-                  "$ref": "#/definitions/max-items-property"
-              },
-              "uniqueItems": {
-                  "$ref": "#/definitions/unique-items-property"
-              },
-              "required": {
-                  "$ref": "#/definitions/required-property"
-              },
-              "properties": {
-                  "$ref": "#/definitions/properties-property"
-              },
-              "patternProperties": {
-                  "$ref": "#/definitions/pattern-properties-property"
-              },
-              "additionalProperties": {
-                  "$ref": "#/definitions/additional-properties-property"
-              },
-              "minProperties": {
-                  "$ref": "#/definitions/min-properties-property"
-              },
-              "maxProperties": {
-                  "$ref": "#/definitions/max-properties-property"
-              },
-              "const": {
-                  "$ref": "#/definitions/const-property"
-              },
-              "default": {
-                  "$ref": "#/definitions/default-property"
-              },
-              "examples": {
-                  "$ref": "#/definitions/examples-property"
-              },
-              "not": {
-                  "$ref": "#/definitions/not-property"
-              },
-              "anyOf": {
-                  "$ref": "#/definitions/any-of-property"
-              },
-              "oneOf": {
-                  "$ref": "#/definitions/one-of-property"
-              },
-              "allOf": {
-                  "$ref": "#/definitions/all-of-property"
-              },
-              "if": {
-                  "$ref": "#/definitions/if-property"
-              },
-              "then": {
-                  "$ref": "#/definitions/then-property"
-              },
-              "else": {
-                  "$ref": "#/definitions/else-property"
-              }
-          },
-          "$ref": "#/definitions/entity-dependencies",
           "minProperties": 1,
           "additionalProperties": false
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/additional-properties-property"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/min-properties-property"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/max-properties-property"
+        }
       },
-      "condition-entity": {
-          "description": "A mapping from sub-property name to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-          "type": "object",
-          "properties": {
-              "$comment": {
-                  "$ref": "#/definitions/comment-property"
-              },
-              "$ref": {
-                  "$ref": "#/definitions/ref-property"
-              },
-              "type": {
-                  "$ref": "#/definitions/type-property"
-              },
-              "minimum": {
-                  "$ref": "#/definitions/minimum-property"
-              },
-              "maximum": {
-                  "$ref": "#/definitions/maximum-property"
-              },
-              "exclusiveMinimum": {
-                  "$ref": "#/definitions/exclusive-minimum-property"
-              },
-              "exclusiveMaximum": {
-                  "$ref": "#/definitions/exclusive-maximum-property"
-              },
-              "multipleOf": {
-                  "$ref": "#/definitions/multiple-of-property"
-              },
-              "minLength": {
-                  "$ref": "#/definitions/min-length-property"
-              },
-              "maxLength": {
-                  "$ref": "#/definitions/max-length-property"
-              },
-              "pattern": {
-                  "$ref": "#/definitions/pattern-property"
-              },
-              "enum": {
-                  "$ref": "#/definitions/enum-property"
-              },
-              "items": {
-                  "$ref": "#/definitions/condition-entity"
-              },
-              "minItems": {
-                  "$ref": "#/definitions/min-items-property"
-              },
-              "maxItems": {
-                  "$ref": "#/definitions/max-items-property"
-              },
-              "uniqueItems": {
-                  "$ref": "#/definitions/unique-items-property"
-              },
-              "required": {
-                  "$ref": "#/definitions/required-property"
-              },
-              "properties": {
-                  "$ref": "#/definitions/properties-property"
-              },
-              "patternProperties": {
-                  "$ref": "#/definitions/pattern-properties-property"
-              },
-              "additionalProperties": {
-                  "$ref": "#/definitions/additional-properties-property"
-              },
-              "minProperties": {
-                  "$ref": "#/definitions/min-properties-property"
-              },
-              "maxProperties": {
-                  "$ref": "#/definitions/max-properties-property"
-              },
-              "const": {
-                  "$ref": "#/definitions/const-property"
-              },
-              "default": {
-                  "$ref": "#/definitions/default-property"
-              }
-          },
-          "additionalProperties": false
-      },
-      "requirement-entity": {
-          "description": "A mapping from sub-property name to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-          "type": "object",
-          "properties": {
-              "$comment": {
-                  "$ref": "#/definitions/comment-property"
-              },
-              "$ref": {
-                  "$ref": "#/definitions/ref-property"
-              },
-              "title": {
-                  "$ref": "#/definitions/title-property"
-              },
-              "description": {
-                  "$ref": "#/definitions/description-property"
-              },
-              "type": {
-                  "$ref": "#/definitions/type-property"
-              },
-              "minimum": {
-                  "$ref": "#/definitions/minimum-property"
-              },
-              "maximum": {
-                  "$ref": "#/definitions/maximum-property"
-              },
-              "exclusiveMinimum": {
-                  "$ref": "#/definitions/exclusive-minimum-property"
-              },
-              "exclusiveMaximum": {
-                  "$ref": "#/definitions/exclusive-maximum-property"
-              },
-              "multipleOf": {
-                  "$ref": "#/definitions/multiple-of-property"
-              },
-              "minLength": {
-                  "$ref": "#/definitions/min-length-property"
-              },
-              "maxLength": {
-                  "$ref": "#/definitions/max-length-property"
-              },
-              "pattern": {
-                  "$ref": "#/definitions/pattern-property"
-              },
-              "enum": {
-                  "$ref": "#/definitions/enum-property"
-              },
-              "items": {
-                  "$ref": "#/definitions/requirement-entity"
-              },
-              "minItems": {
-                  "$ref": "#/definitions/min-items-property"
-              },
-              "maxItems": {
-                  "$ref": "#/definitions/max-items-property"
-              },
-              "uniqueItems": {
-                  "$ref": "#/definitions/unique-items-property"
-              },
-              "required": {
-                  "$ref": "#/definitions/required-property"
-              },
-              "properties": {
-                  "$ref": "#/definitions/properties-property"
-              },
-              "patternProperties": {
-                  "$ref": "#/definitions/pattern-properties-property"
-              },
-              "additionalProperties": {
-                  "$ref": "#/definitions/additional-properties-property"
-              },
-              "minProperties": {
-                  "$ref": "#/definitions/min-properties-property"
-              },
-              "maxProperties": {
-                  "$ref": "#/definitions/max-properties-property"
-              },
-              "default": {
-                  "$ref": "#/definitions/default-property"
-              },
-              "examples": {
-                  "$ref": "#/definitions/examples-property"
-              }
-          },
-          "additionalProperties": false
-      },
-      "requirements": {
-          "required": [
-              "properties"
-          ],
-          "properties": {
-              "properties": {
-                  "description": "A mapping from sub-property names to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-                  "type": "object",
-                  "patternProperties": {
-                      ".": {
-                          "$ref": "#/definitions/requirement-entity"
-                      }
-                  },
-                  "minProperties": 1,
-                  "additionalProperties": false
-              },
-              "additionalProperties": {
-                  "$ref": "#/definitions/additional-properties-property"
-              },
-              "minProperties": {
-                  "$ref": "#/definitions/min-properties-property"
-              },
-              "maxProperties": {
-                  "$ref": "#/definitions/max-properties-property"
-              }
-          },
-          "additionalProperties": false
-      },
-      "entity-dependencies": {
-          "dependencies": {
-              "minimum": {
-                  "$ref": "#/definitions/numeric-type-requirement"
-              },
-              "maximum": {
-                  "$ref": "#/definitions/numeric-type-requirement"
-              },
-              "exclusiveMinimum": {
-                  "$ref": "#/definitions/numeric-type-requirement"
-              },
-              "exclusiveMaximum": {
-                  "$ref": "#/definitions/numeric-type-requirement"
-              },
-              "multipleOf": {
-                  "$ref": "#/definitions/numeric-type-requirement"
-              },
-              "minLength": {
-                  "$ref": "#/definitions/string-type-requirement"
-              },
-              "maxLength": {
-                  "$ref": "#/definitions/string-type-requirement"
-              },
-              "pattern": {
-                  "$ref": "#/definitions/string-type-requirement"
-              },
-              "enum": {
-                  "$ref": "#/definitions/simple-type-requirement"
-              },
-              "items": {
-                  "$ref": "#/definitions/array-type-requirement"
-              },
-              "minItems": {
-                  "$ref": "#/definitions/array-type-requirement"
-              },
-              "maxItems": {
-                  "$ref": "#/definitions/array-type-requirement"
-              },
-              "uniqueItems": {
-                  "$ref": "#/definitions/array-type-requirement"
-              },
-              "required": {
-                  "$ref": "#/definitions/object-type-requirement"
-              },
-              "properties": {
-                  "$ref": "#/definitions/object-type-requirement"
-              },
-              "patternProperties": {
-                  "$ref": "#/definitions/object-type-requirement"
-              },
-              "additionalProperties": {
-                  "$ref": "#/definitions/object-type-requirement"
-              },
-              "minProperties": {
-                  "$ref": "#/definitions/object-type-requirement"
-              },
-              "maxProperties": {
-                  "$ref": "#/definitions/object-type-requirement"
-              },
-              "if": [
-                  "then"
-              ],
-              "then": [
-                  "if"
-              ],
-              "else": [
-                  "if",
-                  "then"
-              ],
-              "$ref": {
-                  "required": []
-              }
-          }
-      },
-      "entity-requirements-and-dependencies": {
-          "required": [
-              "title",
-              "description",
-              "type"
-          ],
-          "$ref": "#/definitions/entity-dependencies"
-      },
-      "if-property": {
-          "description": "A conditional header of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-          "type": "object",
-          "required": [
-              "properties"
-          ],
-          "properties": {
-              "properties": {
-                  "description": "A mapping from sub-property names to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-                  "type": "object",
-                  "patternProperties": {
-                      ".": {
-                          "$ref": "#/definitions/condition-entity"
-                      }
-                  },
-                  "additionalProperties": false
-              }
-          },
-          "additionalProperties": false
-      },
-      "then-property": {
-          "description": "A conditional branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-          "type": "object",
-          "$ref": "#/definitions/requirements"
-      },
-      "else-property": {
-          "description": "A conditional else branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-          "type": "object",
-          "$ref": "#/definitions/requirements"
-      },
-      "entity": {
-          "type": "object",
-          "properties": {
-              "$comment": {
-                  "$ref": "#/definitions/comment-property"
-              },
-              "$ref": {
-                  "$ref": "#/definitions/ref-property"
-              },
-              "title": {
-                  "$ref": "#/definitions/title-property"
-              },
-              "description": {
-                  "$ref": "#/definitions/description-property"
-              },
-              "type": {
-                  "$ref": "#/definitions/type-property"
-              },
-              "minimum": {
-                  "$ref": "#/definitions/minimum-property"
-              },
-              "maximum": {
-                  "$ref": "#/definitions/maximum-property"
-              },
-              "exclusiveMinimum": {
-                  "$ref": "#/definitions/exclusive-minimum-property"
-              },
-              "exclusiveMaximum": {
-                  "$ref": "#/definitions/exclusive-maximum-property"
-              },
-              "multipleOf": {
-                  "$ref": "#/definitions/multiple-of-property"
-              },
-              "minLength": {
-                  "$ref": "#/definitions/min-length-property"
-              },
-              "maxLength": {
-                  "$ref": "#/definitions/max-length-property"
-              },
-              "pattern": {
-                  "$ref": "#/definitions/pattern-property"
-              },
-              "enum": {
-                  "$ref": "#/definitions/enum-property"
-              },
-              "items": {
-                  "$ref": "#/definitions/items-property"
-              },
-              "minItems": {
-                  "$ref": "#/definitions/min-items-property"
-              },
-              "maxItems": {
-                  "$ref": "#/definitions/max-items-property"
-              },
-              "uniqueItems": {
-                  "$ref": "#/definitions/unique-items-property"
-              },
-              "required": {
-                  "$ref": "#/definitions/required-property"
-              },
-              "properties": {
-                  "$ref": "#/definitions/properties-property"
-              },
-              "patternProperties": {
-                  "$ref": "#/definitions/pattern-properties-property"
-              },
-              "additionalProperties": {
-                  "$ref": "#/definitions/additional-properties-property"
-              },
-              "minProperties": {
-                  "$ref": "#/definitions/min-properties-property"
-              },
-              "maxProperties": {
-                  "$ref": "#/definitions/max-properties-property"
-              },
-              "const": {
-                  "$ref": "#/definitions/const-property"
-              },
-              "default": {
-                  "$ref": "#/definitions/default-property"
-              },
-              "examples": {
-                  "$ref": "#/definitions/examples-property"
-              },
-              "not": {
-                  "$ref": "#/definitions/not-property"
-              },
-              "anyOf": {
-                  "$ref": "#/definitions/any-of-property"
-              },
-              "oneOf": {
-                  "$ref": "#/definitions/one-of-property"
-              },
-              "allOf": {
-                  "$ref": "#/definitions/all-of-property"
-              },
-              "if": {
-                  "$ref": "#/definitions/if-property"
-              },
-              "then": {
-                  "$ref": "#/definitions/then-property"
-              },
-              "else": {
-                  "$ref": "#/definitions/else-property"
-              }
-          },
-          "$ref": "#/definitions/entity-requirements-and-dependencies",
-          "additionalProperties": false
-      },
-      "root-entity": {
-          "type": "object",
-          "properties": {
-              "$schema": {
-                  "description": "A schema used to validate this JSON schema",
-                  "type": "string",
-                  "minLength": 1,
-                  "examples": [
-                      "http://json-schema.org/draft-04/schema#",
-                      "http://json-schema.org/draft-07/schema#",
-                      "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json"
-                  ]
-              },
-              "definitions": {
-                  "description": "Definitions",
-                  "type": "object",
-                  "patternProperties": {
-                      ".": {
-                          "description": "A definition",
-                          "$ref": "#/definitions/entity"
-                      }
-                  },
-                  "additionalProperties": false
-              },
-              "$comment": {
-                  "$ref": "#/definitions/comment-property"
-              },
-              "$ref": {
-                  "$ref": "#/definitions/ref-property"
-              },
-              "title": {
-                  "$ref": "#/definitions/title-property"
-              },
-              "description": {
-                  "$ref": "#/definitions/description-property"
-              },
-              "type": {
-                  "$ref": "#/definitions/type-property"
-              },
-              "minimum": {
-                  "$ref": "#/definitions/minimum-property"
-              },
-              "maximum": {
-                  "$ref": "#/definitions/maximum-property"
-              },
-              "exclusiveMinimum": {
-                  "$ref": "#/definitions/exclusive-minimum-property"
-              },
-              "exclusiveMaximum": {
-                  "$ref": "#/definitions/exclusive-maximum-property"
-              },
-              "multipleOf": {
-                  "$ref": "#/definitions/multiple-of-property"
-              },
-              "minLength": {
-                  "$ref": "#/definitions/min-length-property"
-              },
-              "maxLength": {
-                  "$ref": "#/definitions/max-length-property"
-              },
-              "pattern": {
-                  "$ref": "#/definitions/pattern-property"
-              },
-              "enum": {
-                  "$ref": "#/definitions/enum-property"
-              },
-              "items": {
-                  "$ref": "#/definitions/items-property"
-              },
-              "minItems": {
-                  "$ref": "#/definitions/min-items-property"
-              },
-              "maxItems": {
-                  "$ref": "#/definitions/max-items-property"
-              },
-              "uniqueItems": {
-                  "$ref": "#/definitions/unique-items-property"
-              },
-              "required": {
-                  "$ref": "#/definitions/required-property"
-              },
-              "properties": {
-                  "$ref": "#/definitions/properties-property"
-              },
-              "patternProperties": {
-                  "$ref": "#/definitions/pattern-properties-property"
-              },
-              "additionalProperties": {
-                  "$ref": "#/definitions/additional-properties-property"
-              },
-              "minProperties": {
-                  "$ref": "#/definitions/min-properties-property"
-              },
-              "maxProperties": {
-                  "$ref": "#/definitions/max-properties-property"
-              },
-              "const": {
-                  "$ref": "#/definitions/const-property"
-              },
-              "default": {
-                  "$ref": "#/definitions/default-property"
-              },
-              "examples": {
-                  "$ref": "#/definitions/examples-property"
-              },
-              "not": {
-                  "$ref": "#/definitions/not-property"
-              },
-              "anyOf": {
-                  "$ref": "#/definitions/any-of-property"
-              },
-              "oneOf": {
-                  "$ref": "#/definitions/one-of-property"
-              },
-              "allOf": {
-                  "$ref": "#/definitions/all-of-property"
-              },
-              "if": {
-                  "$ref": "#/definitions/if-property"
-              },
-              "then": {
-                  "$ref": "#/definitions/then-property"
-              },
-              "else": {
-                  "$ref": "#/definitions/else-property"
-              }
-          },
-          "$ref": "#/definitions/entity-requirements-and-dependencies",
-          "additionalProperties": false
+      "additionalProperties": false
+    },
+    "entity-dependencies": {
+      "dependencies": {
+        "minimum": {
+          "$ref": "#/definitions/numeric-type-requirement"
+        },
+        "maximum": {
+          "$ref": "#/definitions/numeric-type-requirement"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/numeric-type-requirement"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/numeric-type-requirement"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/numeric-type-requirement"
+        },
+        "minLength": {
+          "$ref": "#/definitions/string-type-requirement"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/string-type-requirement"
+        },
+        "pattern": {
+          "$ref": "#/definitions/string-type-requirement"
+        },
+        "enum": {
+          "$ref": "#/definitions/simple-type-requirement"
+        },
+        "items": {
+          "$ref": "#/definitions/array-type-requirement"
+        },
+        "minItems": {
+          "$ref": "#/definitions/array-type-requirement"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/array-type-requirement"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/array-type-requirement"
+        },
+        "required": {
+          "$ref": "#/definitions/object-type-requirement"
+        },
+        "properties": {
+          "$ref": "#/definitions/object-type-requirement"
+        },
+        "patternProperties": {
+          "$ref": "#/definitions/object-type-requirement"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/object-type-requirement"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/object-type-requirement"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/object-type-requirement"
+        },
+        "if": ["then"],
+        "then": ["if"],
+        "else": ["if", "then"],
+        "$ref": {
+          "required": []
+        }
       }
+    },
+    "entity-requirements-and-dependencies": {
+      "required": ["title", "description", "type"],
+      "$ref": "#/definitions/entity-dependencies"
+    },
+    "if-property": {
+      "description": "A conditional header of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "type": "object",
+      "required": ["properties"],
+      "properties": {
+        "properties": {
+          "description": "A mapping from sub-property names to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "$ref": "#/definitions/condition-entity"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "then-property": {
+      "description": "A conditional branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "type": "object",
+      "$ref": "#/definitions/requirements"
+    },
+    "else-property": {
+      "description": "A conditional else branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "type": "object",
+      "$ref": "#/definitions/requirements"
+    },
+    "entity": {
+      "type": "object",
+      "properties": {
+        "$comment": {
+          "$ref": "#/definitions/comment-property"
+        },
+        "$ref": {
+          "$ref": "#/definitions/ref-property"
+        },
+        "title": {
+          "$ref": "#/definitions/title-property"
+        },
+        "description": {
+          "$ref": "#/definitions/description-property"
+        },
+        "type": {
+          "$ref": "#/definitions/type-property"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum-property"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum-property"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusive-minimum-property"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusive-maximum-property"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multiple-of-property"
+        },
+        "minLength": {
+          "$ref": "#/definitions/min-length-property"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/max-length-property"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern-property"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum-property"
+        },
+        "items": {
+          "$ref": "#/definitions/items-property"
+        },
+        "minItems": {
+          "$ref": "#/definitions/min-items-property"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/max-items-property"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/unique-items-property"
+        },
+        "required": {
+          "$ref": "#/definitions/required-property"
+        },
+        "properties": {
+          "$ref": "#/definitions/properties-property"
+        },
+        "patternProperties": {
+          "$ref": "#/definitions/pattern-properties-property"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/additional-properties-property"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/min-properties-property"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/max-properties-property"
+        },
+        "const": {
+          "$ref": "#/definitions/const-property"
+        },
+        "default": {
+          "$ref": "#/definitions/default-property"
+        },
+        "examples": {
+          "$ref": "#/definitions/examples-property"
+        },
+        "not": {
+          "$ref": "#/definitions/not-property"
+        },
+        "anyOf": {
+          "$ref": "#/definitions/any-of-property"
+        },
+        "oneOf": {
+          "$ref": "#/definitions/one-of-property"
+        },
+        "allOf": {
+          "$ref": "#/definitions/all-of-property"
+        },
+        "if": {
+          "$ref": "#/definitions/if-property"
+        },
+        "then": {
+          "$ref": "#/definitions/then-property"
+        },
+        "else": {
+          "$ref": "#/definitions/else-property"
+        }
+      },
+      "$ref": "#/definitions/entity-requirements-and-dependencies",
+      "additionalProperties": false
+    },
+    "root-entity": {
+      "type": "object",
+      "properties": {
+        "$schema": {
+          "description": "A schema used to validate this JSON schema",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "http://json-schema.org/draft-04/schema#",
+            "http://json-schema.org/draft-07/schema#",
+            "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json"
+          ]
+        },
+        "definitions": {
+          "description": "Definitions",
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "description": "A definition",
+              "$ref": "#/definitions/entity"
+            }
+          },
+          "additionalProperties": false
+        },
+        "$comment": {
+          "$ref": "#/definitions/comment-property"
+        },
+        "$ref": {
+          "$ref": "#/definitions/ref-property"
+        },
+        "title": {
+          "$ref": "#/definitions/title-property"
+        },
+        "description": {
+          "$ref": "#/definitions/description-property"
+        },
+        "type": {
+          "$ref": "#/definitions/type-property"
+        },
+        "minimum": {
+          "$ref": "#/definitions/minimum-property"
+        },
+        "maximum": {
+          "$ref": "#/definitions/maximum-property"
+        },
+        "exclusiveMinimum": {
+          "$ref": "#/definitions/exclusive-minimum-property"
+        },
+        "exclusiveMaximum": {
+          "$ref": "#/definitions/exclusive-maximum-property"
+        },
+        "multipleOf": {
+          "$ref": "#/definitions/multiple-of-property"
+        },
+        "minLength": {
+          "$ref": "#/definitions/min-length-property"
+        },
+        "maxLength": {
+          "$ref": "#/definitions/max-length-property"
+        },
+        "pattern": {
+          "$ref": "#/definitions/pattern-property"
+        },
+        "enum": {
+          "$ref": "#/definitions/enum-property"
+        },
+        "items": {
+          "$ref": "#/definitions/items-property"
+        },
+        "minItems": {
+          "$ref": "#/definitions/min-items-property"
+        },
+        "maxItems": {
+          "$ref": "#/definitions/max-items-property"
+        },
+        "uniqueItems": {
+          "$ref": "#/definitions/unique-items-property"
+        },
+        "required": {
+          "$ref": "#/definitions/required-property"
+        },
+        "properties": {
+          "$ref": "#/definitions/properties-property"
+        },
+        "patternProperties": {
+          "$ref": "#/definitions/pattern-properties-property"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/additional-properties-property"
+        },
+        "minProperties": {
+          "$ref": "#/definitions/min-properties-property"
+        },
+        "maxProperties": {
+          "$ref": "#/definitions/max-properties-property"
+        },
+        "const": {
+          "$ref": "#/definitions/const-property"
+        },
+        "default": {
+          "$ref": "#/definitions/default-property"
+        },
+        "examples": {
+          "$ref": "#/definitions/examples-property"
+        },
+        "not": {
+          "$ref": "#/definitions/not-property"
+        },
+        "anyOf": {
+          "$ref": "#/definitions/any-of-property"
+        },
+        "oneOf": {
+          "$ref": "#/definitions/one-of-property"
+        },
+        "allOf": {
+          "$ref": "#/definitions/all-of-property"
+        },
+        "if": {
+          "$ref": "#/definitions/if-property"
+        },
+        "then": {
+          "$ref": "#/definitions/then-property"
+        },
+        "else": {
+          "$ref": "#/definitions/else-property"
+        }
+      },
+      "$ref": "#/definitions/entity-requirements-and-dependencies",
+      "additionalProperties": false
+    }
   },
   "description": "A schema\nhttps://json-schema.org/understanding-json-schema/index.html",
   "$ref": "#/definitions/root-entity"


### PR DESCRIPTION
- links in `description` to documentation are required: to be more precise, it expects that `description` has at least one `\n` followed by url (examples are included as hints)
- allow `type` property in `allOf`/`anyOf`/`oneOf`: it's a common use case to use `type` in this "combiners" to describe some additional restrictions for value of each type
- require non-empty sub-schemas for `allOf`/`anyOf`/`oneOf`: there is no reason to include empty sub-schemas
- deny additional unknown properties: not recognized properties should be prohibited

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
