### PR TITLE
Add a Dependabot config to update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Some GitHub actions defined in the CI workflows are out-of-date. For example, `actions/checkout@v3` is now at v4. There are currently no errors or even deprecation warnings, but I'm opening this PR to add a Dependabot config to keep the action versions updated as needed.

If this merges, you can expect Dependabot to immediately open a PR to update e.g. `actions/checkout@v3` to v4.

Thanks for your work on this project!

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
