### PR TITLE
Register schema for mlos_bench configs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2705,12 +2705,7 @@
     {
       "name": "MLOS Configs",
       "description": "Unified schema for mlos_bench config files",
-      "fileMatch": [
-        "*.mlos.jsonc",
-        "*.mlos.json",
-        "*.mlos.yaml",
-        "*.mlos.yml"
-      ],
+      "fileMatch": ["*.mlos.jsonc", "*.mlos.json", "*.mlos.yaml", "*.mlos.yml"],
       "url": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/mlos-bench-config-schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2703,8 +2703,8 @@
       "url": "https://json.schemastore.org/mkdocs-1.0.json"
     },
     {
-      "name": "MLOS mlos_bench Config",
-      "description": "MLOS mlos_bench Config",
+      "name": "MLOS Configs",
+      "description": "Unified schema for mlos_bench config files",
       "fileMatch": [
         "*.mlos.jsonc",
         "*.mlos.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2703,6 +2703,17 @@
       "url": "https://json.schemastore.org/mkdocs-1.0.json"
     },
     {
+      "name": "MLOS mlos_bench Config",
+      "description": "MLOS mlos_bench Config",
+      "fileMatch": [
+        "*.mlos.jsonc",
+        "*.mlos.json",
+        "*.mlos.yaml",
+        "*.mlos.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/mlos-bench-config-schema.json"
+    },
+    {
       "name": "monospace.yml",
       "description": "MonoSpace configuration file",
       "fileMatch": ["monospace.yml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2704,7 +2704,7 @@
     },
     {
       "name": "MLOS Configs",
-      "description": "Unified schema for mlos_bench config files",
+      "description": "Config files for the mlos_bench utility in MLOS",
       "fileMatch": ["*.mlos.jsonc", "*.mlos.json", "*.mlos.yaml", "*.mlos.yml"],
       "url": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/mlos-bench-config-schema.json"
     },


### PR DESCRIPTION
Adds a file matching rule for `mlos_bench` configs pointing at the unified schema file on published on github so that local editor config rules and `$schema` properties aren't required.

More details can be found at https://github.com/microsoft/MLOS/tree/main/mlos_bench/mlos_bench/config/schemas
See Also: https://github.com/microsoft/MLOS/issues/522

There are extensive tests for both positive and negative config validation against the schema and its subordinates in that repository here:
https://github.com/microsoft/MLOS/tree/main/mlos_bench/mlos_bench/tests/config/schemas