### PR TITLE
fix(circleci): add value "large" resource_class

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -453,6 +453,7 @@
             "enum": [
               "small",
               "medium+",
+              "large",
               "xlarge",
               "2xlarge",
               "2xlarge+",


### PR DESCRIPTION
CircleCI `resource_class` is missing the `large` class, as can be found here: https://circleci.com/docs/configuration-reference/#docker-execution-environment