### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/src/schemas/json/minecraft-advancement.json
+++ b/src/schemas/json/minecraft-advancement.json
@@ -1,10 +1,10 @@
 {
-  "$comment": "https://minecraft.fandom.com/wiki/Advancement/JSON_format",
+  "$comment": "https://minecraft.wiki/w/Advancement/JSON_format",
   "$id": "https://json.schemastore.org/minecraft-advancement.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "jsonTextComponent": {
-      "$comment": "https://minecraft.fandom.com/wiki/Raw_JSON_text_format",
+      "$comment": "https://minecraft.wiki/w/Raw_JSON_text_format",
       "type": ["string", "boolean", "number", "array", "object"],
       "properties": {
         "extra": {
@@ -137,25 +137,25 @@
       }
     }
   },
-  "description": "A data pack advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+  "description": "A data pack advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
   "properties": {
     "display": {
       "title": "display",
-      "description": "Display options for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+      "description": "Display options for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
       "type": "object",
       "properties": {
         "icon": {
           "title": "icon",
-          "description": "Icon options for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "Icon options for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "object",
           "properties": {
             "item": {
-              "description": "An item identifier for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+              "description": "An item identifier for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
               "type": "string",
               "minLength": 1
             },
             "nbt": {
-              "description": "A named binary tag of an item for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+              "description": "A named binary tag of an item for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
               "type": "string",
               "minLength": 1
             }
@@ -163,65 +163,65 @@
         },
         "title": {
           "title": "title",
-          "description": "A title for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "A title for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "$ref": "#/definitions/jsonTextComponent"
         },
         "frame": {
-          "description": "A frame type for the icon for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "A frame type for the icon for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "string",
           "enum": ["challenge", "goal", "task"],
           "default": "task"
         },
         "background": {
-          "description": "A background directory for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "A background directory for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "$ref": "https://json.schemastore.org/base.json#/definitions/path"
         },
         "description": {
           "title": "description",
-          "description": "A description for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "A description for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "$ref": "#/definitions/jsonTextComponent"
         },
         "show_toast": {
-          "description": "Whether or not to show the toast pop up after completing the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "Whether or not to show the toast pop up after completing the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "boolean",
           "default": true
         },
         "annouce_to_chat": {
-          "description": "Whether or not to announce in the chat when the current advancement has been completed\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "Whether or not to announce in the chat when the current advancement has been completed\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "boolean",
           "default": true
         },
         "hidden": {
-          "description": "Whether or not to hide this advancement and all its children from the advancement screen until the current advancement have been completed\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "Whether or not to hide this advancement and all its children from the advancement screen until the current advancement have been completed\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "boolean",
           "default": false
         }
       }
     },
     "parent": {
-      "description": "A parent directory for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+      "description": "A parent directory for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
       "$ref": "https://json.schemastore.org/base.json#/definitions/path"
     },
     "criteria": {
       "title": "criterias",
-      "description": "Required criterias have to be met for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+      "description": "Required criterias have to be met for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
       "type": "object",
       "additionalProperties": {
         "title": "criteria",
-        "description": "Required criteria have to be met for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+        "description": "Required criteria have to be met for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
         "type": "object",
         "properties": {
           "trigger": {
-            "description": "A trigger for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Criteria",
+            "description": "A trigger for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Criteria",
             "type": "string"
           },
           "conditions": {
-            "description": "Conditions need to be met when the trigger gets activated for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Criteria",
+            "description": "Conditions need to be met when the trigger gets activated for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Criteria",
             "type": "object",
             "properties": {
               "player": {
                 "title": "player options",
-                "description": "Check properties of the player for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Criteria",
+                "description": "Check properties of the player for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Criteria",
                 "type": ["array", "object"]
               }
             }
@@ -230,15 +230,15 @@
       }
     },
     "requirements": {
-      "description": "Requirements for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+      "description": "Requirements for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "description": "Criterions for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+        "description": "Criterions for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
         "type": "array",
         "uniqueItems": true,
         "items": {
-          "description": "Criterion name for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "Criterion name for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "string",
           "minLength": 1
         }
@@ -246,36 +246,36 @@
     },
     "rewards": {
       "title": "rewards",
-      "description": "Rewards for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+      "description": "Rewards for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
       "type": "object",
       "properties": {
         "recipes": {
-          "description": "Recipes to unlock for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "Recipes to unlock for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "description": "A namespaced identifier for a recipe for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+            "description": "A namespaced identifier for a recipe for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
             "type": "string",
             "minLength": 1
           }
         },
         "loot": {
-          "description": "Loot tables to give to the player for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "Loot tables to give to the player for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "description": "A namespaced identifier for a loot table for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+            "description": "A namespaced identifier for a loot table for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
             "type": "string",
             "minLength": 1
           }
         },
         "experience": {
-          "description": "An experience amount for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "An experience amount for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "integer",
           "minimum": 0
         },
         "function": {
-          "description": "A function to run for the current advancement\nhttps://minecraft.fandom.com/wiki/Advancement/JSON_format#Legend",
+          "description": "A function to run for the current advancement\nhttps://minecraft.wiki/w/Advancement/JSON_format#Legend",
           "type": "string",
           "minLength": 1
         }


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki