### PR TITLE
More Dependabot 2.0 testing

### DIFF
--- a/src/negative_test/dependabot-2.0/labels-duplicate-values.json
+++ b/src/negative_test/dependabot-2.0/labels-duplicate-values.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "labels": ["duplicate", "duplicate"]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/labels-value-empty-string.json
+++ b/src/negative_test/dependabot-2.0/labels-value-empty-string.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "labels": [""]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/labels-value-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/labels-value-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "labels": [2.0]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/labels-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/labels-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "labels": "several"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/milestone-min-value-exceeded.json
+++ b/src/negative_test/dependabot-2.0/milestone-min-value-exceeded.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "milestone": 0
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/milestone-wrong-type-float.json
+++ b/src/negative_test/dependabot-2.0/milestone-wrong-type-float.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "milestone": 1.1
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/milestone-wrong-type-string.json
+++ b/src/negative_test/dependabot-2.0/milestone-wrong-type-string.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "milestone": "milestone label not allowed"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/open-pull-requests-limit-min-value-exceeded.json
+++ b/src/negative_test/dependabot-2.0/open-pull-requests-limit-min-value-exceeded.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "open-pull-requests-limit": -1
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/open-pull-requests-limit-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/open-pull-requests-limit-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "open-pull-requests-limit": "5"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-value-min-length-exceeded-betas-enabled.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-value-min-length-exceeded-betas-enabled.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "enable-beta-ecosystems": true,
+  "updates": [
+    {
+      "package-ecosystem": "",
+      "directory": "/",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-value-unknown-betas-disabled.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-value-unknown-betas-disabled.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "enable-beta-ecosystems": false,
+  "updates": [
+    {
+      "package-ecosystem": "'enable-beta-ecosystems' is false",
+      "directory": "/",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-value-unknown-betas-unspecified.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-value-unknown-betas-unspecified.json
@@ -1,0 +1,12 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "'enable-beta-ecosystems' is unspecified",
+      "directory": "/",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/pull-request-branch-name-missing-required-property.json
+++ b/src/negative_test/dependabot-2.0/pull-request-branch-name-missing-required-property.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "pull-request-branch-name": {}
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/pull-request-branch-name-unknown-property.json
+++ b/src/negative_test/dependabot-2.0/pull-request-branch-name-unknown-property.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "pull-request-branch-name": {
+        "unknown": "property"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/pull-request-branch-name-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/pull-request-branch-name-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "pull-request-branch-name": "updates"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/pull-request-branch-name.separator-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/pull-request-branch-name.separator-wrong-type.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "pull-request-branch-name": {
+        "separator": false
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/pull-request-branch-name.separator-wrong-value.json
+++ b/src/negative_test/dependabot-2.0/pull-request-branch-name.separator-wrong-value.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "pull-request-branch-name": {
+        "separator": "!"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/rebase-strategy-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/rebase-strategy-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "rebase-strategy": true
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/rebase-strategy-wrong-value.json
+++ b/src/negative_test/dependabot-2.0/rebase-strategy-wrong-value.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "rebase-strategy": "constantly"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-duplicate-values.json
+++ b/src/negative_test/dependabot-2.0/registries-duplicate-values.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "registries": {
+    "my-custom-registry": {
+      "type": "npm-registry",
+      "url": "https://example.example",
+      "username": "success",
+      "password": "${{ secrets.password }}"
+    }
+  },
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "registries": ["my-custom-registry", "my-custom-registry"]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-missing-values.json
+++ b/src/negative_test/dependabot-2.0/registries-missing-values.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "registries": {
+    "my-custom-registry": {
+      "type": "npm-registry",
+      "url": "https://example.example",
+      "username": "success",
+      "password": "${{ secrets.password }}"
+    }
+  },
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "registries": []
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-top-level-no-subkeys.json
+++ b/src/negative_test/dependabot-2.0/registries-top-level-no-subkeys.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "registries": {},
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-top-level-subkey-empty-string.json
+++ b/src/negative_test/dependabot-2.0/registries-top-level-subkey-empty-string.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "registries": {
+    "": {
+      "type": "npm-registry"
+    }
+  },
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-top-level-type-missing.json
+++ b/src/negative_test/dependabot-2.0/registries-top-level-type-missing.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "registries": {
+    "custom": {
+      "url": "https://example.example"
+    }
+  },
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-top-level-url-missing.json
+++ b/src/negative_test/dependabot-2.0/registries-top-level-url-missing.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "registries": {
+    "custom": {
+      "type": "npm-registry"
+    }
+  },
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-top-level-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/registries-top-level-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "registries": [],
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-value-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/registries-value-wrong-type.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "registries": {
+    "my-custom-registry": {
+      "type": "npm-registry",
+      "url": "https://example.example",
+      "username": "success",
+      "password": "${{ secrets.password }}"
+    }
+  },
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "registries": [true]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/registries-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/registries-wrong-type.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "registries": {
+    "my-custom-registry": {
+      "type": "npm-registry",
+      "url": "https://example.example",
+      "username": "success",
+      "password": "${{ secrets.password }}"
+    }
+  },
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "registries": "my-custom-registry"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/reviewers-duplicate-values.json
+++ b/src/negative_test/dependabot-2.0/reviewers-duplicate-values.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "reviewers": ["duplicate", "duplicate"]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/reviewers-min-length-exceeded.json
+++ b/src/negative_test/dependabot-2.0/reviewers-min-length-exceeded.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "reviewers": []
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/reviewers-value-empty-string.json
+++ b/src/negative_test/dependabot-2.0/reviewers-value-empty-string.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "reviewers": [""]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/reviewers-value-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/reviewers-value-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "reviewers": [false]
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/reviewers-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/reviewers-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "reviewers": "me, always"
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/target-branch-empty-string.json
+++ b/src/negative_test/dependabot-2.0/target-branch-empty-string.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "target-branch": ""
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/target-branch-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/target-branch-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "target-branch": false
+    }
+  ]
+}

--- a/src/negative_test/dependabot-2.0/vendor-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/vendor-wrong-type.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "vendor": "bundler"
+    }
+  ]
+}

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -889,6 +889,15 @@
           "enum": ["auto", "disabled"],
           "default": "auto"
         },
+        "registries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        },
         "reviewers": {
           "type": "array",
           "items": {
@@ -940,11 +949,10 @@
     },
     "registry": {
       "type": "object",
-      "title": "registries",
       "description": "The top-level registries key is optional. It allows you to specify authentication details that Dependabot can use to access private package registries.",
       "additionalProperties": false,
       "patternProperties": {
-        ".*": {
+        ".+": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -965,7 +973,7 @@
               ]
             },
             "url": {
-              "description": "The URL to use to access the dependencies in this registry. The protocol is optional. If not specified, https:// is assumed. Dependabot adds or ignores trailing slashes as required.",
+              "description": "The URL to use to access the dependencies in this registry. The protocol is optional. If not specified, 'https://' is assumed. Dependabot adds or ignores trailing slashes as required.",
               "type": "string"
             },
             "username": {
@@ -1005,9 +1013,10 @@
               "type": "string"
             }
           },
-          "required": ["type"]
+          "required": ["type", "url"]
         }
-      }
+      },
+      "minProperties": 1
     }
   },
   "properties": {
@@ -1030,7 +1039,6 @@
       }
     },
     "registries": {
-      "type": "object",
       "$ref": "#/definitions/registry"
     }
   },

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -888,10 +888,12 @@
         "reviewers": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
-          "description": "Reviewers to set on pull requests",
-          "minimum": 1
+          "description": "Specify individual reviewers or teams of reviewers for all pull requests raised for a package manager. You must use the full team name, including the organization, as if you were @mentioning the team.",
+          "minItems": 1,
+          "uniqueItems": true
         },
         "schedule": {
           "description": "Schedule preferences",

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -924,7 +924,7 @@
           "minLength": 1
         },
         "vendor": {
-          "description": "Update vendored or cached dependencies",
+          "description": "Tell Dependabot to vendor dependencies when updating them. Don't use this option if you're using 'gomod'.",
           "type": "boolean"
         },
         "versioning-strategy": {

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -645,8 +645,7 @@
         }
       }
     },
-    "package-ecosystem": {
-      "type": "string",
+    "package-ecosystem-values": {
       "enum": [
         "bundler",
         "cargo",
@@ -863,7 +862,12 @@
         },
         "package-ecosystem": {
           "description": "Package manager to use",
-          "$ref": "#/definitions/package-ecosystem"
+          "$comment": "These values are restricted by a top-level if-then-else when 'enable-beta-ecosystems' is not enabled.",
+          "type": "string",
+          "anyOf": [
+            { "$ref": "#/definitions/package-ecosystem-values" },
+            { "minLength": 1 }
+          ]
         },
         "pull-request-branch-name": {
           "description": "Pull request branch name preferences",
@@ -1032,5 +1036,32 @@
   },
   "required": ["version", "updates"],
   "title": "GitHub Dependabot v2 config",
-  "type": "object"
+  "type": "object",
+  "allOf": [
+    {
+      "$comment": "If 'enable-beta-ecosystems' is NOT enabled, enforce known 'package-ecosystem' values.",
+      "if": {
+        "properties": {
+          "enable-beta-ecosystems": {
+            "const": true
+          }
+        },
+        "required": ["enable-beta-ecosystems"]
+      },
+      "then": {},
+      "else": {
+        "properties": {
+          "updates": {
+            "items": {
+              "properties": {
+                "package-ecosystem": {
+                  "$ref": "#/definitions/package-ecosystem-values"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -851,15 +851,9 @@
           "default": ["dependencies"]
         },
         "milestone": {
-          "description": "Milestone to set on pull requests",
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "integer"
-            }
-          ]
+          "description": "Associate all pull requests raised for a package manager with a milestone. You need to specify the numeric identifier of the milestone and not its label.",
+          "type": "integer",
+          "minimum": 1
         },
         "open-pull-requests-limit": {
           "description": "Limit number of open pull requests for version updates",

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -843,8 +843,11 @@
           "description": "Labels to set on pull requests",
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
+          "minItems": 0,
+          "uniqueItems": true,
           "default": ["dependencies"]
         },
         "milestone": {

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -919,8 +919,9 @@
           "required": ["interval"]
         },
         "target-branch": {
+          "description": "Specify a different branch for manifest files and for pull requests.",
           "type": "string",
-          "description": "Branch to create pull requests against"
+          "minLength": 1
         },
         "vendor": {
           "description": "Update vendored or cached dependencies",

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -880,7 +880,7 @@
           "additionalProperties": false
         },
         "rebase-strategy": {
-          "description": "Disable automatic rebasing",
+          "description": "Disable automatic rebasing. 'auto' is the default and Dependabot will rebase open pull requests when changes are detected. 'disabled' will disable automatic rebasing.",
           "type": "string",
           "enum": ["auto", "disabled"],
           "default": "auto"

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -876,7 +876,8 @@
               "enum": ["-", "_", "/"]
             }
           },
-          "required": ["separator"]
+          "required": ["separator"],
+          "additionalProperties": false
         },
         "rebase-strategy": {
           "description": "Disable automatic rebasing",

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -858,6 +858,7 @@
         "open-pull-requests-limit": {
           "description": "Limit number of open pull requests for version updates",
           "type": "integer",
+          "minimum": 0,
           "default": 5
         },
         "package-ecosystem": {

--- a/src/test/dependabot-2.0/enable-beta-ecosystems-disabled.json
+++ b/src/test/dependabot-2.0/enable-beta-ecosystems-disabled.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "enable-beta-ecosystems": false,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/enable-beta-ecosystems-enabled.json
+++ b/src/test/dependabot-2.0/enable-beta-ecosystems-enabled.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "enable-beta-ecosystems": true,
+  "updates": [
+    {
+      "package-ecosystem": "beta-ecosystem",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/example.json
+++ b/src/test/dependabot-2.0/example.json
@@ -27,6 +27,7 @@
     },
     "github-hex-org": {
       "type": "hex-organization",
+      "url": "https://example.example",
       "organization": "github",
       "key": "${{secrets.MY_HEX_ORGANIZATION_KEY}}"
     },

--- a/src/test/dependabot-2.0/labels.json
+++ b/src/test/dependabot-2.0/labels.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "labels": []
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/2",
+      "schedule": {
+        "interval": "daily"
+      },
+      "labels": ["rose", "tulip", "daisy", "daffodil"]
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/milestone.json
+++ b/src/test/dependabot-2.0/milestone.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "milestone": 1
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/open-pull-requests-limit.json
+++ b/src/test/dependabot-2.0/open-pull-requests-limit.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "open-pull-requests-limit": 0
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/2",
+      "schedule": {
+        "interval": "daily"
+      },
+      "open-pull-requests-limit": 10
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/pull-request-branch-name.json
+++ b/src/test/dependabot-2.0/pull-request-branch-name.json
@@ -1,0 +1,35 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "pull-request-branch-name": {
+        "separator": "/"
+      }
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/2",
+      "schedule": {
+        "interval": "daily"
+      },
+      "pull-request-branch-name": {
+        "separator": "-"
+      }
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/3",
+      "schedule": {
+        "interval": "daily"
+      },
+      "pull-request-branch-name": {
+        "separator": "_"
+      }
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/rebase-strategy.json
+++ b/src/test/dependabot-2.0/rebase-strategy.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "rebase-strategy": "auto"
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/2",
+      "schedule": {
+        "interval": "daily"
+      },
+      "rebase-strategy": "disabled"
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/registries-top-level.json
+++ b/src/test/dependabot-2.0/registries-top-level.json
@@ -1,0 +1,29 @@
+{
+  "version": 2,
+  "registries": {
+    "my-custom-registry": {
+      "type": "npm-registry",
+      "url": "https://example.example",
+      "username": "success",
+      "password": "${{ secrets.password }}"
+    }
+  },
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/1",
+      "schedule": {
+        "interval": "daily"
+      },
+      "registries": ["my-custom-registry"]
+    },
+    {
+      "package-ecosystem": "npm",
+      "directory": "/2",
+      "schedule": {
+        "interval": "daily"
+      },
+      "registries": ["*"]
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/reviewers.json
+++ b/src/test/dependabot-2.0/reviewers.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "reviewers": ["reviewer1"]
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/target-branch.json
+++ b/src/test/dependabot-2.0/target-branch.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "npm",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "target-branch": "develop"
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/vendor.json
+++ b/src/test/dependabot-2.0/vendor.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "bundler",
+      "directory": "/",
+      "schedule": {
+        "interval": "daily"
+      },
+      "vendor": true
+    }
+  ]
+}


### PR DESCRIPTION
This PR heavily tests and refines the following Dependabot keys:

* `enable-beta-ecosystems`
  * `package-ecosystem` enum values are conditionally enforced based on this value.
  
    If beta ecosystems are enabled, the `package-ecosystem` is allowed to be any value (minimum string length of 1). If beta ecosystems are disabled, only known (enumerated) `package-ecosystem` values are allowed.
* `vendor`
  * The description was updated.
* `target-branch`
  * The branch name must be at least 1 character.
* `reviewers`
  * List and string lengths, and uniqueness, are now enforced.
* `rebase-strategy`
  * The description was updated.
* `pull-request-branch-name`
  * Additional properties are forbidden.
* `open-pull-requests-limit`
  * Negative integer values are excluded.
* `milestone`
  * Integer values are now enforced, as documented.
* `labels`
  * List and string lengths, and uniqueness, are validated.
* `registries`
  * `url` is now a required property for the top-level `registries` key.
  * `updates.registries` is now supported (previously it was completely undefined).

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
