### PR TITLE
chore: bump scikit-build schema to 0.7

### DIFF
--- a/src/schemas/json/scikit-build.json
+++ b/src/schemas/json/scikit-build.json
@@ -150,6 +150,22 @@
             "type": "string"
           },
           "description": "A list of license files to include in the wheel. Supports glob patterns."
+        },
+        "cmake": {
+          "type": "boolean",
+          "default": true,
+          "description": "If set to True (the default), CMake will be run before building the wheel."
+        },
+        "platlib": {
+          "type": "boolean",
+          "description": "Target the platlib or the purelib. If not set, the default is to target the platlib if wheel.cmake is true, and the purelib otherwise."
+        },
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A set of patterns to exclude from the wheel. This is additive to the SDist exclude patterns. This applies to the source files, not the final paths. Editable installs may not respect this exclusion."
         }
       }
     },
@@ -169,9 +185,9 @@
       "additionalProperties": false,
       "properties": {
         "mode": {
-          "enum": ["redirect"],
+          "enum": ["redirect", "inplace"],
           "default": "redirect",
-          "description": "Select the editable mode to use. Currently only \"redirect\" is supported."
+          "description": "Select the editable mode to use. Can be \"redirect\" (default) or \"inplace\"."
         },
         "verbose": {
           "type": "boolean",
@@ -333,29 +349,21 @@
         "additionalProperties": false,
         "properties": {
           "if": {
-            "type": "object",
-            "minProperties": 1,
-            "additionalProperties": false,
-            "properties": {
-              "python-version": {
-                "type": "string"
+            "anyOf": [
+              {
+                "$ref": "#/$defs/if_overrides"
               },
-              "implementation-name": {
-                "type": "string"
-              },
-              "implementation-version": {
-                "type": "string"
-              },
-              "platform-system": {
-                "type": "string"
-              },
-              "platform-machine": {
-                "type": "string"
-              },
-              "platform-node": {
-                "type": "string"
+              {
+                "type": "object",
+                "properties": {
+                  "any": {
+                    "$ref": "#/$defs/if_overrides"
+                  }
+                },
+                "required": ["any"],
+                "additionalProperties": false
               }
-            }
+            ]
           },
           "cmake": {
             "$ref": "#/properties/cmake"
@@ -412,6 +420,48 @@
         },
         "provider-path": {
           "type": "string"
+        }
+      }
+    },
+    "if_overrides": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "python-version": {
+          "type": "string"
+        },
+        "implementation-name": {
+          "type": "string"
+        },
+        "implementation-version": {
+          "type": "string"
+        },
+        "platform-system": {
+          "type": "string"
+        },
+        "platform-machine": {
+          "type": "string"
+        },
+        "platform-node": {
+          "type": "string"
+        },
+        "env": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "minProperties": 1
         }
       }
     }


### PR DESCRIPTION
This bumps the Scikit-build schema to 0.7.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
