### PR TITLE
Add dropdown default attribute on GitHub Issue Form Schema

### DIFF
--- a/src/schemas/json/github-issue-forms.json
+++ b/src/schemas/json/github-issue-forms.json
@@ -1134,6 +1134,11 @@
                       "minLength": 1,
                       "examples": ["Sample choice"]
                     }
+                  },
+                  "default": {
+                    "description": "Index of the default option\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+                    "type": "integer",
+                    "examples": [0]
                   }
                 },
                 "additionalProperties": false

--- a/src/test/github-issue-forms/third-party-example.json
+++ b/src/test/github-issue-forms/third-party-example.json
@@ -53,7 +53,8 @@
           "Welcome / PowerToys Tour window",
           "System tray interaction",
           "Installer"
-        ]
+        ],
+        "default": 2
       },
       "validations": {
         "required": true


### PR DESCRIPTION
The GitHub Issue Form Schema supports a default field for the dropdown input.
Docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#dropdown

I noticed it was missing on the schema here.