### PR TITLE
Add schema for devbox to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -892,6 +892,12 @@
       "url": "https://deta.space/assets/spacefile.schema.json"
     },
     {
+      "name": "Devbox Config",
+      "description": "Configuration for a Devbox shell environment",
+      "fileMatch": ["devbox.json"],
+      "url": "https://raw.githubusercontent.com/jetpack-io/devbox/main/.schema/devbox.schema.json"
+    },
+    {
       "name": "Drupal Breakpoints",
       "description": "Drupal configuration for breakpoints",
       "fileMatch": ["*.breakpoints.yml"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Added schema for jetpack-io/devbox project's devbox.json
The schema definition is residing in jetpack-io/devbox/.schema/devbox.schema.json 
