### PR TITLE
golangci-lint: update configuration

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -466,6 +466,7 @@
     "output": {
       "description": "Output configuration options.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "format": {
           "description": "Output format to use.",
@@ -487,7 +488,7 @@
           "type": "boolean",
           "default": true
         },
-        "unique-by-line": {
+        "uniq-by-line": {
           "description": "Make issues output unique by line.",
           "type": "boolean",
           "default": true
@@ -496,6 +497,11 @@
           "description": "Add a prefix to the output file references.",
           "type": "string",
           "default": ""
+        },
+        "sort-results": {
+          "description": "Sort results by: filepath, line and column.",
+          "type": "boolean",
+          "default": true
         }
       }
     },


### PR DESCRIPTION
fix typo: `unique-by-line` -> `uniq-by-line`
add missing option `sort-results`