### PR TITLE
fix(catalog-info): support $text, $json and $yaml in metadata.annotations

### DIFF
--- a/src/schemas/json/catalog-info.json
+++ b/src/schemas/json/catalog-info.json
@@ -940,7 +940,22 @@
               "additionalProperties": true,
               "patternProperties": {
                 "^.+$": {
-                  "type": "string"
+                  "type": ["string", "object"],
+                  "properties": {
+                    "$text": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "$json": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "$yaml": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "additionalProperties": false
                 }
               }
             },

--- a/src/test/catalog-info/entity-with-$json.json
+++ b/src/test/catalog-info/entity-with-$json.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "backstage.io/v1alpha1",
+  "kind": "API",
+  "metadata": {
+    "name": "entity-with-json",
+    "description": "Webhook example in YAML format",
+    "tags": ["none"],
+    "annotations": {
+      "test": "test annotation",
+      "test/json": {
+        "$json": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.json"
+      }
+    }
+  },
+  "spec": {
+    "type": "openapi",
+    "lifecycle": "production",
+    "owner": "openapi",
+    "definition": {
+      "$text": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.yaml"
+    }
+  }
+}

--- a/src/test/catalog-info/entity-with-$text.json
+++ b/src/test/catalog-info/entity-with-$text.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "backstage.io/v1alpha1",
+  "kind": "API",
+  "metadata": {
+    "name": "entity-with-text",
+    "description": "Webhook example in YAML format",
+    "tags": ["none"],
+    "annotations": {
+      "test": "test annotation",
+      "test/json": {
+        "$text": "Readme.md"
+      }
+    }
+  },
+  "spec": {
+    "type": "openapi",
+    "lifecycle": "production",
+    "owner": "openapi",
+    "definition": {
+      "$text": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.yaml"
+    }
+  }
+}

--- a/src/test/catalog-info/entity-with-$yaml.json
+++ b/src/test/catalog-info/entity-with-$yaml.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "backstage.io/v1alpha1",
+  "kind": "API",
+  "metadata": {
+    "name": "entity-with-yaml",
+    "description": "Webhook example in YAML format",
+    "tags": ["none"],
+    "annotations": {
+      "test": "test annotation",
+      "test/json": {
+        "$yaml": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.yaml"
+      }
+    }
+  },
+  "spec": {
+    "type": "openapi",
+    "lifecycle": "production",
+    "owner": "openapi",
+    "definition": {
+      "$text": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/webhook-example.yaml"
+    }
+  }
+}


### PR DESCRIPTION
As a follow up to https://github.com/SchemaStore/schemastore/pull/2047 our configs are currently not validating in our code editors, because [substitutions](https://backstage.io/docs/features/software-catalog/descriptor-format/#substitutions-in-the-descriptor-format) are not supported in the `annotations`.