### PR TITLE
fix: format of git dependencies for pyproject.toml

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -160,7 +160,7 @@
         "git": {
           "type": "string",
           "description": "The url of the git repository.",
-          "format": "uri"
+          "pattern": "^([A-Za-z0-9\\-]+@|https://|http://)[A-Za-z0-9\\-]+\\.[A-Za-z0-9\\-]+(:|/)[A-Za-z0-9\\-]+/[A-Za-z0-9\\-]+\\.git$"
         },
         "branch": {
           "type": "string",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -160,7 +160,14 @@
         "git": {
           "type": "string",
           "description": "The url of the git repository.",
-          "pattern": "^([A-Za-z0-9\\-]+@|https://|http://)[A-Za-z0-9\\-]+\\.[A-Za-z0-9\\-]+(:|/)[A-Za-z0-9\\-]+/[A-Za-z0-9\\-]+\\.git$"
+          "anyOf": [
+            {
+              "format": "uri"
+            },
+            {
+              "pattern": "^([A-Za-z0-9\\-]+@|https://|http://)[A-Za-z0-9\\-]+\\.[A-Za-z0-9\\-]+(:|/)[A-Za-z0-9\\-]+/[A-Za-z0-9\\-]+\\.git$"
+            }
+          ]
         },
         "branch": {
           "type": "string",

--- a/src/test/pyproject/3821.toml
+++ b/src/test/pyproject/3821.toml
@@ -1,0 +1,10 @@
+[tool.poetry]
+name = "project"
+version = "0.1.0"
+description = "blah"
+authors = ["Sébastien Eustace <sebastien@eustace.io>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = ""
+cleo = { git = "git@github.com/sdispater/cleo.git", branch = "master" }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
Changed validation format of git dependencies in pyproject.toml from `uri` to a custom regex that allows git repository strings (http, https & ssh). Fixes #3188