### PR TITLE
fix: upgrade max package version for minecraft pack.mcmeta

### DIFF
--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -17,7 +17,7 @@
           "description": "A version for the current pack\nhttps://minecraft.wiki/w/Data_pack#Contents",
           "type": "integer",
           "minimum": 1,
-          "maximum": 15,
+          "maximum": 18,
           "default": 4
         }
       },


### PR DESCRIPTION
According to https://minecraft.wiki/w/Data_pack#Contents, the max version for minecraft resource packs is 18 for 1.20.2