### PR TITLE
Support undocumented name/remote in buf.gen.yaml

### DIFF
--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -86,6 +86,7 @@
           }
         },
         "required": ["out"],
+        "additionalProperties": false
       }
     },
     "managed": {

--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -85,17 +85,7 @@
             "type": "string"
           }
         },
-        "oneOf": [
-          {
-            "required": ["plugin", "out"]
-          },
-          {
-            "required": ["name", "out"]
-          },
-          {
-            "required": ["remote", "out"]
-          }
-        ]
+        "required": ["out"],
       }
     },
     "managed": {

--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -19,10 +19,18 @@
       "items": {
         "type": "object",
         "properties": {
-          "plugin": {
-            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin",
-            "type": "string",
-            "description": "Required. The name of the plugin to use—can be local or remote. See https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin."
+          "oneOf": {
+            "plugin": {
+              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin",
+              "type": "string",
+              "description": "Required. The name of the plugin to use—can be local or remote. See https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin."
+            },
+            "name": {
+              "type": "string"
+            },
+            "remote": {
+              "type": "string"
+            }
           },
           "out": {
             "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#out",
@@ -77,7 +85,17 @@
             "type": "string"
           }
         },
-        "required": ["plugin", "out"]
+        "oneOf": [
+          {
+            "required": ["plugin", "out"]
+          },
+          {
+            "required": ["name", "out"]
+          },
+          {
+            "required": ["remote", "out"]
+          }
+        ]
       }
     },
     "managed": {

--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -19,18 +19,16 @@
       "items": {
         "type": "object",
         "properties": {
-          "oneOf": {
-            "plugin": {
-              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin",
-              "type": "string",
-              "description": "Required. The name of the plugin to use—can be local or remote. See https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin."
-            },
-            "name": {
-              "type": "string"
-            },
-            "remote": {
-              "type": "string"
-            }
+          "plugin": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin",
+            "type": "string",
+            "description": "Required. The name of the plugin to use—can be local or remote. See https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin."
+          },
+          "name": {
+            "type": "string"
+          },
+          "remote": {
+            "type": "string"
           },
           "out": {
             "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#out",

--- a/src/test/buf.gen/name.buf.gen.yaml
+++ b/src/test/buf.gen/name.buf.gen.yaml
@@ -1,0 +1,14 @@
+# Below is from https://github.com/connectrpc/connect-go/blob/96effedc8ac84da9f49392e5f7bdfee2e648247b/buf.gen.yaml.
+
+version: v1
+managed:
+  enabled: true
+  go_package_prefix:
+    default: connectrpc.com/connect/internal/gen
+plugins:
+  - name: go
+    out: internal/gen
+    opt: paths=source_relative
+  - name: connect-go
+    out: internal/gen
+    opt: paths=source_relative

--- a/src/test/buf.gen/name.buf.gen.yaml
+++ b/src/test/buf.gen/name.buf.gen.yaml
@@ -1,4 +1,4 @@
-# Below is from https://github.com/connectrpc/connect-go/blob/96effedc8ac84da9f49392e5f7bdfee2e648247b/buf.gen.yaml.
+# Below is from https://github.com/connectrpc/connect-go/blob/96effedc8ac84da9f49392e5f7bdfee2e648247b/buf.gen.yaml
 
 version: v1
 managed:

--- a/src/test/buf.gen/remote.buf.gen.yaml
+++ b/src/test/buf.gen/remote.buf.gen.yaml
@@ -1,0 +1,22 @@
+# Below is from https://github.com/grpc-ecosystem/grpc-gateway/blob/bb2225c08f5f8ff7ed3935b68cfcbb1538af6475/buf.gen.yaml.
+
+version: v1
+plugins:
+  - remote: buf.build/library/plugins/go:v1.27.1-1
+    out: .
+    opt:
+      - paths=source_relative
+  - remote: buf.build/library/plugins/go-grpc:v1.1.0-2
+    out: .
+    opt:
+      - paths=source_relative
+      - require_unimplemented_servers=false
+  - name: grpc-gateway
+    out: .
+    opt:
+      - paths=source_relative
+      - allow_repeated_fields_in_body=true
+  - name: openapiv2
+    out: .
+    opt:
+      - allow_repeated_fields_in_body=true

--- a/src/test/buf.gen/remote.buf.gen.yaml
+++ b/src/test/buf.gen/remote.buf.gen.yaml
@@ -1,4 +1,4 @@
-# Below is from https://github.com/grpc-ecosystem/grpc-gateway/blob/bb2225c08f5f8ff7ed3935b68cfcbb1538af6475/buf.gen.yaml.
+# Below is from https://github.com/grpc-ecosystem/grpc-gateway/blob/bb2225c08f5f8ff7ed3935b68cfcbb1538af6475/buf.gen.yaml
 
 version: v1
 plugins:


### PR DESCRIPTION
Noticed after #3310 was merged that a few older buf.gen.yaml files had these undocumented properties still around - they're supported, so I don't think they should be "deprecated". They're exclusive of each other, but one of them must be set.

(Otherwise, #3310 is working great on my end integrated with my $EDITOR - thanks for the hard work on this project!)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
