### PR TITLE
Add swift support in dependabot 2.0 schema

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -83,6 +83,7 @@
         "nuget",
         "pip",
         "pub",
+        "swift",
         "terraform"
       ]
     },

--- a/src/test/dependabot-2.0/example.json
+++ b/src/test/dependabot-2.0/example.json
@@ -209,6 +209,14 @@
       "schedule": {
         "interval": "daily"
       }
+    },
+    {
+      "package-ecosystem": "swift",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "target-branch": "main"
     }
   ],
   "version": 2


### PR DESCRIPTION
Support for `swift`, means the [package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) enum needs an update.
