### PR TITLE
make genericName optional in publiccode.json

### DIFF
--- a/src/schemas/json/publiccode.json
+++ b/src/schemas/json/publiccode.json
@@ -382,7 +382,7 @@
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["genericName", "shortDescription"],
+        "required": ["shortDescription"],
         "properties": {
           "localisedName": {
             "description": "This key is an opportunity to localise the name in a specific language. It contains the (short) public name of the product. It should be the name most people usually refer to the software. In case the software has both an internal \"code\" name and a commercial name, use the commercial name.",


### PR DESCRIPTION
Since GenericName is deprecated since version 0.3 it should be removed from the publiccode.json schema. 

Thanks a lot!