### PR TITLE
fix(hugo.json): fix hugoVersion, menu and theme definition errors

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -268,93 +268,7 @@
     },
     "hugoVersion": {
       "type": "string",
-      "enum": [
-        "v0.119.0",
-        "v0.118.2",
-        "v0.118.1",
-        "v0.118.0",
-        "v0.117.0",
-        "v0.116.1",
-        "v0.116.0",
-        "v0.115.4",
-        "v0.115.3",
-        "v0.115.2",
-        "v0.115.1",
-        "v0.115.0",
-        "v0.114.1",
-        "v0.114.0",
-        "v0.113.0",
-        "v0.112.7",
-        "v0.112.6",
-        "v0.112.5",
-        "v0.112.4",
-        "v0.112.3",
-        "v0.112.2",
-        "v0.112.1",
-        "v0.112.0",
-        "v0.111.3",
-        "v0.111.2",
-        "v0.111.1",
-        "v0.111.0",
-        "v0.110.0",
-        "v0.109.0",
-        "v0.108.0",
-        "v0.107.0",
-        "v0.106.0",
-        "v0.105.0",
-        "v0.104.3",
-        "v0.104.2",
-        "v0.104.1",
-        "v0.104.0",
-        "v0.103.1",
-        "v0.103.0",
-        "v0.102.3",
-        "v0.102.2",
-        "v0.102.1",
-        "v0.102.0",
-        "v0.101.0",
-        "v0.100.2",
-        "v0.100.1",
-        "v0.100.0",
-        "v0.99.1",
-        "v0.99.0",
-        "v0.98.0",
-        "v0.97.3",
-        "v0.97.2",
-        "v0.97.1",
-        "v0.97.0",
-        "v0.96.0",
-        "v0.95.0",
-        "v0.94.2",
-        "v0.94.1",
-        "v0.94.0",
-        "v0.93.3",
-        "v0.93.2",
-        "v0.93.1",
-        "v0.93.0",
-        "v0.92.2",
-        "v0.92.1",
-        "v0.92.0",
-        "v0.91.2",
-        "v0.91.1",
-        "v0.91.0",
-        "v0.90.1",
-        "v0.90.0",
-        "v0.89.4",
-        "v0.89.3",
-        "v0.89.2",
-        "v0.89.1",
-        "v0.89.0",
-        "v0.88.1",
-        "v0.88.0",
-        "v0.87.0",
-        "v0.86.1",
-        "v0.86.0",
-        "v0.85.0",
-        "v0.84.4",
-        "v0.84.3",
-        "v0.84.2"
-      ]
+      "pattern": "^\\d+\\.\\d+\\.\\d+.*$"
     }
   },
   "properties": {
@@ -1892,6 +1806,10 @@
               "url": {
                 "description": "Required for external links.\nhttps://gohugo.io/content-management/menus/#properties-site-configuration",
                 "type": "string"
+              },
+              "params": {
+                "description": "User-defined properties for the menu entry.\nhttps://gohugo.io/content-management/menus/#properties-front-matter",
+                "type": "object"
               }
             },
             "additionalProperties": false
@@ -2660,9 +2578,18 @@
       }
     },
     "theme": {
-      "description": "\nhttps://gohugo.io/hugo-modules/configuration/#module-config-imports",
-      "type": "string",
-      "minLength": 1
+      "description": "Theme or Theme list\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-imports",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "themesDir": {
       "description": "The directory where themes are stored\nhttps://gohugo.io/getting-started/configuration/#themesdir",


### PR DESCRIPTION
fix(hugo.json): fix hugoVersion, menu and theme definition errors

## Related Links

- https://github.com/tamasfe/taplo/issues/481
- test file [hugo.toml](https://github.com/hugo-fixit/FixIt/blob/dba2e38ac84bb67ad5ebbd5e22e649bc2fc41fe5/hugo.toml)
