### PR TITLE
Add schema for Atlassian Forge app manifest

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5535,6 +5535,12 @@
       "description": "TunnelHub Automation Configuration File",
       "fileMatch": ["tunnelhub.yml", "tunnelhub.yaml"],
       "url": "https://json.schemastore.org/tunnelhub.json"
+    },
+    {
+      "name": "Forge manifest",
+      "description": "App manifest for Atlassian Forge platform. See https://developer.atlassian.com/platform/forge/manifest-reference/",
+      "url": "https://unpkg.com/@forge/manifest/out/schema/manifest-schema.json",
+      "fileMatch": ["manifest.yml"]
     }
   ],
   "version": 1


### PR DESCRIPTION
Adding schema for the [Atlassian Forge apps manifest](https://developer.atlassian.com/platform/forge/manifest-reference/). It's published to NPM automatically as it's updated so the link is pointing to unpkg.