### PR TITLE
Fixes the $id of problem-object-rfc9457.json to the right one.

### DIFF
--- a/src/schemas/json/problem-object-rfc9457.json
+++ b/src/schemas/json/problem-object-rfc9457.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://json.schemastore.org/problem-schema-rfc9457.json",
+  "$id": "https://json.schemastore.org/problem-object-rfc9457.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "An RFC 9457 problem object",
   "description": "Definition from https://datatracker.ietf.org/doc/html/rfc9457#name-json-schema-for-http-proble",


### PR DESCRIPTION
I forgot to change the $id of the schema to the right one (`problem-schema` 👎  -> `problem-object` 👍 ) when the build checks suggested to not use schema in the name of the files.
