### PR TITLE
Add Ubuntu2204 to appveyor.json

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -134,6 +134,7 @@
         "Ubuntu1604",
         "Ubuntu1804",
         "Ubuntu2004",
+        "Ubuntu2204",
         "Previous Ubuntu",
         "Previous Ubuntu1604",
         "Previous Ubuntu1804",


### PR DESCRIPTION
Adding Ubuntu2204 to appveyor schema.

Docs showing it is supported:
- [Docs on their base ubuntu img software matrix](https://www.appveyor.com/docs/linux-images-software/#:~:text=Ubuntu2004-,Ubuntu2204,-Operating%20system)
- [Release Notes](https://www.appveyor.com/updates/#:~:text=file%20as%20follows%3A-,image%3A%20Ubuntu2204,-Visual%20Studio%20images)

Please let me know if I missed anything, it's my first time contributing here.