### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -467,16 +467,6 @@
       },
       "additionalProperties": false
     },
-    "FormatOrOutputFormat": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/FormatOptions"
-        },
-        {
-          "$ref": "#/definitions/SerializationFormat"
-        }
-      ]
-    },
     "ImportSection": {
       "anyOf": [
         {
@@ -700,8 +690,8 @@
       "description": "The length of a line of text that is considered too long.\n\nThe allowed range of values is 1..=320",
       "type": "integer",
       "format": "uint16",
-      "minimum": 1.0,
-      "maximum": 320.0
+      "maximum": 320.0,
+      "minimum": 1.0
     },
     "LintOptions": {
       "description": "Experimental section to configure Ruff's linting. This new section will eventually replace the top-level linting options.\n\nOptions specified in the `lint` section take precedence over the top-level settings.",
@@ -741,8 +731,22 @@
             }
           }
         },
+        "extend-safe-fixes": {
+          "description": "A list of rule codes or prefixes for which unsafe fixes should be considered safe.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
         "extend-select": {
           "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
+        "extend-unsafe-fixes": {
+          "description": "A list of rule codes or prefixes for which safe fixes should be considered unsafe.",
           "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/RuleSelector"
@@ -1703,6 +1707,7 @@
         "FURB145",
         "FURB148",
         "FURB17",
+        "FURB171",
         "FURB177",
         "G",
         "G0",
@@ -1939,6 +1944,7 @@
         "PLR17",
         "PLR170",
         "PLR1701",
+        "PLR1706",
         "PLR171",
         "PLR1711",
         "PLR1714",
@@ -2163,6 +2169,8 @@
         "RUF015",
         "RUF016",
         "RUF017",
+        "RUF018",
+        "RUF019",
         "RUF1",
         "RUF10",
         "RUF100",
@@ -2528,8 +2536,22 @@
         }
       }
     },
+    "extend-safe-fixes": {
+      "description": "A list of rule codes or prefixes for which unsafe fixes should be considered safe.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/RuleSelector"
+      }
+    },
     "extend-select": {
       "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/RuleSelector"
+      }
+    },
+    "extend-unsafe-fixes": {
+      "description": "A list of rule codes or prefixes for which safe fixes should be considered unsafe.",
       "type": ["array", "null"],
       "items": {
         "$ref": "#/definitions/RuleSelector"
@@ -2543,7 +2565,7 @@
       }
     },
     "fix": {
-      "description": "Enable fix behavior by-default when running `ruff` (overridden by the `--fix` and `--no-fix` command-line flags).",
+      "description": "Enable fix behavior by-default when running `ruff` (overridden by the `--fix` and `--no-fix` command-line flags). Only includes automatic fixes unless `--unsafe-fixes` is provided.",
       "type": ["boolean", "null"]
     },
     "fix-only": {
@@ -2738,10 +2760,10 @@
       "type": ["boolean", "null"]
     },
     "format": {
-      "description": "Options to configure the code formatting.\n\nPreviously: The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).\n\nThis option has been **deprecated** in favor of `output-format` to avoid ambiguity with Ruff's upcoming formatter.",
+      "description": "Options to configure code formatting.",
       "anyOf": [
         {
-          "$ref": "#/definitions/FormatOrOutputFormat"
+          "$ref": "#/definitions/FormatOptions"
         },
         {
           "type": "null"
@@ -2993,6 +3015,10 @@
       "items": {
         "$ref": "#/definitions/RuleSelector"
       }
+    },
+    "unsafe-fixes": {
+      "description": "Enable application of unsafe fixes.",
+      "type": ["boolean", "null"]
     }
   },
   "title": "Options",


### PR DESCRIPTION
This updates ruff's JSON schema to [4113d65836e1b3baa3aa77cbdf44f83207e9f424](https://github.com/astral-sh/ruff/commit/4113d65836e1b3baa3aa77cbdf44f83207e9f424)
