### PR TITLE
Update buf.gen.yaml java_package_prefix to oneOf

### DIFF
--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -101,7 +101,7 @@
         "cc_enable_arenas": {
           "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#cc_enable_arenas",
           "description": "Optional. If unset, this option is left as specified in your .proto files. As of Protocol Buffers release v3.14.0, changing this value no longer has any effect.",
-          "type": "string"
+          "type": "boolean"
         },
         "csharp_namespace": {
           "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#csharp_namespace",

--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -10,7 +10,10 @@
       "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#version",
       "description": "Required. Defines the current configuration version. Accepted values are v1beta1 and v1.",
       "type": "string",
-      "enum": ["v1beta1", "v1"]
+      "enum": [
+        "v1beta1",
+        "v1"
+      ]
     },
     "plugins": {
       "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugins",
@@ -76,7 +79,10 @@
             "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy",
             "description": "Optional. Specifies the invocation strategy to use. See https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy.",
             "type": "string",
-            "enum": ["directory", "all"]
+            "enum": [
+              "directory",
+              "all"
+            ]
           },
           "protoc_path": {
             "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path",
@@ -84,7 +90,9 @@
             "type": "string"
           }
         },
-        "required": ["out"],
+        "required": [
+          "out"
+        ],
         "additionalProperties": false
       }
     },
@@ -149,7 +157,9 @@
               }
             }
           },
-          "required": ["default"],
+          "required": [
+            "default"
+          ],
           "additionalProperties": false
         },
         "java_multiple_files": {
@@ -159,30 +169,39 @@
         },
         "java_package_prefix": {
           "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_package_prefix",
-          "description": "Optional. Controls what is prepended to the java_package value is set to for all of the .proto files contained within the input.",
-          "type": "object",
-          "properties": {
-            "default": {
-              "description": "Required if the java_package_prefix key is set. The default value is used as a prefix for the java_package value set in each of the files.",
+          "description": "Optional. Controls what is prepended to the java_package value is set to for all of the .proto files contained within the input. If this is unset, managed mode's default value is `com`.",
+          "oneOf": [
+            {
               "type": "string"
             },
-            "except": {
-              "description": "Optional. Removes the specified modules from the java_package option behavior. The except keys must be valid module names.",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "override": {
-              "description": "Optional. Overrides the java_package option value used for specific modules. The override keys must be valid module names.",
+            {
               "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "properties": {
+                "default": {
+                  "description": "Required if the java_package_prefix key is set. The default value is used as a prefix for the java_package value set in each of the files.",
+                  "type": "string"
+                },
+                "except": {
+                  "description": "Optional. Removes the specified modules from the java_package option behavior. The except keys must be valid module names.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "override": {
+                  "description": "Optional. Overrides the java_package option value used for specific modules. The override keys must be valid module names.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "default"
+              ],
+              "additionalProperties": false
             }
-          },
-          "required": ["default"],
-          "additionalProperties": false
+          ]
         },
         "java_string_check_utf8": {
           "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_string_check_utf8",
@@ -213,14 +232,20 @@
               }
             }
           },
-          "required": ["default"],
+          "required": [
+            "default"
+          ],
           "additionalProperties": false
         },
         "optimize_for": {
           "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#optimize_for",
           "description": "Optional. Controls what the optimize_for value is set to for all of the .proto files contained within the input. The only accepted values are SPEED, CODE_SIZE and LITE_RUNTIME. Managed mode will not modify this option if unset.",
           "type": "string",
-          "enum": ["SPEED", "CODE_SIZE", "LITE_RUNTIME"]
+          "enum": [
+            "SPEED",
+            "CODE_SIZE",
+            "LITE_RUNTIME"
+          ]
         },
         "ruby_package": {
           "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#ruby_package",
@@ -320,5 +345,8 @@
       }
     }
   },
-  "required": ["version", "plugins"]
+  "required": [
+    "version",
+    "plugins"
+  ]
 }

--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -10,10 +10,7 @@
       "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#version",
       "description": "Required. Defines the current configuration version. Accepted values are v1beta1 and v1.",
       "type": "string",
-      "enum": [
-        "v1beta1",
-        "v1"
-      ]
+      "enum": ["v1beta1", "v1"]
     },
     "plugins": {
       "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugins",
@@ -79,10 +76,7 @@
             "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy",
             "description": "Optional. Specifies the invocation strategy to use. See https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy.",
             "type": "string",
-            "enum": [
-              "directory",
-              "all"
-            ]
+            "enum": ["directory", "all"]
           },
           "protoc_path": {
             "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path",
@@ -90,9 +84,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "out"
-        ],
+        "required": ["out"],
         "additionalProperties": false
       }
     },
@@ -157,9 +149,7 @@
               }
             }
           },
-          "required": [
-            "default"
-          ],
+          "required": ["default"],
           "additionalProperties": false
         },
         "java_multiple_files": {
@@ -196,9 +186,7 @@
                   }
                 }
               },
-              "required": [
-                "default"
-              ],
+              "required": ["default"],
               "additionalProperties": false
             }
           ]
@@ -232,20 +220,14 @@
               }
             }
           },
-          "required": [
-            "default"
-          ],
+          "required": ["default"],
           "additionalProperties": false
         },
         "optimize_for": {
           "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#optimize_for",
           "description": "Optional. Controls what the optimize_for value is set to for all of the .proto files contained within the input. The only accepted values are SPEED, CODE_SIZE and LITE_RUNTIME. Managed mode will not modify this option if unset.",
           "type": "string",
-          "enum": [
-            "SPEED",
-            "CODE_SIZE",
-            "LITE_RUNTIME"
-          ]
+          "enum": ["SPEED", "CODE_SIZE", "LITE_RUNTIME"]
         },
         "ruby_package": {
           "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#ruby_package",
@@ -345,8 +327,5 @@
       }
     }
   },
-  "required": [
-    "version",
-    "plugins"
-  ]
+  "required": ["version", "plugins"]
 }

--- a/src/test/buf.gen/buf-examples.gen.yaml
+++ b/src/test/buf.gen/buf-examples.gen.yaml
@@ -1,0 +1,33 @@
+# Below is from https://github.com/bufbuild/buf-examples/blob/59593726295d04a2103d08837fc8e00e77e3f1cc/managed-mode/buf.gen.yaml
+
+version: v1
+managed:
+  enabled: true
+  optimize_for: CODE_SIZE
+
+  # C++
+  cc_enable_arenas: true
+
+  # Go
+  go_package_prefix:
+    default: github.com/acme/weather/v1
+
+  # Java
+  java_multiple_files: false
+  java_package_prefix: io
+  java_string_check_utf8: false
+plugins:
+  - plugin: buf.build/protocolbuffers/cpp
+    out: gen/proto/cpp
+  - plugin: buf.build/protocolbuffers/csharp
+    out: gen/proto/csharp
+  - plugin: buf.build/protocolbuffers/go
+    out: gen/proto/go
+  - plugin: buf.build/protocolbuffers/java
+    out: gen/proto/java
+  - plugin: buf.build/protocolbuffers/objc
+    out: gen/proto/objc
+  - plugin: buf.build/protocolbuffers/php
+    out: gen/proto/php
+  - plugin: buf.build/protocolbuffers/ruby
+    out: gen/proto/ruby

--- a/src/test/buf.gen/buf.managed.yaml
+++ b/src/test/buf.gen/buf.managed.yaml
@@ -3,7 +3,7 @@
 version: v1
 managed:
   enabled: true
-  java_package_prefix: "com"
+  java_package_prefix: 'com'
 plugins:
   - plugin: connect-kotlin
     out: generated-google-java/build/generated/sources/bufgen

--- a/src/test/buf.gen/buf.managed.yaml
+++ b/src/test/buf.gen/buf.managed.yaml
@@ -1,0 +1,27 @@
+# Below is from https://github.com/connectrpc/connect-kotlin/blob/65fb4e45d6b72a632460de59b2de905bc62b9d97/examples/buf.gen.yaml
+
+version: v1
+managed:
+  enabled: true
+  java_package_prefix: "com"
+plugins:
+  - plugin: connect-kotlin
+    out: generated-google-java/build/generated/sources/bufgen
+    path: ./protoc-gen-connect-kotlin/build/install/protoc-gen-connect-kotlin/bin/protoc-gen-connect-kotlin
+  - plugin: java
+    out: generated-google-java/build/generated/sources/bufgen
+    protoc_path: .tmp/bin/protoc
+  - plugin: kotlin
+    out: generated-google-java/build/generated/sources/bufgen
+    protoc_path: .tmp/bin/protoc
+  - plugin: connect-kotlin
+    out: generated-google-javalite/build/generated/sources/bufgen
+    path: ./protoc-gen-connect-kotlin/build/install/protoc-gen-connect-kotlin/bin/protoc-gen-connect-kotlin
+  - plugin: java
+    out: generated-google-javalite/build/generated/sources/bufgen
+    protoc_path: .tmp/bin/protoc
+    opt: lite
+  - plugin: kotlin
+    out: generated-google-javalite/build/generated/sources/bufgen
+    protoc_path: .tmp/bin/protoc
+    opt: lite


### PR DESCRIPTION
This can be set as a string or an object - if a string, it'll be set as if the [`default` value of the object was set][1].

Added a test with a valid file.

[1]: https://github.com/bufbuild/buf/blob/21ba19590be4afe6fa3af0406e138c4fdc36fedf/private/buf/bufgen/bufgen.go#L433-L437

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
