### PR TITLE
add stella config schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3837,7 +3837,7 @@
     },
     {
       "name": "Stella configuration file",
-      "description": "Configuration schema for stella. See https://github.com/Shravan-1908/stellapy",
+      "description": "Configuration file for stella. See https://github.com/Shravan-1908/stellapy",
       "fileMatch": [
         "stella.yml",
         "stella.json"

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3836,6 +3836,15 @@
       "url": "https://raw.githubusercontent.com/Konafets/statamic-blueprint-validation/main/statamic.blueprint.schema.json"
     },
     {
+      "name": "Stella configuration file",
+      "description": "Configuration schema for stella. See https://github.com/Shravan-1908/stellapy",
+      "fileMatch": [
+        "stella.yml",
+        "stella.json"
+      ],
+      "url": "https://raw.githubusercontent.com/Shravan-1908/stellapy/master/schema.json"
+    },
+    {
       "name": "stripe-app.json",
       "description": "Stripe Apps manifest file",
       "fileMatch": ["stripe-app.json"],


### PR DESCRIPTION
This PR adds a reference to the configuration schema of stella on the master branch of https://github.com/Shravan-1908/stellapy