### PR TITLE
Update circleciconfig.json

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -452,9 +452,7 @@
             "default": "medium",
             "enum": [
               "small",
-              "medium",
               "medium+",
-              "large",
               "xlarge",
               "2xlarge",
               "2xlarge+",
@@ -466,7 +464,6 @@
               "gpu.nvidia.medium",
               "windows.gpu.nvidia.medium",
               "macos.x86.medium.gen2",
-              "macos.x86.metal.gen1",
               "macos.m1.medium.gen1",
               "macos.m1.large.gen1"
             ]

--- a/src/test/circleciconfig/executors.json
+++ b/src/test/circleciconfig/executors.json
@@ -27,7 +27,7 @@
       },
       "shell": "/bin/zsh",
       "working_directory": "/projects",
-      "resource_class": "medium"
+      "resource_class": "medium+"
     }
   },
   "jobs": {

--- a/src/test/circleciconfig/executors.json
+++ b/src/test/circleciconfig/executors.json
@@ -19,7 +19,7 @@
         "image": "ubuntu-1604:202007-01",
         "docker_layer_caching": true
       },
-      "resource_class": "large"
+      "resource_class": "small"
     },
     "macos-executor": {
       "macos": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
As of October 2, the macOS medium, large, and macos.x86.metal.gen1 resource classes are no longer available.
source : https://circleci.com/changelog/