### PR TITLE
Add Talhelper config to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3833,6 +3833,12 @@
       "url": "https://json.schemastore.org/task.json"
     },
     {
+      "name": "Talhelper",
+      "description": "A helper tool to help creating Talos Kubernetes cluster",
+      "fileMatch": ["talconfig.yaml", "talconfig.yml"],
+      "url": "https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json"
+    },
+    {
       "name": "Talisman configuration",
       "description": "Configuration for .talismanrc",
       "fileMatch": [".talismanrc"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
This add schema for https://github.com/budimanjojo/talhelper. It's based on draft 2020-12 because it's generated using a library that only supports the latest draft. I tested it in https://github.com/redhat-developer/yaml-language-server which only supports draft-07 and it works fine, maybe because the schema is not too complicated.