### PR TITLE
chore(codeowners): change ownership of CircleCI config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,8 @@ src/test/yamllint/ansible-* @ssbarnea @webknjaz
 src/schemas/json/zuul.json @ssbarnea
 src/test/zuul/ @ssbarnea
 src/negative_test/zuul/ @ssbarnea
+
+# Managed by CircleCI Developer Experience team:
+src/schemas/json/circleciconfig.json @CircleCI-Public/developer-experience
+src/test/circleciconfig/ @CircleCI-Public/developer-experience
+src/negative_test/circleciconfig/ @CircleCI-Public/developer-experience


### PR DESCRIPTION
We are the Developer Experience team at CircleCI, and we develop the [CircleCI VS Code extension](https://circleci.com/product/vscode-extension/) and the [CircleCI YAML language server](https://github.com/CircleCI-Public/circleci-yaml-language-server).

Our users often use our software in conjunction with the [Red Hat YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) for VS Code. This extension provides schema validation for many YAML file formats, based on the schemas in SchemaStore.

As a consequence, many of our users report errors to us errors with the schema in SchemaStore, whether it be mistakes in the schema, or simply our product deprecating or changing certain features, believing that the error comes from our extension.

When this happens, we often contribute to SchemaStore to provide our users with a smooth experience across products. However, the work cycle is less than optimal, as we need our contributions to go through a fork and a pull request.

Today, we wish to go one step further. We would like to share our updates to the SchemaStore community faster and in a more proactive manner. We wish to take ownership of the schema for CircleCI config files in the SchemaStore in order to ensure continuous updates and avoid desynchronization between our product and SchemaStore.

If this seems like a valid arrangement, could you please approve and merge this PR, and grant write privileges to the [CircleCI-Public/developer-experience](https://github.com/orgs/CircleCI-Public/teams/developer-experience) team?

Thank you!