### PR TITLE
TextMate Grammar: Support YAML and improve description

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3840,9 +3840,13 @@
       "url": "https://json.schemastore.org/tldr.json"
     },
     {
-      "name": "tmLanguage",
-      "description": "Language grammar description files in Textmate and compatible editors",
-      "fileMatch": ["*.tmLanguage.json"],
+      "name": "TextMate Grammar",
+      "description": "Language grammar description files for TextMate and compatible editors",
+      "fileMatch": [
+        "*.tmLanguage.json",
+        "*.tmLanguage.yaml",
+        "*.tmLanguage.yml"
+      ],
       "url": "https://json.schemastore.org/tmlanguage.json"
     },
     {


### PR DESCRIPTION
- Add `.yaml` and `.yml` associations since a lot of projects write their grammar in YAML and then convert them to JSON.
- Use a more descriptive name

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->