### PR TITLE
Add schema for JFrog Applications Config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2153,6 +2153,12 @@
       "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2mcr.schema.json"
     },
     {
+      "name": "JFrog Applications Config",
+      "description": "Refines JFrog Advanced Security scans behavior",
+      "fileMatch": ["jfrog-apps-config.yml"],
+      "url": "https://raw.githubusercontent.com/jfrog/jfrog-apps-config/main/schema.json"
+    },
+    {
       "name": "JFrog File Spec",
       "description": "JFrog File Spec",
       "fileMatch": ["**/filespecs/*.json", "*filespec*.json", "*.filespec"],


### PR DESCRIPTION
**What is JFrog Applications Config?**
The JFrog Applications Config schema is used to define the configuration schema used by some for the JFrog applications, such as JFrog CLI, JFrog Frogbot, and the JFrog IDE integrations. This configuration schema is used to define the rules and settings for the JFrog source code scanning tools.

**JFrog Applications Config Schema**
The [JFrog Applications Config](https://github.com/jfrog/jfrog-apps-config/blob/main/schema.json) is located in the [jfrog-apps-config](https://github.com/jfrog/jfrog-apps-config) repository.

**Tests**
Some [schema unit tests](https://github.com/jfrog/jfrog-apps-config/blob/main/go/schema_test.go) are available in the JFrog Applications Config repository.