### PR TITLE
hugo: update mediaTypes field values

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -1720,6 +1720,17 @@
             "examples": ["jsx"]
           }
         },
+        "text/markdown": {
+          "description": "\nhttps://gohugo.io/templates/output-formats/#media-types",
+          "type": "array",
+          "default": ["md", "markdown"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "examples": ["md"]
+          }
+        },
         "text/plain": {
           "description": "\nhttps://gohugo.io/templates/output-formats/#media-types",
           "type": "array",


### PR DESCRIPTION
Adding the `text/markdown` media type to another property that was missing it.

This PR is just to make a correction that I missed with my last PR. If I have time this week (or weekend), I might spend some time opening another PR with a fully updated Hugo schema.
