### PR TITLE
Support `groups` in Dependabot 2.0

### DIFF
--- a/src/negative_test/dependabot-2.0/assignees-duplicate-values.json
+++ b/src/negative_test/dependabot-2.0/assignees-duplicate-values.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "assignees": ["duplicate", "duplicate"]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/assignees-no-values.json
+++ b/src/negative_test/dependabot-2.0/assignees-no-values.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "assignees": []
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/assignees-value-is-empty-string.json
+++ b/src/negative_test/dependabot-2.0/assignees-value-is-empty-string.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "assignees": [""]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/assignees-value-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/assignees-value-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "assignees": [1]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/assignees-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/assignees-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "assignees": "myself"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message-no-subkeys.json
+++ b/src/negative_test/dependabot-2.0/commit-message-no-subkeys.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {}
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message-unknown-property.json
+++ b/src/negative_test/dependabot-2.0/commit-message-unknown-property.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": { "easy-street": "yes, please" }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/commit-message-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": "update"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message.prefix-development-max-length-exceeded.json
+++ b/src/negative_test/dependabot-2.0/commit-message.prefix-development-max-length-exceeded.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "prefix-development": "-------10|-------20|-------30|-------40|-------50|+"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message.prefix-development-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/commit-message.prefix-development-wrong-type.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "prefix-development": true
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message.prefix-max-length-exceeded.json
+++ b/src/negative_test/dependabot-2.0/commit-message.prefix-max-length-exceeded.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "prefix": "-------10|-------20|-------30|-------40|-------50|+"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message.prefix-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/commit-message.prefix-wrong-type.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "prefix": true
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message.scope-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/commit-message.scope-wrong-type.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "scope": 1
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/commit-message.scope-wrong-value.json
+++ b/src/negative_test/dependabot-2.0/commit-message.scope-wrong-value.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "scope": "enabled+"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups-no-subkeys.json
+++ b/src/negative_test/dependabot-2.0/groups-no-subkeys.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {}
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups-subkey-is-empty-string.json
+++ b/src/negative_test/dependabot-2.0/groups-subkey-is-empty-string.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "": {
+          "patterns": "*"
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups-wrong-value.json
+++ b/src/negative_test/dependabot-2.0/groups-wrong-value.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": "the popular ones, thanks"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x-no-required-properties.json
+++ b/src/negative_test/dependabot-2.0/groups.x-no-required-properties.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "exclude-patterns": ["*"]
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x-no-subkeys.json
+++ b/src/negative_test/dependabot-2.0/groups.x-no-subkeys.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {}
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x-unknown-properties.json
+++ b/src/negative_test/dependabot-2.0/groups.x-unknown-properties.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": ["*"],
+          "just realized": "unknown properties are not allowed"
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/groups.x-wrong-type.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "npm-dependencies": "group all of them"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.dependency-type-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/groups.x.dependency-type-wrong-type.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "dependency-type": []
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.dependency-type-wrong-value.json
+++ b/src/negative_test/dependabot-2.0/groups.x.dependency-type-wrong-value.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "dependency-type": "any and all"
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.exclude-patterns-missing-values.json
+++ b/src/negative_test/dependabot-2.0/groups.x.exclude-patterns-missing-values.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": "*",
+          "exclude-patterns": []
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.exclude-patterns-value-empty-string.json
+++ b/src/negative_test/dependabot-2.0/groups.x.exclude-patterns-value-empty-string.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": "*",
+          "exclude-patterns": [""]
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.exclude-patterns-value-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/groups.x.exclude-patterns-value-wrong-type.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": "*",
+          "exclude-patterns": [1]
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.exclude-patterns-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/groups.x.exclude-patterns-wrong-type.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": "*",
+          "exclude-patterns": false
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.patterns-missing-values.json
+++ b/src/negative_test/dependabot-2.0/groups.x.patterns-missing-values.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": []
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.patterns-value-empty-string.json
+++ b/src/negative_test/dependabot-2.0/groups.x.patterns-value-empty-string.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": [""]
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.patterns-value-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/groups.x.patterns-value-wrong-type.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": [1]
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.patterns-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/groups.x.patterns-wrong-type.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "patterns": "*"
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.update-types-duplicate-values.json
+++ b/src/negative_test/dependabot-2.0/groups.x.update-types-duplicate-values.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "update-types": ["major", "major"]
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.update-types-missing-values.json
+++ b/src/negative_test/dependabot-2.0/groups.x.update-types-missing-values.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "update-types": []
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.update-types-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/groups.x.update-types-wrong-type.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "update-types": "*"
+        }
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/groups.x.update-types-wrong-value.json
+++ b/src/negative_test/dependabot-2.0/groups.x.update-types-wrong-value.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "update-types": ["all types"]
+        }
+      }
+    }
+  ]
+}

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -749,6 +749,60 @@
           "type": "string",
           "default": "/"
         },
+        "groups": {
+          "description": "Configure groups for dependencies. Each 'groups' property is arbitrary will appear in pull request titles and branch names. For example, the code snippet '{\"groups\": {\"NPM dependencies\": {\"patterns\": [\"*\"]}}}' sets the group name to 'NPM dependencies'.",
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {
+              "type": "object",
+              "properties": {
+                "dependency-type": {
+                  "description": "Specify a dependency type to be included in the group.",
+                  "type": "string",
+                  "enum": ["development", "production"]
+                },
+                "patterns": {
+                  "description": "Define strings of characters that match with a dependency name (or multiple dependency names) to include those dependencies in the group.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "uniqueItems": true,
+                  "minItems": 1
+                },
+                "exclude-patterns": {
+                  "description": "Exclude certain dependencies from the group. If a dependency is excluded from a group, Dependabot will continue to raise single pull requests to update the dependency to its latest version.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "uniqueItems": true,
+                  "minItems": 1
+                },
+                "update-types": {
+                  "description": "Specify the semantic versioning level to include in the group",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["major", "minor", "patch"]
+                  },
+                  "minItems": 1,
+                  "uniqueItems": true
+                }
+              },
+              "anyOf": [
+                { "required": ["dependency-type"] },
+                { "required": ["patterns"] },
+                { "required": ["update-types"] }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false,
+          "minProperties": 1
+        },
         "ignore": {
           "description": "Ignore certain dependencies or versions",
           "type": "array",

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -717,21 +717,32 @@
           "uniqueItems": true
         },
         "commit-message": {
-          "description": "Commit message preferences",
+          "description": "Dependabot attempts to detect your commit message preferences and use similar patterns. Use this option to specify your preferences explicitly.",
           "type": "object",
           "properties": {
             "prefix": {
-              "type": "string"
+              "description": "A prefix for all commit messages. When you specify a prefix for commit messages, GitHub will automatically add a colon between the defined prefix and the commit message provided the defined prefix ends with a letter, number, closing parenthesis, or closing bracket. This means that, for example, if you end the prefix with a whitespace, there will be no colon added between the prefix and the commit message.",
+              "type": "string",
+              "maxLength": 50
             },
             "prefix-development": {
-              "type": "string"
+              "description": "A separate prefix for all commit messages that update dependencies in the Development dependency group. When you specify a value for this option, the prefix is used only for updates to dependencies in the Production dependency group. This is not supported by all package ecosystems.",
+              "type": "string",
+              "maxLength": 50
             },
             "include": {
+              "description": "Specifies that any prefix is followed by a list of the dependencies updated in the commit.",
               "type": "string",
               "enum": ["scope"],
               "default": "scope"
             }
-          }
+          },
+          "anyOf": [
+            { "required": ["prefix"] },
+            { "required": ["prefix-development"] },
+            { "required": ["include"] }
+          ],
+          "additionalProperties": false
         },
         "directory": {
           "description": "Location of package manifests",

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -710,9 +710,11 @@
           "description": "Assignees to set on pull requests",
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
-          "minimum": 1
+          "minItems": 1,
+          "uniqueItems": true
         },
         "commit-message": {
           "description": "Commit message preferences",

--- a/src/test/dependabot-2.0/assignees.json
+++ b/src/test/dependabot-2.0/assignees.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "assignees": ["rose", "tulip", "daffodil", "daisy"]
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/commit-message.json
+++ b/src/test/dependabot-2.0/commit-message.json
@@ -1,0 +1,47 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "prefix": "",
+        "prefix-development": "",
+        "include": "scope"
+      }
+    },
+    {
+      "package-ecosystem": "pip",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "prefix": "-------10|-------20|-------30|-------40|-------50|"
+      }
+    },
+    {
+      "package-ecosystem": "pip",
+      "directory": "/2",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "prefix-development": "-------10|-------20|-------30|-------40|-------50|"
+      }
+    },
+    {
+      "package-ecosystem": "pip",
+      "directory": "/3",
+      "schedule": {
+        "interval": "daily"
+      },
+      "commit-message": {
+        "include": "scope"
+      }
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/groups.dependency-type.json
+++ b/src/test/dependabot-2.0/groups.dependency-type.json
@@ -1,0 +1,29 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "dependency-type": "development"
+        }
+      }
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/2",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "x": {
+          "dependency-type": "production"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/groups.exclude-patterns.json
+++ b/src/test/dependabot-2.0/groups.exclude-patterns.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "pip",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "Python dependencies": {
+          "patterns": ["*"],
+          "exclude-patterns": ["dep1*", "dep2*"]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/groups.patterns.json
+++ b/src/test/dependabot-2.0/groups.patterns.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "NPM dependencies": {
+          "patterns": ["*"]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/groups.update-types.json
+++ b/src/test/dependabot-2.0/groups.update-types.json
@@ -1,0 +1,29 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "NPM dependencies": {
+          "update-types": ["major"]
+        }
+      }
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/2",
+      "schedule": {
+        "interval": "daily"
+      },
+      "groups": {
+        "NPM dependencies": {
+          "update-types": ["major", "minor", "patch"]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces the following changes:

* `assignees`
  * The array must not be empty
  * Each assignee (GitHub username) has a minimum length of 1
* `commit-message`
  * `prefix` enforces a max length of 50, as documented
  * `prefix-development` enforces a max length of 50, as documented
  * Required properties are enforced
  * Unknown properties are disallowed
  * Descriptions have been added/updated
* `groups`
  * Net-new support

I've added positive and negative tests to demonstrate and enforce each of these changes.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
