### PR TITLE
fix(circleciconfig): Update circleci schema resource_classes for windows machine

### DIFF
--- a/src/negative_test/circleciconfig/resource-class.yml
+++ b/src/negative_test/circleciconfig/resource-class.yml
@@ -19,7 +19,7 @@ executors:
   machine-windows-arm-medium:
     machine:
       image: 'windows-server-2019:current'
-    resource_class: arm.medium
+    resource_class: windows.arm.medium
   macos-medium:
     macos:
       xcode: '14.0.1'

--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -518,7 +518,7 @@
               "required": ["image"],
               "properties": {
                 "image": {
-                  "description": "The VM image to use. View [available images](https://circleci.com/docs/configuration-reference/#available-linux-gpu-images). **Note:** This key is **not** supported on the installable CircleCI. For information about customizing machine executor images on CircleCI installed on your servers, see our [VM Service documentation](https://circleci.com/docs/vm-service).",
+                  "description": "The VM image to use. View [available images](https://circleci.com/docs/configuration-reference/#available-windows-machine-images-cloud). **Note:** This key is **not** supported on the installable CircleCI. For information about customizing machine executor images on CircleCI installed on your servers, see our [VM Service documentation](https://circleci.com/docs/vm-service).",
                   "type": "string",
                   "enum": [
                     "windows-server-2022-gui:2023.10.1",
@@ -549,9 +549,9 @@
               }
             },
             "resource_class": {
-              "description": "Amount of CPU and RAM allocated for each job. View [available resource classes](https://circleci.com/docs/configuration-reference/#gpu-execution-environment-linux)",
+              "description": "Amount of CPU and RAM allocated for each job. View [available resource classes](https://circleci.com/docs/configuration-reference/#windows-execution-environment)",
               "type": "string",
-              "enum": ["medium", "large", "xlarge", "2xlarge"]
+              "enum": ["windows.medium", "windows.large", "windows.xlarge", "windows.2xlarge"]
             }
           }
         },
@@ -563,7 +563,7 @@
               "required": ["image"],
               "properties": {
                 "image": {
-                  "description": "The VM image to use. View [available images](https://circleci.com/docs/configuration-reference/#available-linux-gpu-images). **Note:** This key is **not** supported on the installable CircleCI. For information about customizing machine executor images on CircleCI installed on your servers, see our [VM Service documentation](https://circleci.com/docs/vm-service).",
+                  "description": "The VM image to use. View [available images](https://circleci.com/docs/configuration-reference/#available-windows-gpu-image). **Note:** This key is **not** supported on the installable CircleCI. For information about customizing machine executor images on CircleCI installed on your servers, see our [VM Service documentation](https://circleci.com/docs/vm-service).",
                   "type": "string",
                   "enum": [
                     "windows-server-2019-cuda:current",
@@ -576,7 +576,7 @@
               }
             },
             "resource_class": {
-              "description": "Amount of CPU and RAM allocated for each job. View [available resource classes](https://circleci.com/docs/configuration-reference/#gpu-execution-environment-linux)",
+              "description": "Amount of CPU and RAM allocated for each job. View [available resource classes](https://circleci.com/docs/configuration-reference/#gpu-execution-environment-windows)",
               "type": "string",
               "enum": ["windows.gpu.nvidia.medium"]
             }

--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -551,7 +551,12 @@
             "resource_class": {
               "description": "Amount of CPU and RAM allocated for each job. View [available resource classes](https://circleci.com/docs/configuration-reference/#windows-execution-environment)",
               "type": "string",
-              "enum": ["windows.medium", "windows.large", "windows.xlarge", "windows.2xlarge"]
+              "enum": [
+                "windows.medium",
+                "windows.large",
+                "windows.xlarge",
+                "windows.2xlarge"
+              ]
             }
           }
         },

--- a/src/test/circleciconfig/resource-class.yml
+++ b/src/test/circleciconfig/resource-class.yml
@@ -23,7 +23,7 @@ executors:
   machine-windows-medium:
     machine:
       image: 'windows-server-2019:current'
-    resource_class: medium
+    resource_class: windows.medium
   machine-windows-gpu-medium:
     machine:
       image: 'windows-server-2019-cuda:current'


### PR DESCRIPTION
This fixes the resource classes for Windows execution environments. It looks like the resource classes have to be prefixed with `windows` when specifying the machine images directly (as opposed to using the executors in the Windows orb).

I also updated links in the description to point to the right locations.


<img width="709" alt="Screenshot 2023-12-04 at 8 44 13 AM" src="https://github.com/SchemaStore/schemastore/assets/430092/5aa03468-504d-444a-b303-7e2705ac4be1">


