### PR TITLE
Add cibuildwheel to pyproject.toml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -803,6 +803,12 @@
       "fileMatch": ["catalog-info.yaml"]
     },
     {
+      "name": "cibuildwheel",
+      "description": "cibuildwheel, a Python redistributable wheel builder",
+      "url": "https://json.schemastore.org/cibuildwheel.json",
+      "fileMatch": ["cibuildwheel.toml", ".cibuildwheel.toml"]
+    },
+    {
       "name": "CityJSON",
       "description": "the representation of 3D city models",
       "url": "https://raw.githubusercontent.com/cityjson/specs/master/schemas/cityjson.min.schema.json"

--- a/src/negative_test/cibuildwheel/cibuildwheel-bad-override.toml
+++ b/src/negative_test/cibuildwheel/cibuildwheel-bad-override.toml
@@ -1,0 +1,2 @@
+[[tool.cibuildwheel.overrides]]
+select = "cp*"

--- a/src/negative_test/cibuildwheel/cibuildwheel-unreco.toml
+++ b/src/negative_test/cibuildwheel/cibuildwheel-unreco.toml
@@ -1,0 +1,2 @@
+[tool.cibuildwheel]
+not-an-option = true

--- a/src/negative_test/pyproject/cibuildwheel-bad-override.toml
+++ b/src/negative_test/pyproject/cibuildwheel-bad-override.toml
@@ -1,0 +1,2 @@
+[[tool.cibuildwheel.overrides]]
+select = "cp*"

--- a/src/negative_test/pyproject/cibuildwheel-unreco.toml
+++ b/src/negative_test/pyproject/cibuildwheel-unreco.toml
@@ -1,0 +1,2 @@
+[tool.cibuildwheel]
+not-an-option = true

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -750,7 +750,7 @@
     },
     {
       "pyproject.json": {
-        "externalSchema": ["ruff.json"],
+        "externalSchema": ["cibuildwheel.json", "ruff.json"],
         "unknownKeywords": ["x-taplo", "x-taplo-info"],
         "unknownFormat": ["uint16", "uint8", "uint", "int"]
       }

--- a/src/schemas/json/cibuildwheel.json
+++ b/src/schemas/json/cibuildwheel.json
@@ -1,0 +1,694 @@
+{
+  "$id": "https://json.schemastore.org/cibuildwheel.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "cibuildwheel's toml file, generated with ./bin/generate_schema.py --schemastore from cibuildwheel.",
+  "type": "object",
+  "properties": {
+    "tool": {
+      "type": "object",
+      "properties": {
+        "cibuildwheel": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "archs": {
+              "description": "Change the architectures built on your machine by default.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_ARCHS"
+            },
+            "before-all": {
+              "description": "Execute a shell command on the build system before any wheels are built.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_BEFORE_ALL"
+            },
+            "before-build": {
+              "description": "Execute a shell command preparing each wheel's build.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_BEFORE_BUILD"
+            },
+            "before-test": {
+              "description": "Execute a shell command before testing each wheel.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_BEFORE_TEST"
+            },
+            "build": {
+              "default": ["*"],
+              "description": "Choose the Python versions to build.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_BUILD"
+            },
+            "build-frontend": {
+              "default": "default",
+              "description": "Set the tool to use to build, either \"pip\" (default for now) or \"build\"",
+              "oneOf": [
+                {
+                  "enum": ["pip", "build", "default"]
+                },
+                {
+                  "type": "string",
+                  "pattern": "^pip; ?args:"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^build; ?args:"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "enum": ["pip", "build"]
+                    },
+                    "args": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              ],
+              "title": "CIBW_BUILD_FRONTEND"
+            },
+            "build-verbosity": {
+              "type": "integer",
+              "minimum": -3,
+              "maximum": 3,
+              "default": 0,
+              "description": "Increase/decrease the output of pip wheel.",
+              "title": "CIBW_BUILD_VERBOSITY"
+            },
+            "config-settings": {
+              "description": "Specify config-settings for the build backend.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    ".+": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "title": "CIBW_CONFIG_SETTINGS"
+            },
+            "container-engine": {
+              "oneOf": [
+                {
+                  "enum": ["docker", "podman"]
+                },
+                {
+                  "type": "string",
+                  "pattern": "^docker; ?create_args:"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^podman; ?create_args:"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "enum": ["docker", "podman"]
+                    },
+                    "create-args": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              ],
+              "title": "CIBW_CONTAINER_ENGINE"
+            },
+            "dependency-versions": {
+              "default": "pinned",
+              "description": "Specify how cibuildwheel controls the versions of the tools it uses",
+              "type": "string",
+              "title": "CIBW_DEPENDENCY_VERSIONS"
+            },
+            "environment": {
+              "description": "Set environment variables needed during the build.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    ".+": {
+                      "type": "string"
+                    }
+                  }
+                }
+              ],
+              "title": "CIBW_ENVIRONMENT"
+            },
+            "environment-pass": {
+              "description": "Set environment variables on the host to pass-through to the container during the build.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_ENVIRONMENT_PASS"
+            },
+            "manylinux-aarch64-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MANYLINUX_AARCH64_IMAGE"
+            },
+            "manylinux-i686-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MANYLINUX_I686_IMAGE"
+            },
+            "manylinux-ppc64le-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MANYLINUX_PPC64LE_IMAGE"
+            },
+            "manylinux-pypy_aarch64-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MANYLINUX_PYPY_AARCH64_IMAGE"
+            },
+            "manylinux-pypy_i686-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MANYLINUX_PYPY_I686_IMAGE"
+            },
+            "manylinux-pypy_x86_64-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MANYLINUX_PYPY_X86_64_IMAGE"
+            },
+            "manylinux-s390x-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MANYLINUX_S390X_IMAGE"
+            },
+            "manylinux-x86_64-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MANYLINUX_X86_64_IMAGE"
+            },
+            "musllinux-aarch64-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MUSLLINUX_AARCH64_IMAGE"
+            },
+            "musllinux-i686-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MUSLLINUX_I686_IMAGE"
+            },
+            "musllinux-ppc64le-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MUSLLINUX_PPC64LE_IMAGE"
+            },
+            "musllinux-s390x-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MUSLLINUX_S390X_IMAGE"
+            },
+            "musllinux-x86_64-image": {
+              "type": "string",
+              "description": "Specify alternative manylinux / musllinux container images",
+              "title": "CIBW_MUSLLINUX_X86_64_IMAGE"
+            },
+            "repair-wheel-command": {
+              "description": "Execute a shell command to repair each built wheel.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_REPAIR_WHEEL_COMMAND"
+            },
+            "skip": {
+              "description": "Choose the Python versions to skip.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_SKIP"
+            },
+            "test-command": {
+              "description": "Execute a shell command to test each built wheel.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_TEST_COMMAND"
+            },
+            "test-extras": {
+              "description": "Install your wheel for testing using `extras_require`",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_TEST_EXTRAS"
+            },
+            "test-requires": {
+              "description": "Install Python dependencies before running the tests",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_TEST_REQUIRES"
+            },
+            "test-skip": {
+              "description": "Skip running tests on some builds.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "title": "CIBW_TEST_SKIP"
+            },
+            "overrides": {
+              "type": "array",
+              "description": "An overrides array",
+              "items": {
+                "type": "object",
+                "required": ["select"],
+                "minProperties": 2,
+                "additionalProperties": false,
+                "properties": {
+                  "select": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  },
+                  "before-all": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-all"
+                  },
+                  "before-build": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-build"
+                  },
+                  "before-test": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-test"
+                  },
+                  "build-frontend": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/build-frontend"
+                  },
+                  "build-verbosity": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/build-verbosity"
+                  },
+                  "config-settings": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/config-settings"
+                  },
+                  "dependency-versions": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/dependency-versions"
+                  },
+                  "environment": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/environment"
+                  },
+                  "environment-pass": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/environment-pass"
+                  },
+                  "manylinux-aarch64-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-aarch64-image"
+                  },
+                  "manylinux-i686-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-i686-image"
+                  },
+                  "manylinux-ppc64le-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-ppc64le-image"
+                  },
+                  "manylinux-pypy_aarch64-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-pypy_aarch64-image"
+                  },
+                  "manylinux-pypy_i686-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-pypy_i686-image"
+                  },
+                  "manylinux-pypy_x86_64-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-pypy_x86_64-image"
+                  },
+                  "manylinux-s390x-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-s390x-image"
+                  },
+                  "manylinux-x86_64-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-x86_64-image"
+                  },
+                  "musllinux-aarch64-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-aarch64-image"
+                  },
+                  "musllinux-i686-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-i686-image"
+                  },
+                  "musllinux-ppc64le-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-ppc64le-image"
+                  },
+                  "musllinux-s390x-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-s390x-image"
+                  },
+                  "musllinux-x86_64-image": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-x86_64-image"
+                  },
+                  "repair-wheel-command": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/repair-wheel-command"
+                  },
+                  "test-command": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-command"
+                  },
+                  "test-extras": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-extras"
+                  },
+                  "test-requires": {
+                    "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-requires"
+                  }
+                }
+              }
+            },
+            "linux": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "archs": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/archs"
+                },
+                "before-all": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-all"
+                },
+                "before-build": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-build"
+                },
+                "before-test": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-test"
+                },
+                "build-frontend": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/build-frontend"
+                },
+                "build-verbosity": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/build-verbosity"
+                },
+                "config-settings": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/config-settings"
+                },
+                "environment": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/environment"
+                },
+                "environment-pass": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/environment-pass"
+                },
+                "manylinux-aarch64-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-aarch64-image"
+                },
+                "manylinux-i686-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-i686-image"
+                },
+                "manylinux-ppc64le-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-ppc64le-image"
+                },
+                "manylinux-pypy_aarch64-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-pypy_aarch64-image"
+                },
+                "manylinux-pypy_i686-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-pypy_i686-image"
+                },
+                "manylinux-pypy_x86_64-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-pypy_x86_64-image"
+                },
+                "manylinux-s390x-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-s390x-image"
+                },
+                "manylinux-x86_64-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/manylinux-x86_64-image"
+                },
+                "musllinux-aarch64-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-aarch64-image"
+                },
+                "musllinux-i686-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-i686-image"
+                },
+                "musllinux-ppc64le-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-ppc64le-image"
+                },
+                "musllinux-s390x-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-s390x-image"
+                },
+                "musllinux-x86_64-image": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/musllinux-x86_64-image"
+                },
+                "repair-wheel-command": {
+                  "description": "Execute a shell command to repair each built wheel.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "title": "CIBW_REPAIR_WHEEL_COMMAND",
+                  "default": "auditwheel repair -w {dest_dir} {wheel}"
+                },
+                "test-command": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-command"
+                },
+                "test-extras": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-extras"
+                },
+                "test-requires": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-requires"
+                }
+              }
+            },
+            "windows": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "archs": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/archs"
+                },
+                "before-all": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-all"
+                },
+                "before-build": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-build"
+                },
+                "before-test": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-test"
+                },
+                "build-frontend": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/build-frontend"
+                },
+                "build-verbosity": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/build-verbosity"
+                },
+                "config-settings": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/config-settings"
+                },
+                "dependency-versions": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/dependency-versions"
+                },
+                "environment": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/environment"
+                },
+                "repair-wheel-command": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/repair-wheel-command"
+                },
+                "test-command": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-command"
+                },
+                "test-extras": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-extras"
+                },
+                "test-requires": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-requires"
+                }
+              }
+            },
+            "macos": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "archs": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/archs"
+                },
+                "before-all": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-all"
+                },
+                "before-build": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-build"
+                },
+                "before-test": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/before-test"
+                },
+                "build-frontend": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/build-frontend"
+                },
+                "build-verbosity": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/build-verbosity"
+                },
+                "config-settings": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/config-settings"
+                },
+                "dependency-versions": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/dependency-versions"
+                },
+                "environment": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/environment"
+                },
+                "repair-wheel-command": {
+                  "description": "Execute a shell command to repair each built wheel.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "title": "CIBW_REPAIR_WHEEL_COMMAND",
+                  "default": "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+                },
+                "test-command": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-command"
+                },
+                "test-extras": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-extras"
+                },
+                "test-requires": {
+                  "$ref": "#/properties/tool/properties/cibuildwheel/properties/test-requires"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -499,6 +499,9 @@
         }
       },
       "properties": {
+        "cibuildwheel": {
+          "$ref": "https://json.schemastore.org/cibuildwheel.json#/properties/tool/properties/cibuildwheel"
+        },
         "ruff": {
           "$ref": "https://json.schemastore.org/ruff.json"
         },

--- a/src/test/cibuildwheel/cibuildwheel-default.toml
+++ b/src/test/cibuildwheel/cibuildwheel-default.toml
@@ -1,0 +1,47 @@
+[tool.cibuildwheel]
+build = "*"
+skip = ""
+test-skip = ""
+
+archs = ["auto"]
+build-frontend = "default"
+config-settings = {}
+dependency-versions = "pinned"
+environment = {}
+environment-pass = []
+build-verbosity = 0
+
+before-all = ""
+before-build = ""
+repair-wheel-command = ""
+
+test-command = ""
+before-test = ""
+test-requires = []
+test-extras = []
+
+container-engine = "docker"
+
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+manylinux-ppc64le-image = "manylinux2014"
+manylinux-s390x-image = "manylinux2014"
+manylinux-pypy_x86_64-image = "manylinux2014"
+manylinux-pypy_i686-image = "manylinux2014"
+manylinux-pypy_aarch64-image = "manylinux2014"
+
+musllinux-x86_64-image = "musllinux_1_1"
+musllinux-i686-image = "musllinux_1_1"
+musllinux-aarch64-image = "musllinux_1_1"
+musllinux-ppc64le-image = "musllinux_1_1"
+musllinux-s390x-image = "musllinux_1_1"
+
+
+[tool.cibuildwheel.linux]
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.macos]
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+
+[tool.cibuildwheel.windows]

--- a/src/test/cibuildwheel/cibuildwheel-overrides.toml
+++ b/src/test/cibuildwheel/cibuildwheel-overrides.toml
@@ -1,0 +1,3 @@
+[[tool.cibuildwheel.overrides]]
+select = "cp*"
+test-command = "something"

--- a/src/test/pyproject/cibuildwheel-default.toml
+++ b/src/test/pyproject/cibuildwheel-default.toml
@@ -1,0 +1,47 @@
+[tool.cibuildwheel]
+build = "*"
+skip = ""
+test-skip = ""
+
+archs = ["auto"]
+build-frontend = "default"
+config-settings = {}
+dependency-versions = "pinned"
+environment = {}
+environment-pass = []
+build-verbosity = 0
+
+before-all = ""
+before-build = ""
+repair-wheel-command = ""
+
+test-command = ""
+before-test = ""
+test-requires = []
+test-extras = []
+
+container-engine = "docker"
+
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+manylinux-ppc64le-image = "manylinux2014"
+manylinux-s390x-image = "manylinux2014"
+manylinux-pypy_x86_64-image = "manylinux2014"
+manylinux-pypy_i686-image = "manylinux2014"
+manylinux-pypy_aarch64-image = "manylinux2014"
+
+musllinux-x86_64-image = "musllinux_1_1"
+musllinux-i686-image = "musllinux_1_1"
+musllinux-aarch64-image = "musllinux_1_1"
+musllinux-ppc64le-image = "musllinux_1_1"
+musllinux-s390x-image = "musllinux_1_1"
+
+
+[tool.cibuildwheel.linux]
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.macos]
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+
+[tool.cibuildwheel.windows]

--- a/src/test/pyproject/cibuildwheel-overrides.toml
+++ b/src/test/pyproject/cibuildwheel-overrides.toml
@@ -1,0 +1,3 @@
+[[tool.cibuildwheel.overrides]]
+select = "cp*"
+test-command = "something"


### PR DESCRIPTION
This adds cibuildwheel to `pyproject.toml`, mostly following Ruff's example. I'm not sure how to add a schema that's only a subschema (without its own file name), but cibuildwheel technically does allow its own config file (and `cibuildwheel.toml` is the recommended name). You have to specify it manually if you want it to look somewhere other than pyproject.toml, but it does support it. Unlike Ruff and some other projects, it still expects the `tool.cibuildwheel` header in it's own file format (makes documentation, copy/paste, and the implementation better), but I was able to make that work in both cases correctly.
