### PR TITLE
Add `lfx_crowdfunding` key to github-funding.json

### DIFF
--- a/src/schemas/json/github-funding.json
+++ b/src/schemas/json/github-funding.json
@@ -82,6 +82,12 @@
       "$ref": "#/definitions/nullable_string",
       "pattern": "^(npm|pypi|rubygems|maven|packagist|nuget)/.+$"
     },
+    "lfx_crowdfunding": {
+      "title": "LFX Crowdfunding",
+      "description": "Project name on LFX Crowdfunding.",
+      "$ref": "#/definitions/nullable_string",
+      "minLength": 1
+    },
     "custom": {
       "title": "Custom URL",
       "description": "Link or links where funding is accepted on external locations.",


### PR DESCRIPTION
I just created a new `FUNDING.yml` using GitHub's web interface, and it created a `lfx_crowdfunding` key automatically. It was described as follows:
```
lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
```

Thanks for maintaining this repository!
