### PR TITLE
Add additional buf breaking rules

### DIFF
--- a/src/schemas/json/buf.json
+++ b/src/schemas/json/buf.json
@@ -63,7 +63,68 @@
     "breaking-rule": {
       "type": "string",
       "description": "https://buf.build/docs/breaking/rules",
-      "enum": ["FILE", "PACKAGE", "WIRE_JSON", "WIRE"]
+      "enum": [
+        "FILE",
+        "PACKAGE",
+        "WIRE_JSON",
+        "WIRE",
+        "ENUM_NO_DELETE",
+        "MESSAGE_NO_DELETE",
+        "SERVICE_NO_DELETE",
+        "PACKAGE_ENUM_NO_DELETE",
+        "PACKAGE_MESSAGE_NO_DELETE",
+        "PACKAGE_SERVICE_NO_DELETE",
+        "FILE_NO_DELETE",
+        "PACKAGE_NO_DELETE",
+        "ENUM_VALUE_NO_DELETE",
+        "FIELD_NO_DELETE",
+        "ENUM_VALUE_NO_DELETE_UNLESS_NUMBER_RESERVED",
+        "FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED",
+        "ENUM_VALUE_NO_DELETE_UNLESS_NAME_RESERVED",
+        "FIELD_NO_DELETE_UNLESS_NAME_RESERVED",
+        "RPC_NO_DELETE",
+        "ONEOF_NO_DELETE",
+        "MESSAGE_NO_REMOVE_STANDARD_DESCRIPTOR_ACCESSOR",
+        "FILE_SAME_PACKAGE",
+        "FILE_SAME_SYNTAX",
+        "ENUM_VALUE_SAME_NAME",
+        "FIELD_SAME_CTYPE",
+        "FIELD_SAME_JSTYPE",
+        "FIELD_SAME_TYPE",
+        "FIELD_WIRE_COMPATIBLE_TYPE",
+        "FIELD_WIRE_JSON_COMPATIBLE_TYPE",
+        "FIELD_SAME_LABEL",
+        "FIELD_SAME_ONEOF",
+        "FIELD_SAME_NAME",
+        "FIELD_SAME_JSON_NAME",
+        "RESERVED_ENUM_NO_DELETE",
+        "RESERVED_MESSAGE_NO_DELETE",
+        "EXTENSION_MESSAGE_NO_DELETE",
+        "MESSAGE_SAME_MESSAGE_SET_WIRE_FORMAT",
+        "RPC_SAME_REQUEST_TYPE",
+        "RPC_SAME_RESPONSE_TYPE",
+        "RPC_SAME_CLIENT_STREAMING",
+        "RPC_SAME_SERVER_STREAMING",
+        "RPC_SAME_IDEMPOTENCY_LEVEL",
+        "FILE_SAME_CC_ENABLE_ARENAS",
+        "FILE_SAME_CC_GENERIC_SERVICES",
+        "FILE_SAME_CSHARP_NAMESPACE",
+        "FILE_SAME_GO_PACKAGE",
+        "FILE_SAME_JAVA_GENERIC_SERVICES",
+        "FILE_SAME_JAVA_MULTIPLE_FILES",
+        "FILE_SAME_JAVA_OUTER_CLASSNAME",
+        "FILE_SAME_JAVA_PACKAGE",
+        "FILE_SAME_JAVA_STRING_CHECK_UTF8",
+        "FILE_SAME_OBJC_CLASS_PREFIX",
+        "FILE_SAME_OPTIMIZE_FOR",
+        "FILE_SAME_PHP_CLASS_PREFIX",
+        "FILE_SAME_PHP_GENERIC_SERVICES",
+        "FILE_SAME_PHP_METADATA_NAMESPACE",
+        "FILE_SAME_PHP_NAMESPACE",
+        "FILE_SAME_PY_GENERIC_SERVICES",
+        "FILE_SAME_RUBY_PACKAGE",
+        "FILE_SAME_SWIFT_PREFIX"
+      ]
     }
   },
   "required": ["version"],
@@ -511,6 +572,342 @@
               }
             },
             "WIRE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "MESSAGE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "SERVICE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_ENUM_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_MESSAGE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_SERVICE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PACKAGE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_VALUE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_VALUE_NO_DELETE_UNLESS_NUMBER_RESERVED": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_VALUE_NO_DELETE_UNLESS_NAME_RESERVED": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_NO_DELETE_UNLESS_NAME_RESERVED": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ONEOF_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "MESSAGE_NO_REMOVE_STANDARD_DESCRIPTOR_ACCESSOR": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_SYNTAX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ENUM_VALUE_SAME_NAME": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_SAME_CTYPE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_SAME_JSTYPE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_SAME_TYPE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_WIRE_COMPATIBLE_TYPE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_WIRE_JSON_COMPATIBLE_TYPE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_SAME_LABEL": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_SAME_ONEOF": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_SAME_NAME": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FIELD_SAME_JSON_NAME": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RESERVED_ENUM_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RESERVED_MESSAGE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "EXTENSION_MESSAGE_NO_DELETE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "MESSAGE_SAME_MESSAGE_SET_WIRE_FORMAT": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_SAME_REQUEST_TYPE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_SAME_RESPONSE_TYPE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_SAME_CLIENT_STREAMING": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_SAME_SERVER_STREAMING": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "RPC_SAME_IDEMPOTENCY_LEVEL": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_CC_ENABLE_ARENAS": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_CC_GENERIC_SERVICES": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_CSHARP_NAMESPACE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_GO_PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_JAVA_GENERIC_SERVICES": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_JAVA_MULTIPLE_FILES": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_JAVA_OUTER_CLASSNAME": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_JAVA_PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_JAVA_STRING_CHECK_UTF8": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_OBJC_CLASS_PREFIX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_OPTIMIZE_FOR": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_PHP_CLASS_PREFIX": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_PHP_GENERIC_SERVICES": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_PHP_METADATA_NAMESPACE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_PHP_NAMESPACE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_PY_GENERIC_SERVICES": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_RUBY_PACKAGE": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "FILE_SAME_SWIFT_PREFIX": {
               "type": "array",
               "items": {
                 "type": "string"

--- a/src/test/buf/buf.test4.yaml
+++ b/src/test/buf/buf.test4.yaml
@@ -1,0 +1,9 @@
+# Below is excerpted from https://github.com/bufbuild/buf/blob/44af737aea49f9975394b873639a1ae1a05e0144/proto/buf.yaml.
+
+version: v1
+breaking:
+  use:
+    - WIRE_JSON
+  except:
+    - FIELD_NO_DELETE_UNLESS_NAME_RESERVED
+    - FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED


### PR DESCRIPTION
The initial 4 were just the "categories" of rules that are typically set, but individual rules can be used / ignored. Matches up with the `buf lint` rules in the same file.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
