### PR TITLE
More constraints in our draft 07 schema

### DIFF
--- a/src/schemas/json/metaschema-draft-07-unofficial-strict.json
+++ b/src/schemas/json/metaschema-draft-07-unofficial-strict.json
@@ -168,6 +168,29 @@
         "^#[0-9a-fA-F]{6}$"
       ]
     },
+    "format-property": {
+      "description": "A format of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#regular-expressions",
+      "type": "string",
+      "enum": [
+        "date",
+        "time",
+        "date-time",
+        "duration",
+        "regex",
+        "email",
+        "idn-email",
+        "hostname",
+        "idn-hostname",
+        "ipv4",
+        "ipv6",
+        "json-pointer",
+        "relative-json-pointer",
+        "uri",
+        "uri-reference",
+        "uri-template",
+        "uuid"
+      ]
+    },
     "enum-property": {
       "description": "Valid values of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
       "type": "array",
@@ -461,6 +484,9 @@
         "pattern": {
           "$ref": "#/definitions/pattern-property"
         },
+        "format": {
+          "$ref": "#/definitions/format-property"
+        },
         "enum": {
           "$ref": "#/definitions/enum-property"
         },
@@ -546,6 +572,9 @@
         },
         "pattern": {
           "$ref": "#/definitions/pattern-property"
+        },
+        "format": {
+          "$ref": "#/definitions/format-property"
         },
         "enum": {
           "$ref": "#/definitions/enum-property"
@@ -674,6 +703,9 @@
         "pattern": {
           "$ref": "#/definitions/string-type-requirement"
         },
+        "format": {
+          "$ref": "#/definitions/string-type-requirement"
+        },
         "enum": {
           "$ref": "#/definitions/simple-type-requirement"
         },
@@ -771,6 +803,9 @@
         },
         "pattern": {
           "$ref": "#/definitions/pattern-property"
+        },
+        "format": {
+          "$ref": "#/definitions/format-property"
         },
         "enum": {
           "$ref": "#/definitions/enum-property"
@@ -901,6 +936,9 @@
         },
         "pattern": {
           "$ref": "#/definitions/pattern-property"
+        },
+        "format": {
+          "$ref": "#/definitions/format-property"
         },
         "enum": {
           "$ref": "#/definitions/enum-property"

--- a/src/schemas/json/metaschema-draft-07-unofficial-strict.json
+++ b/src/schemas/json/metaschema-draft-07-unofficial-strict.json
@@ -178,7 +178,7 @@
     },
     "items-property": {
       "description": "Items of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#items",
-      "$ref": "#/definitions/entity"
+      "$ref": "#/definitions/sub-schema-entity"
     },
     "min-items-property": {
       "description": "A minimum item count of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/array.html?highlight=items#length",

--- a/src/schemas/json/metaschema-draft-07-unofficial-strict.json
+++ b/src/schemas/json/metaschema-draft-07-unofficial-strict.json
@@ -6,7 +6,13 @@
       "pattern": "^\\s+$|\\s{2,}"
     },
     "simple-type": {
-      "type": ["boolean", "integer", "null", "number", "string"]
+      "type": [
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "string"
+      ]
     },
     "numeric-type-requirement": {
       "oneOf": [
@@ -48,56 +54,34 @@
       }
     },
     "simple-type-requirement": {
-      "oneOf": [
-        {
-          "properties": {
-            "type": {
-              "const": "boolean"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "integer"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "null"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "number"
-            }
-          }
-        },
-        {
-          "properties": {
-            "type": {
-              "const": "string"
-            }
-          }
+      "properties": {
+        "type": {
+          "enum": [
+            "boolean",
+            "integer",
+            "null",
+            "number",
+            "string"
+          ]
         }
-      ]
+      }
     },
     "comment-property": {
       "description": "A comment of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html#id3",
       "type": "string",
       "minLength": 1,
-      "examples": ["Don't remove until #issue is closed."]
+      "examples": [
+        "Don't remove until #issue is closed."
+      ]
     },
     "ref-property": {
       "description": "A reference of the current property or definition\nhttps://json-schema.org/understanding-json-schema/structuring.html#ref",
       "type": "string",
       "minLength": 1,
       "pattern": "^#/definitions/.",
-      "examples": ["#/definitions/reference"]
+      "examples": [
+        "#/definitions/reference"
+      ]
     },
     "title-property": {
       "description": "A title of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
@@ -106,7 +90,10 @@
       "not": {
         "$ref": "#/definitions/space-string"
       },
-      "examples": ["image", "image type"]
+      "examples": [
+        "image",
+        "image type"
+      ]
     },
     "description-property": {
       "description": "A description of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title#annotations",
@@ -116,7 +103,10 @@
         "$ref": "#/definitions/space-string"
       },
       "pattern": "\\nhttps?://.",
-      "examples": ["An image\nurl", "An image type\nurl"]
+      "examples": [
+        "An image\nurl",
+        "An image type\nurl"
+      ]
     },
     "type-property": {
       "description": "A type of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/type.html",
@@ -172,7 +162,11 @@
       "description": "A pattern of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#regular-expressions",
       "type": "string",
       "format": "regex",
-      "examples": ["^.+=.*$", "^--?\\w+", "^#[0-9a-fA-F]{6}$"]
+      "examples": [
+        "^.+=.*$",
+        "^--?\\w+",
+        "^#[0-9a-fA-F]{6}$"
+      ]
     },
     "enum-property": {
       "description": "Valid values of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
@@ -182,7 +176,10 @@
       "items": {
         "description": "A valid value of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/generic.html?highlight=enum#enumerated-values",
         "$ref": "#/definitions/simple-type",
-        "examples": ["success", "failure"]
+        "examples": [
+          "success",
+          "failure"
+        ]
       }
     },
     "items-property": {
@@ -210,6 +207,7 @@
       "description": "Required sub-properties of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
       "type": "array",
       "uniqueItems": true,
+      "minItems": 1,
       "items": {
         "description": "A required sub-property of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties",
         "type": "string",
@@ -503,6 +501,7 @@
           "$ref": "#/definitions/default-property"
         }
       },
+      "minProperties": 1,
       "additionalProperties": false
     },
     "requirement-entity": {
@@ -591,7 +590,9 @@
       "additionalProperties": false
     },
     "requirements": {
-      "required": ["properties"],
+      "required": [
+        "properties"
+      ],
       "properties": {
         "properties": {
           "description": "A mapping from sub-property names to requirements of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
@@ -615,6 +616,37 @@
         }
       },
       "additionalProperties": false
+    },
+    "if-property": {
+      "description": "A conditional header of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "type": "object",
+      "required": [
+        "properties"
+      ],
+      "properties": {
+        "properties": {
+          "description": "A mapping from sub-property names to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "$ref": "#/definitions/condition-entity"
+            }
+          },
+          "minProperties": 1,
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "then-property": {
+      "description": "A conditional branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "type": "object",
+      "$ref": "#/definitions/requirements"
+    },
+    "else-property": {
+      "description": "A conditional else branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
+      "type": "object",
+      "$ref": "#/definitions/requirements"
     },
     "entity-dependencies": {
       "dependencies": {
@@ -675,45 +707,28 @@
         "maxProperties": {
           "$ref": "#/definitions/object-type-requirement"
         },
-        "if": ["then"],
-        "then": ["if"],
-        "else": ["if", "then"],
+        "if": [
+          "then"
+        ],
+        "then": [
+          "if"
+        ],
+        "else": [
+          "if",
+          "then"
+        ],
         "$ref": {
           "required": []
         }
       }
     },
     "entity-requirements-and-dependencies": {
-      "required": ["title", "description", "type"],
+      "required": [
+        "title",
+        "description",
+        "type"
+      ],
       "$ref": "#/definitions/entity-dependencies"
-    },
-    "if-property": {
-      "description": "A conditional header of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-      "type": "object",
-      "required": ["properties"],
-      "properties": {
-        "properties": {
-          "description": "A mapping from sub-property names to conditions of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-          "type": "object",
-          "patternProperties": {
-            ".": {
-              "$ref": "#/definitions/condition-entity"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "then-property": {
-      "description": "A conditional branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-      "type": "object",
-      "$ref": "#/definitions/requirements"
-    },
-    "else-property": {
-      "description": "A conditional else branch of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=condition#if-then-else",
-      "type": "object",
-      "$ref": "#/definitions/requirements"
     },
     "entity": {
       "type": "object",
@@ -843,7 +858,7 @@
           "patternProperties": {
             ".": {
               "description": "A definition",
-              "$ref": "#/definitions/entity"
+              "$ref": "#/definitions/sub-schema-entity"
             }
           },
           "additionalProperties": false

--- a/src/schemas/json/metaschema-draft-07-unofficial-strict.json
+++ b/src/schemas/json/metaschema-draft-07-unofficial-strict.json
@@ -143,7 +143,7 @@
       "examples": ["^.+=.*$", "^--?\\w+", "^#[0-9a-fA-F]{6}$"]
     },
     "format-property": {
-      "description": "A format of the current property or definition\nhttps://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#regular-expressions",
+      "description": "A format of the current property or definition\nhttps://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.7.2.1",
       "type": "string",
       "enum": [
         "date",

--- a/src/schemas/json/metaschema-draft-07-unofficial-strict.json
+++ b/src/schemas/json/metaschema-draft-07-unofficial-strict.json
@@ -843,6 +843,15 @@
             "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json"
           ]
         },
+        "id": {
+          "description": "An id of the current property or definition\nhttps://json-schema.org/learn/getting-started-step-by-step#create-a-schema-definition",
+          "type": "string",
+          "minLength": 1,
+          "not": {
+            "$ref": "#/definitions/space-string"
+          },
+          "examples": ["https://json.schemastore.org/schema-catalog.json"]
+        },
         "definitions": {
           "description": "Definitions",
           "type": "object",


### PR DESCRIPTION
- [x] require at least 1 property in more places
- [x] don't require titles and descriptions in definitions
- [x] enhance simple type requirement
- [x] deny `title` and `description` in `items` property
- [x] support `format` property
- [x] support top-level `id` property

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
