### PR TITLE
Hatch: add new `format.config-path` option

### DIFF
--- a/src/schemas/json/hatch.json
+++ b/src/schemas/json/hatch.json
@@ -6,6 +6,28 @@
     "Platform": {
       "enum": ["linux", "windows", "macos"]
     },
+    "Format": {
+      "title": "Format",
+      "description": "Options for static analysis and formatting",
+      "x-taplo": {
+        "links": {
+          "key": "https://hatch.pypa.io/dev/config/static-analysis/"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "config-path": {
+          "title": "Config-Path",
+          "description": "Path to default configuration",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/dev/config/static-analysis/#persistent-config"
+            }
+          },
+          "type": "string"
+        }
+      }
+    },
     "Metadata": {
       "title": "Metadata",
       "description": "Metadata for the project",


### PR DESCRIPTION
This will be released tomorrow https://hatch.pypa.io/dev/config/static-analysis/#persistent-config