### PR TITLE
Fix additionalProperties

### DIFF
--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -439,12 +439,12 @@
         "dockerfile": {
           "description": "Dockerfile used for builds. Defaults to './Dockerfile'",
           "type": "string"
-        },
-        "additionalProperties": false
-      }
-    },
-    "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
   },
+  "additionalProperties": true,
   "title": "Fly.io config schema (fly.toml)",
   "type": "object",
   "x-taplo-info": {

--- a/src/schemas/json/github-issue-config.json
+++ b/src/schemas/json/github-issue-config.json
@@ -37,9 +37,9 @@
         },
         "additionalProperties": false
       }
-    },
-    "additionalProperties": false
+    }
   },
+  "additionalProperties": false,
   "title": "GitHub issue template chooser config file schema",
   "type": "object"
 }

--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -2469,9 +2469,9 @@
                 "type": "string",
                 "minLength": 1
               }
-            },
-            "additionalProperties": false
-          }
+            }
+          },
+          "additionalProperties": false
         },
         "funcs": {
           "description": "\nhttps://gohugo.io/about/security-model/#security-policy",
@@ -2520,12 +2520,12 @@
                 "type": "string",
                 "minLength": 1
               }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "sitemap": {
       "title": "sitemap options",


### PR DESCRIPTION
Some schemas had additionalProperties as a child of properties, rather than a sibling:

	"properties": {
		"a": {"type": "int"},
		"b": {"type": "int"},
		"additionalProperties": false,
	}

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
