### PR TITLE
feat: update swcrc.json with missing property `importSource`.

### DIFF
--- a/src/schemas/json/swcrc.json
+++ b/src/schemas/json/swcrc.json
@@ -413,6 +413,10 @@
                     "development": {
                       "type": "boolean"
                     },
+                    "importSource": {
+                      "type": "string",
+                      "default": "react"
+                    },
                     "pragma": {
                       "type": "string",
                       "default": "React.createElement"


### PR DESCRIPTION
`importSource` documentation [here](https://swc.rs/docs/configuration/compilation#jsctransformreactimportsource).