### PR TITLE
Add buf PROTOVALIDATE lint rule

### DIFF
--- a/src/schemas/json/buf.json
+++ b/src/schemas/json/buf.json
@@ -46,6 +46,7 @@
         "RPC_REQUEST_STANDARD_NAME",
         "RPC_RESPONSE_STANDARD_NAME",
         "PACKAGE_VERSION_SUFFIX",
+        "PROTOVALIDATE",
         "SERVICE_SUFFIX",
         "COMMENT_ENUM",
         "COMMENT_ENUM_VALUE",
@@ -342,6 +343,12 @@
               }
             },
             "PACKAGE_VERSION_SUFFIX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PROTOVALIDATE": {
               "type": "array",
               "items": {
                 "type": "string"

--- a/src/test/buf/buf.protovalidate.yaml
+++ b/src/test/buf/buf.protovalidate.yaml
@@ -1,0 +1,8 @@
+version: v1
+lint:
+  use:
+    - PROTOVALIDATE
+  ignore_only:
+    PROTOVALIDATE:
+      - foo
+      - bar


### PR DESCRIPTION
Added in buf [v1.28.0][1] - seen in the docs at https://buf.build/docs/lint/rules#protovalidate.

[1]: https://github.com/bufbuild/buf/releases/tag/v1.28.0

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
