### PR TITLE
add FiQuS schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1749,19 +1749,19 @@
       "fileMatch": ["**/.well-known/first-party-set.json"]
     },
     {
-        "name": "FiQuS",
-        "description": "FiQuS input file",
-        "fileMatch": [
-          "*_fiqus.json",
-          "*_fiqus.json5",
-          "*_fiqus.yaml",
-          "*_fiqus.yml",
-          "*_FiQuS.json",
-          "*_FiQuS.json5",
-          "*_FiQuS.yaml",
-          "*_FiQuS.yml"
-        ],
-        "url": "https://gitlab.cern.ch/steam/fiqus/-/raw/master/docs/schema.json"
+      "name": "FiQuS",
+      "description": "FiQuS input file",
+      "fileMatch": [
+        "*_fiqus.json",
+        "*_fiqus.json5",
+        "*_fiqus.yaml",
+        "*_fiqus.yml",
+        "*_FiQuS.json",
+        "*_FiQuS.json5",
+        "*_FiQuS.yaml",
+        "*_FiQuS.yml"
+      ],
+      "url": "https://gitlab.cern.ch/steam/fiqus/-/raw/master/docs/schema.json"
     },
     {
       "name": "first-timers-bot",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1749,6 +1749,21 @@
       "fileMatch": ["**/.well-known/first-party-set.json"]
     },
     {
+        "name": "FiQuS",
+        "description": "FiQuS input file",
+        "fileMatch": [
+          "*_fiqus.json",
+          "*_fiqus.json5",
+          "*_fiqus.yaml",
+          "*_fiqus.yml",
+          "*_FiQuS.json",
+          "*_FiQuS.json5",
+          "*_FiQuS.yaml",
+          "*_FiQuS.yml"
+        ],
+        "url": "https://gitlab.cern.ch/steam/fiqus/-/raw/master/docs/schema.json"
+    },
+    {
       "name": "first-timers-bot",
       "description": "A bot that helps onboarding new open-source contributors",
       "fileMatch": ["**/.github/first-timers.yml"],


### PR DESCRIPTION
Hello,

This pull request adds the schema of [FiQuS](https://gitlab.cern.ch/steam/fiqus), an open-source finite-element simulation program developed at CERN that is dedicated to magneto-thermal transient analyses of superconducting magnets.

Thanks,
Sina Atalay