### PR TITLE
Add remote schema for Liferay client-extension.yaml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2485,6 +2485,12 @@
       "url": "https://json.schemastore.org/license-report-config.json"
     },
     {
+      "name": "Liferay client-extension.yaml",
+      "description": "Liferay Client Extension Definition File",
+      "fileMatch": ["client-extension.yaml"],
+      "url": "https://raw.githubusercontent.com/liferay/liferay-portal/master/modules/sdk/gradle-plugins-workspace/src/main/resources/schemas/client-extension.schema.json"
+    },
+    {
       "name": "linkinator.config.json",
       "description": "Linkinator config file",
       "fileMatch": ["linkinator.config.json"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

~Will mark as ready for review once~ The [schema URL](https://raw.githubusercontent.com/liferay/liferay-portal/master/modules/sdk/gradle-plugins-workspace/src/main/resources/schemas/client-extension.schema.json) is live.
