### PR TITLE
Add missing route parameters

### DIFF
--- a/src/schemas/json/mtad.json
+++ b/src/schemas/json/mtad.json
@@ -227,10 +227,7 @@
             "type": "string",
             "anyOf": [
               {
-                "enum": [
-                  "http1",
-                  "http2"
-                ]
+                "enum": ["http1", "http2"]
               }
             ]
           },

--- a/src/schemas/json/mtad.json
+++ b/src/schemas/json/mtad.json
@@ -222,6 +222,23 @@
         "properties": {
           "route": {
             "type": "string"
+          },
+          "protocol": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": [
+                  "http1",
+                  "http2"
+                ]
+              }
+            ]
+          },
+          "no-hostname": {
+            "type": "boolean"
+          },
+          "apply-namespace": {
+            "type": "boolean"
           }
         }
       }


### PR DESCRIPTION
Add missing parameters in mtad.json file.
The file is used for deploying MTA applications.
Examples: https://github.com/SAP-samples/cf-mta-examples/tree/main/app-routes
