### PR TITLE
Add support for buf

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -413,19 +413,19 @@
     },
     {
       "name": "buf.yaml",
-      "description": "buf.yaml is used to define a module. It's the primary configuration file, and is responsible for the module's name, dependencies, and lint and breaking configuration.",
+      "description": "buf.yaml is used to define a module. It's the primary configuration file, and is responsible for the module's name, dependencies, and lint and breaking configuration",
       "fileMatch": ["buf.yaml"],
       "url": "https://json.schemastore.org/buf.json"
     },
     {
       "name": "buf.gen.yaml",
-      "description": "buf.gen.yaml is a configuration file used by the buf generate command to generate integration code for the languages of your choice.",
+      "description": "buf.gen.yaml is a configuration file used by the buf generate command to generate integration code for the languages of your choice",
       "fileMatch": ["buf.gen.yaml"],
       "url": "https://json.schemastore.org/buf.gen.json"
     },
     {
       "name": "buf.work.yaml",
-      "description": "buf.work.yaml is used to define a workspace, which is an advanced local development feature. Workspaces make it possible to consolidate one or more modules into a single buildable unit. They also allow users to run buf operations across multiple modules with a single execution (such as buf lint).",
+      "description": "buf.work.yaml is used to define a workspace, which is an advanced local development feature. Workspaces make it possible to consolidate one or more modules into a single buildable unit. They also allow users to run buf operations across multiple modules with a single execution (such as buf lint)",
       "fileMatch": ["buf.work.yaml"],
       "url": "https://json.schemastore.org/buf.work.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -413,19 +413,19 @@
     },
     {
       "name": "buf.yaml",
-      "description": "https://buf.build/docs/configuration/v1/buf-yaml",
+      "description": "buf.yaml is used to define a module. It's the primary configuration file, and is responsible for the module's name, dependencies, and lint and breaking configuration.",
       "fileMatch": ["buf.yaml"],
       "url": "https://json.schemastore.org/buf.json"
     },
     {
       "name": "buf.gen.yaml",
-      "description": "https://buf.build/docs/configuration/v1/buf-gen-yaml",
+      "description": "buf.gen.yaml is a configuration file used by the buf generate command to generate integration code for the languages of your choice.",
       "fileMatch": ["buf.gen.yaml"],
       "url": "https://json.schemastore.org/buf.gen.json"
     },
     {
       "name": "buf.work.yaml",
-      "description": "https://buf.build/docs/configuration/v1/buf-work-yaml",
+      "description": "buf.work.yaml is used to define a workspace, which is an advanced local development feature. Workspaces make it possible to consolidate one or more modules into a single buildable unit. They also allow users to run buf operations across multiple modules with a single execution (such as buf lint).",
       "fileMatch": ["buf.work.yaml"],
       "url": "https://json.schemastore.org/buf.work.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -412,6 +412,24 @@
       }
     },
     {
+      "name": "buf.yaml",
+      "description": "https://buf.build/docs/configuration/v1/buf-yaml",
+      "fileMatch": ["buf.yaml"],
+      "url": "https://json.schemastore.org/buf.json"
+    },
+    {
+      "name": "buf.gen.yaml",
+      "description": "https://buf.build/docs/configuration/v1/buf-gen-yaml",
+      "fileMatch": ["buf.gen.yaml"],
+      "url": "https://json.schemastore.org/buf.gen.json"
+    },
+    {
+      "name": "buf.work.yaml",
+      "description": "https://buf.build/docs/configuration/v1/buf-work-yaml",
+      "fileMatch": ["buf.work.yaml"],
+      "url": "https://json.schemastore.org/buf.work.json"
+    },
+    {
       "name": "CodeCV",
       "description": "CV format specification",
       "fileMatch": [

--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -81,7 +81,7 @@
       }
     },
     "managed": {
-      "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#managed - TODO: can we 'require' enabled?",
+      "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#managed",
       "description": "The managed key is used to configure managed mode, an advanced feature for Protobuf options. See https://buf.build/docs/generate/managed-mode.",
       "type": "object",
       "properties": {

--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -1,0 +1,316 @@
+{
+  "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml",
+  "$id": "https://json.schemastore.org/buf.gen.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "buf.gen.yaml",
+  "description": "buf.gen.yaml is a configuration file used by the buf generate command to generate integration code for the languages of your choice.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#version",
+      "description": "Required. Defines the current configuration version. Accepted values are v1beta1 and v1.",
+      "type": "string",
+      "enum": ["v1beta1", "v1"]
+    },
+    "plugins": {
+      "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugins",
+      "description": "Required. Each entry in the plugins key is a protoc plugin configuration. Plugins are invoked in parallel and their outputs are written in the order you specify here.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "plugin": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin",
+            "type": "string",
+            "description": "Required. The name of the plugin to use—can be local or remote. See https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin."
+          },
+          "out": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#out",
+            "type": "string",
+            "description": "Required. Controls where the generated files are deposited for a given plugin. Although absolute paths are supported, this configuration is typically a relative output directory to where buf generate is run."
+          },
+          "opt": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#opt",
+            "description": "Optional. Specifies one or more plugin options for each plugin independently. You can provide options as either a single string or a list of strings.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "path": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#path",
+            "description": "Optional. Only works with local plugins. Overrides the default location and explicitly specifies where to locate the plugin.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "revision": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#revision",
+            "description": "Optional. May be used along with the plugin field to pin an exact version of a remote plugin. In most cases, we recommend omitting revision, in which case the latest revision of that version of the plugin will be used (automatically pulling in the latest bug fixes).",
+            "type": "integer",
+            "minimum": 0
+          },
+          "strategy": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy",
+            "description": "Optional. Specifies the invocation strategy to use. See https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy.",
+            "type": "string",
+            "enum": ["directory", "all"]
+          },
+          "protoc_path": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path",
+            "description": "Optional. Only applies to the code generators that are built in to protoc. Normally, a plugin is a separate executable with a binary name like protoc-gen-<name>. But for a handful of plugins, the executable used is protoc itself. See https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path.",
+            "type": "string"
+          }
+        },
+        "required": ["plugin", "out"]
+      }
+    },
+    "managed": {
+      "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#managed - TODO: can we 'require' enabled?",
+      "description": "The managed key is used to configure managed mode, an advanced feature for Protobuf options. See https://buf.build/docs/generate/managed-mode.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#enabled",
+          "description": "Required if any other managed keys are set. Setting enabled equal to true with no other keys set enables managed mode according to default behavior. See https://buf.build/docs/generate/managed-mode#default-behavior.",
+          "type": "boolean"
+        },
+        "cc_enable_arenas": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#cc_enable_arenas",
+          "description": "Optional. If unset, this option is left as specified in your .proto files. As of Protocol Buffers release v3.14.0, changing this value no longer has any effect.",
+          "type": "string"
+        },
+        "csharp_namespace": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#csharp_namespace",
+          "description": "Optional. Controls the default C# namespace for classes generated from all of the .proto files contained within the input. Managed mode generates C# files with a top-level namespace based on each .proto file’s package, with each part transformed to PascalCase.",
+          "type": "object",
+          "properties": {
+            "except": {
+              "description": "Optional. Removes the specified modules from the default csharp_namespace option behavior. The except keys must be valid module names.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "override": {
+              "description": "Optional. Overrides the csharp_namespace value used for specific modules. The override keys must be valid module names.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "go_package_prefix": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#go_package_prefix",
+          "description": "Optional. Controls what the go_package value is set to for all of the .proto files contained within the input. If unset, this option is left as specified in your .proto files.",
+          "type": "object",
+          "properties": {
+            "default": {
+              "description": "Required if the go_package_prefix key is set. The default value is used as a prefix for the go_package value set in each of the files. It must be a relative file path that must not jump context from the current directory—that is, it must be subdirectories relative to the current working directory.",
+              "type": "string"
+            },
+            "except": {
+              "description": "Optional. Removes certain modules from the go_package option behavior. The except values must be valid module names. There are situations where you may want to enable managed mode for the go_package option in most of your Protobuf files, but not necessarily for all of your Protobuf files. This is particularly relevant for the buf.build/googleapis/googleapis module, which points its go_package value to an external repository. Popular libraries such as grpc-go depend on these go_package values, so it's important that managed mode does not overwrite them.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "override": {
+              "description": "Optional. Overrides the go_package file option value used for specific modules. The override keys must be valid module names. Additionally, the corresponding override values must be a valid Go import path and must not jump context from the current directory. As an example, ../external is invalid. This setting is used for workspace environments, where you have a module that imports from another module in the same workspace, and you need to generate the Go code for each module in different directories. This is particularly relevant for repositories that decouple their private API definitions from their public API definitions.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["default"],
+          "additionalProperties": false
+        },
+        "java_multiple_files": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_multiple_files",
+          "description": "Optional. Controls what the java_multiple_files value is set to for all of the .proto files contained within the input. The only accepted values are false and true. Managed mode defaults to true (Protobuf's default is false). See https://buf.build/docs/configuration/v1/buf-gen-yaml#java_multiple_files.",
+          "type": "boolean"
+        },
+        "java_package_prefix": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_package_prefix",
+          "description": "Optional. Controls what is prepended to the java_package value is set to for all of the .proto files contained within the input.",
+          "type": "object",
+          "properties": {
+            "default": {
+              "description": "Required if the java_package_prefix key is set. The default value is used as a prefix for the java_package value set in each of the files.",
+              "type": "string"
+            },
+            "except": {
+              "description": "Optional. Removes the specified modules from the java_package option behavior. The except keys must be valid module names.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "override": {
+              "description": "Optional. Overrides the java_package option value used for specific modules. The override keys must be valid module names.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["default"],
+          "additionalProperties": false
+        },
+        "java_string_check_utf8": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_string_check_utf8",
+          "description": "Optional. Controls what the java_string_check_utf8 value is set to for all of the .proto files contained within the input. The only accepted values are false and true. If unset, this option is left as specified in your .proto files. Protobuf's default is false.",
+          "type": "boolean"
+        },
+        "objc_class_prefix": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#objc_class_prefix",
+          "description": "Optional. When managed mode is enabled, this defaults to an abbreviation of the package name as described in the default behavior section. The value is prepended to all generated classes. See https://buf.build/docs/generate/managed-mode#default-behavior.",
+          "type": "object",
+          "properties": {
+            "default": {
+              "description": "Optional. Overrides managed mode's default value for the class prefix.",
+              "type": "string"
+            },
+            "except": {
+              "description": "Optional. Removes the specified modules from the objc_class_prefix option behavior. The except keys must be valid module names.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "override": {
+              "description": "Optional. Overrides any default objc_class_prefix option value for specific modules. The override keys must be valid module names.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["default"],
+          "additionalProperties": false
+        },
+        "optimize_for": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#optimize_for",
+          "description": "Optional. Controls what the optimize_for value is set to for all of the .proto files contained within the input. The only accepted values are SPEED, CODE_SIZE and LITE_RUNTIME. Managed mode will not modify this option if unset.",
+          "type": "string",
+          "enum": ["SPEED", "CODE_SIZE", "LITE_RUNTIME"]
+        },
+        "ruby_package": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#ruby_package",
+          "description": "Optional. Controls what the ruby_package value is set to for all of the .proto files contained within the input. Managed mode's default value is the package name with each package sub-name capitalized, with :: substituted for .",
+          "type": "object",
+          "properties": {
+            "except": {
+              "description": "Optional. Removes the specified modules from the ruby_package file option override behavior. The except keys must be valid module names.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "override": {
+              "description": "Optional. Overrides the ruby_package file option value used for specific modules. The override keys must be valid module names.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "override": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#per-file-override",
+          "description": "Optional. This is a list of per-file overrides for each modifier. See https://buf.build/docs/configuration/v1/buf-gen-yaml#per-file-override.",
+          "type": "object",
+          "properties": {
+            "CSHARP_NAMESPACE": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "GO_PACKAGE": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "JAVA_MULTIPLE_FILES": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "JAVA_OUTER_CLASSNAME": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "JAVA_PACKAGE": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "JAVA_STRING_CHECK_UTF8": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "OBJC_CLASS_PREFIX": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "OPTIMIZE_FOR": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "PHP_METADATA_NAMESPACE": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "PHP_NAMESPACE": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "RUBY_PACKAGE": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["version", "plugins"]
+}

--- a/src/schemas/json/buf.json
+++ b/src/schemas/json/buf.json
@@ -1,0 +1,454 @@
+{
+  "$comment": "https://buf.build/docs/configuration/v1/buf-yaml",
+  "$id": "https://json.schemastore.org/buf.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "buf.yaml",
+  "description": "buf.yaml is used to define a module. It's the primary configuration file, and is responsible for the module's name, dependencies, and lint and breaking configuration.",
+  "type": "object",
+  "$defs": {
+    "lint-rule": {
+      "type": "string",
+      "description": "https://buf.build/docs/lint/rules",
+      "enum": [
+        "DEFAULT",
+        "BASIC",
+        "MINIMAL",
+        "COMMENTS",
+        "UNARY_RPC",
+        "DIRECTORY_SAME_PACKAGE",
+        "PACKAGE_DEFINED",
+        "PACKAGE_DIRECTORY_MATCH",
+        "PACKAGE_SAME_DIRECTORY",
+        "ENUM_PASCAL_CASE",
+        "ENUM_VALUE_UPPER_SNAKE_CASE",
+        "FIELD_LOWER_SNAKE_CASE",
+        "MESSAGE_PASCAL_CASE",
+        "ONEOF_LOWER_SNAKE_CASE",
+        "PACKAGE_LOWER_SNAKE_CASE",
+        "RPC_PASCAL_CASE",
+        "SERVICE_PASCAL_CASE",
+        "PACKAGE_SAME_CSHARP_NAMESPACE",
+        "PACKAGE_SAME_GO_PACKAGE",
+        "PACKAGE_SAME_JAVA_MULTIPLE_FILES",
+        "PACKAGE_SAME_JAVA_PACKAGE",
+        "PACKAGE_SAME_PHP_NAMESPACE",
+        "PACKAGE_SAME_RUBY_PACKAGE",
+        "PACKAGE_SAME_SWIFT_PREFIX",
+        "ENUM_FIRST_VALUE_ZERO",
+        "ENUM_NO_ALLOW_ALIAS",
+        "IMPORT_NO_WEAK",
+        "IMPORT_NO_PUBLIC",
+        "IMPORT_USED",
+        "ENUM_VALUE_PREFIX",
+        "ENUM_ZERO_VALUE_SUFFIX",
+        "FILE_LOWER_SNAKE_CASE",
+        "RPC_REQUEST_RESPONSE_UNIQUE",
+        "RPC_REQUEST_STANDARD_NAME",
+        "RPC_RESPONSE_STANDARD_NAME",
+        "PACKAGE_VERSION_SUFFIX",
+        "SERVICE_SUFFIX"
+      ]
+    },
+    "breaking-rule": {
+      "type": "string",
+      "description": "https://buf.build/docs/breaking/rules",
+      "enum": ["FILE", "PACKAGE", "WIRE_JSON", "WIRE"]
+    }
+  },
+  "required": ["version"],
+  "properties": {
+    "version": {
+      "description": "The version key is required, and defines the current configuration version. The only accepted values are v1beta1 and v1.",
+      "type": "string",
+      "enum": ["v1", "v1beta1"]
+    },
+    "name": {
+      "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#name",
+      "description": "The name is optional, and uniquely identifies your module. The name must be a valid module name and is directly associated with the repository that owns it.",
+      "type": "string"
+    },
+    "deps": {
+      "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#deps",
+      "description": "The deps key is optional, and declares one or more modules that your module depends on. Each deps entry must be a module reference, and, is directly associated with a repository, as well as a reference, which is either a tag or commit.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "build": {
+      "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#build",
+      "description": "The build key is optional, and is used to control how buf builds modules.",
+      "type": "object",
+      "properties": {
+        "excludes": {
+          "description": "The excludes key is optional, and lists directories to ignore from .proto file discovery. Any directories added to this list are completely skipped and excluded in the module. We do not recommend using this option in general, however in some situations it is unavoidable.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "lint": {
+      "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#lint",
+      "description": "The lint key is optional, and specifies the lint rules enforced on the files in the module. See https://buf.build/docs/lint/rules.",
+      "type": "object",
+      "properties": {
+        "use": {
+          "description": "The use key is optional, and lists the IDs or categories to use for linting.",
+          "type": "array",
+          "default": ["DEFAULT"],
+          "items": {
+            "$ref": "#/$defs/lint-rule"
+          }
+        },
+        "except": {
+          "description": "The except key is optional, and removes IDs or categories from the use list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/lint-rule"
+          }
+        },
+        "ignore": {
+          "description": "The ignore key is optional, and allows directories or files to be excluded from all lint rules when running buf lint. If a directory is ignored, then all files and subfolders of the directory will also be ignored. The specified directory or file paths must be relative to the buf.yaml.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignore_only": {
+          "$comment": "All of the #/$defs/lint-rule values can be keys",
+          "description": "The ignore_only key is optional, and allows directories or files to be excluded from specific lint rules when running buf lint by taking a map from lint rule ID or category to path. As with ignore, the paths must be relative to the buf.yaml.",
+          "type": "object",
+          "properties": {
+            "DEFAULT": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "BASIC": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "MINIMAL": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "COMMENTS": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "UNARY_RPC": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "DIRECTORY_SAME_PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_DEFINED": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_DIRECTORY_MATCH": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SAME_DIRECTORY": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_PASCAL_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_VALUE_UPPER_SNAKE_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_LOWER_SNAKE_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "MESSAGE_PASCAL_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ONEOF_LOWER_SNAKE_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_LOWER_SNAKE_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_PASCAL_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "SERVICE_PASCAL_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SAME_CSHARP_NAMESPACE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SAME_GO_PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SAME_JAVA_MULTIPLE_FILES": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SAME_JAVA_PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SAME_PHP_NAMESPACE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SAME_RUBY_PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SAME_SWIFT_PREFIX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_FIRST_VALUE_ZERO": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_NO_ALLOW_ALIAS": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "IMPORT_NO_WEAK": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "IMPORT_NO_PUBLIC": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "IMPORT_USED": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_VALUE_PREFIX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_ZERO_VALUE_SUFFIX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_LOWER_SNAKE_CASE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_REQUEST_RESPONSE_UNIQUE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_REQUEST_STANDARD_NAME": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_RESPONSE_STANDARD_NAME": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_VERSION_SUFFIX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "SERVICE_SUFFIX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "allow_comment_ignores": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#allow_comment_ignores",
+          "description": "The allow_comment_ignores key is optional, and turns on comment-driven ignores. We do not recommend using this option in general, however in some situations it is unavoidable. See https://buf.build/docs/configuration/v1/buf-yaml#allow_comment_ignores.",
+          "type": "boolean",
+          "default": false
+        },
+        "enum_zero_value_suffix": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#enum_zero_value_suffix",
+          "description": "The enum_zero_value_suffix key is optional, and controls the behavior of the ENUM_ZERO_VALUE_SUFFIX lint rule. See https://buf.build/docs/configuration/v1/buf-yaml#enum_zero_value_suffix.",
+          "type": "string",
+          "default": "_UNSPECIFIED"
+        },
+        "rpc_allow_same_request_response": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_same_request_response",
+          "description": "The rpc_allow_same_request_response key is optional, and allows the same message type to be used for a single RPC's request and response type. We do not recommend using this option in general.",
+          "type": "boolean",
+          "default": false
+        },
+        "rpc_allow_google_protobuf_empty_requests": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_google_protobuf_empty_requests",
+          "description": "The rpc_allow_google_protobuf_empty_requests key is optional, and allows RPC requests to be google.protobuf.Empty messages. This can be set if you want to allow messages to be void forever, that is, to never take any parameters. We do not recommend using this option in general.",
+          "type": "boolean",
+          "default": false
+        },
+        "rpc_allow_google_protobuf_empty_responses": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_google_protobuf_empty_responses",
+          "description": "The rpc_allow_google_protobuf_empty_responses key is optional, and allows RPC responses to be google.protobuf.Empty messages. This can be set if you want to allow messages to never return any parameters. We do not recommend using this option in general.",
+          "type": "boolean",
+          "default": false
+        },
+        "service_suffix": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#service_suffix",
+          "description": "The service_suffix key is optional, and controls the behavior of the SERVICE_SUFFIX lint rule. See https://buf.build/docs/configuration/v1/buf-yaml#service_suffix.",
+          "type": "string",
+          "default": "Service"
+        }
+      }
+    },
+    "breaking": {
+      "description": "The breaking key is optional, and specifies the breaking change detection rules enforced on the files contained within the module.",
+      "type": "object",
+      "properties": {
+        "use": {
+          "description": "The use key is optional, and lists the IDs or categories to use for breaking change detection. The default value is the single item FILE, which is what we recommend.",
+          "type": "array",
+          "default": ["FILE"],
+          "items": {
+            "$ref": "#/$defs/breaking-rule"
+          }
+        },
+        "except": {
+          "description": "The except key is optional, and removes IDs or categories from the use list. We do not recommend using this option in general.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/breaking-rule"
+          }
+        },
+        "ignore": {
+          "description": "The ignore key is optional, and allows directories or files to be excluded from all breaking rules when running buf breaking. If a directory is ignored, then all files and subfolders of the directory will also be ignored. The specified directory or file paths must be relative to the buf.yaml. This option can be useful for ignoring packages that are in active development but not deployed in production, especially alpha or beta packages, and we expect ignore to be commonly used for this case.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignore_only": {
+          "$comment": "All of the #/$defs/breaking-rule values can be keys.",
+          "description": "The ignore_only key is optional, and allows directories or files to be excluded from specific breaking rules when running buf breaking by taking a map from breaking rule ID or category to path. As with ignore, the paths must be relative to the buf.yaml. We do not recommend this option in general.",
+          "type": "object",
+          "properties": {
+            "FILE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "WIRE_JSON": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "WIRE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ignore_unstable_packages": {
+          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#ignore_unstable_packages",
+          "description": "The ignore_unstable_packages key is optional, and ignores packages with a last component that is one of the unstable forms recognized by PACKAGE_VERSION_SUFFIX.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/buf.work.json
+++ b/src/schemas/json/buf.work.json
@@ -1,0 +1,23 @@
+{
+  "$comment": "https://buf.build/docs/configuration/v1/buf-work-yaml",
+  "$id": "https://json.schemastore.org/buf.work.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "buf.work.yaml",
+  "description": "buf.work.yaml is used to define a workspace, which is an advanced local development feature. Workspaces make it possible to consolidate one or more modules into a single buildable unit. They also allow users to run buf operations across multiple modules with a single execution (such as buf lint).",
+  "type": "object",
+  "properties": {
+    "version": {
+      "description": "Required. Defines the current configuration version. The only accepted value is v1.",
+      "type": "string",
+      "const": "v1"
+    },
+    "directories": {
+      "description": "Required. Lists the directories that define modules to be included in the workspace. The directory paths must be relative to the buf.work.yaml, and can't point to a location outside of the directory where your buf.work.yaml is.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["version", "directories"]
+}

--- a/src/test/buf.gen/buf.gen.yaml
+++ b/src/test/buf.gen/buf.gen.yaml
@@ -1,0 +1,11 @@
+# Below is from https://buf.build/docs/reference/cli/buf/generate#usage.
+
+# buf.gen.yaml
+version: v1
+plugins:
+  - plugin: go
+    out: gen/go
+    opt: paths=source_relative
+  - plugin: go-grpc
+    out: gen/go
+    opt: paths=source_relative,require_unimplemented_servers=false

--- a/src/test/buf.work/buf.work.yaml
+++ b/src/test/buf.work/buf.work.yaml
@@ -1,0 +1,6 @@
+# Below is from https://buf.build/docs/configuration/v1/buf-work-yaml.
+
+version: v1
+directories:
+  - paymentapis
+  - petapis

--- a/src/test/buf/buf.test2.yaml
+++ b/src/test/buf/buf.test2.yaml
@@ -1,0 +1,26 @@
+# Below is from https://buf.build/docs/configuration/v1/buf-yaml.
+
+version: v1
+name: ''
+deps: []
+build:
+  excludes: []
+lint:
+  use:
+    - DEFAULT
+  except: []
+  ignore: []
+  ignore_only: {}
+  allow_comment_ignores: false
+  enum_zero_value_suffix: _UNSPECIFIED
+  rpc_allow_same_request_response: false
+  rpc_allow_google_protobuf_empty_requests: false
+  rpc_allow_google_protobuf_empty_responses: false
+  service_suffix: Service
+breaking:
+  use:
+    - FILE
+  except: []
+  ignore: []
+  ignore_only: {}
+  ignore_unstable_packages: false

--- a/src/test/buf/buf.yaml
+++ b/src/test/buf/buf.yaml
@@ -1,0 +1,215 @@
+# Below is the output of `buf mod init --doc`, with `build:` commented-out.
+
+# This specifies the configuration file version.
+#
+# This controls the configuration file layout, defaults, and lint/breaking
+# rules and rule categories. Buf takes breaking changes seriously in
+# all aspects, and none of these will ever change for a given version.
+#
+# The only valid versions are "v1beta1", "v1".
+# This key is required.
+version: v1
+
+# name is the module name.
+#name: buf.build/acme/weather
+
+# deps are the module dependencies
+#deps:
+#  - buf.build/acme/petapis
+#  - buf.build/acme/pkg:alpha
+#  - buf.build/acme/paymentapis:7e8b594e68324329a7aefc6e750d18b9
+
+# build contains the options for builds.
+#
+# This affects the behavior of buf build, as well as the build behavior
+# for source lint and breaking change rules.
+#
+# If you want to build all files in your repository, this section can be
+# omitted.
+#build:
+
+# excludes is the list of directories to exclude.
+#
+# These directories will not be built or checked. If a directory is excluded,
+# buf treats the directory as if it does not exist.
+#
+# All directory paths in exclude must be relative to the directory of
+# your buf.yaml. Only directories can be specified, and all specified
+# directories must within the root directory.
+#excludes:
+#  - foo
+#  - bar/baz
+
+# lint contains the options for lint rules.
+lint:
+  # use is the list of rule categories and ids to use for buf lint.
+  #
+  # Categories are sets of rule ids.
+  # Run buf config ls-lint-rules --all to get a list of all rules.
+  #
+  # The union of the categories and ids will be used.
+  #
+  # The default is [DEFAULT].
+  use:
+    - DEFAULT
+
+  # except is the list of rule ids or categories to remove from the use
+  # list.
+  #
+  # This allows removal of specific rules from the union of rules derived
+  # from the use list of categories and ids.
+  #except:
+  #  - ENUM_VALUE_UPPER_SNAKE_CASE
+
+  # ignore is the list of directories or files to ignore for all rules.
+  #
+  # All directories and file paths are specified relative to the root directory.
+  # The directory "." is not allowed - this is equivalent to ignoring
+  # everything.
+  #ignore:
+  #  - bat
+  #  - ban/ban.proto
+
+  # ignore_only is the map from rule id or category to file or directory to
+  # ignore.
+  #
+  # All directories and file paths are specified relative to the root directory.
+  # The directory "." is not allowed - this is equivalent to using the "except"
+  # option.
+  #
+  # Note you can generate this section using
+  # "buf lint --error-format=config-ignore-yaml". The result of this command
+  # can be copy/pasted here.
+  #ignore_only:
+  #  ENUM_PASCAL_CASE:
+  #    - foo/foo.proto
+  #    - bar
+  #  FIELD_LOWER_SNAKE_CASE:
+  #    - foo
+
+  # enum_zero_value_suffix affects the behavior of the ENUM_ZERO_VALUE_SUFFIX
+  # rule.
+  #
+  # This will result in this suffix being used instead of the default
+  # "_UNSPECIFIED" suffix.
+  #enum_zero_value_suffix: _UNSPECIFIED
+
+  # rpc_allow_same_request_response affects the behavior of the
+  # RPC_REQUEST_RESPONSE_UNIQUE rule.
+  #
+  # This will result in requests and responses being allowed to be the same
+  # type for a single RPC.
+  #rpc_allow_same_request_response: false
+
+  # rpc_allow_google_protobuf_empty_requests affects the behavior of the
+  # RPC_REQUEST_STANDARD_NAME and RPC_REQUEST_RESPONSE_UNIQUE rules.
+  #
+  # This will result in google.protobuf.Empty requests being ignored for
+  # RPC_REQUEST_STANDARD_NAME, and google.protobuf.Empty requests being allowed
+  # in multiple RPCs.
+  #rpc_allow_google_protobuf_empty_requests: false
+
+  # rpc_allow_google_protobuf_empty_responses affects the behavior of the
+  # RPC_RESPONSE_STANDARD_NAME and the RPC_REQUEST_RESPONSE_UNIQUE rules.
+  #
+  # This will result in google.protobuf.Empty responses being ignored for
+  # RPC_RESPONSE_STANDARD_NAME, and google.protobuf.Empty responses being
+  # allowed in multiple RPCs.
+  #rpc_allow_google_protobuf_empty_responses: false
+
+  # service_suffix affects the behavior of the SERVICE_SUFFIX rule.
+  #
+  # This will result in this suffix being used instead of the default "Service"
+  # suffix.
+  #service_suffix: Service
+
+  # allow_comment_ignores allows comment-driven ignores.
+  #
+  # If this option is set, leading comments can be added within Protobuf files
+  # to ignore lint errors for certain components. If any line in a leading
+  # comment starts with "buf:lint:ignore ID", then Buf will ignore lint errors
+  # for this id. For example:
+  #
+  #   syntax = "proto3";
+  #
+  #   // buf:lint:ignore PACKAGE_LOWER_SNAKE_CASE
+  #   // buf:lint:ignore PACKAGE_VERSION_SUFFIX
+  #   package A;
+  #
+  # We do not recommend using this, as it allows individual engineers in a
+  # large organization to decide on their own lint rule exceptions. However,
+  # there are cases where this is necessarily, and we want users to be able to
+  # make informed decisions, so we provide this as an opt-in.
+  #allow_comment_ignores: false
+
+# breaking contains the options for breaking rules.
+breaking:
+  # use is the list of rule categories and ids to use for
+  # buf breaking.
+  #
+  # Categories are sets of rule ids.
+  # Run buf config ls-breaking-rules --all to get a list of all rules.
+  #
+  # The union of the categories and ids will be used.
+  #
+  # As opposed to lint, where you may want to do more customization, with
+  # breaking is is generally better to only choose one of the following
+  # options:
+  #
+  # - [FILE]
+  # - [PACKAGE]
+  # - [WIRE]
+  # - [WIRE_JSON]
+  #
+  # The default is [FILE], as done below.
+  use:
+    - FILE
+
+  # except is the list of rule ids or categories to remove from the use
+  # list.
+  #
+  # This allows removal of specific rules from the union of rules derived
+  # from the use list of categories and ids.
+  #
+  # As opposed to lint, we generally recommend using one of the preconfigured
+  # options. Removing specific rules from breaking change detection is an
+  # advanced option.
+  #except:
+  #  - FIELD_SAME_NAME
+
+  # ignore is the list of directories or files to ignore for all rules.
+  #
+  # All directories and file paths are specified relative to the root directory.
+  # The directory "." is not allowed - this is equivalent to ignoring
+  # everything.
+  #ignore:
+  #  - bat
+  #  - ban/ban.proto
+
+  # ignore_only is the map from rule id or category to file or directory to
+  # ignore.
+  #
+  # All directories and file paths are specified relative to a root directory.
+  # The directory "." is not allowed - this is equivalent to using the "except"
+  # option.
+  #ignore_only:
+  #  FIELD_NO_DELETE:
+  #    - foo/foo.proto
+  #    - bar
+  #  WIRE_JSON:
+  #    - foo
+
+  # ignore_unstable_packages results in ignoring packages with a last component
+  # that is one of the unstable forms recognized by the "PACKAGE_VERSION_SUFFIX"
+  # lint rule. The following forms will be ignored:
+  #
+  # - v\d+test.*
+  # - v\d+(alpha|beta)\d+
+  # - v\d+p\d+(alpha|beta)\d+
+  #
+  # For example, if this option is set, the following packages will be ignored:
+  #
+  # - foo.bar.v1alpha1
+  # - foo.bar.v1beta1
+  # - foo.bar.v1test
+  #ignore_unstable_packages: false


### PR DESCRIPTION
This adds support for:
* [buf.yaml](https://buf.build/docs/configuration/v1/buf-yaml)
* [buf.gen.yaml](https://buf.build/docs/configuration/v1/buf-gen-yaml)
* [buf.work.yaml](https://buf.build/docs/configuration/v1/buf-work-yaml)

Didn't include [buf.lock](https://buf.build/docs/configuration/v1/buf-lock) - although it's technically a yaml file, it's generated by the `buf` CLI and isn't intended to be managed by external processes, so I'm not sure it's worth including its schema.

Requested in https://github.com/bufbuild/buf/issues/2408 and https://github.com/bufbuild/buf/issues/1413 and related to https://github.com/bufbuild/intellij-buf/issues/144.

In terms of formatting, I just ran `npm run prettier:fix` from the `src/` directory before committing, so let me know if there's anything to adjust. I'll add some minor comments/questions below.