### PR TITLE
feat: Allow Runner Scale Sets

### DIFF
--- a/src/negative_test/github-workflow/runs-on.yaml
+++ b/src/negative_test/github-workflow/runs-on.yaml
@@ -6,11 +6,5 @@ on:
 jobs:
   self-hosted-custom:
     runs-on:
-      - self-hosted
-      - x86
-      - windows
-      - gpu
-      - large
-      - 5
     steps:
       - run: echo 'Hello from self-hosted ${{ runner.os }}'

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -569,32 +569,10 @@
         "runs-on": {
           "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on",
           "description": "The type of machine to run the job on. The machine can be either a GitHub-hosted runner, or a self-hosted runner.",
-          "oneOf": [
+          "anyOf": [
             {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#github-hosted-runners",
-              "type": "string",
-              "enum": [
-                "macos-10.15",
-                "macos-11",
-                "macos-12",
-                "macos-12-xl",
-                "macos-13",
-                "macos-13-xl",
-                "macos-latest",
-                "macos-latest-xl",
-                "self-hosted",
-                "ubuntu-18.04",
-                "ubuntu-20.04",
-                "ubuntu-22.04",
-                "ubuntu-latest",
-                "ubuntu-latest-4-cores",
-                "ubuntu-latest-8-cores",
-                "ubuntu-latest-16-cores",
-                "windows-2019",
-                "windows-2022",
-                "windows-latest",
-                "windows-latest-8-cores"
-              ]
+              "type": "string"
             },
             {
               "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#self-hosted-runners",
@@ -603,99 +581,10 @@
                 {
                   "items": [
                     {
-                      "const": "self-hosted"
+                      "type": "string"
                     }
                   ],
-                  "minItems": 1,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "self-hosted"
-                    },
-                    {
-                      "$ref": "#/definitions/machine"
-                    }
-                  ],
-                  "minItems": 2,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "self-hosted"
-                    },
-                    {
-                      "$ref": "#/definitions/architecture"
-                    }
-                  ],
-                  "minItems": 2,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "self-hosted"
-                    },
-                    {
-                      "$ref": "#/definitions/machine"
-                    },
-                    {
-                      "$ref": "#/definitions/architecture"
-                    }
-                  ],
-                  "minItems": 3,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "self-hosted"
-                    },
-                    {
-                      "$ref": "#/definitions/architecture"
-                    },
-                    {
-                      "$ref": "#/definitions/machine"
-                    }
-                  ],
-                  "minItems": 3,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "linux"
-                    }
-                  ],
-                  "minItems": 2,
-                  "maxItems": 2,
-                  "additionalItems": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "items": [
-                    {
-                      "const": "windows"
-                    }
-                  ],
-                  "minItems": 2,
-                  "maxItems": 2,
-                  "additionalItems": {
-                    "type": "string"
-                  }
+                  "minItems": 1
                 }
               ]
             },
@@ -723,6 +612,9 @@
             },
             {
               "$ref": "#/definitions/stringContainingExpressionSyntax"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
             }
           ]
         },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Fixes https://github.com/SchemaStore/schemastore/issues/3192.

Since GitHub's new Runner Scale Sets must be referenced in `runs-on` by their scale set name, `runs-on` can now be a simple array or string, and we can't validate against a known list of OS types.

More info on [GitHub's documentation page regarding Runner Scale Sets](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/using-actions-runner-controller-runners-in-a-workflow#about-using-arc-runners-in-a-workflow-file).