### PR TITLE
Add OpenUtau character.yaml schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2887,6 +2887,12 @@
       "url": "https://meta.open-rpc.org/"
     },
     {
+      "name": "OpenUtau character yaml",
+      "description": "OpenUtau voicebank configuration file, character.yaml",
+      "fileMatch": ["character.yaml"],
+      "url": "https://json.schemastore.org/openutau-character.json"
+    },
+    {
       "name": "ops.yaml",
       "description": "Ops configuration file (ops.yaml)",
       "fileMatch": ["ops.yml", "ops.yaml"],

--- a/src/schemas/json/openutau-character.json
+++ b/src/schemas/json/openutau-character.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/openutau-character.json",
+  "additionalProperties": true,
+  "description": "character.yaml for OpenUtau, including the basic informations of a voicebank",
+  "type": "object",
+  "properties": {
+      "text_file_encoding": {
+          "description": "The encoding used to read character.txt, prefix.map and oto.ini",
+          "type": "string",
+          "examples": [
+              "utf-8",
+              "us-ascii",
+              "shift_jis",
+              "gb2312",
+              "big5",
+              "ks_c_5601-1987",
+              "windows-1252",
+              "macintosh"
+          ]
+      },
+      "name": {
+          "description": "The name of the voicebank",
+          "type": "string"
+      },
+      "localized_names": {
+          "description": "display localized names for the user's selected singer name display language",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+              "en-US": {
+                  "description": "English (United States)",
+                  "type": "string"
+              },
+              "de-DE": {
+                  "description": "German (Germany)",
+                  "type": "string"
+              },
+              "es-ES": {
+                  "description": "Spanish (Spain)",
+                  "type": "string"
+              },
+              "es-MX": {
+                  "description": "Spanish (Mexico)",
+                  "type": "string"
+              },
+              "fi-FI": {
+                  "description": "Finnish (Finland)",
+                  "type": "string"
+              },
+              "fr-FR": {
+                  "description": "French (France)",
+                  "type": "string"
+              },
+              "id-ID": {
+                  "description": "Indonesian (Indonesia)",
+                  "type": "string"
+              },
+              "it-IT": {
+                  "description": "Italian (Italy)",
+                  "type": "string"
+              },
+              "ja-JP": {
+                  "description": "Japanese (Japan)",
+                  "type": "string"
+              },
+              "ko-KR": {
+                  "description": "Korean (Korea)",
+                  "type": "string"
+              },
+              "nl-NL": {
+                  "description": "Dutch (Netherlands)",
+                  "type": "string"
+              },
+              "pl-PL": {
+                  "description": "Polish (Poland)",
+                  "type": "string"
+              },
+              "pt-BR": {
+                  "description": "Portuguese (Brazil)",
+                  "type": "string"
+              },
+              "ru-RU": {
+                  "description": "Russian (Russia)",
+                  "type": "string"
+              },
+              "th-TH": {
+                  "description": "Thai (Thailand)",
+                  "type": "string"
+              },
+              "vi-VN": {
+                  "description": "Vietnamese (Vietnam)",
+                  "type": "string"
+              },
+              "zh-CN": {
+                  "description": "Chinese (Simplified, China)",
+                  "type": "string"
+              },
+              "zh-TW": {
+                  "description": "Chinese (Traditional, Taiwan)",
+                  "type": "string"
+              }
+          },
+          "required": []
+      },
+      "singer_type": {
+          "description": "The type of the voicebank",
+          "type": "string",
+          "enum": [
+              "utau",
+              "enunu",
+              "diffsinger"
+          ]
+      },
+      "image": {
+          "description": "relative path to the icon of the voicebank",
+          "type": "string"
+      },
+      "author": {
+          "description": "The author of the voicebank",
+          "type": "string"
+      },
+      "voice": {
+          "description": "The voice provider of the voicebank",
+          "type": "string"
+      },
+      "version": {
+          "description": "The version number of the voicebank",
+          "type": "string"
+      },
+      "web": {
+          "description": "The website of the voicebank",
+          "type": "string"
+      },
+      "portrait": {
+          "description": "Relative path to the portrait of the voicebank",
+          "type": "string"
+      },
+      "portrait_opacity": {
+          "description": "Opacity of the portrait, from 0 to 1",
+          "type": "number"
+      },
+      "default_phonemizer": {
+          "description": "The default phonemizer of the voicebank",
+          "type": "string",
+          "examples": [
+              "OpenUtau.Plugin.Builtin.GermanDiphonePhonemizer",
+              "OpenUtau.Plugin.Builtin.GermanVCCVPhonemizer",
+              "OpenUtau.Core.DefaultPhonemizer",
+              "OpenUtau.Core.DiffSinger.DiffSingerPhonemizer",
+              "OpenUtau.Core.DiffSinger.DiffSingerEnglishPhonemizer",
+              "OpenUtau.Core.DiffSinger.DiffSingerPortuguesePhonemizer",
+              "OpenUtau.Core.DiffSinger.DiffSingerRhythmizerPhonemizer",
+              "OpenUtau.Core.DiffSinger.DiffSingerRussianPhonemizer",
+              "OpenUtau.Plugin.Builtin.ArpasingPhonemizer",
+              "OpenUtau.Plugin.Builtin.ENtoJAPhonemizer",
+              "OpenUtau.Plugin.Builtin.EnglishVCCVPhonemizer",
+              "OpenUtau.Plugin.Builtin.EnXSampaPhonemizer",
+              "OpenUtau.Core.Enunu.EnunuPhonemizer",
+              "OpenUtau.Core.Enunu.EnunuEnglishPhonemizer",
+              "OpenUtau.Plugin.Builtin.EnunuOnnxPhonemizer",
+              "OpenUtau.Plugin.Builtin.EnunuOnnxEnglishPhonemizer",
+              "OpenUtau.Plugin.Builtin.SpanishMakkusanPhonemizer",
+              "OpenUtau.Plugin.Builtin.SpanishSyllableBasedPhonemizer",
+              "OpenUtau.Plugin.Builtin.EStoJAPhonemizer",
+              "OpenUtau.Plugin.Builtin.SpanishVCCVPhonemizer",
+              "OpenUtau.Plugin.Builtin.FrenchCVVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.FrenchCMUSphinxPhonemizer",
+              "OpenUtau.Plugin.Builtin.FrenchVCCVPhonemizer",
+              "OpenUtau.Plugin.Builtin.ItalianCVVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.ItalianSyllableBasedPhonemizer",
+              "OpenUtau.Plugin.Builtin.JapaneseCVVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.JapaneseVCVPhonemizer",
+              "OpenUtau.Plugin.Builtin.JapanesePresampPhonemizer",
+              "OpenUtau.Plugin.Builtin.KoreanCBNNPhonemizer",
+              "OpenUtau.Plugin.Builtin.KoreanCVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.KoreanCVCCVPhonemizer",
+              "OpenUtau.Plugin.Builtin.KoreanCVVCStandardPronunciationPhonemizer",
+              "OpenUtau.Plugin.Builtin.KoreanVCVPhonemizer",
+              "OpenUtau.Plugin.Builtin.PolishCVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.BrazilianPortugueseCVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.RussianCVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.RussianVCCVPhonemizer",
+              "OpenUtau.Plugin.Builtin.VietnameseCVVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.VietnameseVCVPhonemizer",
+              "OpenUtau.Plugin.Builtin.VietnameseVINAPhonemizer",
+              "OpenUtau.Core.Vogen.VogenMandarinPhonemizer",
+              "OpenUtau.Core.Vogen.VogenYuePhonemizer",
+              "OpenUtau.Plugin.Builtin.ChineseCVVMonophonePhonemizer",
+              "OpenUtau.Plugin.Builtin.ChineseCVVCPhonemizer",
+              "OpenUtau.Plugin.Builtin.PresampSamplePhonemizer"
+          ]
+      },
+      "subbanks": {
+          "description": "The subbanks of the voicebank for different pitch and voice color",
+          "type": "array",
+          "items": {
+              "description": "A subbank of the voicebank",
+              "type": "object",
+              "properties": {
+                  "color": {
+                      "description": "Voice color that this subbank belongs to",
+                      "type": "string"
+                  },
+                  "prefix": {
+                      "description": "Prefix for this subbank in the oto.ini",
+                      "type": "string"
+                  },
+                  "suffix": {
+                      "description": "Suffix for this subbank in the oto.ini",
+                      "type": "string"
+                  },
+                  "tone_ranges": {
+                      "description": "The tone ranges that this subbank covers",
+                      "type": "array",
+                      "items": {
+                          "description": "A tone range that this subbank cover",
+                          "type": "string"
+                      }
+                  }
+              }
+          }
+      }
+  },
+  "required": []
+}

--- a/src/schemas/json/openutau-character.json
+++ b/src/schemas/json/openutau-character.json
@@ -5,222 +5,218 @@
   "description": "character.yaml for OpenUtau, including the basic informations of a voicebank",
   "type": "object",
   "properties": {
-      "text_file_encoding": {
-          "description": "The encoding used to read character.txt, prefix.map and oto.ini",
-          "type": "string",
-          "examples": [
-              "utf-8",
-              "us-ascii",
-              "shift_jis",
-              "gb2312",
-              "big5",
-              "ks_c_5601-1987",
-              "windows-1252",
-              "macintosh"
-          ]
-      },
-      "name": {
-          "description": "The name of the voicebank",
+    "text_file_encoding": {
+      "description": "The encoding used to read character.txt, prefix.map and oto.ini",
+      "type": "string",
+      "examples": [
+        "utf-8",
+        "us-ascii",
+        "shift_jis",
+        "gb2312",
+        "big5",
+        "ks_c_5601-1987",
+        "windows-1252",
+        "macintosh"
+      ]
+    },
+    "name": {
+      "description": "The name of the voicebank",
+      "type": "string"
+    },
+    "localized_names": {
+      "description": "display localized names for the user's selected singer name display language",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "en-US": {
+          "description": "English (United States)",
           "type": "string"
+        },
+        "de-DE": {
+          "description": "German (Germany)",
+          "type": "string"
+        },
+        "es-ES": {
+          "description": "Spanish (Spain)",
+          "type": "string"
+        },
+        "es-MX": {
+          "description": "Spanish (Mexico)",
+          "type": "string"
+        },
+        "fi-FI": {
+          "description": "Finnish (Finland)",
+          "type": "string"
+        },
+        "fr-FR": {
+          "description": "French (France)",
+          "type": "string"
+        },
+        "id-ID": {
+          "description": "Indonesian (Indonesia)",
+          "type": "string"
+        },
+        "it-IT": {
+          "description": "Italian (Italy)",
+          "type": "string"
+        },
+        "ja-JP": {
+          "description": "Japanese (Japan)",
+          "type": "string"
+        },
+        "ko-KR": {
+          "description": "Korean (Korea)",
+          "type": "string"
+        },
+        "nl-NL": {
+          "description": "Dutch (Netherlands)",
+          "type": "string"
+        },
+        "pl-PL": {
+          "description": "Polish (Poland)",
+          "type": "string"
+        },
+        "pt-BR": {
+          "description": "Portuguese (Brazil)",
+          "type": "string"
+        },
+        "ru-RU": {
+          "description": "Russian (Russia)",
+          "type": "string"
+        },
+        "th-TH": {
+          "description": "Thai (Thailand)",
+          "type": "string"
+        },
+        "vi-VN": {
+          "description": "Vietnamese (Vietnam)",
+          "type": "string"
+        },
+        "zh-CN": {
+          "description": "Chinese (Simplified, China)",
+          "type": "string"
+        },
+        "zh-TW": {
+          "description": "Chinese (Traditional, Taiwan)",
+          "type": "string"
+        }
       },
-      "localized_names": {
-          "description": "display localized names for the user's selected singer name display language",
-          "type": "object",
-          "additionalProperties": true,
-          "properties": {
-              "en-US": {
-                  "description": "English (United States)",
-                  "type": "string"
-              },
-              "de-DE": {
-                  "description": "German (Germany)",
-                  "type": "string"
-              },
-              "es-ES": {
-                  "description": "Spanish (Spain)",
-                  "type": "string"
-              },
-              "es-MX": {
-                  "description": "Spanish (Mexico)",
-                  "type": "string"
-              },
-              "fi-FI": {
-                  "description": "Finnish (Finland)",
-                  "type": "string"
-              },
-              "fr-FR": {
-                  "description": "French (France)",
-                  "type": "string"
-              },
-              "id-ID": {
-                  "description": "Indonesian (Indonesia)",
-                  "type": "string"
-              },
-              "it-IT": {
-                  "description": "Italian (Italy)",
-                  "type": "string"
-              },
-              "ja-JP": {
-                  "description": "Japanese (Japan)",
-                  "type": "string"
-              },
-              "ko-KR": {
-                  "description": "Korean (Korea)",
-                  "type": "string"
-              },
-              "nl-NL": {
-                  "description": "Dutch (Netherlands)",
-                  "type": "string"
-              },
-              "pl-PL": {
-                  "description": "Polish (Poland)",
-                  "type": "string"
-              },
-              "pt-BR": {
-                  "description": "Portuguese (Brazil)",
-                  "type": "string"
-              },
-              "ru-RU": {
-                  "description": "Russian (Russia)",
-                  "type": "string"
-              },
-              "th-TH": {
-                  "description": "Thai (Thailand)",
-                  "type": "string"
-              },
-              "vi-VN": {
-                  "description": "Vietnamese (Vietnam)",
-                  "type": "string"
-              },
-              "zh-CN": {
-                  "description": "Chinese (Simplified, China)",
-                  "type": "string"
-              },
-              "zh-TW": {
-                  "description": "Chinese (Traditional, Taiwan)",
-                  "type": "string"
-              }
+      "required": []
+    },
+    "singer_type": {
+      "description": "The type of the voicebank",
+      "type": "string",
+      "enum": ["utau", "enunu", "diffsinger"]
+    },
+    "image": {
+      "description": "relative path to the icon of the voicebank",
+      "type": "string"
+    },
+    "author": {
+      "description": "The author of the voicebank",
+      "type": "string"
+    },
+    "voice": {
+      "description": "The voice provider of the voicebank",
+      "type": "string"
+    },
+    "version": {
+      "description": "The version number of the voicebank",
+      "type": "string"
+    },
+    "web": {
+      "description": "The website of the voicebank",
+      "type": "string"
+    },
+    "portrait": {
+      "description": "Relative path to the portrait of the voicebank",
+      "type": "string"
+    },
+    "portrait_opacity": {
+      "description": "Opacity of the portrait, from 0 to 1",
+      "type": "number"
+    },
+    "default_phonemizer": {
+      "description": "The default phonemizer of the voicebank",
+      "type": "string",
+      "examples": [
+        "OpenUtau.Plugin.Builtin.GermanDiphonePhonemizer",
+        "OpenUtau.Plugin.Builtin.GermanVCCVPhonemizer",
+        "OpenUtau.Core.DefaultPhonemizer",
+        "OpenUtau.Core.DiffSinger.DiffSingerPhonemizer",
+        "OpenUtau.Core.DiffSinger.DiffSingerEnglishPhonemizer",
+        "OpenUtau.Core.DiffSinger.DiffSingerPortuguesePhonemizer",
+        "OpenUtau.Core.DiffSinger.DiffSingerRhythmizerPhonemizer",
+        "OpenUtau.Core.DiffSinger.DiffSingerRussianPhonemizer",
+        "OpenUtau.Plugin.Builtin.ArpasingPhonemizer",
+        "OpenUtau.Plugin.Builtin.ENtoJAPhonemizer",
+        "OpenUtau.Plugin.Builtin.EnglishVCCVPhonemizer",
+        "OpenUtau.Plugin.Builtin.EnXSampaPhonemizer",
+        "OpenUtau.Core.Enunu.EnunuPhonemizer",
+        "OpenUtau.Core.Enunu.EnunuEnglishPhonemizer",
+        "OpenUtau.Plugin.Builtin.EnunuOnnxPhonemizer",
+        "OpenUtau.Plugin.Builtin.EnunuOnnxEnglishPhonemizer",
+        "OpenUtau.Plugin.Builtin.SpanishMakkusanPhonemizer",
+        "OpenUtau.Plugin.Builtin.SpanishSyllableBasedPhonemizer",
+        "OpenUtau.Plugin.Builtin.EStoJAPhonemizer",
+        "OpenUtau.Plugin.Builtin.SpanishVCCVPhonemizer",
+        "OpenUtau.Plugin.Builtin.FrenchCVVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.FrenchCMUSphinxPhonemizer",
+        "OpenUtau.Plugin.Builtin.FrenchVCCVPhonemizer",
+        "OpenUtau.Plugin.Builtin.ItalianCVVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.ItalianSyllableBasedPhonemizer",
+        "OpenUtau.Plugin.Builtin.JapaneseCVVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.JapaneseVCVPhonemizer",
+        "OpenUtau.Plugin.Builtin.JapanesePresampPhonemizer",
+        "OpenUtau.Plugin.Builtin.KoreanCBNNPhonemizer",
+        "OpenUtau.Plugin.Builtin.KoreanCVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.KoreanCVCCVPhonemizer",
+        "OpenUtau.Plugin.Builtin.KoreanCVVCStandardPronunciationPhonemizer",
+        "OpenUtau.Plugin.Builtin.KoreanVCVPhonemizer",
+        "OpenUtau.Plugin.Builtin.PolishCVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.BrazilianPortugueseCVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.RussianCVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.RussianVCCVPhonemizer",
+        "OpenUtau.Plugin.Builtin.VietnameseCVVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.VietnameseVCVPhonemizer",
+        "OpenUtau.Plugin.Builtin.VietnameseVINAPhonemizer",
+        "OpenUtau.Core.Vogen.VogenMandarinPhonemizer",
+        "OpenUtau.Core.Vogen.VogenYuePhonemizer",
+        "OpenUtau.Plugin.Builtin.ChineseCVVMonophonePhonemizer",
+        "OpenUtau.Plugin.Builtin.ChineseCVVCPhonemizer",
+        "OpenUtau.Plugin.Builtin.PresampSamplePhonemizer"
+      ]
+    },
+    "subbanks": {
+      "description": "The subbanks of the voicebank for different pitch and voice color",
+      "type": "array",
+      "items": {
+        "description": "A subbank of the voicebank",
+        "type": "object",
+        "properties": {
+          "color": {
+            "description": "Voice color that this subbank belongs to",
+            "type": "string"
           },
-          "required": []
-      },
-      "singer_type": {
-          "description": "The type of the voicebank",
-          "type": "string",
-          "enum": [
-              "utau",
-              "enunu",
-              "diffsinger"
-          ]
-      },
-      "image": {
-          "description": "relative path to the icon of the voicebank",
-          "type": "string"
-      },
-      "author": {
-          "description": "The author of the voicebank",
-          "type": "string"
-      },
-      "voice": {
-          "description": "The voice provider of the voicebank",
-          "type": "string"
-      },
-      "version": {
-          "description": "The version number of the voicebank",
-          "type": "string"
-      },
-      "web": {
-          "description": "The website of the voicebank",
-          "type": "string"
-      },
-      "portrait": {
-          "description": "Relative path to the portrait of the voicebank",
-          "type": "string"
-      },
-      "portrait_opacity": {
-          "description": "Opacity of the portrait, from 0 to 1",
-          "type": "number"
-      },
-      "default_phonemizer": {
-          "description": "The default phonemizer of the voicebank",
-          "type": "string",
-          "examples": [
-              "OpenUtau.Plugin.Builtin.GermanDiphonePhonemizer",
-              "OpenUtau.Plugin.Builtin.GermanVCCVPhonemizer",
-              "OpenUtau.Core.DefaultPhonemizer",
-              "OpenUtau.Core.DiffSinger.DiffSingerPhonemizer",
-              "OpenUtau.Core.DiffSinger.DiffSingerEnglishPhonemizer",
-              "OpenUtau.Core.DiffSinger.DiffSingerPortuguesePhonemizer",
-              "OpenUtau.Core.DiffSinger.DiffSingerRhythmizerPhonemizer",
-              "OpenUtau.Core.DiffSinger.DiffSingerRussianPhonemizer",
-              "OpenUtau.Plugin.Builtin.ArpasingPhonemizer",
-              "OpenUtau.Plugin.Builtin.ENtoJAPhonemizer",
-              "OpenUtau.Plugin.Builtin.EnglishVCCVPhonemizer",
-              "OpenUtau.Plugin.Builtin.EnXSampaPhonemizer",
-              "OpenUtau.Core.Enunu.EnunuPhonemizer",
-              "OpenUtau.Core.Enunu.EnunuEnglishPhonemizer",
-              "OpenUtau.Plugin.Builtin.EnunuOnnxPhonemizer",
-              "OpenUtau.Plugin.Builtin.EnunuOnnxEnglishPhonemizer",
-              "OpenUtau.Plugin.Builtin.SpanishMakkusanPhonemizer",
-              "OpenUtau.Plugin.Builtin.SpanishSyllableBasedPhonemizer",
-              "OpenUtau.Plugin.Builtin.EStoJAPhonemizer",
-              "OpenUtau.Plugin.Builtin.SpanishVCCVPhonemizer",
-              "OpenUtau.Plugin.Builtin.FrenchCVVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.FrenchCMUSphinxPhonemizer",
-              "OpenUtau.Plugin.Builtin.FrenchVCCVPhonemizer",
-              "OpenUtau.Plugin.Builtin.ItalianCVVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.ItalianSyllableBasedPhonemizer",
-              "OpenUtau.Plugin.Builtin.JapaneseCVVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.JapaneseVCVPhonemizer",
-              "OpenUtau.Plugin.Builtin.JapanesePresampPhonemizer",
-              "OpenUtau.Plugin.Builtin.KoreanCBNNPhonemizer",
-              "OpenUtau.Plugin.Builtin.KoreanCVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.KoreanCVCCVPhonemizer",
-              "OpenUtau.Plugin.Builtin.KoreanCVVCStandardPronunciationPhonemizer",
-              "OpenUtau.Plugin.Builtin.KoreanVCVPhonemizer",
-              "OpenUtau.Plugin.Builtin.PolishCVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.BrazilianPortugueseCVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.RussianCVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.RussianVCCVPhonemizer",
-              "OpenUtau.Plugin.Builtin.VietnameseCVVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.VietnameseVCVPhonemizer",
-              "OpenUtau.Plugin.Builtin.VietnameseVINAPhonemizer",
-              "OpenUtau.Core.Vogen.VogenMandarinPhonemizer",
-              "OpenUtau.Core.Vogen.VogenYuePhonemizer",
-              "OpenUtau.Plugin.Builtin.ChineseCVVMonophonePhonemizer",
-              "OpenUtau.Plugin.Builtin.ChineseCVVCPhonemizer",
-              "OpenUtau.Plugin.Builtin.PresampSamplePhonemizer"
-          ]
-      },
-      "subbanks": {
-          "description": "The subbanks of the voicebank for different pitch and voice color",
-          "type": "array",
-          "items": {
-              "description": "A subbank of the voicebank",
-              "type": "object",
-              "properties": {
-                  "color": {
-                      "description": "Voice color that this subbank belongs to",
-                      "type": "string"
-                  },
-                  "prefix": {
-                      "description": "Prefix for this subbank in the oto.ini",
-                      "type": "string"
-                  },
-                  "suffix": {
-                      "description": "Suffix for this subbank in the oto.ini",
-                      "type": "string"
-                  },
-                  "tone_ranges": {
-                      "description": "The tone ranges that this subbank covers",
-                      "type": "array",
-                      "items": {
-                          "description": "A tone range that this subbank cover",
-                          "type": "string"
-                      }
-                  }
-              }
+          "prefix": {
+            "description": "Prefix for this subbank in the oto.ini",
+            "type": "string"
+          },
+          "suffix": {
+            "description": "Suffix for this subbank in the oto.ini",
+            "type": "string"
+          },
+          "tone_ranges": {
+            "description": "The tone ranges that this subbank covers",
+            "type": "array",
+            "items": {
+              "description": "A tone range that this subbank cover",
+              "type": "string"
+            }
           }
+        }
       }
+    }
   },
   "required": []
 }

--- a/src/test/openutau-character/openutau-character.yaml
+++ b/src/test/openutau-character/openutau-character.yaml
@@ -1,0 +1,86 @@
+# Source: https://github.com/stakira/OpenUtau/wiki/tech-note:-character.yaml
+
+name: 闇音レンリ・連続音Ver1.5
+localized_names:
+  en-US: Renri Yamine VCV Ver1.5
+singer_type: utau
+text_file_encoding: shift_jis
+image: renri.bmp
+portrait: portrait.webp
+portrait_opacity: 0.67
+author: ゆずり
+voice: ゆずり
+version: "1.5"
+web: https://renrivoice.wixsite.com/renri-voice/utau
+default_phonemizer: OpenUtau.Plugin.Builtin.JapaneseVCVPhonemizer
+subbanks:
+- color: ''
+  prefix: ''
+  suffix: C5
+  tone_ranges:
+  - C5-B7
+- color: ''
+  prefix: ''
+  suffix: G4
+  tone_ranges:
+  - G4-B4
+- color: ''
+  prefix: ''
+  suffix: D4
+  tone_ranges:
+  - D4-F#4
+- color: ''
+  prefix: ''
+  suffix: A3
+  tone_ranges:
+  - C1-C#4
+- color: ↑
+  prefix: ''
+  suffix: ↑
+  tone_ranges:
+  - C1-B7
+- color: Clear
+  prefix: ''
+  suffix: CC5
+  tone_ranges:
+  - C5-B7
+- color: Clear
+  prefix: ''
+  suffix: CG4
+  tone_ranges:
+  - G4-B4
+- color: Clear
+  prefix: ''
+  suffix: CD4
+  tone_ranges:
+  - D4-F#4
+- color: Clear
+  prefix: ''
+  suffix: CA3
+  tone_ranges:
+  - C1-C#4
+- color: Whisper
+  prefix: ''
+  suffix: WC5
+  tone_ranges:
+  - C5-B7
+- color: Whisper
+  prefix: ''
+  suffix: WG4
+  tone_ranges:
+  - G4-B4
+- color: Whisper
+  prefix: ''
+  suffix: WD4
+  tone_ranges:
+  - D4-F#4
+- color: Whisper
+  prefix: ''
+  suffix: WA3
+  tone_ranges:
+  - C1-C#4
+- color: Edge
+  prefix: ''
+  suffix: "'"
+  tone_ranges:
+  - C1-B7

--- a/src/test/openutau-character/openutau-character.yaml
+++ b/src/test/openutau-character/openutau-character.yaml
@@ -10,77 +10,77 @@ portrait: portrait.webp
 portrait_opacity: 0.67
 author: ゆずり
 voice: ゆずり
-version: "1.5"
+version: '1.5'
 web: https://renrivoice.wixsite.com/renri-voice/utau
 default_phonemizer: OpenUtau.Plugin.Builtin.JapaneseVCVPhonemizer
 subbanks:
-- color: ''
-  prefix: ''
-  suffix: C5
-  tone_ranges:
-  - C5-B7
-- color: ''
-  prefix: ''
-  suffix: G4
-  tone_ranges:
-  - G4-B4
-- color: ''
-  prefix: ''
-  suffix: D4
-  tone_ranges:
-  - D4-F#4
-- color: ''
-  prefix: ''
-  suffix: A3
-  tone_ranges:
-  - C1-C#4
-- color: ↑
-  prefix: ''
-  suffix: ↑
-  tone_ranges:
-  - C1-B7
-- color: Clear
-  prefix: ''
-  suffix: CC5
-  tone_ranges:
-  - C5-B7
-- color: Clear
-  prefix: ''
-  suffix: CG4
-  tone_ranges:
-  - G4-B4
-- color: Clear
-  prefix: ''
-  suffix: CD4
-  tone_ranges:
-  - D4-F#4
-- color: Clear
-  prefix: ''
-  suffix: CA3
-  tone_ranges:
-  - C1-C#4
-- color: Whisper
-  prefix: ''
-  suffix: WC5
-  tone_ranges:
-  - C5-B7
-- color: Whisper
-  prefix: ''
-  suffix: WG4
-  tone_ranges:
-  - G4-B4
-- color: Whisper
-  prefix: ''
-  suffix: WD4
-  tone_ranges:
-  - D4-F#4
-- color: Whisper
-  prefix: ''
-  suffix: WA3
-  tone_ranges:
-  - C1-C#4
-- color: Edge
-  prefix: ''
-  suffix: "'"
-  tone_ranges:
-  - C1-B7
+  - color: ''
+    prefix: ''
+    suffix: C5
+    tone_ranges:
+      - C5-B7
+  - color: ''
+    prefix: ''
+    suffix: G4
+    tone_ranges:
+      - G4-B4
+  - color: ''
+    prefix: ''
+    suffix: D4
+    tone_ranges:
+      - D4-F#4
+  - color: ''
+    prefix: ''
+    suffix: A3
+    tone_ranges:
+      - C1-C#4
+  - color: ↑
+    prefix: ''
+    suffix: ↑
+    tone_ranges:
+      - C1-B7
+  - color: Clear
+    prefix: ''
+    suffix: CC5
+    tone_ranges:
+      - C5-B7
+  - color: Clear
+    prefix: ''
+    suffix: CG4
+    tone_ranges:
+      - G4-B4
+  - color: Clear
+    prefix: ''
+    suffix: CD4
+    tone_ranges:
+      - D4-F#4
+  - color: Clear
+    prefix: ''
+    suffix: CA3
+    tone_ranges:
+      - C1-C#4
+  - color: Whisper
+    prefix: ''
+    suffix: WC5
+    tone_ranges:
+      - C5-B7
+  - color: Whisper
+    prefix: ''
+    suffix: WG4
+    tone_ranges:
+      - G4-B4
+  - color: Whisper
+    prefix: ''
+    suffix: WD4
+    tone_ranges:
+      - D4-F#4
+  - color: Whisper
+    prefix: ''
+    suffix: WA3
+    tone_ranges:
+      - C1-C#4
+  - color: Edge
+    prefix: ''
+    suffix: "'"
+    tone_ranges:
+      - C1-B7


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
This PR adds a schema for character.yaml in [OpenUtau](https://github.com/stakira/openutau), an open source singing synthesis platform. character.yaml includes informations about a voicebank, including its name, type, and structure.