### PR TITLE
fix: add electronLanguages in electron-builder.json global option

### DIFF
--- a/src/schemas/json/electron-builder.json
+++ b/src/schemas/json/electron-builder.json
@@ -4277,6 +4277,20 @@
       "$ref": "#/definitions/ElectronDownloadOptions",
       "description": "The [electron-download](https://github.com/electron-userland/electron-download#usage) options."
     },
+    "electronLanguages": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "The electron locales. By default Electron locales used as is."
+    },
     "electronUpdaterCompatibility": {
       "description": "The [electron-updater compatibility](/auto-update#compatibility) semver range.",
       "type": ["null", "string"]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

`electronLanguages` has been moved to global config since `electron-builder@24.2.0`

https://github.com/electron-userland/electron-builder/pull/7516
