### PR TITLE
Add setuptools to pyproject.toml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3580,6 +3580,12 @@
       "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/paf-module.schema.json"
     },
     {
+      "name": "Setuptools",
+      "description": "Setuptools, the classic Python buildsystem",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/setuptools.json"
+    },
+    {
       "name": "sfdx-hardis configuration",
       "description": "Configuration file for sfdx-hardis Salesforce DX plugin",
       "fileMatch": [

--- a/src/negative_test/pyproject/setuptools-invalid-find.toml
+++ b/src/negative_test/pyproject/setuptools-invalid-find.toml
@@ -1,0 +1,2 @@
+[tool.setuptools.packages.find]
+where = "src"

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -756,10 +756,20 @@
           "cibuildwheel.json",
           "ruff.json",
           "scikit-build.json",
-          "setuptools"
+          "setuptools.json"
         ],
         "unknownKeywords": ["x-taplo", "x-taplo-info"],
-        "unknownFormat": ["uint16", "uint8", "uint", "int"]
+        "unknownFormat": [
+          "uint16",
+          "uint8",
+          "uint",
+          "int",
+          "python-module-name",
+          "pep508-identifier",
+          "python-qualified-identifier",
+          "python-identifier",
+          "pep561-stub-name"
+        ]
       }
     },
     {
@@ -780,6 +790,17 @@
     {
       "rust-toolchain.json": {
         "unknownKeywords": ["x-taplo", "x-taplo-info"]
+      }
+    },
+    {
+      "setuptools.json": {
+        "unknownFormat": [
+          "python-module-name",
+          "pep508-identifier",
+          "python-qualified-identifier",
+          "python-identifier",
+          "pep561-stub-name"
+        ]
       }
     },
     {

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -755,7 +755,8 @@
         "externalSchema": [
           "cibuildwheel.json",
           "ruff.json",
-          "scikit-build.json"
+          "scikit-build.json",
+          "setuptools"
         ],
         "unknownKeywords": ["x-taplo", "x-taplo-info"],
         "unknownFormat": ["uint16", "uint8", "uint", "int"]

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -515,6 +515,9 @@
         "scikit-build": {
           "$ref": "https://json.schemastore.org/scikit-build.json"
         },
+        "setuptools": {
+          "$ref": "https://json.schemastore.org/setuptools.json"
+        },
         "poetry": {
           "type": "object",
           "additionalProperties": true,

--- a/src/schemas/json/setuptools.json
+++ b/src/schemas/json/setuptools.json
@@ -13,14 +13,16 @@
     "provides": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "pep508-identifier"
       },
       "description": "Package and virtual package names contained within this package **(not supported by pip)**"
     },
     "obsoletes": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "pep508-identifier"
       },
       "description": "Packages which this package renders obsolete **(not supported by pip)**"
     },
@@ -84,7 +86,8 @@
       "propertyNames": {
         "anyOf": [
           {
-            "type": "string"
+            "type": "string",
+            "format": "python-module-name"
           },
           {
             "const": "*"
@@ -111,7 +114,8 @@
       "propertyNames": {
         "anyOf": [
           {
-            "type": "string"
+            "type": "string",
+            "format": "python-module-name"
           },
           {
             "const": "*"
@@ -131,7 +135,8 @@
     "namespace-packages": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "python-module-name"
       },
       "$comment": "https://setuptools.pypa.io/en/latest/userguide/package_discovery.html",
       "description": "**DEPRECATED**: use implicit namespaces instead (:pep:`420`)."
@@ -140,7 +145,8 @@
       "description": "Modules that setuptools will manipulate",
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "python-module-name"
       },
       "$comment": "TODO: clarify the relationship with ``packages``"
     },
@@ -160,7 +166,8 @@
       "type": "object",
       "patternProperties": {
         "^.*$": {
-          "type": "string"
+          "type": "string",
+          "format": "python-qualified-identifier"
         }
       },
       "description": "Mapping of distutils-style command names to ``setuptools.Command`` subclasses which in turn should be represented by strings with a qualified class name (i.e., \"dotted\" form with module), e.g.::\n\n     cmdclass = {mycmd = \"pkg.subpkg.module.CommandClass\"}\n\n The command class should be a directly defined at the top-level of the containing module (no class nesting)."
@@ -204,7 +211,8 @@
         "optional-dependencies": {
           "type": "object",
           "propertyNames": {
-            "type": "string"
+            "type": "string",
+            "format": "python-identifier"
           },
           "additionalProperties": false,
           "patternProperties": {
@@ -244,7 +252,12 @@
       "type": "string",
       "anyOf": [
         {
-          "type": "string"
+          "type": "string",
+          "format": "python-module-name"
+        },
+        {
+          "type": "string",
+          "format": "pep561-stub-name"
         }
       ]
     },
@@ -287,7 +300,8 @@
       "additionalProperties": false,
       "properties": {
         "attr": {
-          "type": "string"
+          "type": "string",
+          "format": "python-qualified-identifier"
         }
       },
       "required": ["attr"],

--- a/src/schemas/json/setuptools.json
+++ b/src/schemas/json/setuptools.json
@@ -1,0 +1,338 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "``tool.setuptools`` table",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "platforms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "provides": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Package and virtual package names contained within this package **(not supported by pip)**"
+    },
+    "obsoletes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Packages which this package renders obsolete **(not supported by pip)**"
+    },
+    "zip-safe": {
+      "type": "boolean",
+      "description": "Whether the project can be safely installed and run from a zip file. **OBSOLETE**: only relevant for ``pkg_resources``, ``easy_install`` and ``setup.py install`` in the context of ``eggs`` (**DEPRECATED**)."
+    },
+    "script-files": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "$comment": "TODO: is this field deprecated/should be removed?",
+      "description": "Legacy way of defining scripts (entry-points are preferred). Equivalent to the ``script`` keyword in ``setup.py`` (it was renamed to avoid confusion with entry-point based ``project.scripts`` defined in :pep:`621`). **DISCOURAGED**: generic script wrappers are tricky and may not work properly. Whenever possible, please use ``project.scripts`` instead."
+    },
+    "eager-resources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Resources that should be extracted together, if any of them is needed, or if any C extensions included in the project are imported. **OBSOLETE**: only relevant for ``pkg_resources``, ``easy_install`` and ``setup.py install`` in the context of ``eggs`` (**DEPRECATED**)."
+    },
+    "packages": {
+      "oneOf": [
+        {
+          "title": "Array of Python package identifiers",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/package-name"
+          }
+        },
+        {
+          "$ref": "#/definitions/find-directive"
+        }
+      ],
+      "description": "Packages that should be included in the distribution. It can be given either as a list of package identifiers or as a ``dict``-like structure with a single key ``find`` which corresponds to a dynamic call to ``setuptools.config.expand.find_packages`` function. The ``find`` key is associated with a nested ``dict``-like structure that can contain ``where``, ``include``, ``exclude`` and ``namespaces`` keys, mimicking the keyword arguments of the associated function."
+    },
+    "package-dir": {
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "$ref": "#/definitions/package-name"
+          }
+        ]
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "string"
+        }
+      },
+      "description": ":class:`dict`-like structure mapping from package names to directories where their code can be found. The empty string (as key) means that all packages are contained inside the given directory will be included in the distribution."
+    },
+    "package-data": {
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "const": "*"
+          }
+        ]
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Mapping from package names to lists of glob patterns. Usually this option is not needed when using ``include-package-data = true`` For more information on how to include data files, check ``setuptools`` `docs <https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+    },
+    "include-package-data": {
+      "type": "boolean",
+      "description": "Automatically include any data files inside the package directories that are specified by ``MANIFEST.in`` For more information on how to include data files, check ``setuptools`` `docs <https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+    },
+    "exclude-package-data": {
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "const": "*"
+          }
+        ]
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Mapping from package names to lists of glob patterns that should be excluded For more information on how to include data files, check ``setuptools`` `docs <https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+    },
+    "namespace-packages": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "$comment": "https://setuptools.pypa.io/en/latest/userguide/package_discovery.html",
+      "description": "**DEPRECATED**: use implicit namespaces instead (:pep:`420`)."
+    },
+    "py-modules": {
+      "description": "Modules that setuptools will manipulate",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "$comment": "TODO: clarify the relationship with ``packages``"
+    },
+    "data-files": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "``dict``-like structure where each key represents a directory and the value is a list of glob patterns that should be installed in them. **DISCOURAGED**: please notice this might not work as expected with wheels. Whenever possible, consider using data files inside the package directories (or create a new namespace package that only contains data files). See `data files support <https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+    },
+    "cmdclass": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "type": "string"
+        }
+      },
+      "description": "Mapping of distutils-style command names to ``setuptools.Command`` subclasses which in turn should be represented by strings with a qualified class name (i.e., \"dotted\" form with module), e.g.::\n\n     cmdclass = {mycmd = \"pkg.subpkg.module.CommandClass\"}\n\n The command class should be a directly defined at the top-level of the containing module (no class nesting)."
+    },
+    "license-files": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "$comment": "TODO: revise if PEP 639 is accepted. Probably ``project.license-files``?",
+      "description": "**PROVISIONAL**: list of glob patterns for all license files being distributed. (likely to become standard with :pep:`639`). By default: ``['LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*']``"
+    },
+    "dynamic": {
+      "type": "object",
+      "description": "Instructions for loading :pep:`621`-related metadata dynamically",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/attr-directive"
+            },
+            {
+              "$ref": "#/definitions/file-directive"
+            }
+          ],
+          "description": "A version dynamically loaded via either the ``attr:`` or ``file:`` directives. Please make sure the given file or attribute respects :pep:`440`. Also ensure to set ``project.dynamic`` accordingly."
+        },
+        "classifiers": {
+          "$ref": "#/definitions/file-directive"
+        },
+        "description": {
+          "$ref": "#/definitions/file-directive"
+        },
+        "entry-points": {
+          "$ref": "#/definitions/file-directive"
+        },
+        "dependencies": {
+          "$ref": "#/definitions/file-directive-for-dependencies"
+        },
+        "optional-dependencies": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            ".+": {
+              "$ref": "#/definitions/file-directive-for-dependencies"
+            }
+          }
+        },
+        "readme": {
+          "type": "object",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/file-directive"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "content-type": {
+                  "type": "string"
+                },
+                "file": {
+                  "$ref": "#/definitions/file-directive/properties/file"
+                }
+              },
+              "additionalProperties": false
+            }
+          ],
+          "required": ["file"]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "package-name": {
+      "title": "Valid package name",
+      "description": "Valid package name (importable or :pep:`561`).",
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "file-directive": {
+      "title": "'file:' directive",
+      "description": "Value is read from a file (or list of files and then concatenated)",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "required": ["file"]
+    },
+    "file-directive-for-dependencies": {
+      "title": "'file:' directive for dependencies",
+      "allOf": [
+        {
+          "description": "**BETA**: subset of the ``requirements.txt`` format without ``pip`` flags and options (one :pep:`508`-compliant string per line, lines that are blank or start with ``#`` are excluded). See `dynamic metadata <https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata>`_."
+        },
+        {
+          "$ref": "#/definitions/file-directive"
+        }
+      ]
+    },
+    "attr-directive": {
+      "title": "'attr:' directive",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attr": {
+          "type": "string"
+        }
+      },
+      "required": ["attr"],
+      "description": "Value is read from a module attribute. Supports callables and iterables; unsupported types are cast via ``str()``"
+    },
+    "find-directive": {
+      "title": "'find:' directive",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "find": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "where": {
+              "description": "Directories to be searched for packages (Unix-style relative path)",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Exclude packages that match the values listed in this field. Can container shell-style wildcards (e.g. ``'pkg.*'``)"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Restrict the found packages to just the ones listed in this field. Can container shell-style wildcards (e.g. ``'pkg.*'``)"
+            },
+            "namespaces": {
+              "type": "boolean",
+              "description": "When ``True``, directories without a ``__init__.py`` file will also be scanned for :pep:`420`-style implicit namespaces"
+            }
+          },
+          "description": "Dynamic `package discovery <https://setuptools.pypa.io/en/latest/userguide/package_discovery.html>`_."
+        }
+      }
+    }
+  },
+  "description": "``setuptools``-specific configurations that can be set by users that require customization. These configurations are completely optional and probably can be skipped when creating simple packages. They are equivalent to some of the `Keywords <https://setuptools.pypa.io/en/latest/references/keywords.html>`_ used by the ``setup.py`` file, and can be set via the ``tool.setuptools`` table. It considers only ``setuptools`` `parameters <https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration>`_ that are not covered by :pep:`621`; and intentionally excludes ``dependency_links`` and ``setup_requires`` (incompatible with modern workflows/standards).",
+  "$id": "https://json.schemastore.org/setuptools.json"
+}

--- a/src/test/pyproject/01-setuptools.toml
+++ b/src/test/pyproject/01-setuptools.toml
@@ -1,0 +1,36 @@
+[project]
+name = "some-project"
+authors = [{ name = "Anderson Bravalheri" }]
+description = "Some description"
+license = { text = "MIT" }
+readme = "README.rst"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Topic :: Utilities",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+]
+dynamic = ["version"]
+requires-python = ">=3.6"
+dependencies = [
+    "importlib-metadata; python_version<\"3.8\"",
+    "appdirs>=1.4.4,<2",
+]
+
+[tool.setuptools]
+zip-safe = false
+include-package-data = true
+exclude-package-data = { "pkg1" = ["*.yaml"] }
+package-dir = {"" = "src"} # all the packages under the src folder
+platforms = ["any"]
+
+[tool.setuptools.packages]
+find = { where = ["src"], exclude = ["tests"], namespaces = true }

--- a/src/test/pyproject/02-setuptools.toml
+++ b/src/test/pyproject/02-setuptools.toml
@@ -1,0 +1,55 @@
+[project]
+name = "package"
+description = "description"
+authors = [{ name = "Name", email = "email@example.com" }]
+readme = "README.rst"
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Environment :: Web Environment",
+]
+dynamic = ["version"]
+requires-python = ">=3.8"
+dependencies = [
+    "backports.zoneinfo; python_version<\"3.9\"",
+    "tzdata; sys_platform == 'win32'",
+]
+
+[project.license]
+text = "BSD-3-Clause"
+
+[project.urls]
+Homepage = "https://www.example.com/"
+Documentation = "https://docs.example.com/"
+
+[project.optional-dependencies]
+argon2 = ["argon2-cffi >= 19.1.0"]
+
+[project.scripts]
+run = "project.__main__:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = {find = {}}
+include-package-data = true
+zip-safe = false
+
+[tool.setuptools.dynamic]
+version = {attr = "project.__version__"}
+
+[tool.distutils.bdist_rpm]
+doc-files = "docs extras AUTHORS INSTALL LICENSE README.rst"
+install-script = "scripts/rpm-install.sh"
+
+[tool.flake8]
+exclude = "build,.git,.tox,./tests/.env"
+ignore = "W504"
+max-line-length = "999"
+
+[tool.isort]
+default_section = "THIRDPARTY"
+include_trailing_comma = true
+line_length = 4
+multi_line_output = 6

--- a/src/test/pyproject/03-setuptools.toml
+++ b/src/test/pyproject/03-setuptools.toml
@@ -1,0 +1,44 @@
+[project]
+name = "project"
+description = "description"
+license = { text = "BSD-3-Clause" }
+dynamic = ["version"]
+requires-python = ">= 3.6"
+
+[[project.authors]]
+name = "Name 1"
+email = "name1@example1.com"
+
+[[project.authors]]
+name = "Name 2"
+email = "name2@example2.com"
+
+[project.readme]
+file = "README.rst"
+content-type = "text/x-rst"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+script-files = [
+    "bin/run.py"
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.dynamic]
+version = {file = "__version__.txt"}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.paths]
+source = [
+    "src",
+    "*/site-packages",
+]

--- a/src/test/pyproject/04-setuptools.toml
+++ b/src/test/pyproject/04-setuptools.toml
@@ -1,0 +1,34 @@
+[project]
+name = "project"
+readme = "README.md"
+dynamic = ["version"]
+requires-python = ">=3.8"
+dependencies = ["numpy>=1.18.5"]
+license.file = "LICENSE.txt"
+
+[project.entry-points]
+pandas_plotting_backends = {matplotlib = "project.plotting:matplotlib_plot"}
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-xdist",
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+zip-safe = false
+platforms = ["any"]
+
+[tool.setuptools.package-data]
+"*" = ["data/*", "files/**/*.json"]
+
+[tool.setuptools.packages.find]
+include = ["pkg", "pkg.*"]
+
+[tool.distutils.build_ext]
+inplace = true

--- a/src/test/pyproject/05-setuptools.toml
+++ b/src/test/pyproject/05-setuptools.toml
@@ -1,0 +1,24 @@
+[project]
+name = "myproj"
+version = "3.8"
+readme = "README.rst"
+urls = {Homepage = "https://github.com/me/myproj/"}
+requires-python = ">=3.6"
+dependencies = ["dep>=1.0.0"]
+
+[project.entry-points]
+"distutils.setup_keywords" = {use_scm_version = "myproj.setuptools:version_keyword"}
+
+[project.optional-dependencies]
+toml = ["dep>=1.0.0"]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+zip-safe = true
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/test/pyproject/06-setuptools.toml
+++ b/src/test/pyproject/06-setuptools.toml
@@ -1,0 +1,53 @@
+[project]
+name = "myproj"
+keywords = ["some", "key", "words"]
+dynamic = ["version"]
+requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+dependencies = [
+    "importlib-metadata>=0.12;python_version<\"3.8\"",
+    "importlib-resources>=1.0;python_version<\"3.7\"",
+    "pathlib2>=2.3.3,<3;python_version < '3.4' and sys.platform != 'win32'",
+]
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
+
+[project.optional-dependencies]
+docs = [
+    "sphinx>=3",
+    "sphinx-argparse>=0.2.5",
+    "sphinx-rtd-theme>=0.4.3",
+]
+testing = [
+    "pytest>=1",
+    "coverage>=3,<5",
+]
+
+[project.scripts]
+exec = "myproj.__main__:exec"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+zip-safe = true
+platforms = ["any"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.cmdclass]
+sdist = "pkg.mod.CustomSdist"
+
+[tool.setuptools.package-data]
+"myproj.bash" = ["*.sh"]
+"myproj.yaml" = ["*.yml"]
+
+[tool.distutils.sdist]
+formats = "gztar"
+
+[tool.distutils.bdist_wheel]
+universal = true

--- a/src/test/pyproject/07-setuptools.toml
+++ b/src/test/pyproject/07-setuptools.toml
@@ -1,0 +1,65 @@
+[project]
+name = "myproj"
+keywords = ["some", "key", "words"]
+license = {text = "MIT"}
+dynamic = [
+    "version",
+    "description",
+    "readme",
+    "entry-points",
+    "gui-scripts"
+]
+requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+dependencies = [
+    'importlib-metadata>=0.12;python_version<"3.8"',
+    'importlib-resources>=1.0;python_version<"3.7"',
+    'pathlib2>=2.3.3,<3;python_version < "3.4" and sys.platform != "win32"',
+]
+
+[project.optional-dependencies]
+docs = [
+    "sphinx>=3",
+    "sphinx-argparse>=0.2.5",
+    "sphinx-rtd-theme>=0.4.3",
+]
+testing = [
+    "pytest>=1",
+    "coverage>=3,<5",
+]
+
+[project.scripts]
+exec = "pkg.__main__:exec"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+zip-safe = true
+platforms = ["any"]
+license-files = ["LICENSE*", "NOTICE*"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+namespaces = true
+
+[tool.setuptools.cmdclass]
+sdist = "pkg.mod.CustomSdist"
+
+[tool.setuptools.dynamic]
+version = {attr = "pkg.__version__.VERSION"}
+description = {file = ["README.md"]}
+readme = {file = ["README.md"], content-type = "text/markdown"}
+
+[tool.setuptools.package-data]
+"*" = ["*.txt"]
+
+[tool.setuptools.data-files]
+"data" = ["files/*.txt"]
+
+[tool.distutils.sdist]
+formats = "gztar"
+
+[tool.distutils.bdist_wheel]
+universal = true

--- a/src/test/pyproject/08-setuptools.toml
+++ b/src/test/pyproject/08-setuptools.toml
@@ -1,0 +1,18 @@
+# Setuptools should allow stub-only package names in `packages` (PEP 561)
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mypkg-stubs"
+version = "0.0.0"
+
+[tool.setuptools]
+platforms = ["any"]
+packages = ["mypkg-stubs"]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.package-data]
+"*" = ["*.pyi"]

--- a/src/test/pyproject/09-setuptools.toml
+++ b/src/test/pyproject/09-setuptools.toml
@@ -1,0 +1,14 @@
+# Setuptools should allow stub-only package names in `package-dir` (PEP 561)
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mypkg-stubs"
+version = "0.0.0"
+
+[tool.setuptools]
+packages = ["otherpkg-stubs", "namespace.mod.stubs"]
+
+[tool.setuptools.package-dir]
+otherpkg-stubs = "namespace/mod/stubs"

--- a/src/test/pyproject/simple.toml
+++ b/src/test/pyproject/simple.toml
@@ -1,8 +1,8 @@
-["build-system"]
+[build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 64.0", "wheel"]
 
-["project"]
+[project]
 name = "typical-project"
 version = "42.0.1"
 description = "An example typical project"
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["example", "models"]
 urls.homepage = "https://example.com/typical-project"
 authors = [{ name = "John Smith", email = "john@example.com" }]
-license = { "text" = "MIT" }
+license = { text = "MIT" }
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -27,7 +27,7 @@ package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 namespaces = false
-where = "src"
+where = ["src"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

This adds setuptools' schema to pyproject.toml, using a modified form from validate-pyproject used in setuptools itself.

This exposed a bug in the current test suite - `tool.setuptools.packages.find.where` must be an array. If you try to run it with the file (`src/test/pyproject/simple.toml`) as it exists in the current examples:

```
ValueError: invalid pyproject.toml config: `tool.setuptools.packages`.
configuration error: `tool.setuptools.packages` must be valid exactly by one definition (0 matches found):

    - type: array
      items:
        type: string
        at least one of the following:
          - {format: 'python-module-name'}
          - {format: 'pep561-stub-name'}
    - type: table
      additional keys: False
      keys:
        'find':
          type: table
          additional keys: False
          keys:
            'where':
              type: array
              items: {type: string}
            'exclude':
              type: array
              items: {type: string}
            'include':
              type: array
              items: {type: string}
            'namespaces': {type: boolean}


ERROR Backend subprocess exited when trying to invoke get_requires_for_build_sdist
```
