### PR TITLE
fix(github-workflow): fix permissions for re-usable workflow calls

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -480,7 +480,7 @@
           "$ref": "#/definitions/jobNeeds"
         },
         "permissions": {
-          "$ref": "#/definitions/permissions-event"
+          "$ref": "#/definitions/permissions"
         },
         "if": {
           "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif",

--- a/src/test/github-workflow/permissions-none.yaml
+++ b/src/test/github-workflow/permissions-none.yaml
@@ -4,5 +4,10 @@ permissions: {}
 jobs:
   one:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: echo 'Hello from ${{ runner.os }}'
+
+  build-and-publish:
+    uses: exampleowner/example/.github/workflows/build_and_publish.yaml@v1
+    permissions: {}

--- a/src/test/github-workflow/permissions-object.yaml
+++ b/src/test/github-workflow/permissions-object.yaml
@@ -7,5 +7,16 @@ permissions:
 jobs:
   one:
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      packages: none
+      pages: write
     steps:
       - run: echo 'Hello from ${{ runner.os }}'
+
+  build-and-publish:
+    uses: exampleowner/example/.github/workflows/build_and_publish.yaml@v1
+    permissions:
+      issues: read
+      packages: none
+      pages: write

--- a/src/test/github-workflow/permissions-string.yaml
+++ b/src/test/github-workflow/permissions-string.yaml
@@ -7,3 +7,7 @@ jobs:
     permissions: write-all
     steps:
       - run: echo 'Hello from ${{ runner.os }}'
+
+  build-and-publish:
+    uses: exampleowner/example/.github/workflows/build_and_publish.yaml@v1
+    permissions: write-all


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
