### PR TITLE
Add default_install_hook_types to pre-commit-config

### DIFF
--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -216,6 +216,13 @@
         ]
       }
     },
+    "default_install_hook_types": {
+      "description": "A list of hook types which will be used by default when running `pre-commit install`\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
+      "type": "array",
+      "default": [
+        "pre-commit"
+      ]
+    },
     "default_language_version": {
       "description": "Mappings for the default language versions of the current project\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
       "type": "object",

--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -219,9 +219,7 @@
     "default_install_hook_types": {
       "description": "A list of hook types which will be used by default when running `pre-commit install`\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",
       "type": "array",
-      "default": [
-        "pre-commit"
-      ]
+      "default": ["pre-commit"]
     },
     "default_language_version": {
       "description": "Mappings for the default language versions of the current project\nhttps://pre-commit.com/#pre-commit-configyaml---top-level",

--- a/src/test/pre-commit-config/pre-commit-config-test.json
+++ b/src/test/pre-commit-config/pre-commit-config-test.json
@@ -8,6 +8,9 @@
     "skip": ["end-of-file-fixer"],
     "submodules": false
   },
+  "default_install_hook_types": [
+    "pre-commit"
+  ],
   "default_language_version": {
     "python": "python3.7"
   },

--- a/src/test/pre-commit-config/pre-commit-config-test.json
+++ b/src/test/pre-commit-config/pre-commit-config-test.json
@@ -8,9 +8,7 @@
     "skip": ["end-of-file-fixer"],
     "submodules": false
   },
-  "default_install_hook_types": [
-    "pre-commit"
-  ],
+  "default_install_hook_types": ["pre-commit"],
   "default_language_version": {
     "python": "python3.7"
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Adding support for `default_install_hook_types` in `pre-commit-config.json`. See documentation at https://pre-commit.com/#top_level-default_install_hook_types