### PR TITLE
fix: allow arbitrary paths in collection permalink in Jekyll schema

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -66,9 +66,10 @@
         "/:path",
         "/:name",
         "/:title",
-        "/:output_ext"
+        "/:output_ext",
+        "/blog/:title"
       ],
-      "pattern": "^(/(:(collection|path|name|title|output_ext))+)+$"
+      "pattern": "^.*(:(collection|path|name|title|output_ext))+.*$"
     }
   },
   "properties": {

--- a/src/test/jekyll/arbitrary_permalink.yaml
+++ b/src/test/jekyll/arbitrary_permalink.yaml
@@ -1,0 +1,3 @@
+# Test a permalink with an arbitrary path
+
+permalink: /work/:name

--- a/src/test/jekyll/arbitrary_permalink.yaml
+++ b/src/test/jekyll/arbitrary_permalink.yaml
@@ -1,3 +1,6 @@
 # Test a permalink with an arbitrary path
 
-permalink: /work/:name
+collections:
+  posts:
+    output: true
+    permalink: /my/work/:name


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
This PR is a successor to https://github.com/SchemaStore/schemastore/pull/3280 and answers issue https://github.com/SchemaStore/schemastore/issues/3157.

Please let me know if there are any changes you would like me to make. I have incorporated your feedback from #3280 in this new PR.