### PR TITLE
fix: remove editorconfig from prettierrc.json

### DIFF
--- a/src/negative_test/prettierrc/editorconfig-unknown-config.json
+++ b/src/negative_test/prettierrc/editorconfig-unknown-config.json
@@ -1,0 +1,3 @@
+{
+  "editorconfig": true
+}

--- a/src/negative_test/prettierrc/editorconfig-unknown-config.json
+++ b/src/negative_test/prettierrc/editorconfig-unknown-config.json
@@ -1,3 +1,0 @@
-{
-  "editorconfig": true
-}

--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -33,11 +33,6 @@
           "default": -1,
           "type": "integer"
         },
-        "editorconfig": {
-          "description": "Whether parse the .editorconfig file in your project and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by .prettierrc, etc.",
-          "default": false,
-          "type": "boolean"
-        },
         "embeddedLanguageFormatting": {
           "description": "Control how Prettier formats quoted code embedded in the file.",
           "default": "auto",

--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "optionsDefinition": {
-      "additionalProperties": false,
       "type": "object",
       "properties": {
         "arrowParens": {

--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "optionsDefinition": {
+      "additionalProperties": false,
       "type": "object",
       "properties": {
         "arrowParens": {

--- a/src/test/prettierrc/prettierrc.json
+++ b/src/test/prettierrc/prettierrc.json
@@ -1,9 +1,9 @@
 {
     "arrowParens": "always",
+    "bracketSameLine": false,
     "bracketSpacing": true,
     "htmlWhitespaceSensitivity": "css",
     "insertPragma": false,
-    "jsxBracketSameLine": false,
     "jsxSingleQuote": false,
     "overrides": [
         {

--- a/src/test/prettierrc/prettierrc.json
+++ b/src/test/prettierrc/prettierrc.json
@@ -4,6 +4,7 @@
     "bracketSpacing": true,
     "htmlWhitespaceSensitivity": "css",
     "insertPragma": false,
+    "jsxBracketSameLine": false,
     "jsxSingleQuote": false,
     "overrides": [
         {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

According to prettier's maintainer https://github.com/prettier/prettier/issues/6176#issuecomment-498808239, config `editorconfig` can only be used in API function. This option does not exist in json file. Adding `editorconfig` in `prettierrc` will raise `unknown option` warning.
