### PR TITLE
Add Endurica input file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5376,6 +5376,12 @@
         "*.visivo.yaml"
       ],
       "url": "https://docs.visivo.io/assets/visivo_schema.json"
+    },
+    {
+      "name": "Endurica",
+      "description": "Endurica Input File",
+      "fileMatch": ["*.ki.json"],
+      "url": "https://enduricastorage.blob.core.windows.net/public/endurica-cl-schema.json"
     }
   ],
   "version": 1


### PR DESCRIPTION
Add Endurica CL schema to catalog.json with external url.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
