### PR TITLE
Prometheus: update storage collection

### DIFF
--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -1454,28 +1454,28 @@
       "description": "Storage related settings that are runtime reloadable.",
       "type": ["object", "null"],
       "properties": {
-          "tsdb": {
-              "type": ["object", "null"],
-              "properties": {
-                  "out_of_order_time_window": {
-                      "description": "Configures how old an out-of-order/out-of-bounds sample can be w.r.t. the TSDB max time.",
-                      "$ref": "#/definitions/duration",
-                      "default": "0s"
-                  }
-              },
-              "additionalProperties": false
+        "tsdb": {
+          "type": ["object", "null"],
+          "properties": {
+            "out_of_order_time_window": {
+              "description": "Configures how old an out-of-order/out-of-bounds sample can be w.r.t. the TSDB max time.",
+              "$ref": "#/definitions/duration",
+              "default": "0s"
+            }
           },
-          "exemplars": {
-              "type": ["object", "null"],
-              "properties": {
-                  "max_exemplars": {
-                      "description": "Configures the maximum size of the circular buffer used to store exemplars for all series. Resizable during runtime.",
-                      "type": ["integer", "null"],
-                      "default": 100000
-                  }
-              },
-              "additionalProperties": false
-          }
+          "additionalProperties": false
+        },
+        "exemplars": {
+          "type": ["object", "null"],
+          "properties": {
+            "max_exemplars": {
+              "description": "Configures the maximum size of the circular buffer used to store exemplars for all series. Resizable during runtime.",
+              "type": ["integer", "null"],
+              "default": 100000
+            }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     }

--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -1452,17 +1452,32 @@
     },
     "storage": {
       "description": "Storage related settings that are runtime reloadable.",
-      "type": ["array", "null"],
-      "items": {
-        "type": "object",
-        "properties": {
-          "max_exemplars": {
-            "type": ["integer", "null"],
-            "default": 100000
+      "type": ["object", "null"],
+      "properties": {
+          "tsdb": {
+              "type": ["object", "null"],
+              "properties": {
+                  "out_of_order_time_window": {
+                      "description": "Configures how old an out-of-order/out-of-bounds sample can be w.r.t. the TSDB max time.",
+                      "$ref": "#/definitions/duration",
+                      "default": "0s"
+                  }
+              },
+              "additionalProperties": false
+          },
+          "exemplars": {
+              "type": ["object", "null"],
+              "properties": {
+                  "max_exemplars": {
+                      "description": "Configures the maximum size of the circular buffer used to store exemplars for all series. Resizable during runtime.",
+                      "type": ["integer", "null"],
+                      "default": 100000
+                  }
+              },
+              "additionalProperties": false
           }
-        },
-        "additionalProperties": false
-      }
+      },
+      "additionalProperties": false
     }
   },
   "title": "Prometheus",

--- a/src/test/prometheus/prometheus.json
+++ b/src/test/prometheus/prometheus.json
@@ -366,5 +366,13 @@
         }
       ]
     }
-  ]
+  ],
+  "storage": {
+    "tsdb": {
+      "out_of_order_time_window": "10m"
+    },
+    "exemplars": {
+      "max_exemplars": 200000
+    }
+  }
 }


### PR DESCRIPTION
This PR updates the top-level collection `storage` and sub-collections to match the v2.48 config published at https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tsdb.
- `storage` if set, is an object, rather than array
- add property `storage.tsdb.out_of_order_time_window`
- add a description for `storage.exemplars.max_exemplars`
- add storage collection to test file