### PR TITLE
fix: add commonjs for eslintrc

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -1383,9 +1383,9 @@
           "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11 (default), 12, 13, 14 or \"latest\" to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12), 2022 (same as 13) or 2023 (same as 14) to use the year-based naming. \"latest\" always enables the latest supported ECMAScript version."
         },
         "sourceType": {
-          "enum": ["script", "module"],
+          "enum": ["script", "module", "commonjs"],
           "default": "script",
-          "description": "set to \"script\" (default) or \"module\" if your code is in ECMAScript modules"
+          "description": "set to \"script\" (default), \"commonjs\", or \"module\" if your code is in ECMAScript modules"
         }
       }
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->


The `sourceType` property in eslintrc accepts `commonjs` as a valid value as well.

## Sources

> ```js
> /**
>  * …
>  * @property {"script"|"module"|"commonjs"} [sourceType] The source code type.
>  * …
>  */
> ```
> 
> — https://github.com/eslint/eslint/blob/0dd9704c4751e1cd02039f7d6485fee09bbccbf6/lib/shared/types.js#L33

> `sourceType`: `"commonjs"` for `.cjs` files - We are still in a transition period where a lot of Node.js code is written in CommonJS. To support those users, we added a new `sourceType` of `"commonjs"` that configures everything correctly for that environment.
> 
> — https://eslint.org/blog/2022/08/new-config-system-part-2/#setting-logical-defaults-for-linting