### PR TITLE
feat: Add schemas from popular ESLlint plugins

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1766,6 +1766,12 @@
       "url": "https://json.schemastore.org/eslintrc.json"
     },
     {
+      "name": "ESLint Plugin Partial",
+      "description": "Extracted from the most popular ESLint plugins",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/partial-eslint-plugins.json"
+    },
+    {
       "name": "Facets - FSDL - Application",
       "description": "Facets Stack Definition Language for Applications",
       "fileMatch": ["**/application/instances/*.json"],

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -68,6 +68,7 @@
     "dotnetcli.host.json",
     "drone.json",
     "electron-builder.json",
+    "eslintrc.json",
     "esmrc.json",
     "expo-37.0.0.json",
     "expo-38.0.0.json",
@@ -142,6 +143,7 @@
     "package.manifest.json",
     "paper-plugin.json",
     "pattern.json",
+    "partial-eslint-plugins.json",
     "phraseapp.json",
     "plagiarize-0.0.json",
     "plagiarize-me-0.0.json",
@@ -645,6 +647,7 @@
       "package.json": {
         "externalSchema": [
           "eslintrc.json",
+          "partial-eslint-plugins.json",
           "prettierrc.json",
           "ava.json",
           "npm-badges.json",
@@ -1132,6 +1135,11 @@
     {
       "launchsettings.json": {
         "unknownKeywords": ["allowTrailingCommas"]
+      }
+    },
+    {
+      "eslintrc.json": {
+        "externalSchema": ["partial-eslint-plugins.json"]
       }
     }
   ],

--- a/src/schemas/json/ava.json
+++ b/src/schemas/json/ava.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/ava.json",
   "additionalProperties": false,
   "definitions": {
     "path": {
@@ -20,7 +21,6 @@
     }
   },
   "description": "Configuration Schema for the JavaScript test runner AVA",
-  "id": "https://json.schemastore.org/ava.json",
   "properties": {
     "files": {
       "$ref": "#/definitions/array-of-paths",

--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/eslintrc.json",
   "definitions": {
     "stringOrStringArray": {
       "oneOf": [
@@ -1128,7 +1129,6 @@
       }
     }
   },
-  "id": "https://json.schemastore.org/eslintrc.json",
   "properties": {
     "ecmaFeatures": {
       "description": "By default, ESLint supports only ECMAScript 5 syntax. You can override that setting to enable support for ECMAScript 6 as well as JSX by using configuration settings.",
@@ -1431,6 +1431,9 @@
         },
         {
           "$ref": "#/definitions/legacy"
+        },
+        {
+          "$ref": "https://json.schemastore.org/partial-eslint-plugins.json"
         }
       ]
     },

--- a/src/schemas/json/jscpd.json
+++ b/src/schemas/json/jscpd.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/jscpd.json",
   "additionalProperties": false,
   "definitions": {
     "colorPreset": {
@@ -188,7 +189,6 @@
       ]
     }
   },
-  "id": "https://json.schemastore.org/jscpd.json",
   "properties": {
     "minLines": {
       "type": "integer",

--- a/src/schemas/json/npm-badges.json
+++ b/src/schemas/json/npm-badges.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/npm-badges.json",
   "additionalProperties": false,
   "description": "An object hash containing an `items` array and optionally a `config` object",
-  "id": "https://json.schemastore.org/npm-badges.json",
   "properties": {
     "list": {
       "type": "array",

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "JSON schema for NPM package.json files",
   "definitions": {
     "person": {
@@ -853,5 +853,5 @@
       ]
     }
   ],
-  "id": "https://json.schemastore.org/package.json"
+  "$id": "https://json.schemastore.org/package.json"
 }

--- a/src/schemas/json/partial-eslint-plugins.json
+++ b/src/schemas/json/partial-eslint-plugins.json
@@ -1,0 +1,13717 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/partial-eslint-plugins.json",
+  "type": "object",
+  "definitions": {
+    "ruleNumber": {
+      "description": "ESLint rule\n\n0 - turns the rule off\n1 - turn the rule on as a warning (doesn't affect exit code)\n2 - turn the rule on as an error (exit code is 1 when triggered)\n",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2
+    },
+    "ruleString": {
+      "description": "ESLint rule\n\n\"off\" - turns the rule off\n\"warn\" - turn the rule on as a warning (doesn't affect exit code)\n\"error\" - turn the rule on as an error (exit code is 1 when triggered)\n",
+      "type": "string",
+      "enum": ["off", "warn", "error"]
+    }
+  },
+  "properties": {
+    "angular-eslint/component-class-suffix": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "suffixes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Classes decorated with @Component must have suffix \"Component\" (or custom) in their name. See more at https://angular.io/styleguide#style-02-03\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/component-class-suffix.md"
+    },
+    "angular-eslint/component-max-inline-declarations": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "template": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "styles": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "animations": {
+                  "minimum": 0,
+                  "type": "number"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforces a maximum number of lines in inline template, styles and animations. See more at https://angular.io/guide/styleguide#style-05-04\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/component-max-inline-declarations.md"
+    },
+    "angular-eslint/component-selector": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": ["element", "attribute"]
+                      }
+                    }
+                  ]
+                },
+                "prefix": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array"
+                    }
+                  ]
+                },
+                "style": {
+                  "type": "string",
+                  "enum": ["camelCase", "kebab-case"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Component selectors should follow given naming rules. See more at https://angular.io/guide/styleguide#style-02-07, https://angular.io/guide/styleguide#style-05-02\n      and https://angular.io/guide/styleguide#style-05-03.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/component-selector.md"
+    },
+    "angular-eslint/contextual-decorator": {
+      "description": "Ensures that classes use contextual decorators in its body\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/contextual-decorator.md"
+    },
+    "angular-eslint/contextual-lifecycle": {
+      "description": "Ensures that lifecycle methods are used in a correct context\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/contextual-lifecycle.md"
+    },
+    "angular-eslint/directive-class-suffix": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "suffixes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Classes decorated with @Directive must have suffix \"Directive\" (or custom) in their name. See more at https://angular.io/styleguide#style-02-03\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/directive-class-suffix.md"
+    },
+    "angular-eslint/directive-selector": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": ["element", "attribute"]
+                      }
+                    }
+                  ]
+                },
+                "prefix": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array"
+                    }
+                  ]
+                },
+                "style": {
+                  "type": "string",
+                  "enum": ["camelCase", "kebab-case"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Directive selectors should follow given naming rules. See more at https://angular.io/guide/styleguide#style-02-06 and https://angular.io/guide/styleguide#style-02-08.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/directive-selector.md"
+    },
+    "angular-eslint/no-attribute-decorator": {
+      "description": "The @Attribute decorator is used to obtain a single value for an attribute. This is a much less common use-case than getting a stream of values (using @Input), so often the @Attribute decorator is mistakenly used when @Input was what was intended. This rule disallows usage of @Attribute decorator altogether in order to prevent these mistakes.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-attribute-decorator.md"
+    },
+    "angular-eslint/no-conflicting-lifecycle": {
+      "description": "Ensures that directives not implement conflicting lifecycle interfaces.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-conflicting-lifecycle.md"
+    },
+    "angular-eslint/no-empty-lifecycle-method": {
+      "description": "Disallows declaring empty lifecycle methods\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-empty-lifecycle-method.md"
+    },
+    "angular-eslint/no-forward-ref": {
+      "description": "Disallows usage of `forwardRef` references for DI\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-forward-ref.md"
+    },
+    "angular-eslint/no-host-metadata-property": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowStatic": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallows usage of the `host` metadata property. See more at https://angular.io/styleguide#style-06-03\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-host-metadata-property.md"
+    },
+    "angular-eslint/no-input-prefix": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "prefixes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Ensures that input bindings, including aliases, are not named or prefixed by the configured disallowed prefixes\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-input-prefix.md"
+    },
+    "angular-eslint/no-input-rename": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowedNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "A list with allowed input names",
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Ensures that input bindings are not aliased\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-input-rename.md"
+    },
+    "angular-eslint/no-inputs-metadata-property": {
+      "description": "Disallows usage of the `inputs` metadata property. See more at https://angular.io/styleguide#style-05-12\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-inputs-metadata-property.md"
+    },
+    "angular-eslint/no-lifecycle-call": {
+      "description": "Disallows explicit calls to lifecycle methods\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-lifecycle-call.md"
+    },
+    "angular-eslint/no-output-native": {
+      "description": "Ensures that output bindings, including aliases, are not named as standard DOM events\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-output-native.md"
+    },
+    "angular-eslint/no-output-on-prefix": {
+      "description": "Ensures that output bindings, including aliases, are not named \"on\", nor prefixed with it. See more at https://angular.io/guide/styleguide#style-05-16\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-output-on-prefix.md"
+    },
+    "angular-eslint/no-output-rename": {
+      "description": "Ensures that output bindings are not aliased\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-output-rename.md"
+    },
+    "angular-eslint/no-outputs-metadata-property": {
+      "description": "Disallows usage of the `outputs` metadata property. See more at https://angular.io/styleguide#style-05-12\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-outputs-metadata-property.md"
+    },
+    "angular-eslint/no-pipe-impure": {
+      "description": "Disallows the declaration of impure pipes\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-pipe-impure.md"
+    },
+    "angular-eslint/no-queries-metadata-property": {
+      "description": "Disallows usage of the `queries` metadata property. See more at https://angular.io/styleguide#style-05-12.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-queries-metadata-property.md"
+    },
+    "angular-eslint/pipe-prefix": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "prefixes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent prefix for pipes.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/pipe-prefix.md"
+    },
+    "angular-eslint/prefer-on-push-component-change-detection": {
+      "description": "Ensures component's `changeDetection` is set to `ChangeDetectionStrategy.OnPush`\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-on-push-component-change-detection.md"
+    },
+    "angular-eslint/prefer-standalone-component": {
+      "description": "Ensures component `standalone` property is set to `true` in the component decorator\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-standalone-component.md"
+    },
+    "angular-eslint/prefer-output-readonly": {
+      "description": "Prefer to declare `@Output` as `readonly` since they are not supposed to be reassigned\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-output-readonly.md"
+    },
+    "angular-eslint/relative-url-prefix": {
+      "description": "The ./ and ../ prefix is standard syntax for relative URLs; don't depend on Angular's current ability to do without that prefix. See more at https://angular.io/styleguide#style-05-04\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/relative-url-prefix.md"
+    },
+    "angular-eslint/require-localize-metadata": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "requireDescription": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "requireMeaning": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Ensures that $localize tagged messages contain helpful metadata to aid with translations.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/require-localize-metadata.md"
+    },
+    "angular-eslint/sort-lifecycle-methods": {
+      "description": "Ensures that lifecycle methods are declared in order of execution\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/sort-lifecycle-methods.md"
+    },
+    "angular-eslint/sort-ngmodule-metadata-arrays": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "locale": {
+                  "type": "string",
+                  "description": "A string with a BCP 47 language tag.",
+                  "default": "en-US"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual scanning\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md"
+    },
+    "angular-eslint/use-component-selector": {
+      "description": "Component selector must be declared\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-component-selector.md"
+    },
+    "angular-eslint/use-component-view-encapsulation": {
+      "description": "Disallows using `ViewEncapsulation.None`\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-component-view-encapsulation.md"
+    },
+    "angular-eslint/use-injectable-provided-in": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreClassNamePattern": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Using the `providedIn` property makes `Injectables` tree-shakable\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md"
+    },
+    "angular-eslint/use-lifecycle-interface": {
+      "description": "Ensures that classes implement lifecycle interfaces corresponding to the declared lifecycle methods. See more at https://angular.io/styleguide#style-09-01\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-lifecycle-interface.md"
+    },
+    "angular-eslint/use-pipe-transform-interface": {
+      "description": "Ensures that `Pipes` implement `PipeTransform` interface\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-pipe-transform-interface.md"
+    },
+    "eslint-plugin-import/no-unresolved": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "commonjs": {
+                  "type": "boolean"
+                },
+                "amd": {
+                  "type": "boolean"
+                },
+                "esmodule": {
+                  "type": "boolean"
+                },
+                "ignore": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                "caseSensitive": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "caseSensitiveStrict": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Ensure imports point to a file/module that can be resolved.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-unresolved.md"
+    },
+    "eslint-plugin-import/named": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "commonjs": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Ensure named imports correspond to a named export in the remote file.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/named.md"
+    },
+    "eslint-plugin-import/default": {
+      "description": "Ensure a default export is present, given a default import.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/default.md"
+    },
+    "eslint-plugin-import/namespace": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowComputed": {
+                  "description": "If `false`, will report computed (and thus, un-lintable) references to namespace members.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Ensure imported namespaces contain dereferenced properties as they are dereferenced.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/namespace.md"
+    },
+    "eslint-plugin-import/no-namespace": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid namespace (a.k.a. \"wildcard\" `*`) imports.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-namespace.md"
+    },
+    "eslint-plugin-import/export": {
+      "description": "Forbid any invalid exports, i.e. re-export of the same name.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/export.md"
+    },
+    "eslint-plugin-import/no-mutable-exports": {
+      "description": "Forbid the use of mutable exports with `var` or `let`.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-mutable-exports.md"
+    },
+    "eslint-plugin-import/extensions": {
+      "description": "Ensure consistent use of file extension within the import path.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/extensions.md"
+    },
+    "eslint-plugin-import/no-restricted-paths": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "zones": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "target": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "uniqueItems": true,
+                            "minItems": 1
+                          }
+                        ]
+                      },
+                      "from": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "uniqueItems": true,
+                            "minItems": 1
+                          }
+                        ]
+                      },
+                      "except": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "uniqueItems": true
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "basePath": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce which files can be imported in a given folder.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-restricted-paths.md"
+    },
+    "eslint-plugin-import/no-internal-modules": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Forbid importing the submodules of other modules.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-internal-modules.md"
+    },
+    "eslint-plugin-import/group-exports": {
+      "description": "Prefer named exports to be grouped together in a single export declaration\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/group-exports.md"
+    },
+    "eslint-plugin-import/no-relative-packages": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "commonjs": {
+                  "type": "boolean"
+                },
+                "amd": {
+                  "type": "boolean"
+                },
+                "esmodule": {
+                  "type": "boolean"
+                },
+                "ignore": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid importing packages through relative paths.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-relative-packages.md"
+    },
+    "eslint-plugin-import/no-relative-parent-imports": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "commonjs": {
+                  "type": "boolean"
+                },
+                "amd": {
+                  "type": "boolean"
+                },
+                "esmodule": {
+                  "type": "boolean"
+                },
+                "ignore": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid importing modules from parent directories.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-relative-parent-imports.md"
+    },
+    "eslint-plugin-import/consistent-type-specifier-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce or ban the use of inline type-only markers for named imports.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/consistent-type-specifier-style.md"
+    },
+    "eslint-plugin-import/no-self-import": {
+      "description": "Forbid a module from importing itself.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-self-import.md"
+    },
+    "eslint-plugin-import/no-cycle": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "commonjs": {
+                  "type": "boolean"
+                },
+                "amd": {
+                  "type": "boolean"
+                },
+                "esmodule": {
+                  "type": "boolean"
+                },
+                "ignore": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                "maxDepth": {
+                  "anyOf": [
+                    {
+                      "description": "maximum dependency depth to traverse",
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    {
+                      "enum": ["∞"],
+                      "type": "string"
+                    }
+                  ]
+                },
+                "ignoreExternal": {
+                  "description": "ignore external modules",
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowUnsafeDynamicCyclicDependency": {
+                  "description": "Allow cyclic dependency if there is at least one dynamic import in the chain",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid a module from importing a module with a dependency path back to itself.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-cycle.md"
+    },
+    "eslint-plugin-import/no-named-default": {
+      "description": "Forbid named default exports.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-named-default.md"
+    },
+    "eslint-plugin-import/no-named-as-default": {
+      "description": "Forbid use of exported name as identifier of default export.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-named-as-default.md"
+    },
+    "eslint-plugin-import/no-named-as-default-member": {
+      "description": "Forbid use of exported name as property of default export.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-named-as-default-member.md"
+    },
+    "eslint-plugin-import/no-anonymous-default-export": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowArray": {
+                  "description": "If `false`, will report default export of an array",
+                  "type": "boolean"
+                },
+                "allowArrowFunction": {
+                  "description": "If `false`, will report default export of an arrow function",
+                  "type": "boolean"
+                },
+                "allowCallExpression": {
+                  "description": "If `false`, will report default export of a function call",
+                  "type": "boolean"
+                },
+                "allowAnonymousClass": {
+                  "description": "If `false`, will report default export of an anonymous class",
+                  "type": "boolean"
+                },
+                "allowAnonymousFunction": {
+                  "description": "If `false`, will report default export of an anonymous function",
+                  "type": "boolean"
+                },
+                "allowLiteral": {
+                  "description": "If `false`, will report default export of a literal",
+                  "type": "boolean"
+                },
+                "allowObject": {
+                  "description": "If `false`, will report default export of an object expression",
+                  "type": "boolean"
+                },
+                "allowNew": {
+                  "description": "If `false`, will report default export of a class instantiation",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid anonymous values as default exports.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-anonymous-default-export.md"
+    },
+    "eslint-plugin-import/no-unused-modules": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "src": {
+                  "description": "files/paths to be analyzed (only for unused exports)",
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "ignoreExports": {
+                  "description": "files/paths for which unused exports will not be reported (e.g module entry points)",
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "missingExports": {
+                  "description": "report modules without any exports",
+                  "type": "boolean"
+                },
+                "unusedExports": {
+                  "description": "report exports without any usage",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid modules without exports, or exports without matching import in another module.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-unused-modules.md"
+    },
+    "eslint-plugin-import/no-commonjs": {
+      "description": "Forbid CommonJS `require` calls and `module.exports` or `exports.*`.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-commonjs.md"
+    },
+    "eslint-plugin-import/no-amd": {
+      "description": "Forbid AMD `require` and `define` calls.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-amd.md"
+    },
+    "eslint-plugin-import/no-duplicates": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "considerQueryString": {
+                  "type": "boolean"
+                },
+                "prefer-inline": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid repeated import of the same module in multiple places.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-duplicates.md"
+    },
+    "eslint-plugin-import/first": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Ensure all imports appear before other statements.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/first.md"
+    },
+    "eslint-plugin-import/max-dependencies": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "max": {
+                  "type": "number"
+                },
+                "ignoreTypeImports": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce the maximum number of dependencies a module can have.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/max-dependencies.md"
+    },
+    "eslint-plugin-import/no-extraneous-dependencies": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "devDependencies": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    }
+                  ]
+                },
+                "optionalDependencies": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    }
+                  ]
+                },
+                "peerDependencies": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    }
+                  ]
+                },
+                "bundledDependencies": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    }
+                  ]
+                },
+                "packageDir": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    }
+                  ]
+                },
+                "includeInternal": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                },
+                "includeTypes": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid the use of extraneous packages.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-extraneous-dependencies.md"
+    },
+    "eslint-plugin-import/no-absolute-path": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "commonjs": {
+                  "type": "boolean"
+                },
+                "amd": {
+                  "type": "boolean"
+                },
+                "esmodule": {
+                  "type": "boolean"
+                },
+                "ignore": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid import of modules using absolute paths.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-absolute-path.md"
+    },
+    "eslint-plugin-import/no-nodejs-modules": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid Node.js builtin modules.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-nodejs-modules.md"
+    },
+    "eslint-plugin-import/no-webpack-loader-syntax": {
+      "description": "Forbid webpack loader syntax in imports.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-webpack-loader-syntax.md"
+    },
+    "eslint-plugin-import/order": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "groups": {
+                  "type": "array"
+                },
+                "pathGroupsExcludedImportTypes": {
+                  "type": "array"
+                },
+                "distinctGroup": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "pathGroups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "pattern": {
+                        "type": "string"
+                      },
+                      "patternOptions": {
+                        "type": "object"
+                      },
+                      "group": {
+                        "type": "string",
+                        "enum": [
+                          "builtin",
+                          "external",
+                          "internal",
+                          "unknown",
+                          "parent",
+                          "sibling",
+                          "index",
+                          "object",
+                          "type"
+                        ]
+                      },
+                      "position": {
+                        "type": "string",
+                        "enum": ["after", "before"]
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": ["pattern", "group"]
+                  }
+                },
+                "newlines-between": {
+                  "enum": [
+                    "ignore",
+                    "always",
+                    "always-and-inside-groups",
+                    "never"
+                  ]
+                },
+                "alphabetize": {
+                  "type": "object",
+                  "properties": {
+                    "caseInsensitive": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "order": {
+                      "enum": ["ignore", "asc", "desc"],
+                      "default": "ignore"
+                    },
+                    "orderImportKind": {
+                      "enum": ["ignore", "asc", "desc"],
+                      "default": "ignore"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "warnOnUnassignedImports": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce a convention in module import order.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/order.md"
+    },
+    "eslint-plugin-import/newline-after-import": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "exactCount": {
+                  "type": "boolean"
+                },
+                "considerComments": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce a newline after import statements.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/newline-after-import.md"
+    },
+    "eslint-plugin-import/prefer-default-export": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "target": {
+                  "type": "string",
+                  "enum": ["single", "any"],
+                  "default": "single"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer a default export if module exports a single name or multiple names.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/prefer-default-export.md"
+    },
+    "eslint-plugin-import/no-default-export": {
+      "description": "Forbid default exports.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-default-export.md"
+    },
+    "eslint-plugin-import/no-named-export": {
+      "description": "Forbid named exports.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-named-export.md"
+    },
+    "eslint-plugin-import/no-dynamic-require": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "esmodule": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid `require()` calls with expressions.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-dynamic-require.md"
+    },
+    "eslint-plugin-import/unambiguous": {
+      "description": "Forbid potentially ambiguous parse goal (`script` vs. `module`).\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/unambiguous.md"
+    },
+    "eslint-plugin-import/no-unassigned-import": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "devDependencies": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    }
+                  ]
+                },
+                "optionalDependencies": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    }
+                  ]
+                },
+                "peerDependencies": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    }
+                  ]
+                },
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid unassigned imports\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-unassigned-import.md"
+    },
+    "eslint-plugin-import/no-useless-path-segments": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "commonjs": {
+                  "type": "boolean"
+                },
+                "noUselessIndex": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid unnecessary path segments in import and require statements.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-useless-path-segments.md"
+    },
+    "eslint-plugin-import/dynamic-import-chunkname": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "importFunctions": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "webpackChunknameFormat": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce a leading comment with the webpackChunkName for dynamic imports.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/dynamic-import-chunkname.md"
+    },
+    "eslint-plugin-import/no-import-module-exports": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "exceptions": {
+                  "type": "array"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Forbid import statements with CommonJS module.exports.\n"
+    },
+    "eslint-plugin-import/no-empty-named-blocks": {
+      "description": "Forbid empty named import blocks.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-empty-named-blocks.md"
+    },
+    "eslint-plugin-import/exports-last": {
+      "description": "Ensure all exports appear after other statements.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/exports-last.md"
+    },
+    "eslint-plugin-import/no-deprecated": {
+      "description": "Forbid imported names marked with `@deprecated` documentation tag.\nhttps://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-deprecated.md"
+    },
+    "eslint-plugin-import/imports-first": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Replaced by `import/first`.\nhttps://github.com/import-js/eslint-plugin-import/blob/7b25c1cb95ee18acc1531002fd343e1e6031f9ed/docs/rules/imports-first.md"
+    },
+    "eslint-plugin-unicorn/better-regex": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "sortCharacterClasses": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Improve regexes by making them shorter, consistent, and safer.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/better-regex.md"
+    },
+    "eslint-plugin-unicorn/catch-error-name": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "ignore": {
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce a specific parameter name in catch clauses.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/catch-error-name.md"
+    },
+    "eslint-plugin-unicorn/consistent-destructuring": {
+      "description": "Use destructured variables over properties.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/consistent-destructuring.md"
+    },
+    "eslint-plugin-unicorn/consistent-function-scoping": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkArrowFunctions": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Move function definitions to the highest possible scope.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/consistent-function-scoping.md"
+    },
+    "eslint-plugin-unicorn/custom-error-definition": {
+      "description": "Enforce correct `Error` subclassing.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/custom-error-definition.md"
+    },
+    "eslint-plugin-unicorn/empty-brace-spaces": {
+      "description": "Enforce no spaces between braces.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/empty-brace-spaces.md"
+    },
+    "eslint-plugin-unicorn/error-message": {
+      "description": "Enforce passing a `message` value when creating a built-in error.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/error-message.md"
+    },
+    "eslint-plugin-unicorn/escape-case": {
+      "description": "Require escape sequences to use uppercase values.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/escape-case.md"
+    },
+    "eslint-plugin-unicorn/expiring-todo-comments": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "terms": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ignore": {
+                  "type": "array",
+                  "uniqueItems": true
+                },
+                "ignoreDatesOnPullRequests": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "allowWarningComments": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "date": {
+                  "type": "string",
+                  "format": "date"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Add expiration conditions to TODO comments.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/expiring-todo-comments.md"
+    },
+    "eslint-plugin-unicorn/explicit-length-check": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "non-zero": {
+                  "enum": ["greater-than", "not-equal"],
+                  "default": "greater-than"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce explicitly comparing the `length` or `size` property of a value.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/explicit-length-check.md"
+    },
+    "eslint-plugin-unicorn/filename-case": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce a case style for filenames.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/filename-case.md"
+    },
+    "eslint-plugin-unicorn/import-style": {
+      "description": "Enforce specific import styles per module.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/import-style.md"
+    },
+    "eslint-plugin-unicorn/new-for-builtins": {
+      "description": "Enforce the use of `new` for all builtins, except `String`, `Number`, `Boolean`, `Symbol` and `BigInt`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/new-for-builtins.md"
+    },
+    "eslint-plugin-unicorn/no-abusive-eslint-disable": {
+      "description": "Enforce specifying rules to disable in `eslint-disable` comments.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-abusive-eslint-disable.md"
+    },
+    "eslint-plugin-unicorn/no-array-callback-reference": {
+      "description": "Prevent passing a function reference directly to iterator methods.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-array-callback-reference.md"
+    },
+    "eslint-plugin-unicorn/no-array-for-each": {
+      "description": "Prefer `for…of` over the `forEach` method.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-array-for-each.md"
+    },
+    "eslint-plugin-unicorn/no-array-method-this-argument": {
+      "description": "Disallow using the `this` argument in array methods.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-array-method-this-argument.md"
+    },
+    "eslint-plugin-unicorn/no-array-push-push": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignore": {
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce combining multiple `Array#push()` into one call.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-array-push-push.md"
+    },
+    "eslint-plugin-unicorn/no-array-reduce": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowSimpleOperations": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow `Array#reduce()` and `Array#reduceRight()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-array-reduce.md"
+    },
+    "eslint-plugin-unicorn/no-await-expression-member": {
+      "description": "Disallow member access from await expression.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-await-expression-member.md"
+    },
+    "eslint-plugin-unicorn/no-console-spaces": {
+      "description": "Do not use leading/trailing space between `console.log` parameters.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-console-spaces.md"
+    },
+    "eslint-plugin-unicorn/no-document-cookie": {
+      "description": "Do not use `document.cookie` directly.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-document-cookie.md"
+    },
+    "eslint-plugin-unicorn/no-empty-file": {
+      "description": "Disallow empty files.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-empty-file.md"
+    },
+    "eslint-plugin-unicorn/no-for-loop": {
+      "description": "Do not use a `for` loop that can be replaced with a `for-of` loop.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-for-loop.md"
+    },
+    "eslint-plugin-unicorn/no-hex-escape": {
+      "description": "Enforce the use of Unicode escapes instead of hexadecimal escapes.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-hex-escape.md"
+    },
+    "eslint-plugin-unicorn/no-instanceof-array": {
+      "description": "Require `Array.isArray()` instead of `instanceof Array`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-instanceof-array.md"
+    },
+    "eslint-plugin-unicorn/no-invalid-remove-event-listener": {
+      "description": "Prevent calling `EventTarget#removeEventListener()` with the result of an expression.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-invalid-remove-event-listener.md"
+    },
+    "eslint-plugin-unicorn/no-keyword-prefix": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "disallowedPrefixes": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "maxItems": 1
+                },
+                "checkProperties": {
+                  "type": "boolean"
+                },
+                "onlyCamelCase": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow identifiers starting with `new` or `class`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-keyword-prefix.md"
+    },
+    "eslint-plugin-unicorn/no-lonely-if": {
+      "description": "Disallow `if` statements as the only statement in `if` blocks without `else`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-lonely-if.md"
+    },
+    "eslint-plugin-unicorn/no-negated-condition": {
+      "description": "Disallow negated conditions.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-negated-condition.md"
+    },
+    "eslint-plugin-unicorn/no-nested-ternary": {
+      "description": "Disallow nested ternary expressions.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-nested-ternary.md"
+    },
+    "eslint-plugin-unicorn/no-new-array": {
+      "description": "Disallow `new Array()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-new-array.md"
+    },
+    "eslint-plugin-unicorn/no-new-buffer": {
+      "description": "Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead of the deprecated `new Buffer()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-new-buffer.md"
+    },
+    "eslint-plugin-unicorn/no-null": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkStrictEquality": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow the use of the `null` literal.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-null.md"
+    },
+    "eslint-plugin-unicorn/no-object-as-default-parameter": {
+      "description": "Disallow the use of objects as default parameters.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-object-as-default-parameter.md"
+    },
+    "eslint-plugin-unicorn/no-process-exit": {
+      "description": "Disallow `process.exit()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-process-exit.md"
+    },
+    "eslint-plugin-unicorn/no-static-only-class": {
+      "description": "Disallow classes that only have static members.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-static-only-class.md"
+    },
+    "eslint-plugin-unicorn/no-thenable": {
+      "description": "Disallow `then` property.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-thenable.md"
+    },
+    "eslint-plugin-unicorn/no-this-assignment": {
+      "description": "Disallow assigning `this` to a variable.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-this-assignment.md"
+    },
+    "eslint-plugin-unicorn/no-typeof-undefined": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkGlobalVariables": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow comparing `undefined` using `typeof`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-typeof-undefined.md"
+    },
+    "eslint-plugin-unicorn/no-unnecessary-await": {
+      "description": "Disallow awaiting non-promise values.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-unnecessary-await.md"
+    },
+    "eslint-plugin-unicorn/no-unreadable-array-destructuring": {
+      "description": "Disallow unreadable array destructuring.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-unreadable-array-destructuring.md"
+    },
+    "eslint-plugin-unicorn/no-unreadable-iife": {
+      "description": "Disallow unreadable IIFEs.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-unreadable-iife.md"
+    },
+    "eslint-plugin-unicorn/no-unused-properties": {
+      "description": "Disallow unused object properties.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-unused-properties.md"
+    },
+    "eslint-plugin-unicorn/no-useless-fallback-in-spread": {
+      "description": "Disallow useless fallback when spreading in object literals.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-useless-fallback-in-spread.md"
+    },
+    "eslint-plugin-unicorn/no-useless-length-check": {
+      "description": "Disallow useless array length check.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-useless-length-check.md"
+    },
+    "eslint-plugin-unicorn/no-useless-promise-resolve-reject": {
+      "description": "Disallow returning/yielding `Promise.resolve/reject()` in async functions or promise callbacks\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-useless-promise-resolve-reject.md"
+    },
+    "eslint-plugin-unicorn/no-useless-spread": {
+      "description": "Disallow unnecessary spread.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-useless-spread.md"
+    },
+    "eslint-plugin-unicorn/no-useless-switch-case": {
+      "description": "Disallow useless case in switch statements.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-useless-switch-case.md"
+    },
+    "eslint-plugin-unicorn/no-useless-undefined": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkArguments": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow useless `undefined`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-useless-undefined.md"
+    },
+    "eslint-plugin-unicorn/no-zero-fractions": {
+      "description": "Disallow number literals with zero fractions or dangling dots.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/no-zero-fractions.md"
+    },
+    "eslint-plugin-unicorn/number-literal-case": {
+      "description": "Enforce proper case for numeric literals.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/number-literal-case.md"
+    },
+    "eslint-plugin-unicorn/numeric-separators-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "binary": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "onlyIfContainsSeparator": {
+                      "type": "boolean"
+                    },
+                    "minimumDigits": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 0
+                    },
+                    "groupLength": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "default": 4
+                    }
+                  }
+                },
+                "octal": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "onlyIfContainsSeparator": {
+                      "type": "boolean"
+                    },
+                    "minimumDigits": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 0
+                    },
+                    "groupLength": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "default": 4
+                    }
+                  }
+                },
+                "hexadecimal": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "onlyIfContainsSeparator": {
+                      "type": "boolean"
+                    },
+                    "minimumDigits": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 0
+                    },
+                    "groupLength": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "default": 2
+                    }
+                  }
+                },
+                "number": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "onlyIfContainsSeparator": {
+                      "type": "boolean"
+                    },
+                    "minimumDigits": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 5
+                    },
+                    "groupLength": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "default": 3
+                    }
+                  }
+                },
+                "onlyIfContainsSeparator": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce the style of numeric separators by correctly grouping digits.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/numeric-separators-style.md"
+    },
+    "eslint-plugin-unicorn/prefer-add-event-listener": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "excludedPackages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer `.addEventListener()` and `.removeEventListener()` over `on`-functions.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-add-event-listener.md"
+    },
+    "eslint-plugin-unicorn/prefer-array-find": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkFromLast": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer `.find(…)` and `.findLast(…)` over the first or last element from `.filter(…)`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-array-find.md"
+    },
+    "eslint-plugin-unicorn/prefer-array-flat-map": {
+      "description": "Prefer `.flatMap(…)` over `.map(…).flat()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-array-flat-map.md"
+    },
+    "eslint-plugin-unicorn/prefer-array-flat": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "functions": {
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer `Array#flat()` over legacy techniques to flatten arrays.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-array-flat.md"
+    },
+    "eslint-plugin-unicorn/prefer-array-index-of": {
+      "description": "Prefer `Array#{indexOf,lastIndexOf}()` over `Array#{findIndex,findLastIndex}()` when looking for the index of an item.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-array-index-of.md"
+    },
+    "eslint-plugin-unicorn/prefer-array-some": {
+      "description": "Prefer `.some(…)` over `.filter(…).length` check and `.{find,findLast}(…)`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-array-some.md"
+    },
+    "eslint-plugin-unicorn/prefer-at": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "getLastElementFunctions": {
+                  "type": "array",
+                  "uniqueItems": true
+                },
+                "checkAllIndexAccess": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer `.at()` method for index access and `String#charAt()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-at.md"
+    },
+    "eslint-plugin-unicorn/prefer-blob-reading-methods": {
+      "description": "Prefer `Blob#arrayBuffer()` over `FileReader#readAsArrayBuffer(…)` and `Blob#text()` over `FileReader#readAsText(…)`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-blob-reading-methods.md"
+    },
+    "eslint-plugin-unicorn/prefer-code-point": {
+      "description": "Prefer `String#codePointAt(…)` over `String#charCodeAt(…)` and `String.fromCodePoint(…)` over `String.fromCharCode(…)`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-code-point.md"
+    },
+    "eslint-plugin-unicorn/prefer-date-now": {
+      "description": "Prefer `Date.now()` to get the number of milliseconds since the Unix Epoch.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-date-now.md"
+    },
+    "eslint-plugin-unicorn/prefer-default-parameters": {
+      "description": "Prefer default parameters over reassignment.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-default-parameters.md"
+    },
+    "eslint-plugin-unicorn/prefer-dom-node-append": {
+      "description": "Prefer `Node#append()` over `Node#appendChild()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-dom-node-append.md"
+    },
+    "eslint-plugin-unicorn/prefer-dom-node-dataset": {
+      "description": "Prefer using `.dataset` on DOM elements over calling attribute methods.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-dom-node-dataset.md"
+    },
+    "eslint-plugin-unicorn/prefer-dom-node-remove": {
+      "description": "Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-dom-node-remove.md"
+    },
+    "eslint-plugin-unicorn/prefer-dom-node-text-content": {
+      "description": "Prefer `.textContent` over `.innerText`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-dom-node-text-content.md"
+    },
+    "eslint-plugin-unicorn/prefer-event-target": {
+      "description": "Prefer `EventTarget` over `EventEmitter`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-event-target.md"
+    },
+    "eslint-plugin-unicorn/prefer-export-from": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreUsedVariables": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer `export…from` when re-exporting.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-export-from.md"
+    },
+    "eslint-plugin-unicorn/prefer-includes": {
+      "description": "Prefer `.includes()` over `.indexOf()` and `Array#some()` when checking for existence or non-existence.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-includes.md"
+    },
+    "eslint-plugin-unicorn/prefer-json-parse-buffer": {
+      "description": "Prefer reading a JSON file as a buffer.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-json-parse-buffer.md"
+    },
+    "eslint-plugin-unicorn/prefer-keyboard-event-key": {
+      "description": "Prefer `KeyboardEvent#key` over `KeyboardEvent#keyCode`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-keyboard-event-key.md"
+    },
+    "eslint-plugin-unicorn/prefer-logical-operator-over-ternary": {
+      "description": "Prefer using a logical operator over a ternary.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-logical-operator-over-ternary.md"
+    },
+    "eslint-plugin-unicorn/prefer-math-trunc": {
+      "description": "Enforce the use of `Math.trunc` instead of bitwise operators.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-math-trunc.md"
+    },
+    "eslint-plugin-unicorn/prefer-modern-dom-apis": {
+      "description": "Prefer `.before()` over `.insertBefore()`, `.replaceWith()` over `.replaceChild()`, prefer one of `.before()`, `.after()`, `.append()` or `.prepend()` over `insertAdjacentText()` and `insertAdjacentElement()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-modern-dom-apis.md"
+    },
+    "eslint-plugin-unicorn/prefer-modern-math-apis": {
+      "description": "Prefer modern `Math` APIs over legacy patterns.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-modern-math-apis.md"
+    },
+    "eslint-plugin-unicorn/prefer-module": {
+      "description": "Prefer JavaScript modules (ESM) over CommonJS.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-module.md"
+    },
+    "eslint-plugin-unicorn/prefer-native-coercion-functions": {
+      "description": "Prefer using `String`, `Number`, `BigInt`, `Boolean`, and `Symbol` directly.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-native-coercion-functions.md"
+    },
+    "eslint-plugin-unicorn/prefer-negative-index": {
+      "description": "Prefer negative index over `.length - index` when possible.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-negative-index.md"
+    },
+    "eslint-plugin-unicorn/prefer-node-protocol": {
+      "description": "Prefer using the `node:` protocol when importing Node.js builtin modules.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-node-protocol.md"
+    },
+    "eslint-plugin-unicorn/prefer-number-properties": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkInfinity": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer `Number` static properties over global ones.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-number-properties.md"
+    },
+    "eslint-plugin-unicorn/prefer-object-from-entries": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "functions": {
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer using `Object.fromEntries(…)` to transform a list of key-value pairs into an object.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-object-from-entries.md"
+    },
+    "eslint-plugin-unicorn/prefer-optional-catch-binding": {
+      "description": "Prefer omitting the `catch` binding parameter.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-optional-catch-binding.md"
+    },
+    "eslint-plugin-unicorn/prefer-prototype-methods": {
+      "description": "Prefer borrowing methods from the prototype instead of the instance.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-prototype-methods.md"
+    },
+    "eslint-plugin-unicorn/prefer-query-selector": {
+      "description": "Prefer `.querySelector()` over `.getElementById()`, `.querySelectorAll()` over `.getElementsByClassName()` and `.getElementsByTagName()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-query-selector.md"
+    },
+    "eslint-plugin-unicorn/prefer-reflect-apply": {
+      "description": "Prefer `Reflect.apply()` over `Function#apply()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-reflect-apply.md"
+    },
+    "eslint-plugin-unicorn/prefer-regexp-test": {
+      "description": "Prefer `RegExp#test()` over `String#match()` and `RegExp#exec()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-regexp-test.md"
+    },
+    "eslint-plugin-unicorn/prefer-set-has": {
+      "description": "Prefer `Set#has()` over `Array#includes()` when checking for existence or non-existence.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-set-has.md"
+    },
+    "eslint-plugin-unicorn/prefer-set-size": {
+      "description": "Prefer using `Set#size` instead of `Array#length`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-set-size.md"
+    },
+    "eslint-plugin-unicorn/prefer-spread": {
+      "description": "Prefer the spread operator over `Array.from(…)`, `Array#concat(…)`, `Array#{slice,toSpliced}()` and `String#split('')`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-spread.md"
+    },
+    "eslint-plugin-unicorn/prefer-string-replace-all": {
+      "description": "Prefer `String#replaceAll()` over regex searches with the global flag.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-string-replace-all.md"
+    },
+    "eslint-plugin-unicorn/prefer-string-slice": {
+      "description": "Prefer `String#slice()` over `String#substr()` and `String#substring()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-string-slice.md"
+    },
+    "eslint-plugin-unicorn/prefer-string-starts-ends-with": {
+      "description": "Prefer `String#startsWith()` & `String#endsWith()` over `RegExp#test()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-string-starts-ends-with.md"
+    },
+    "eslint-plugin-unicorn/prefer-string-trim-start-end": {
+      "description": "Prefer `String#trimStart()` / `String#trimEnd()` over `String#trimLeft()` / `String#trimRight()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-string-trim-start-end.md"
+    },
+    "eslint-plugin-unicorn/prefer-switch": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "minimumCases": {
+                  "type": "integer",
+                  "minimum": 2,
+                  "default": 3
+                },
+                "emptyDefaultCase": {
+                  "enum": [
+                    "no-default-comment",
+                    "do-nothing-comment",
+                    "no-default-case"
+                  ],
+                  "default": "no-default-comment"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Prefer `switch` over multiple `else-if`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-switch.md"
+    },
+    "eslint-plugin-unicorn/prefer-ternary": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Prefer ternary expressions over simple `if-else` statements.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-ternary.md"
+    },
+    "eslint-plugin-unicorn/prefer-top-level-await": {
+      "description": "Prefer top-level await over top-level promises and async function calls.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-top-level-await.md"
+    },
+    "eslint-plugin-unicorn/prefer-type-error": {
+      "description": "Enforce throwing `TypeError` in type checking conditions.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prefer-type-error.md"
+    },
+    "eslint-plugin-unicorn/prevent-abbreviations": {
+      "description": "Prevent abbreviations.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/prevent-abbreviations.md"
+    },
+    "eslint-plugin-unicorn/relative-url-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent relative URL style.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/relative-url-style.md"
+    },
+    "eslint-plugin-unicorn/require-array-join-separator": {
+      "description": "Enforce using the separator argument with `Array#join()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/require-array-join-separator.md"
+    },
+    "eslint-plugin-unicorn/require-number-to-fixed-digits-argument": {
+      "description": "Enforce using the digits argument with `Number#toFixed()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/require-number-to-fixed-digits-argument.md"
+    },
+    "eslint-plugin-unicorn/require-post-message-target-origin": {
+      "description": "Enforce using the `targetOrigin` argument with `window.postMessage()`.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/require-post-message-target-origin.md"
+    },
+    "eslint-plugin-unicorn/string-content": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "patterns": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "required": ["suggest"],
+                        "properties": {
+                          "suggest": {
+                            "type": "string"
+                          },
+                          "fix": {
+                            "type": "boolean"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce better string content.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/string-content.md"
+    },
+    "eslint-plugin-unicorn/switch-case-braces": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent brace style for `case` clauses.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/switch-case-braces.md"
+    },
+    "eslint-plugin-unicorn/template-indent": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "indent": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^\\s+$"
+                    },
+                    {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  ]
+                },
+                "tags": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "functions": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "selectors": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "comments": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Fix whitespace-insensitive template indentation.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/template-indent.md"
+    },
+    "eslint-plugin-unicorn/text-encoding-identifier-case": {
+      "description": "Enforce consistent case for text encoding identifiers.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/text-encoding-identifier-case.md"
+    },
+    "eslint-plugin-unicorn/throw-new-error": {
+      "description": "Require `new` when throwing an error.\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/rules/throw-new-error.md"
+    },
+    "eslint-plugin-unicorn/import-index": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#import-index"
+    },
+    "eslint-plugin-unicorn/no-array-instanceof": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#no-array-instanceof"
+    },
+    "eslint-plugin-unicorn/no-fn-reference-in-iterator": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#no-fn-reference-in-iterator"
+    },
+    "eslint-plugin-unicorn/no-reduce": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#no-reduce"
+    },
+    "eslint-plugin-unicorn/no-unsafe-regex": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#no-unsafe-regex"
+    },
+    "eslint-plugin-unicorn/prefer-dataset": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-dataset"
+    },
+    "eslint-plugin-unicorn/prefer-event-key": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-event-key"
+    },
+    "eslint-plugin-unicorn/prefer-exponentiation-operator": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-exponentiation-operator"
+    },
+    "eslint-plugin-unicorn/prefer-flat-map": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-flat-map"
+    },
+    "eslint-plugin-unicorn/prefer-node-append": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-node-append"
+    },
+    "eslint-plugin-unicorn/prefer-node-remove": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-node-remove"
+    },
+    "eslint-plugin-unicorn/prefer-object-has-own": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-object-has-own"
+    },
+    "eslint-plugin-unicorn/prefer-replace-all": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-replace-all"
+    },
+    "eslint-plugin-unicorn/prefer-starts-ends-with": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-starts-ends-with"
+    },
+    "eslint-plugin-unicorn/prefer-text-content": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-text-content"
+    },
+    "eslint-plugin-unicorn/prefer-trim-start-end": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#prefer-trim-start-end"
+    },
+    "eslint-plugin-unicorn/regex-shorthand": {
+      "description": "\nhttps://github.com/sindresorhus/eslint-plugin-unicorn/blob/v49.0.0/docs/deprecated-rules.md#regex-shorthand"
+    },
+    "eslint-plugin-vue/array-bracket-newline": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce linebreaks after opening and before closing array brackets in `<template>`\nhttps://eslint.vuejs.org/rules/array-bracket-newline.html"
+    },
+    "eslint-plugin-vue/array-bracket-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing inside array brackets in `<template>`\nhttps://eslint.vuejs.org/rules/array-bracket-spacing.html"
+    },
+    "eslint-plugin-vue/array-element-newline": {
+      "description": "Enforce line breaks after each array element in `<template>`\nhttps://eslint.vuejs.org/rules/array-element-newline.html"
+    },
+    "eslint-plugin-vue/arrow-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "before": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "after": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing before and after the arrow in arrow functions in `<template>`\nhttps://eslint.vuejs.org/rules/arrow-spacing.html"
+    },
+    "eslint-plugin-vue/attribute-hyphenation": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce attribute naming style on custom components in template\nhttps://eslint.vuejs.org/rules/attribute-hyphenation.html"
+    },
+    "eslint-plugin-vue/attributes-order": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "order": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "DEFINITION",
+                          "LIST_RENDERING",
+                          "CONDITIONALS",
+                          "RENDER_MODIFIERS",
+                          "GLOBAL",
+                          "UNIQUE",
+                          "SLOT",
+                          "TWO_WAY_BINDING",
+                          "OTHER_DIRECTIVES",
+                          "OTHER_ATTR",
+                          "ATTR_STATIC",
+                          "ATTR_DYNAMIC",
+                          "ATTR_SHORTHAND_BOOL",
+                          "EVENTS",
+                          "CONTENT"
+                        ]
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "enum": [
+                            "DEFINITION",
+                            "LIST_RENDERING",
+                            "CONDITIONALS",
+                            "RENDER_MODIFIERS",
+                            "GLOBAL",
+                            "UNIQUE",
+                            "SLOT",
+                            "TWO_WAY_BINDING",
+                            "OTHER_DIRECTIVES",
+                            "OTHER_ATTR",
+                            "ATTR_STATIC",
+                            "ATTR_DYNAMIC",
+                            "ATTR_SHORTHAND_BOOL",
+                            "EVENTS",
+                            "CONTENT"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "uniqueItems": true
+                },
+                "alphabetical": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce order of attributes\nhttps://eslint.vuejs.org/rules/attributes-order.html"
+    },
+    "eslint-plugin-vue/block-lang": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "disallow use other than available `lang`\nhttps://eslint.vuejs.org/rules/block-lang.html"
+    },
+    "eslint-plugin-vue/block-order": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "order": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce order of component top-level elements\nhttps://eslint.vuejs.org/rules/block-order.html"
+    },
+    "eslint-plugin-vue/block-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Disallow or enforce spaces inside of blocks after opening block and before closing block in `<template>`\nhttps://eslint.vuejs.org/rules/block-spacing.html"
+    },
+    "eslint-plugin-vue/block-tag-newline": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "singleline": {
+                  "enum": ["always", "never", "consistent", "ignore"]
+                },
+                "multiline": {
+                  "enum": ["always", "never", "consistent", "ignore"]
+                },
+                "maxEmptyLines": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "blocks": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^(?:\\S+)$": {
+                      "type": "object",
+                      "properties": {
+                        "singleline": {
+                          "enum": ["always", "never", "consistent", "ignore"]
+                        },
+                        "multiline": {
+                          "enum": ["always", "never", "consistent", "ignore"]
+                        },
+                        "maxEmptyLines": {
+                          "type": "number",
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce line breaks after opening and before closing block-level tags\nhttps://eslint.vuejs.org/rules/block-tag-newline.html"
+    },
+    "eslint-plugin-vue/brace-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent brace style for blocks in `<template>`\nhttps://eslint.vuejs.org/rules/brace-style.html"
+    },
+    "eslint-plugin-vue/camelcase": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreDestructuring": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ignoreImports": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ignoreGlobals": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "properties": {
+                  "enum": ["always", "never"]
+                },
+                "allow": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "minItems": 0,
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce camelcase naming convention in `<template>`\nhttps://eslint.vuejs.org/rules/camelcase.html"
+    },
+    "eslint-plugin-vue/comma-dangle": {
+      "description": "Require or disallow trailing commas in `<template>`\nhttps://eslint.vuejs.org/rules/comma-dangle.html"
+    },
+    "eslint-plugin-vue/comma-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "before": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "after": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing before and after commas in `<template>`\nhttps://eslint.vuejs.org/rules/comma-spacing.html"
+    },
+    "eslint-plugin-vue/comma-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent comma style in `<template>`\nhttps://eslint.vuejs.org/rules/comma-style.html"
+    },
+    "eslint-plugin-vue/comment-directive": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "reportUnusedDisableDirectives": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "support comment-directives in `<template>`\nhttps://eslint.vuejs.org/rules/comment-directive.html"
+    },
+    "eslint-plugin-vue/component-api-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce component API style\nhttps://eslint.vuejs.org/rules/component-api-style.html"
+    },
+    "eslint-plugin-vue/component-definition-name-casing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce specific casing for component definition name\nhttps://eslint.vuejs.org/rules/component-definition-name-casing.html"
+    },
+    "eslint-plugin-vue/component-name-in-template-casing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce specific casing for the component naming style in template\nhttps://eslint.vuejs.org/rules/component-name-in-template-casing.html"
+    },
+    "eslint-plugin-vue/component-options-name-casing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce the casing of component name in `components` options\nhttps://eslint.vuejs.org/rules/component-options-name-casing.html"
+    },
+    "eslint-plugin-vue/component-tags-order": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "order": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce order of component top-level elements\nhttps://eslint.vuejs.org/rules/component-tags-order.html"
+    },
+    "eslint-plugin-vue/custom-event-name-casing": {
+      "description": "enforce specific casing for custom event name\nhttps://eslint.vuejs.org/rules/custom-event-name-casing.html"
+    },
+    "eslint-plugin-vue/define-emits-declaration": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce declaration style of `defineEmits`\nhttps://eslint.vuejs.org/rules/define-emits-declaration.html"
+    },
+    "eslint-plugin-vue/define-macros-order": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "order": {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "defineEmits",
+                      "defineProps",
+                      "defineOptions",
+                      "defineSlots"
+                    ]
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce order of `defineEmits` and `defineProps` compiler macros\nhttps://eslint.vuejs.org/rules/define-macros-order.html"
+    },
+    "eslint-plugin-vue/define-props-declaration": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce declaration style of `defineProps`\nhttps://eslint.vuejs.org/rules/define-props-declaration.html"
+    },
+    "eslint-plugin-vue/dot-location": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent newlines before and after dots in `<template>`\nhttps://eslint.vuejs.org/rules/dot-location.html"
+    },
+    "eslint-plugin-vue/dot-notation": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowKeywords": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "allowPattern": {
+                  "type": "string",
+                  "default": ""
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce dot notation whenever possible in `<template>`\nhttps://eslint.vuejs.org/rules/dot-notation.html"
+    },
+    "eslint-plugin-vue/eqeqeq": {
+      "description": "Require the use of `===` and `!==` in `<template>`\nhttps://eslint.vuejs.org/rules/eqeqeq.html"
+    },
+    "eslint-plugin-vue/first-attribute-linebreak": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "multiline": {
+                  "enum": ["below", "beside", "ignore"]
+                },
+                "singleline": {
+                  "enum": ["below", "beside", "ignore"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce the location of first attribute\nhttps://eslint.vuejs.org/rules/first-attribute-linebreak.html"
+    },
+    "eslint-plugin-vue/func-call-spacing": {
+      "description": "Require or disallow spacing between function identifiers and their invocations in `<template>`\nhttps://eslint.vuejs.org/rules/func-call-spacing.html"
+    },
+    "eslint-plugin-vue/html-button-has-type": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "button": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "submit": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "reset": {
+                  "default": true,
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow usage of button without an explicit type attribute\nhttps://eslint.vuejs.org/rules/html-button-has-type.html"
+    },
+    "eslint-plugin-vue/html-closing-bracket-newline": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "singleline": {
+                  "enum": ["always", "never"]
+                },
+                "multiline": {
+                  "enum": ["always", "never"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require or disallow a line break before tag's closing brackets\nhttps://eslint.vuejs.org/rules/html-closing-bracket-newline.html"
+    },
+    "eslint-plugin-vue/html-closing-bracket-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "startTag": {
+                  "enum": ["always", "never"]
+                },
+                "endTag": {
+                  "enum": ["always", "never"]
+                },
+                "selfClosingTag": {
+                  "enum": ["always", "never"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require or disallow a space before tag's closing brackets\nhttps://eslint.vuejs.org/rules/html-closing-bracket-spacing.html"
+    },
+    "eslint-plugin-vue/html-comment-content-newline": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce unified line brake in HTML comments\nhttps://eslint.vuejs.org/rules/html-comment-content-newline.html"
+    },
+    "eslint-plugin-vue/html-comment-content-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce unified spacing in HTML comments\nhttps://eslint.vuejs.org/rules/html-comment-content-spacing.html"
+    },
+    "eslint-plugin-vue/html-comment-indent": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce consistent indentation in HTML comments\nhttps://eslint.vuejs.org/rules/html-comment-indent.html"
+    },
+    "eslint-plugin-vue/html-end-tags": {
+      "description": "enforce end tag style\nhttps://eslint.vuejs.org/rules/html-end-tags.html"
+    },
+    "eslint-plugin-vue/html-indent": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce consistent indentation in `<template>`\nhttps://eslint.vuejs.org/rules/html-indent.html"
+    },
+    "eslint-plugin-vue/html-quotes": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce quotes style of HTML attributes\nhttps://eslint.vuejs.org/rules/html-quotes.html"
+    },
+    "eslint-plugin-vue/html-self-closing": {
+      "description": "enforce self-closing style\nhttps://eslint.vuejs.org/rules/html-self-closing.html"
+    },
+    "eslint-plugin-vue/jsx-uses-vars": {
+      "description": "prevent variables used in JSX to be marked as unused\nhttps://eslint.vuejs.org/rules/jsx-uses-vars.html"
+    },
+    "eslint-plugin-vue/key-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing between keys and values in object literal properties in `<template>`\nhttps://eslint.vuejs.org/rules/key-spacing.html"
+    },
+    "eslint-plugin-vue/keyword-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "before": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "after": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "overrides": {
+                  "type": "object",
+                  "properties": {
+                    "abstract": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "as": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "async": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "await": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "boolean": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "break": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "byte": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "case": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "catch": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "char": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "class": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "const": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "continue": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "debugger": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "default": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "delete": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "do": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "double": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "else": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "enum": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "export": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "extends": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "false": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "final": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "finally": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "float": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "for": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "from": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "function": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "get": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "goto": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "if": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "implements": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "import": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "in": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "instanceof": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "int": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "interface": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "let": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "long": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "native": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "new": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "null": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "of": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "package": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "private": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "protected": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "public": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "return": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "set": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "short": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "static": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "super": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "switch": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "synchronized": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "this": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "throw": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "throws": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "transient": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "true": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "try": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "typeof": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "var": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "void": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "volatile": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "while": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "with": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "yield": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing before and after keywords in `<template>`\nhttps://eslint.vuejs.org/rules/keyword-spacing.html"
+    },
+    "eslint-plugin-vue/match-component-file-name": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "extensions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                "shouldMatchCase": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require component name property to match its file name\nhttps://eslint.vuejs.org/rules/match-component-file-name.html"
+    },
+    "eslint-plugin-vue/match-component-import-name": {
+      "description": "require the registered component name to match the imported component name\nhttps://eslint.vuejs.org/rules/match-component-import-name.html"
+    },
+    "eslint-plugin-vue/max-attributes-per-line": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "singleline": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 1
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "max": {
+                          "type": "number",
+                          "minimum": 1
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "multiline": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "minimum": 1
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "max": {
+                          "type": "number",
+                          "minimum": 1
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce the maximum number of attributes per line\nhttps://eslint.vuejs.org/rules/max-attributes-per-line.html"
+    },
+    "eslint-plugin-vue/max-len": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce a maximum line length in `.vue` files\nhttps://eslint.vuejs.org/rules/max-len.html"
+    },
+    "eslint-plugin-vue/max-lines-per-block": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "style": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "template": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "script": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "skipBlankLines": {
+                  "type": "boolean",
+                  "minimum": 0
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce maximum number of lines in Vue SFC blocks\nhttps://eslint.vuejs.org/rules/max-lines-per-block.html"
+    },
+    "eslint-plugin-vue/multi-word-component-names": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignores": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require component names to be always multi-word\nhttps://eslint.vuejs.org/rules/multi-word-component-names.html"
+    },
+    "eslint-plugin-vue/multiline-html-element-content-newline": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreWhenEmpty": {
+                  "type": "boolean"
+                },
+                "ignores": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                "allowEmptyLines": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require a line break before and after the contents of a multiline element\nhttps://eslint.vuejs.org/rules/multiline-html-element-content-newline.html"
+    },
+    "eslint-plugin-vue/multiline-ternary": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce newlines between operands of ternary expressions in `<template>`\nhttps://eslint.vuejs.org/rules/multiline-ternary.html"
+    },
+    "eslint-plugin-vue/mustache-interpolation-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce unified spacing in mustache interpolations\nhttps://eslint.vuejs.org/rules/mustache-interpolation-spacing.html"
+    },
+    "eslint-plugin-vue/new-line-between-multi-line-property": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "minLineOfMultilineProperty": {
+                  "type": "number",
+                  "minimum": 2
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce new lines between multi-line properties in Vue components\nhttps://eslint.vuejs.org/rules/new-line-between-multi-line-property.html"
+    },
+    "eslint-plugin-vue/next-tick-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce Promise or callback style in `nextTick`\nhttps://eslint.vuejs.org/rules/next-tick-style.html"
+    },
+    "eslint-plugin-vue/no-arrow-functions-in-watch": {
+      "description": "disallow using arrow functions to define watcher\nhttps://eslint.vuejs.org/rules/no-arrow-functions-in-watch.html"
+    },
+    "eslint-plugin-vue/no-async-in-computed-properties": {
+      "description": "disallow asynchronous actions in computed properties\nhttps://eslint.vuejs.org/rules/no-async-in-computed-properties.html"
+    },
+    "eslint-plugin-vue/no-bare-strings-in-template": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowlist": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                "attributes": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^(?:\\S+|/.*/[a-z]*)$": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "uniqueItems": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "directives": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^v-"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow the use of bare strings in `<template>`\nhttps://eslint.vuejs.org/rules/no-bare-strings-in-template.html"
+    },
+    "eslint-plugin-vue/no-boolean-default": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "disallow boolean defaults\nhttps://eslint.vuejs.org/rules/no-boolean-default.html"
+    },
+    "eslint-plugin-vue/no-child-content": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "additionalDirectives": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow element's child contents which would be overwritten by a directive like `v-html` or `v-text`\nhttps://eslint.vuejs.org/rules/no-child-content.html"
+    },
+    "eslint-plugin-vue/no-computed-properties-in-data": {
+      "description": "disallow accessing computed properties in `data`.\nhttps://eslint.vuejs.org/rules/no-computed-properties-in-data.html"
+    },
+    "eslint-plugin-vue/no-console": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow the use of `console` in `<template>`\nhttps://eslint.vuejs.org/rules/no-console.html"
+    },
+    "eslint-plugin-vue/no-constant-condition": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkLoops": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow constant expressions in conditions in `<template>`\nhttps://eslint.vuejs.org/rules/no-constant-condition.html"
+    },
+    "eslint-plugin-vue/no-custom-modifiers-on-v-model": {
+      "description": "disallow custom modifiers on v-model used on the component\nhttps://eslint.vuejs.org/rules/no-custom-modifiers-on-v-model.html"
+    },
+    "eslint-plugin-vue/no-deprecated-data-object-declaration": {
+      "description": "disallow using deprecated object declaration on data (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-data-object-declaration.html"
+    },
+    "eslint-plugin-vue/no-deprecated-destroyed-lifecycle": {
+      "description": "disallow using deprecated `destroyed` and `beforeDestroy` lifecycle hooks (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-destroyed-lifecycle.html"
+    },
+    "eslint-plugin-vue/no-deprecated-dollar-listeners-api": {
+      "description": "disallow using deprecated `$listeners` (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-dollar-listeners-api.html"
+    },
+    "eslint-plugin-vue/no-deprecated-dollar-scopedslots-api": {
+      "description": "disallow using deprecated `$scopedSlots` (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-dollar-scopedslots-api.html"
+    },
+    "eslint-plugin-vue/no-deprecated-events-api": {
+      "description": "disallow using deprecated events api (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-events-api.html"
+    },
+    "eslint-plugin-vue/no-deprecated-filter": {
+      "description": "disallow using deprecated filters syntax (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-filter.html"
+    },
+    "eslint-plugin-vue/no-deprecated-functional-template": {
+      "description": "disallow using deprecated the `functional` template (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-functional-template.html"
+    },
+    "eslint-plugin-vue/no-deprecated-html-element-is": {
+      "description": "disallow using deprecated the `is` attribute on HTML elements (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-html-element-is.html"
+    },
+    "eslint-plugin-vue/no-deprecated-inline-template": {
+      "description": "disallow using deprecated `inline-template` attribute (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-inline-template.html"
+    },
+    "eslint-plugin-vue/no-deprecated-model-definition": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowVue3Compat": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow deprecated `model` definition (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-model-definition.html"
+    },
+    "eslint-plugin-vue/no-deprecated-props-default-this": {
+      "description": "disallow deprecated `this` access in props default function (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-props-default-this.html"
+    },
+    "eslint-plugin-vue/no-deprecated-router-link-tag-prop": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "components": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true,
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow using deprecated `tag` property on `RouterLink` (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-router-link-tag-prop.html"
+    },
+    "eslint-plugin-vue/no-deprecated-scope-attribute": {
+      "description": "disallow deprecated `scope` attribute (in Vue.js 2.5.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-scope-attribute.html"
+    },
+    "eslint-plugin-vue/no-deprecated-slot-attribute": {
+      "description": "disallow deprecated `slot` attribute (in Vue.js 2.6.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-slot-attribute.html"
+    },
+    "eslint-plugin-vue/no-deprecated-slot-scope-attribute": {
+      "description": "disallow deprecated `slot-scope` attribute (in Vue.js 2.6.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-slot-scope-attribute.html"
+    },
+    "eslint-plugin-vue/no-deprecated-v-bind-sync": {
+      "description": "disallow use of deprecated `.sync` modifier on `v-bind` directive (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-v-bind-sync.html"
+    },
+    "eslint-plugin-vue/no-deprecated-v-is": {
+      "description": "disallow deprecated `v-is` directive (in Vue.js 3.1.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-v-is.html"
+    },
+    "eslint-plugin-vue/no-deprecated-v-on-native-modifier": {
+      "description": "disallow using deprecated `.native` modifiers (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-v-on-native-modifier.html"
+    },
+    "eslint-plugin-vue/no-deprecated-v-on-number-modifiers": {
+      "description": "disallow using deprecated number (keycode) modifiers (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-v-on-number-modifiers.html"
+    },
+    "eslint-plugin-vue/no-deprecated-vue-config-keycodes": {
+      "description": "disallow using deprecated `Vue.config.keyCodes` (in Vue.js 3.0.0+)\nhttps://eslint.vuejs.org/rules/no-deprecated-vue-config-keycodes.html"
+    },
+    "eslint-plugin-vue/no-dupe-keys": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "groups": {
+                  "type": "array"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow duplication of field names\nhttps://eslint.vuejs.org/rules/no-dupe-keys.html"
+    },
+    "eslint-plugin-vue/no-dupe-v-else-if": {
+      "description": "disallow duplicate conditions in `v-if` / `v-else-if` chains\nhttps://eslint.vuejs.org/rules/no-dupe-v-else-if.html"
+    },
+    "eslint-plugin-vue/no-duplicate-attr-inheritance": {
+      "description": "enforce `inheritAttrs` to be set to `false` when using `v-bind=\"$attrs\"`\nhttps://eslint.vuejs.org/rules/no-duplicate-attr-inheritance.html"
+    },
+    "eslint-plugin-vue/no-duplicate-attributes": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowCoexistClass": {
+                  "type": "boolean"
+                },
+                "allowCoexistStyle": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow duplication of attributes\nhttps://eslint.vuejs.org/rules/no-duplicate-attributes.html"
+    },
+    "eslint-plugin-vue/no-empty-component-block": {
+      "description": "disallow the `<template>` `<script>` `<style>` block to be empty\nhttps://eslint.vuejs.org/rules/no-empty-component-block.html"
+    },
+    "eslint-plugin-vue/no-empty-pattern": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowObjectPatternsAsParameters": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow empty destructuring patterns in `<template>`\nhttps://eslint.vuejs.org/rules/no-empty-pattern.html"
+    },
+    "eslint-plugin-vue/no-export-in-script-setup": {
+      "description": "disallow `export` in `<script setup>`\nhttps://eslint.vuejs.org/rules/no-export-in-script-setup.html"
+    },
+    "eslint-plugin-vue/no-expose-after-await": {
+      "description": "disallow asynchronously registered `expose`\nhttps://eslint.vuejs.org/rules/no-expose-after-await.html"
+    },
+    "eslint-plugin-vue/no-extra-parens": {
+      "description": "Disallow unnecessary parentheses in `<template>`\nhttps://eslint.vuejs.org/rules/no-extra-parens.html"
+    },
+    "eslint-plugin-vue/no-invalid-model-keys": {
+      "description": "require valid keys in model option\nhttps://eslint.vuejs.org/rules/no-invalid-model-keys.html"
+    },
+    "eslint-plugin-vue/no-irregular-whitespace": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "skipComments": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "skipStrings": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "skipTemplates": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "skipRegExps": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "skipHTMLAttributeValues": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "skipHTMLTextContents": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow irregular whitespace in `.vue` files\nhttps://eslint.vuejs.org/rules/no-irregular-whitespace.html"
+    },
+    "eslint-plugin-vue/no-lifecycle-after-await": {
+      "description": "disallow asynchronously registered lifecycle hooks\nhttps://eslint.vuejs.org/rules/no-lifecycle-after-await.html"
+    },
+    "eslint-plugin-vue/no-lone-template": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreAccessible": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow unnecessary `<template>`\nhttps://eslint.vuejs.org/rules/no-lone-template.html"
+    },
+    "eslint-plugin-vue/no-loss-of-precision": {
+      "description": "Disallow literal numbers that lose precision in `<template>`\nhttps://eslint.vuejs.org/rules/no-loss-of-precision.html"
+    },
+    "eslint-plugin-vue/no-multi-spaces": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreProperties": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow multiple spaces\nhttps://eslint.vuejs.org/rules/no-multi-spaces.html"
+    },
+    "eslint-plugin-vue/no-multiple-objects-in-class": {
+      "description": "disallow to pass multiple objects into array to class\nhttps://eslint.vuejs.org/rules/no-multiple-objects-in-class.html"
+    },
+    "eslint-plugin-vue/no-multiple-slot-args": {
+      "description": "disallow to pass multiple arguments to scoped slots\nhttps://eslint.vuejs.org/rules/no-multiple-slot-args.html"
+    },
+    "eslint-plugin-vue/no-multiple-template-root": {
+      "description": "disallow adding multiple root nodes to the template\nhttps://eslint.vuejs.org/rules/no-multiple-template-root.html"
+    },
+    "eslint-plugin-vue/no-mutating-props": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "shallowOnly": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow mutation of component props\nhttps://eslint.vuejs.org/rules/no-mutating-props.html"
+    },
+    "eslint-plugin-vue/no-parsing-error": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "abrupt-closing-of-empty-comment": {
+                  "type": "boolean"
+                },
+                "absence-of-digits-in-numeric-character-reference": {
+                  "type": "boolean"
+                },
+                "cdata-in-html-content": {
+                  "type": "boolean"
+                },
+                "character-reference-outside-unicode-range": {
+                  "type": "boolean"
+                },
+                "control-character-in-input-stream": {
+                  "type": "boolean"
+                },
+                "control-character-reference": {
+                  "type": "boolean"
+                },
+                "eof-before-tag-name": {
+                  "type": "boolean"
+                },
+                "eof-in-cdata": {
+                  "type": "boolean"
+                },
+                "eof-in-comment": {
+                  "type": "boolean"
+                },
+                "eof-in-tag": {
+                  "type": "boolean"
+                },
+                "incorrectly-closed-comment": {
+                  "type": "boolean"
+                },
+                "incorrectly-opened-comment": {
+                  "type": "boolean"
+                },
+                "invalid-first-character-of-tag-name": {
+                  "type": "boolean"
+                },
+                "missing-attribute-value": {
+                  "type": "boolean"
+                },
+                "missing-end-tag-name": {
+                  "type": "boolean"
+                },
+                "missing-semicolon-after-character-reference": {
+                  "type": "boolean"
+                },
+                "missing-whitespace-between-attributes": {
+                  "type": "boolean"
+                },
+                "nested-comment": {
+                  "type": "boolean"
+                },
+                "noncharacter-character-reference": {
+                  "type": "boolean"
+                },
+                "noncharacter-in-input-stream": {
+                  "type": "boolean"
+                },
+                "null-character-reference": {
+                  "type": "boolean"
+                },
+                "surrogate-character-reference": {
+                  "type": "boolean"
+                },
+                "surrogate-in-input-stream": {
+                  "type": "boolean"
+                },
+                "unexpected-character-in-attribute-name": {
+                  "type": "boolean"
+                },
+                "unexpected-character-in-unquoted-attribute-value": {
+                  "type": "boolean"
+                },
+                "unexpected-equals-sign-before-attribute-name": {
+                  "type": "boolean"
+                },
+                "unexpected-null-character": {
+                  "type": "boolean"
+                },
+                "unexpected-question-mark-instead-of-tag-name": {
+                  "type": "boolean"
+                },
+                "unexpected-solidus-in-tag": {
+                  "type": "boolean"
+                },
+                "unknown-named-character-reference": {
+                  "type": "boolean"
+                },
+                "end-tag-with-attributes": {
+                  "type": "boolean"
+                },
+                "duplicate-attribute": {
+                  "type": "boolean"
+                },
+                "end-tag-with-trailing-solidus": {
+                  "type": "boolean"
+                },
+                "non-void-html-element-start-tag-with-trailing-solidus": {
+                  "type": "boolean"
+                },
+                "x-invalid-end-tag": {
+                  "type": "boolean"
+                },
+                "x-invalid-namespace": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow parsing errors in `<template>`\nhttps://eslint.vuejs.org/rules/no-parsing-error.html"
+    },
+    "eslint-plugin-vue/no-potential-component-option-typo": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "presets": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["all", "vue", "vue-router", "nuxt"]
+                  },
+                  "uniqueItems": true,
+                  "minItems": 0
+                },
+                "custom": {
+                  "type": "array",
+                  "minItems": 0,
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                "threshold": {
+                  "type": "number",
+                  "minimum": 1
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow a potential typo in your component property\nhttps://eslint.vuejs.org/rules/no-potential-component-option-typo.html"
+    },
+    "eslint-plugin-vue/no-ref-as-operand": {
+      "description": "disallow use of value wrapped by `ref()` (Composition API) as an operand\nhttps://eslint.vuejs.org/rules/no-ref-as-operand.html"
+    },
+    "eslint-plugin-vue/no-ref-object-destructure": {
+      "description": "disallow usages of ref objects that can lead to loss of reactivity\nhttps://eslint.vuejs.org/rules/no-ref-object-destructure.html"
+    },
+    "eslint-plugin-vue/no-ref-object-reactivity-loss": {
+      "description": "disallow usages of ref objects that can lead to loss of reactivity\nhttps://eslint.vuejs.org/rules/no-ref-object-reactivity-loss.html"
+    },
+    "eslint-plugin-vue/no-required-prop-with-default": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "autofix": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce props with default values to be optional\nhttps://eslint.vuejs.org/rules/no-required-prop-with-default.html"
+    },
+    "eslint-plugin-vue/no-reserved-component-names": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "disallowVueBuiltInComponents": {
+                  "type": "boolean"
+                },
+                "disallowVue3BuiltInComponents": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow the use of reserved names in component definitions\nhttps://eslint.vuejs.org/rules/no-reserved-component-names.html"
+    },
+    "eslint-plugin-vue/no-reserved-keys": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "reserved": {
+                  "type": "array"
+                },
+                "groups": {
+                  "type": "array"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow overwriting reserved keys\nhttps://eslint.vuejs.org/rules/no-reserved-keys.html"
+    },
+    "eslint-plugin-vue/no-reserved-props": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "vueVersion": {
+                  "enum": [2, 3]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow reserved names in props\nhttps://eslint.vuejs.org/rules/no-reserved-props.html"
+    },
+    "eslint-plugin-vue/no-restricted-block": {
+      "description": "disallow specific block\nhttps://eslint.vuejs.org/rules/no-restricted-block.html"
+    },
+    "eslint-plugin-vue/no-restricted-call-after-await": {
+      "description": "disallow asynchronously called restricted methods\nhttps://eslint.vuejs.org/rules/no-restricted-call-after-await.html"
+    },
+    "eslint-plugin-vue/no-restricted-class": {
+      "description": "disallow specific classes in Vue components\nhttps://eslint.vuejs.org/rules/no-restricted-class.html"
+    },
+    "eslint-plugin-vue/no-restricted-component-names": {
+      "description": "disallow specific component names\nhttps://eslint.vuejs.org/rules/no-restricted-component-names.html"
+    },
+    "eslint-plugin-vue/no-restricted-component-options": {
+      "description": "disallow specific component option\nhttps://eslint.vuejs.org/rules/no-restricted-component-options.html"
+    },
+    "eslint-plugin-vue/no-restricted-custom-event": {
+      "description": "disallow specific custom event\nhttps://eslint.vuejs.org/rules/no-restricted-custom-event.html"
+    },
+    "eslint-plugin-vue/no-restricted-html-elements": {
+      "description": "disallow specific HTML elements\nhttps://eslint.vuejs.org/rules/no-restricted-html-elements.html"
+    },
+    "eslint-plugin-vue/no-restricted-props": {
+      "description": "disallow specific props\nhttps://eslint.vuejs.org/rules/no-restricted-props.html"
+    },
+    "eslint-plugin-vue/no-restricted-static-attribute": {
+      "description": "disallow specific attribute\nhttps://eslint.vuejs.org/rules/no-restricted-static-attribute.html"
+    },
+    "eslint-plugin-vue/no-restricted-syntax": {
+      "description": "Disallow specified syntax in `<template>`\nhttps://eslint.vuejs.org/rules/no-restricted-syntax.html"
+    },
+    "eslint-plugin-vue/no-restricted-v-bind": {
+      "description": "disallow specific argument in `v-bind`\nhttps://eslint.vuejs.org/rules/no-restricted-v-bind.html"
+    },
+    "eslint-plugin-vue/no-root-v-if": {
+      "description": "disallow `v-if` directives on root element\nhttps://eslint.vuejs.org/rules/no-root-v-if.html"
+    },
+    "eslint-plugin-vue/no-setup-props-destructure": {
+      "description": "disallow usages that lose the reactivity of `props` passed to `setup`\nhttps://eslint.vuejs.org/rules/no-setup-props-destructure.html"
+    },
+    "eslint-plugin-vue/no-setup-props-reactivity-loss": {
+      "description": "disallow usages that lose the reactivity of `props` passed to `setup`\nhttps://eslint.vuejs.org/rules/no-setup-props-reactivity-loss.html"
+    },
+    "eslint-plugin-vue/no-shared-component-data": {
+      "description": "enforce component's data property to be a function\nhttps://eslint.vuejs.org/rules/no-shared-component-data.html"
+    },
+    "eslint-plugin-vue/no-side-effects-in-computed-properties": {
+      "description": "disallow side effects in computed properties\nhttps://eslint.vuejs.org/rules/no-side-effects-in-computed-properties.html"
+    },
+    "eslint-plugin-vue/no-spaces-around-equal-signs-in-attribute": {
+      "description": "disallow spaces around equal signs in attribute\nhttps://eslint.vuejs.org/rules/no-spaces-around-equal-signs-in-attribute.html"
+    },
+    "eslint-plugin-vue/no-sparse-arrays": {
+      "description": "Disallow sparse arrays in `<template>`\nhttps://eslint.vuejs.org/rules/no-sparse-arrays.html"
+    },
+    "eslint-plugin-vue/no-static-inline-styles": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowBinding": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow static inline `style` attributes\nhttps://eslint.vuejs.org/rules/no-static-inline-styles.html"
+    },
+    "eslint-plugin-vue/no-template-key": {
+      "description": "disallow `key` attribute on `<template>`\nhttps://eslint.vuejs.org/rules/no-template-key.html"
+    },
+    "eslint-plugin-vue/no-template-shadow": {
+      "description": "disallow variable declarations from shadowing variables declared in the outer scope\nhttps://eslint.vuejs.org/rules/no-template-shadow.html"
+    },
+    "eslint-plugin-vue/no-template-target-blank": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowReferrer": {
+                  "type": "boolean"
+                },
+                "enforceDynamicLinks": {
+                  "enum": ["always", "never"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow target=\"_blank\" attribute without rel=\"noopener noreferrer\"\nhttps://eslint.vuejs.org/rules/no-template-target-blank.html"
+    },
+    "eslint-plugin-vue/no-textarea-mustache": {
+      "description": "disallow mustaches in `<textarea>`\nhttps://eslint.vuejs.org/rules/no-textarea-mustache.html"
+    },
+    "eslint-plugin-vue/no-this-in-before-route-enter": {
+      "description": "disallow `this` usage in a `beforeRouteEnter` method\nhttps://eslint.vuejs.org/rules/no-this-in-before-route-enter.html"
+    },
+    "eslint-plugin-vue/no-undef-components": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignorePatterns": {
+                  "type": "array"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow use of undefined components in `<template>`\nhttps://eslint.vuejs.org/rules/no-undef-components.html"
+    },
+    "eslint-plugin-vue/no-undef-properties": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignores": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow undefined properties\nhttps://eslint.vuejs.org/rules/no-undef-properties.html"
+    },
+    "eslint-plugin-vue/no-unsupported-features": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "string"
+                },
+                "ignores": {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "slot-scope-attribute",
+                      "dynamic-directive-arguments",
+                      "v-slot",
+                      "script-setup",
+                      "style-css-vars-injection",
+                      "v-model-argument",
+                      "v-model-custom-modifiers",
+                      "v-is",
+                      "is-attribute-with-vue-prefix",
+                      "v-memo",
+                      "v-bind-prop-modifier-shorthand",
+                      "v-bind-attr-modifier",
+                      "define-options",
+                      "define-slots"
+                    ]
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow unsupported Vue.js syntax on the specified version\nhttps://eslint.vuejs.org/rules/no-unsupported-features.html"
+    },
+    "eslint-plugin-vue/no-unused-components": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreWhenBindingPresent": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow registering components that are not used inside templates\nhttps://eslint.vuejs.org/rules/no-unused-components.html"
+    },
+    "eslint-plugin-vue/no-unused-properties": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "groups": {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "props",
+                      "data",
+                      "asyncData",
+                      "computed",
+                      "methods",
+                      "setup"
+                    ]
+                  },
+                  "uniqueItems": true
+                },
+                "deepData": {
+                  "type": "boolean"
+                },
+                "ignorePublicMembers": {
+                  "type": "boolean"
+                },
+                "unreferencedOptions": {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "unknownMemberAsUnreferenced",
+                      "returnAsUnreferenced"
+                    ]
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow unused properties\nhttps://eslint.vuejs.org/rules/no-unused-properties.html"
+    },
+    "eslint-plugin-vue/no-unused-refs": {
+      "description": "disallow unused refs\nhttps://eslint.vuejs.org/rules/no-unused-refs.html"
+    },
+    "eslint-plugin-vue/no-unused-vars": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignorePattern": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow unused variable definitions of v-for directives or scope attributes\nhttps://eslint.vuejs.org/rules/no-unused-vars.html"
+    },
+    "eslint-plugin-vue/no-use-computed-property-like-method": {
+      "description": "disallow use computed property like method\nhttps://eslint.vuejs.org/rules/no-use-computed-property-like-method.html"
+    },
+    "eslint-plugin-vue/no-use-v-else-with-v-for": {
+      "description": "disallow using `v-else-if`/`v-else` on the same element as `v-for`\nhttps://eslint.vuejs.org/rules/no-use-v-else-with-v-for.html"
+    },
+    "eslint-plugin-vue/no-use-v-if-with-v-for": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowUsingIterationVar": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow using `v-if` on the same element as `v-for`\nhttps://eslint.vuejs.org/rules/no-use-v-if-with-v-for.html"
+    },
+    "eslint-plugin-vue/no-useless-concat": {
+      "description": "Disallow unnecessary concatenation of literals or template literals in `<template>`\nhttps://eslint.vuejs.org/rules/no-useless-concat.html"
+    },
+    "eslint-plugin-vue/no-useless-mustaches": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreIncludesComment": {
+                  "type": "boolean"
+                },
+                "ignoreStringEscape": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow unnecessary mustache interpolations\nhttps://eslint.vuejs.org/rules/no-useless-mustaches.html"
+    },
+    "eslint-plugin-vue/no-useless-template-attributes": {
+      "description": "disallow useless attribute on `<template>`\nhttps://eslint.vuejs.org/rules/no-useless-template-attributes.html"
+    },
+    "eslint-plugin-vue/no-useless-v-bind": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreIncludesComment": {
+                  "type": "boolean"
+                },
+                "ignoreStringEscape": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "disallow unnecessary `v-bind` directives\nhttps://eslint.vuejs.org/rules/no-useless-v-bind.html"
+    },
+    "eslint-plugin-vue/no-v-for-template-key-on-child": {
+      "description": "disallow key of `<template v-for>` placed on child elements\nhttps://eslint.vuejs.org/rules/no-v-for-template-key-on-child.html"
+    },
+    "eslint-plugin-vue/no-v-for-template-key": {
+      "description": "disallow `key` attribute on `<template v-for>`\nhttps://eslint.vuejs.org/rules/no-v-for-template-key.html"
+    },
+    "eslint-plugin-vue/no-v-html": {
+      "description": "disallow use of v-html to prevent XSS attack\nhttps://eslint.vuejs.org/rules/no-v-html.html"
+    },
+    "eslint-plugin-vue/no-v-model-argument": {
+      "description": "disallow adding an argument to `v-model` used in custom component\nhttps://eslint.vuejs.org/rules/no-v-model-argument.html"
+    },
+    "eslint-plugin-vue/no-v-text-v-html-on-component": {
+      "description": "disallow v-text / v-html on component\nhttps://eslint.vuejs.org/rules/no-v-text-v-html-on-component.html"
+    },
+    "eslint-plugin-vue/no-v-text": {
+      "description": "disallow use of v-text\nhttps://eslint.vuejs.org/rules/no-v-text.html"
+    },
+    "eslint-plugin-vue/no-watch-after-await": {
+      "description": "disallow asynchronously registered `watch`\nhttps://eslint.vuejs.org/rules/no-watch-after-await.html"
+    },
+    "eslint-plugin-vue/object-curly-newline": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent line breaks after opening and before closing braces in `<template>`\nhttps://eslint.vuejs.org/rules/object-curly-newline.html"
+    },
+    "eslint-plugin-vue/object-curly-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing inside braces in `<template>`\nhttps://eslint.vuejs.org/rules/object-curly-spacing.html"
+    },
+    "eslint-plugin-vue/object-property-newline": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowAllPropertiesOnSameLine": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowMultiplePropertiesPerLine": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce placing object properties on separate lines in `<template>`\nhttps://eslint.vuejs.org/rules/object-property-newline.html"
+    },
+    "eslint-plugin-vue/object-shorthand": {
+      "description": "Require or disallow method and property shorthand syntax for object literals in `<template>`\nhttps://eslint.vuejs.org/rules/object-shorthand.html"
+    },
+    "eslint-plugin-vue/one-component-per-file": {
+      "description": "enforce that each component should be in its own file\nhttps://eslint.vuejs.org/rules/one-component-per-file.html"
+    },
+    "eslint-plugin-vue/operator-linebreak": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent linebreak style for operators in `<template>`\nhttps://eslint.vuejs.org/rules/operator-linebreak.html"
+    },
+    "eslint-plugin-vue/order-in-components": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "order": {
+                  "type": "array"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce order of properties in components\nhttps://eslint.vuejs.org/rules/order-in-components.html"
+    },
+    "eslint-plugin-vue/padding-line-between-blocks": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "require or disallow padding lines between blocks\nhttps://eslint.vuejs.org/rules/padding-line-between-blocks.html"
+    },
+    "eslint-plugin-vue/padding-line-between-tags": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "require or disallow newlines between sibling tags in template\nhttps://eslint.vuejs.org/rules/padding-line-between-tags.html"
+    },
+    "eslint-plugin-vue/padding-lines-in-component-definition": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "require or disallow padding lines in component definition\nhttps://eslint.vuejs.org/rules/padding-lines-in-component-definition.html"
+    },
+    "eslint-plugin-vue/prefer-define-options": {
+      "description": "enforce use of `defineOptions` instead of default export.\nhttps://eslint.vuejs.org/rules/prefer-define-options.html"
+    },
+    "eslint-plugin-vue/prefer-import-from-vue": {
+      "description": "enforce import from 'vue' instead of import from '@vue/*'\nhttps://eslint.vuejs.org/rules/prefer-import-from-vue.html"
+    },
+    "eslint-plugin-vue/prefer-prop-type-boolean-first": {
+      "description": "enforce `Boolean` comes first in component prop types\nhttps://eslint.vuejs.org/rules/prefer-prop-type-boolean-first.html"
+    },
+    "eslint-plugin-vue/prefer-separate-static-class": {
+      "description": "require static class names in template to be in a separate `class` attribute\nhttps://eslint.vuejs.org/rules/prefer-separate-static-class.html"
+    },
+    "eslint-plugin-vue/prefer-template": {
+      "description": "Require template literals instead of string concatenation in `<template>`\nhttps://eslint.vuejs.org/rules/prefer-template.html"
+    },
+    "eslint-plugin-vue/prefer-true-attribute-shorthand": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "require shorthand form attribute when `v-bind` value is `true`\nhttps://eslint.vuejs.org/rules/prefer-true-attribute-shorthand.html"
+    },
+    "eslint-plugin-vue/prop-name-casing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce specific casing for the Prop name in Vue components\nhttps://eslint.vuejs.org/rules/prop-name-casing.html"
+    },
+    "eslint-plugin-vue/quote-props": {
+      "description": "Require quotes around object literal property names in `<template>`\nhttps://eslint.vuejs.org/rules/quote-props.html"
+    },
+    "eslint-plugin-vue/require-component-is": {
+      "description": "require `v-bind:is` of `<component>` elements\nhttps://eslint.vuejs.org/rules/require-component-is.html"
+    },
+    "eslint-plugin-vue/require-default-prop": {
+      "description": "require default value for props\nhttps://eslint.vuejs.org/rules/require-default-prop.html"
+    },
+    "eslint-plugin-vue/require-direct-export": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "disallowFunctionalComponentFunction": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require the component to be directly exported\nhttps://eslint.vuejs.org/rules/require-direct-export.html"
+    },
+    "eslint-plugin-vue/require-emit-validator": {
+      "description": "require type definitions in emits\nhttps://eslint.vuejs.org/rules/require-emit-validator.html"
+    },
+    "eslint-plugin-vue/require-explicit-emits": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowProps": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require `emits` option with name triggered by `$emit()`\nhttps://eslint.vuejs.org/rules/require-explicit-emits.html"
+    },
+    "eslint-plugin-vue/require-expose": {
+      "description": "require declare public properties using `expose`\nhttps://eslint.vuejs.org/rules/require-expose.html"
+    },
+    "eslint-plugin-vue/require-macro-variable-name": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "defineProps": {
+                  "type": "string",
+                  "default": "props"
+                },
+                "defineEmits": {
+                  "type": "string",
+                  "default": "emit"
+                },
+                "defineSlots": {
+                  "type": "string",
+                  "default": "slots"
+                },
+                "useSlots": {
+                  "type": "string",
+                  "default": "slots"
+                },
+                "useAttrs": {
+                  "type": "string",
+                  "default": "attrs"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require a certain macro variable name\nhttps://eslint.vuejs.org/rules/require-macro-variable-name.html"
+    },
+    "eslint-plugin-vue/require-name-property": {
+      "description": "require a name property in Vue components\nhttps://eslint.vuejs.org/rules/require-name-property.html"
+    },
+    "eslint-plugin-vue/require-prop-comment": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "enum": ["JSDoc", "line", "block", "any"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require props to have a comment\nhttps://eslint.vuejs.org/rules/require-prop-comment.html"
+    },
+    "eslint-plugin-vue/require-prop-type-constructor": {
+      "description": "require prop type to be a constructor\nhttps://eslint.vuejs.org/rules/require-prop-type-constructor.html"
+    },
+    "eslint-plugin-vue/require-prop-types": {
+      "description": "require type definitions in props\nhttps://eslint.vuejs.org/rules/require-prop-types.html"
+    },
+    "eslint-plugin-vue/require-render-return": {
+      "description": "enforce render function to always return value\nhttps://eslint.vuejs.org/rules/require-render-return.html"
+    },
+    "eslint-plugin-vue/require-slots-as-functions": {
+      "description": "enforce properties of `$slots` to be used as a function\nhttps://eslint.vuejs.org/rules/require-slots-as-functions.html"
+    },
+    "eslint-plugin-vue/require-toggle-inside-transition": {
+      "description": "require control the display of the content inside `<transition>`\nhttps://eslint.vuejs.org/rules/require-toggle-inside-transition.html"
+    },
+    "eslint-plugin-vue/require-typed-object-prop": {
+      "description": "enforce adding type declarations to object props\nhttps://eslint.vuejs.org/rules/require-typed-object-prop.html"
+    },
+    "eslint-plugin-vue/require-typed-ref": {
+      "description": "require `ref` and `shallowRef` functions to be strongly typed\nhttps://eslint.vuejs.org/rules/require-typed-ref.html"
+    },
+    "eslint-plugin-vue/require-v-for-key": {
+      "description": "require `v-bind:key` with `v-for` directives\nhttps://eslint.vuejs.org/rules/require-v-for-key.html"
+    },
+    "eslint-plugin-vue/require-valid-default-prop": {
+      "description": "enforce props default values to be valid\nhttps://eslint.vuejs.org/rules/require-valid-default-prop.html"
+    },
+    "eslint-plugin-vue/return-in-computed-property": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "treatUndefinedAsUnspecified": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce that a return statement is present in computed property\nhttps://eslint.vuejs.org/rules/return-in-computed-property.html"
+    },
+    "eslint-plugin-vue/return-in-emits-validator": {
+      "description": "enforce that a return statement is present in emits validator\nhttps://eslint.vuejs.org/rules/return-in-emits-validator.html"
+    },
+    "eslint-plugin-vue/script-indent": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce consistent indentation in `<script>`\nhttps://eslint.vuejs.org/rules/script-indent.html"
+    },
+    "eslint-plugin-vue/script-setup-uses-vars": {
+      "description": "prevent `<script setup>` variables used in `<template>` to be marked as unused\nhttps://eslint.vuejs.org/rules/script-setup-uses-vars.html"
+    },
+    "eslint-plugin-vue/singleline-html-element-content-newline": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreWhenNoAttributes": {
+                  "type": "boolean"
+                },
+                "ignoreWhenEmpty": {
+                  "type": "boolean"
+                },
+                "ignores": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "require a line break before and after the contents of a singleline element\nhttps://eslint.vuejs.org/rules/singleline-html-element-content-newline.html"
+    },
+    "eslint-plugin-vue/sort-keys": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce sort-keys in a manner that is compatible with order-in-components\nhttps://eslint.vuejs.org/rules/sort-keys.html"
+    },
+    "eslint-plugin-vue/space-in-parens": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing inside parentheses in `<template>`\nhttps://eslint.vuejs.org/rules/space-in-parens.html"
+    },
+    "eslint-plugin-vue/space-infix-ops": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "int32Hint": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require spacing around infix operators in `<template>`\nhttps://eslint.vuejs.org/rules/space-infix-ops.html"
+    },
+    "eslint-plugin-vue/space-unary-ops": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "words": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "nonwords": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "overrides": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing before or after unary operators in `<template>`\nhttps://eslint.vuejs.org/rules/space-unary-ops.html"
+    },
+    "eslint-plugin-vue/static-class-names-order": {
+      "description": "enforce static class names order\nhttps://eslint.vuejs.org/rules/static-class-names-order.html"
+    },
+    "eslint-plugin-vue/template-curly-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Require or disallow spacing around embedded expressions of template strings in `<template>`\nhttps://eslint.vuejs.org/rules/template-curly-spacing.html"
+    },
+    "eslint-plugin-vue/this-in-template": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "disallow usage of `this` in template\nhttps://eslint.vuejs.org/rules/this-in-template.html"
+    },
+    "eslint-plugin-vue/use-v-on-exact": {
+      "description": "enforce usage of `exact` modifier on `v-on`\nhttps://eslint.vuejs.org/rules/use-v-on-exact.html"
+    },
+    "eslint-plugin-vue/v-bind-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce `v-bind` directive style\nhttps://eslint.vuejs.org/rules/v-bind-style.html"
+    },
+    "eslint-plugin-vue/v-for-delimiter-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce `v-for` directive's delimiter style\nhttps://eslint.vuejs.org/rules/v-for-delimiter-style.html"
+    },
+    "eslint-plugin-vue/v-on-event-hyphenation": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce v-on event naming style on custom components in template\nhttps://eslint.vuejs.org/rules/v-on-event-hyphenation.html"
+    },
+    "eslint-plugin-vue/v-on-function-call": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce or forbid parentheses after method calls without arguments in `v-on` directives\nhttps://eslint.vuejs.org/rules/v-on-function-call.html"
+    },
+    "eslint-plugin-vue/v-on-handler-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce writing style for handlers in `v-on` directives\nhttps://eslint.vuejs.org/rules/v-on-handler-style.html"
+    },
+    "eslint-plugin-vue/v-on-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce `v-on` directive style\nhttps://eslint.vuejs.org/rules/v-on-style.html"
+    },
+    "eslint-plugin-vue/v-slot-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "enforce `v-slot` directive style\nhttps://eslint.vuejs.org/rules/v-slot-style.html"
+    },
+    "eslint-plugin-vue/valid-attribute-name": {
+      "description": "require valid attribute names\nhttps://eslint.vuejs.org/rules/valid-attribute-name.html"
+    },
+    "eslint-plugin-vue/valid-define-emits": {
+      "description": "enforce valid `defineEmits` compiler macro\nhttps://eslint.vuejs.org/rules/valid-define-emits.html"
+    },
+    "eslint-plugin-vue/valid-define-options": {
+      "description": "enforce valid `defineOptions` compiler macro\nhttps://eslint.vuejs.org/rules/valid-define-options.html"
+    },
+    "eslint-plugin-vue/valid-define-props": {
+      "description": "enforce valid `defineProps` compiler macro\nhttps://eslint.vuejs.org/rules/valid-define-props.html"
+    },
+    "eslint-plugin-vue/valid-model-definition": {
+      "description": "require valid keys in model option\nhttps://eslint.vuejs.org/rules/valid-model-definition.html"
+    },
+    "eslint-plugin-vue/valid-next-tick": {
+      "description": "enforce valid `nextTick` function calls\nhttps://eslint.vuejs.org/rules/valid-next-tick.html"
+    },
+    "eslint-plugin-vue/valid-template-root": {
+      "description": "enforce valid template root\nhttps://eslint.vuejs.org/rules/valid-template-root.html"
+    },
+    "eslint-plugin-vue/valid-v-bind-sync": {
+      "description": "enforce valid `.sync` modifier on `v-bind` directives\nhttps://eslint.vuejs.org/rules/valid-v-bind-sync.html"
+    },
+    "eslint-plugin-vue/valid-v-bind": {
+      "description": "enforce valid `v-bind` directives\nhttps://eslint.vuejs.org/rules/valid-v-bind.html"
+    },
+    "eslint-plugin-vue/valid-v-cloak": {
+      "description": "enforce valid `v-cloak` directives\nhttps://eslint.vuejs.org/rules/valid-v-cloak.html"
+    },
+    "eslint-plugin-vue/valid-v-else-if": {
+      "description": "enforce valid `v-else-if` directives\nhttps://eslint.vuejs.org/rules/valid-v-else-if.html"
+    },
+    "eslint-plugin-vue/valid-v-else": {
+      "description": "enforce valid `v-else` directives\nhttps://eslint.vuejs.org/rules/valid-v-else.html"
+    },
+    "eslint-plugin-vue/valid-v-for": {
+      "description": "enforce valid `v-for` directives\nhttps://eslint.vuejs.org/rules/valid-v-for.html"
+    },
+    "eslint-plugin-vue/valid-v-html": {
+      "description": "enforce valid `v-html` directives\nhttps://eslint.vuejs.org/rules/valid-v-html.html"
+    },
+    "eslint-plugin-vue/valid-v-if": {
+      "description": "enforce valid `v-if` directives\nhttps://eslint.vuejs.org/rules/valid-v-if.html"
+    },
+    "eslint-plugin-vue/valid-v-is": {
+      "description": "enforce valid `v-is` directives\nhttps://eslint.vuejs.org/rules/valid-v-is.html"
+    },
+    "eslint-plugin-vue/valid-v-memo": {
+      "description": "enforce valid `v-memo` directives\nhttps://eslint.vuejs.org/rules/valid-v-memo.html"
+    },
+    "eslint-plugin-vue/valid-v-model": {
+      "description": "enforce valid `v-model` directives\nhttps://eslint.vuejs.org/rules/valid-v-model.html"
+    },
+    "eslint-plugin-vue/valid-v-on": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "modifiers": {
+                  "type": "array"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce valid `v-on` directives\nhttps://eslint.vuejs.org/rules/valid-v-on.html"
+    },
+    "eslint-plugin-vue/valid-v-once": {
+      "description": "enforce valid `v-once` directives\nhttps://eslint.vuejs.org/rules/valid-v-once.html"
+    },
+    "eslint-plugin-vue/valid-v-pre": {
+      "description": "enforce valid `v-pre` directives\nhttps://eslint.vuejs.org/rules/valid-v-pre.html"
+    },
+    "eslint-plugin-vue/valid-v-show": {
+      "description": "enforce valid `v-show` directives\nhttps://eslint.vuejs.org/rules/valid-v-show.html"
+    },
+    "eslint-plugin-vue/valid-v-slot": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowModifiers": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "enforce valid `v-slot` directives\nhttps://eslint.vuejs.org/rules/valid-v-slot.html"
+    },
+    "eslint-plugin-vue/valid-v-text": {
+      "description": "enforce valid `v-text` directives\nhttps://eslint.vuejs.org/rules/valid-v-text.html"
+    },
+    "typescript-eslint/adjacent-overload-signatures": {
+      "description": "Require that function overload signatures be consecutive\nhttps://typescript-eslint.io/rules/adjacent-overload-signatures"
+    },
+    "typescript-eslint/array-type": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "default": {
+                  "description": "The array type expected for mutable cases."
+                },
+                "readonly": {
+                  "description": "The array type expected for readonly cases. If omitted, the value for `default` will be used."
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require consistently using either `T[]` or `Array<T>` for arrays\nhttps://typescript-eslint.io/rules/array-type"
+    },
+    "typescript-eslint/await-thenable": {
+      "description": "Disallow awaiting a value that is not a Thenable\nhttps://typescript-eslint.io/rules/await-thenable"
+    },
+    "typescript-eslint/ban-ts-comment": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ts-expect-error": {},
+                "ts-ignore": {},
+                "ts-nocheck": {},
+                "ts-check": {},
+                "minimumDescriptionLength": {
+                  "type": "number",
+                  "default": 3
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow `@ts-<directive>` comments or require descriptions after directives\nhttps://typescript-eslint.io/rules/ban-ts-comment"
+    },
+    "typescript-eslint/ban-tslint-comment": {
+      "description": "Disallow `// tslint:<rule-flag>` comments\nhttps://typescript-eslint.io/rules/ban-tslint-comment"
+    },
+    "typescript-eslint/ban-types": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "types": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "extendDefaults": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow certain types\nhttps://typescript-eslint.io/rules/ban-types"
+    },
+    "typescript-eslint/block-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Disallow or enforce spaces inside of blocks after opening block and before closing block\nhttps://typescript-eslint.io/rules/block-spacing"
+    },
+    "typescript-eslint/brace-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent brace style for blocks\nhttps://typescript-eslint.io/rules/brace-style"
+    },
+    "typescript-eslint/class-literal-property-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce that literals on classes are exposed in a consistent style\nhttps://typescript-eslint.io/rules/class-literal-property-style"
+    },
+    "typescript-eslint/class-methods-use-this": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "exceptMethods": {
+                  "type": "array",
+                  "description": "Allows specified method names to be ignored with this rule",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "enforceForClassFields": {
+                  "type": "boolean",
+                  "description": "Enforces that functions used as instance field initializers utilize `this`",
+                  "default": true
+                },
+                "ignoreOverrideMethods": {
+                  "type": "boolean",
+                  "description": "Ignore members marked with the `override` modifier"
+                },
+                "ignoreClassesThatImplementAnInterface": {
+                  "oneOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Ignore all classes that implement an interface"
+                    },
+                    {
+                      "type": "string",
+                      "enum": ["public-fields"],
+                      "description": "Ignore only the public fields of classes that implement an interface"
+                    }
+                  ],
+                  "description": "Ignore classes that specifically implement some interface"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce that class methods utilize `this`\nhttps://typescript-eslint.io/rules/class-methods-use-this"
+    },
+    "typescript-eslint/comma-dangle": {
+      "description": "Require or disallow trailing commas\nhttps://typescript-eslint.io/rules/comma-dangle"
+    },
+    "typescript-eslint/comma-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "before": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "after": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing before and after commas\nhttps://typescript-eslint.io/rules/comma-spacing"
+    },
+    "typescript-eslint/consistent-generic-constructors": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce specifying generic type arguments on type annotation or constructor name of a constructor call\nhttps://typescript-eslint.io/rules/consistent-generic-constructors"
+    },
+    "typescript-eslint/consistent-indexed-object-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Require or disallow the `Record` type\nhttps://typescript-eslint.io/rules/consistent-indexed-object-style"
+    },
+    "typescript-eslint/consistent-type-assertions": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent usage of type assertions\nhttps://typescript-eslint.io/rules/consistent-type-assertions"
+    },
+    "typescript-eslint/consistent-type-definitions": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce type definitions to consistently use either `interface` or `type`\nhttps://typescript-eslint.io/rules/consistent-type-definitions"
+    },
+    "typescript-eslint/consistent-type-exports": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "fixMixedExportsWithInlineTypeSpecifier": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent usage of type exports\nhttps://typescript-eslint.io/rules/consistent-type-exports"
+    },
+    "typescript-eslint/consistent-type-imports": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "prefer": {
+                  "type": "string",
+                  "enum": ["type-imports", "no-type-imports"]
+                },
+                "disallowTypeAnnotations": {
+                  "type": "boolean"
+                },
+                "fixStyle": {
+                  "type": "string",
+                  "enum": ["separate-type-imports", "inline-type-imports"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent usage of type imports\nhttps://typescript-eslint.io/rules/consistent-type-imports"
+    },
+    "typescript-eslint/default-param-last": {
+      "description": "Enforce default parameters to be last\nhttps://typescript-eslint.io/rules/default-param-last"
+    },
+    "typescript-eslint/dot-notation": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowKeywords": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "allowPattern": {
+                  "type": "string",
+                  "default": ""
+                },
+                "allowPrivateClassPropertyAccess": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowProtectedClassPropertyAccess": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowIndexSignaturePropertyAccess": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce dot notation whenever possible\nhttps://typescript-eslint.io/rules/dot-notation"
+    },
+    "typescript-eslint/explicit-function-return-type": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowConciseArrowFunctionExpressionsStartingWithVoid": {
+                  "description": "Whether to allow arrow functions that start with the `void` keyword.",
+                  "type": "boolean"
+                },
+                "allowExpressions": {
+                  "description": "Whether to ignore function expressions (functions which are not part of a declaration).",
+                  "type": "boolean"
+                },
+                "allowHigherOrderFunctions": {
+                  "description": "Whether to ignore functions immediately returning another function expression.",
+                  "type": "boolean"
+                },
+                "allowTypedFunctionExpressions": {
+                  "description": "Whether to ignore type annotations on the variable of function expressions.",
+                  "type": "boolean"
+                },
+                "allowDirectConstAssertionInArrowFunctions": {
+                  "description": "Whether to ignore arrow functions immediately returning a `as const` value.",
+                  "type": "boolean"
+                },
+                "allowFunctionsWithoutTypeParameters": {
+                  "description": "Whether to ignore functions that don't have generic type parameters.",
+                  "type": "boolean"
+                },
+                "allowedNames": {
+                  "description": "An array of function/method names that will not have their arguments or return values checked.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowIIFEs": {
+                  "description": "Whether to ignore immediately invoked function expressions (IIFEs).",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require explicit return types on functions and class methods\nhttps://typescript-eslint.io/rules/explicit-function-return-type"
+    },
+    "typescript-eslint/explicit-member-accessibility": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "accessibility": {},
+                "overrides": {
+                  "type": "object",
+                  "properties": {
+                    "accessors": {},
+                    "constructors": {},
+                    "methods": {},
+                    "properties": {},
+                    "parameterProperties": {}
+                  },
+                  "additionalProperties": false
+                },
+                "ignoredMethodNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require explicit accessibility modifiers on class properties and methods\nhttps://typescript-eslint.io/rules/explicit-member-accessibility"
+    },
+    "typescript-eslint/explicit-module-boundary-types": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowArgumentsExplicitlyTypedAsAny": {
+                  "description": "Whether to ignore arguments that are explicitly typed as `any`.",
+                  "type": "boolean"
+                },
+                "allowDirectConstAssertionInArrowFunctions": {
+                  "description": "Whether to ignore return type annotations on body-less arrow functions that return an `as const` type assertion.\nYou must still type the parameters of the function.",
+                  "type": "boolean"
+                },
+                "allowedNames": {
+                  "description": "An array of function/method names that will not have their arguments or return values checked.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "allowHigherOrderFunctions": {
+                  "description": "Whether to ignore return type annotations on functions immediately returning another function expression.\nYou must still type the parameters of the function.",
+                  "type": "boolean"
+                },
+                "allowTypedFunctionExpressions": {
+                  "description": "Whether to ignore type annotations on the variable of a function expression.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require explicit return and argument types on exported functions' and classes' public class methods\nhttps://typescript-eslint.io/rules/explicit-module-boundary-types"
+    },
+    "typescript-eslint/func-call-spacing": {
+      "description": "Require or disallow spacing between function identifiers and their invocations\nhttps://typescript-eslint.io/rules/func-call-spacing"
+    },
+    "typescript-eslint/indent": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent indentation\nhttps://typescript-eslint.io/rules/indent"
+    },
+    "typescript-eslint/init-declarations": {
+      "description": "Require or disallow initialization in variable declarations\nhttps://typescript-eslint.io/rules/init-declarations"
+    },
+    "typescript-eslint/key-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing between property names and type annotations in types and interfaces\nhttps://typescript-eslint.io/rules/key-spacing"
+    },
+    "typescript-eslint/keyword-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "before": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "after": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "overrides": {
+                  "type": "object",
+                  "properties": {
+                    "abstract": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "as": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "async": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "await": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "boolean": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "break": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "byte": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "case": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "catch": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "char": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "class": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "const": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "continue": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "debugger": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "default": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "delete": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "do": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "double": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "else": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "enum": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "export": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "extends": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "false": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "final": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "finally": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "float": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "for": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "from": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "function": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "get": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "goto": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "if": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "implements": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "import": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "in": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "instanceof": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "int": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "interface": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "let": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "long": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "native": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "new": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "null": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "of": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "package": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "private": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "protected": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "public": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "return": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "set": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "short": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "static": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "super": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "switch": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "synchronized": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "this": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "throw": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "throws": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "transient": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "true": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "try": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "typeof": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "var": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "void": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "volatile": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "while": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "with": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "yield": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "type": "object",
+                      "properties": {
+                        "before": {
+                          "type": "boolean"
+                        },
+                        "after": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing before and after keywords\nhttps://typescript-eslint.io/rules/keyword-spacing"
+    },
+    "typescript-eslint/lines-around-comment": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "beforeBlockComment": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "afterBlockComment": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "beforeLineComment": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "afterLineComment": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowBlockStart": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowBlockEnd": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowClassStart": {
+                  "type": "boolean"
+                },
+                "allowClassEnd": {
+                  "type": "boolean"
+                },
+                "allowObjectStart": {
+                  "type": "boolean"
+                },
+                "allowObjectEnd": {
+                  "type": "boolean"
+                },
+                "allowArrayStart": {
+                  "type": "boolean"
+                },
+                "allowArrayEnd": {
+                  "type": "boolean"
+                },
+                "allowInterfaceStart": {
+                  "type": "boolean"
+                },
+                "allowInterfaceEnd": {
+                  "type": "boolean"
+                },
+                "allowTypeStart": {
+                  "type": "boolean"
+                },
+                "allowTypeEnd": {
+                  "type": "boolean"
+                },
+                "allowEnumStart": {
+                  "type": "boolean"
+                },
+                "allowEnumEnd": {
+                  "type": "boolean"
+                },
+                "allowModuleStart": {
+                  "type": "boolean"
+                },
+                "allowModuleEnd": {
+                  "type": "boolean"
+                },
+                "ignorePattern": {
+                  "type": "string"
+                },
+                "applyDefaultIgnorePatterns": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require empty lines around comments\nhttps://typescript-eslint.io/rules/lines-around-comment"
+    },
+    "typescript-eslint/lines-between-class-members": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Require or disallow an empty line between class members\nhttps://typescript-eslint.io/rules/lines-between-class-members"
+    },
+    "typescript-eslint/max-params": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "maximum": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "max": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "countVoidThis": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce a maximum number of parameters in function definitions\nhttps://typescript-eslint.io/rules/max-params"
+    },
+    "typescript-eslint/member-delimiter-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "multiline": {
+                  "type": "object",
+                  "properties": {
+                    "delimiter": {},
+                    "requireLast": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "singleline": {
+                  "type": "object",
+                  "properties": {
+                    "delimiter": {},
+                    "requireLast": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "overrides": {
+                  "type": "object",
+                  "properties": {
+                    "interface": {},
+                    "typeLiteral": {}
+                  },
+                  "additionalProperties": false
+                },
+                "multilineDetection": {
+                  "type": "string",
+                  "enum": ["brackets", "last-member"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require a specific member delimiter style for interfaces and type literals\nhttps://typescript-eslint.io/rules/member-delimiter-style"
+    },
+    "typescript-eslint/member-ordering": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "default": {},
+                "classes": {},
+                "classExpressions": {},
+                "interfaces": {},
+                "typeLiterals": {}
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require a consistent member declaration order\nhttps://typescript-eslint.io/rules/member-ordering"
+    },
+    "typescript-eslint/method-signature-style": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce using a particular method signature syntax\nhttps://typescript-eslint.io/rules/method-signature-style"
+    },
+    "typescript-eslint/naming-convention": {
+      "description": "Enforce naming conventions for everything across a codebase\nhttps://typescript-eslint.io/rules/naming-convention"
+    },
+    "typescript-eslint/no-array-constructor": {
+      "description": "Disallow generic `Array` constructors\nhttps://typescript-eslint.io/rules/no-array-constructor"
+    },
+    "typescript-eslint/no-base-to-string": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoredTypeNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require `.toString()` to only be called on objects which provide useful information when stringified\nhttps://typescript-eslint.io/rules/no-base-to-string"
+    },
+    "typescript-eslint/no-confusing-non-null-assertion": {
+      "description": "Disallow non-null assertion in locations that may be confusing\nhttps://typescript-eslint.io/rules/no-confusing-non-null-assertion"
+    },
+    "typescript-eslint/no-confusing-void-expression": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreArrowShorthand": {
+                  "type": "boolean"
+                },
+                "ignoreVoidOperator": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require expressions of type void to appear in statement position\nhttps://typescript-eslint.io/rules/no-confusing-void-expression"
+    },
+    "typescript-eslint/no-dupe-class-members": {
+      "description": "Disallow duplicate class members\nhttps://typescript-eslint.io/rules/no-dupe-class-members"
+    },
+    "typescript-eslint/no-duplicate-enum-values": {
+      "description": "Disallow duplicate enum member values\nhttps://typescript-eslint.io/rules/no-duplicate-enum-values"
+    },
+    "typescript-eslint/no-duplicate-type-constituents": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreIntersections": {
+                  "type": "boolean"
+                },
+                "ignoreUnions": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow duplicate constituents of union or intersection types\nhttps://typescript-eslint.io/rules/no-duplicate-type-constituents"
+    },
+    "typescript-eslint/no-dynamic-delete": {
+      "description": "Disallow using the `delete` operator on computed key expressions\nhttps://typescript-eslint.io/rules/no-dynamic-delete"
+    },
+    "typescript-eslint/no-empty-function": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "functions",
+                      "arrowFunctions",
+                      "generatorFunctions",
+                      "methods",
+                      "generatorMethods",
+                      "getters",
+                      "setters",
+                      "constructors",
+                      "private-constructors",
+                      "protected-constructors",
+                      "asyncFunctions",
+                      "asyncMethods",
+                      "decoratedFunctions",
+                      "overrideMethods"
+                    ],
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow empty functions\nhttps://typescript-eslint.io/rules/no-empty-function"
+    },
+    "typescript-eslint/no-empty-interface": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowSingleExtends": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow the declaration of empty interfaces\nhttps://typescript-eslint.io/rules/no-empty-interface"
+    },
+    "typescript-eslint/no-explicit-any": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "fixToUnknown": {
+                  "description": "Whether to enable auto-fixing in which the `any` type is converted to the `unknown` type.",
+                  "type": "boolean"
+                },
+                "ignoreRestArgs": {
+                  "description": "Whether to ignore rest parameter arrays.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow the `any` type\nhttps://typescript-eslint.io/rules/no-explicit-any"
+    },
+    "typescript-eslint/no-extra-non-null-assertion": {
+      "description": "Disallow extra non-null assertions\nhttps://typescript-eslint.io/rules/no-extra-non-null-assertion"
+    },
+    "typescript-eslint/no-extra-parens": {
+      "description": "Disallow unnecessary parentheses\nhttps://typescript-eslint.io/rules/no-extra-parens"
+    },
+    "typescript-eslint/no-extra-semi": {
+      "description": "Disallow unnecessary semicolons\nhttps://typescript-eslint.io/rules/no-extra-semi"
+    },
+    "typescript-eslint/no-extraneous-class": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowConstructorOnly": {
+                  "description": "Whether to allow extraneous classes that contain only a constructor.",
+                  "type": "boolean"
+                },
+                "allowEmpty": {
+                  "description": "Whether to allow extraneous classes that have no body (i.e. are empty).",
+                  "type": "boolean"
+                },
+                "allowStaticOnly": {
+                  "description": "Whether to allow extraneous classes that only contain static members.",
+                  "type": "boolean"
+                },
+                "allowWithDecorator": {
+                  "description": "Whether to allow extraneous classes that include a decorator.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow classes used as namespaces\nhttps://typescript-eslint.io/rules/no-extraneous-class"
+    },
+    "typescript-eslint/no-floating-promises": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreVoid": {
+                  "description": "Whether to ignore `void` expressions.",
+                  "type": "boolean"
+                },
+                "ignoreIIFE": {
+                  "description": "Whether to ignore async IIFEs (Immediately Invoked Function Expressions).",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require Promise-like statements to be handled appropriately\nhttps://typescript-eslint.io/rules/no-floating-promises"
+    },
+    "typescript-eslint/no-for-in-array": {
+      "description": "Disallow iterating over an array with a for-in loop\nhttps://typescript-eslint.io/rules/no-for-in-array"
+    },
+    "typescript-eslint/no-implied-eval": {
+      "description": "Disallow the use of `eval()`-like methods\nhttps://typescript-eslint.io/rules/no-implied-eval"
+    },
+    "typescript-eslint/no-import-type-side-effects": {
+      "description": "Enforce the use of top-level import type qualifier when an import only has specifiers with inline type qualifiers\nhttps://typescript-eslint.io/rules/no-import-type-side-effects"
+    },
+    "typescript-eslint/no-inferrable-types": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreParameters": {
+                  "type": "boolean"
+                },
+                "ignoreProperties": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow explicit type declarations for variables or parameters initialized to a number, string, or boolean\nhttps://typescript-eslint.io/rules/no-inferrable-types"
+    },
+    "typescript-eslint/no-invalid-this": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "capIsConstructor": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow `this` keywords outside of classes or class-like objects\nhttps://typescript-eslint.io/rules/no-invalid-this"
+    },
+    "typescript-eslint/no-invalid-void-type": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowInGenericTypeArguments": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1
+                    }
+                  ]
+                },
+                "allowAsThisParameter": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow `void` type outside of generic or return types\nhttps://typescript-eslint.io/rules/no-invalid-void-type"
+    },
+    "typescript-eslint/no-loop-func": {
+      "description": "Disallow function declarations that contain unsafe references inside loop statements\nhttps://typescript-eslint.io/rules/no-loop-func"
+    },
+    "typescript-eslint/no-loss-of-precision": {
+      "description": "Disallow literal numbers that lose precision\nhttps://typescript-eslint.io/rules/no-loss-of-precision"
+    },
+    "typescript-eslint/no-magic-numbers": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "detectObjects": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "enforceConst": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ignore": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^[+-]?(?:0|[1-9][0-9]*)n$"
+                      }
+                    ]
+                  },
+                  "uniqueItems": true
+                },
+                "ignoreArrayIndexes": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ignoreDefaultValues": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ignoreClassFieldInitialValues": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ignoreNumericLiteralTypes": {
+                  "type": "boolean"
+                },
+                "ignoreEnums": {
+                  "type": "boolean"
+                },
+                "ignoreReadonlyClassProperties": {
+                  "type": "boolean"
+                },
+                "ignoreTypeIndexes": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow magic numbers\nhttps://typescript-eslint.io/rules/no-magic-numbers"
+    },
+    "typescript-eslint/no-meaningless-void-operator": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkNever": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow the `void` operator except when used to discard a value\nhttps://typescript-eslint.io/rules/no-meaningless-void-operator"
+    },
+    "typescript-eslint/no-misused-new": {
+      "description": "Enforce valid definition of `new` and `constructor`\nhttps://typescript-eslint.io/rules/no-misused-new"
+    },
+    "typescript-eslint/no-misused-promises": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checksConditionals": {
+                  "type": "boolean"
+                },
+                "checksVoidReturn": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "arguments": {
+                          "type": "boolean"
+                        },
+                        "attributes": {
+                          "type": "boolean"
+                        },
+                        "properties": {
+                          "type": "boolean"
+                        },
+                        "returns": {
+                          "type": "boolean"
+                        },
+                        "variables": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                },
+                "checksSpreads": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow Promises in places not designed to handle them\nhttps://typescript-eslint.io/rules/no-misused-promises"
+    },
+    "typescript-eslint/no-mixed-enums": {
+      "description": "Disallow enums from having both number and string members\nhttps://typescript-eslint.io/rules/no-mixed-enums"
+    },
+    "typescript-eslint/no-namespace": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowDeclarations": {
+                  "description": "Whether to allow `declare` with custom TypeScript namespaces.",
+                  "type": "boolean"
+                },
+                "allowDefinitionFiles": {
+                  "description": "Whether to allow `declare` with custom TypeScript namespaces inside definition files.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow TypeScript namespaces\nhttps://typescript-eslint.io/rules/no-namespace"
+    },
+    "typescript-eslint/no-non-null-asserted-nullish-coalescing": {
+      "description": "Disallow non-null assertions in the left operand of a nullish coalescing operator\nhttps://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing"
+    },
+    "typescript-eslint/no-non-null-asserted-optional-chain": {
+      "description": "Disallow non-null assertions after an optional chain expression\nhttps://typescript-eslint.io/rules/no-non-null-asserted-optional-chain"
+    },
+    "typescript-eslint/no-non-null-assertion": {
+      "description": "Disallow non-null assertions using the `!` postfix operator\nhttps://typescript-eslint.io/rules/no-non-null-assertion"
+    },
+    "typescript-eslint/no-redeclare": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "builtinGlobals": {
+                  "type": "boolean"
+                },
+                "ignoreDeclarationMerge": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow variable redeclaration\nhttps://typescript-eslint.io/rules/no-redeclare"
+    },
+    "typescript-eslint/no-redundant-type-constituents": {
+      "description": "Disallow members of unions and intersections that do nothing or override type information\nhttps://typescript-eslint.io/rules/no-redundant-type-constituents"
+    },
+    "typescript-eslint/no-require-imports": {
+      "description": "Disallow invocation of `require()`\nhttps://typescript-eslint.io/rules/no-require-imports"
+    },
+    "typescript-eslint/no-restricted-imports": {
+      "description": "Disallow specified modules when loaded by `import`\nhttps://typescript-eslint.io/rules/no-restricted-imports"
+    },
+    "typescript-eslint/no-shadow": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "builtinGlobals": {
+                  "type": "boolean"
+                },
+                "hoist": {
+                  "type": "string",
+                  "enum": ["all", "functions", "never"]
+                },
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ignoreOnInitialization": {
+                  "type": "boolean"
+                },
+                "ignoreTypeValueShadow": {
+                  "type": "boolean"
+                },
+                "ignoreFunctionTypeParameterNameValueShadow": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow variable declarations from shadowing variables declared in the outer scope\nhttps://typescript-eslint.io/rules/no-shadow"
+    },
+    "typescript-eslint/no-this-alias": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowDestructuring": {
+                  "description": "Whether to ignore destructurings, such as `const { props, state } = this`.",
+                  "type": "boolean"
+                },
+                "allowedNames": {
+                  "description": "Names to ignore, such as [\"self\"] for `const self = this;`.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow aliasing `this`\nhttps://typescript-eslint.io/rules/no-this-alias"
+    },
+    "typescript-eslint/no-throw-literal": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowThrowingAny": {
+                  "type": "boolean"
+                },
+                "allowThrowingUnknown": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow throwing literals as exceptions\nhttps://typescript-eslint.io/rules/no-throw-literal"
+    },
+    "typescript-eslint/no-type-alias": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowAliases": {
+                  "description": "Whether to allow direct one-to-one type aliases."
+                },
+                "allowCallbacks": {
+                  "description": "Whether to allow type aliases for callbacks."
+                },
+                "allowConditionalTypes": {
+                  "description": "Whether to allow type aliases for conditional types."
+                },
+                "allowConstructors": {
+                  "description": "Whether to allow type aliases with constructors."
+                },
+                "allowLiterals": {
+                  "description": "Whether to allow type aliases with object literal types."
+                },
+                "allowMappedTypes": {
+                  "description": "Whether to allow type aliases with mapped types."
+                },
+                "allowTupleTypes": {
+                  "description": "Whether to allow type aliases with tuple types."
+                },
+                "allowGenerics": {
+                  "description": "Whether to allow type aliases with generic types."
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow type aliases\nhttps://typescript-eslint.io/rules/no-type-alias"
+    },
+    "typescript-eslint/no-unnecessary-boolean-literal-compare": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowComparingNullableBooleansToTrue": {
+                  "description": "Whether to allow comparisons between nullable boolean variables and `true`.",
+                  "type": "boolean"
+                },
+                "allowComparingNullableBooleansToFalse": {
+                  "description": "Whether to allow comparisons between nullable boolean variables and `false`.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow unnecessary equality comparisons against boolean literals\nhttps://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare"
+    },
+    "typescript-eslint/no-unnecessary-condition": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowConstantLoopConditions": {
+                  "description": "Whether to ignore constant loop conditions, such as `while (true)`.",
+                  "type": "boolean"
+                },
+                "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+                  "description": "Whether to not error when running with a tsconfig that has strictNullChecks turned.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow conditionals where the type is always truthy or always falsy\nhttps://typescript-eslint.io/rules/no-unnecessary-condition"
+    },
+    "typescript-eslint/no-unnecessary-qualifier": {
+      "description": "Disallow unnecessary namespace qualifiers\nhttps://typescript-eslint.io/rules/no-unnecessary-qualifier"
+    },
+    "typescript-eslint/no-unnecessary-type-arguments": {
+      "description": "Disallow type arguments that are equal to the default\nhttps://typescript-eslint.io/rules/no-unnecessary-type-arguments"
+    },
+    "typescript-eslint/no-unnecessary-type-assertion": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "typesToIgnore": {
+                  "description": "A list of type names to ignore.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow type assertions that do not change the type of an expression\nhttps://typescript-eslint.io/rules/no-unnecessary-type-assertion"
+    },
+    "typescript-eslint/no-unnecessary-type-constraint": {
+      "description": "Disallow unnecessary constraints on generic types\nhttps://typescript-eslint.io/rules/no-unnecessary-type-constraint"
+    },
+    "typescript-eslint/no-unsafe-argument": {
+      "description": "Disallow calling a function with a value with type `any`\nhttps://typescript-eslint.io/rules/no-unsafe-argument"
+    },
+    "typescript-eslint/no-unsafe-assignment": {
+      "description": "Disallow assigning a value with type `any` to variables and properties\nhttps://typescript-eslint.io/rules/no-unsafe-assignment"
+    },
+    "typescript-eslint/no-unsafe-call": {
+      "description": "Disallow calling a value with type `any`\nhttps://typescript-eslint.io/rules/no-unsafe-call"
+    },
+    "typescript-eslint/no-unsafe-declaration-merging": {
+      "description": "Disallow unsafe declaration merging\nhttps://typescript-eslint.io/rules/no-unsafe-declaration-merging"
+    },
+    "typescript-eslint/no-unsafe-enum-comparison": {
+      "description": "Disallow comparing an enum value with a non-enum value\nhttps://typescript-eslint.io/rules/no-unsafe-enum-comparison"
+    },
+    "typescript-eslint/no-unsafe-member-access": {
+      "description": "Disallow member access on a value with type `any`\nhttps://typescript-eslint.io/rules/no-unsafe-member-access"
+    },
+    "typescript-eslint/no-unsafe-return": {
+      "description": "Disallow returning a value with type `any` from a function\nhttps://typescript-eslint.io/rules/no-unsafe-return"
+    },
+    "typescript-eslint/no-unsafe-unary-minus": {
+      "description": "Require unary negation to take a number\nhttps://typescript-eslint.io/rules/no-unsafe-unary-minus"
+    },
+    "typescript-eslint/no-unused-expressions": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowShortCircuit": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowTernary": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowTaggedTemplates": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "enforceForJSX": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow unused expressions\nhttps://typescript-eslint.io/rules/no-unused-expressions"
+    },
+    "typescript-eslint/no-unused-vars": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Disallow unused variables\nhttps://typescript-eslint.io/rules/no-unused-vars"
+    },
+    "typescript-eslint/no-use-before-define": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Disallow the use of variables before they are defined\nhttps://typescript-eslint.io/rules/no-use-before-define"
+    },
+    "typescript-eslint/no-useless-constructor": {
+      "description": "Disallow unnecessary constructors\nhttps://typescript-eslint.io/rules/no-useless-constructor"
+    },
+    "typescript-eslint/no-useless-empty-export": {
+      "description": "Disallow empty exports that don't change anything in a module file\nhttps://typescript-eslint.io/rules/no-useless-empty-export"
+    },
+    "typescript-eslint/no-var-requires": {
+      "description": "Disallow `require` statements except in import statements\nhttps://typescript-eslint.io/rules/no-var-requires"
+    },
+    "typescript-eslint/non-nullable-type-assertion-style": {
+      "description": "Enforce non-null assertions over explicit type casts\nhttps://typescript-eslint.io/rules/non-nullable-type-assertion-style"
+    },
+    "typescript-eslint/object-curly-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing inside braces\nhttps://typescript-eslint.io/rules/object-curly-spacing"
+    },
+    "typescript-eslint/padding-line-between-statements": {
+      "description": "Require or disallow padding lines between statements\nhttps://typescript-eslint.io/rules/padding-line-between-statements"
+    },
+    "typescript-eslint/parameter-properties": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {}
+                },
+                "prefer": {
+                  "type": "string",
+                  "enum": ["class-property", "parameter-property"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require or disallow parameter properties in class constructors\nhttps://typescript-eslint.io/rules/parameter-properties"
+    },
+    "typescript-eslint/prefer-as-const": {
+      "description": "Enforce the use of `as const` over literal type\nhttps://typescript-eslint.io/rules/prefer-as-const"
+    },
+    "typescript-eslint/prefer-destructuring": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Require destructuring from arrays and/or objects\nhttps://typescript-eslint.io/rules/prefer-destructuring"
+    },
+    "typescript-eslint/prefer-enum-initializers": {
+      "description": "Require each enum member value to be explicitly initialized\nhttps://typescript-eslint.io/rules/prefer-enum-initializers"
+    },
+    "typescript-eslint/prefer-for-of": {
+      "description": "Enforce the use of `for-of` loop over the standard `for` loop where possible\nhttps://typescript-eslint.io/rules/prefer-for-of"
+    },
+    "typescript-eslint/prefer-function-type": {
+      "description": "Enforce using function types instead of interfaces with call signatures\nhttps://typescript-eslint.io/rules/prefer-function-type"
+    },
+    "typescript-eslint/prefer-includes": {
+      "description": "Enforce `includes` method over `indexOf` method\nhttps://typescript-eslint.io/rules/prefer-includes"
+    },
+    "typescript-eslint/prefer-literal-enum-member": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowBitwiseExpressions": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require all enum members to be literal values\nhttps://typescript-eslint.io/rules/prefer-literal-enum-member"
+    },
+    "typescript-eslint/prefer-namespace-keyword": {
+      "description": "Require using `namespace` keyword over `module` keyword to declare custom TypeScript modules\nhttps://typescript-eslint.io/rules/prefer-namespace-keyword"
+    },
+    "typescript-eslint/prefer-nullish-coalescing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+                  "type": "boolean"
+                },
+                "ignoreConditionalTests": {
+                  "type": "boolean"
+                },
+                "ignoreMixedLogicalExpressions": {
+                  "type": "boolean"
+                },
+                "ignorePrimitives": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "bigint": {
+                          "type": "boolean"
+                        },
+                        "boolean": {
+                          "type": "boolean"
+                        },
+                        "number": {
+                          "type": "boolean"
+                        },
+                        "string": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    {
+                      "type": "boolean",
+                      "enum": [true]
+                    }
+                  ]
+                },
+                "ignoreTernaryTests": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce using the nullish coalescing operator instead of logical assignments or chaining\nhttps://typescript-eslint.io/rules/prefer-nullish-coalescing"
+    },
+    "typescript-eslint/prefer-optional-chain": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkAny": {
+                  "type": "boolean",
+                  "description": "Check operands that are typed as `any` when inspecting \"loose boolean\" operands."
+                },
+                "checkUnknown": {
+                  "type": "boolean",
+                  "description": "Check operands that are typed as `unknown` when inspecting \"loose boolean\" operands."
+                },
+                "checkString": {
+                  "type": "boolean",
+                  "description": "Check operands that are typed as `string` when inspecting \"loose boolean\" operands."
+                },
+                "checkNumber": {
+                  "type": "boolean",
+                  "description": "Check operands that are typed as `number` when inspecting \"loose boolean\" operands."
+                },
+                "checkBoolean": {
+                  "type": "boolean",
+                  "description": "Check operands that are typed as `boolean` when inspecting \"loose boolean\" operands."
+                },
+                "checkBigInt": {
+                  "type": "boolean",
+                  "description": "Check operands that are typed as `bigint` when inspecting \"loose boolean\" operands."
+                },
+                "requireNullish": {
+                  "type": "boolean",
+                  "description": "Skip operands that are not typed with `null` and/or `undefined` when inspecting \"loose boolean\" operands."
+                },
+                "allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing": {
+                  "type": "boolean",
+                  "description": "Allow autofixers that will change the return type of the expression. This option is considered unsafe as it may break the build."
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce using concise optional chain expressions instead of chained logical ands, negated logical ors, or empty objects\nhttps://typescript-eslint.io/rules/prefer-optional-chain"
+    },
+    "typescript-eslint/prefer-readonly": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "onlyInlineLambdas": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require private members to be marked as `readonly` if they're never modified outside of the constructor\nhttps://typescript-eslint.io/rules/prefer-readonly"
+    },
+    "typescript-eslint/prefer-readonly-parameter-types": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "from": {
+                            "type": "string",
+                            "enum": ["file"]
+                          },
+                          "name": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "array",
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            ]
+                          },
+                          "path": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["from", "name"]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "from": {
+                            "type": "string",
+                            "enum": ["lib"]
+                          },
+                          "name": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "array",
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "required": ["from", "name"]
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "from": {
+                            "type": "string",
+                            "enum": ["package"]
+                          },
+                          "name": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "array",
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            ]
+                          },
+                          "package": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["from", "name", "package"]
+                      }
+                    ]
+                  }
+                },
+                "checkParameterProperties": {
+                  "type": "boolean"
+                },
+                "ignoreInferredTypes": {
+                  "type": "boolean"
+                },
+                "treatMethodsAsReadonly": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require function parameters to be typed as `readonly` to prevent accidental mutation of inputs\nhttps://typescript-eslint.io/rules/prefer-readonly-parameter-types"
+    },
+    "typescript-eslint/prefer-reduce-type-parameter": {
+      "description": "Enforce using type parameter when calling `Array#reduce` instead of casting\nhttps://typescript-eslint.io/rules/prefer-reduce-type-parameter"
+    },
+    "typescript-eslint/prefer-regexp-exec": {
+      "description": "Enforce `RegExp#exec` over `String#match` if no global flag is provided\nhttps://typescript-eslint.io/rules/prefer-regexp-exec"
+    },
+    "typescript-eslint/prefer-return-this-type": {
+      "description": "Enforce that `this` is used when only `this` type is returned\nhttps://typescript-eslint.io/rules/prefer-return-this-type"
+    },
+    "typescript-eslint/prefer-string-starts-ends-with": {
+      "description": "Enforce using `String#startsWith` and `String#endsWith` over other equivalent methods of checking substrings\nhttps://typescript-eslint.io/rules/prefer-string-starts-ends-with"
+    },
+    "typescript-eslint/prefer-ts-expect-error": {
+      "description": "Enforce using `@ts-expect-error` over `@ts-ignore`\nhttps://typescript-eslint.io/rules/prefer-ts-expect-error"
+    },
+    "typescript-eslint/promise-function-async": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowAny": {
+                  "description": "Whether to consider `any` and `unknown` to be Promises.",
+                  "type": "boolean"
+                },
+                "allowedPromiseNames": {
+                  "description": "Any extra names of classes or interfaces to be considered Promises.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "checkArrowFunctions": {
+                  "type": "boolean"
+                },
+                "checkFunctionDeclarations": {
+                  "type": "boolean"
+                },
+                "checkFunctionExpressions": {
+                  "type": "boolean"
+                },
+                "checkMethodDeclarations": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require any function or method that returns a Promise to be marked async\nhttps://typescript-eslint.io/rules/promise-function-async"
+    },
+    "typescript-eslint/quotes": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce the consistent use of either backticks, double, or single quotes\nhttps://typescript-eslint.io/rules/quotes"
+    },
+    "typescript-eslint/require-array-sort-compare": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreStringArrays": {
+                  "description": "Whether to ignore arrays in which all elements are strings.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require `Array#sort` calls to always provide a `compareFunction`\nhttps://typescript-eslint.io/rules/require-array-sort-compare"
+    },
+    "typescript-eslint/require-await": {
+      "description": "Disallow async functions which have no `await` expression\nhttps://typescript-eslint.io/rules/require-await"
+    },
+    "typescript-eslint/restrict-plus-operands": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowAny": {
+                  "description": "Whether to allow `any` typed values.",
+                  "type": "boolean"
+                },
+                "allowBoolean": {
+                  "description": "Whether to allow `boolean` typed values.",
+                  "type": "boolean"
+                },
+                "allowNullish": {
+                  "description": "Whether to allow potentially `null` or `undefined` typed values.",
+                  "type": "boolean"
+                },
+                "allowNumberAndString": {
+                  "description": "Whether to allow `bigint`/`number` typed values and `string` typed values to be added together.",
+                  "type": "boolean"
+                },
+                "allowRegExp": {
+                  "description": "Whether to allow `regexp` typed values.",
+                  "type": "boolean"
+                },
+                "skipCompoundAssignments": {
+                  "description": "Whether to skip compound assignments such as `+=`.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require both operands of addition to be the same type and be `bigint`, `number`, or `string`\nhttps://typescript-eslint.io/rules/restrict-plus-operands"
+    },
+    "typescript-eslint/restrict-template-expressions": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowAny": {
+                  "description": "Whether to allow `any` typed values in template expressions.",
+                  "type": "boolean"
+                },
+                "allowBoolean": {
+                  "description": "Whether to allow `boolean` typed values in template expressions.",
+                  "type": "boolean"
+                },
+                "allowNullish": {
+                  "description": "Whether to allow `nullish` typed values in template expressions.",
+                  "type": "boolean"
+                },
+                "allowNumber": {
+                  "description": "Whether to allow `number` typed values in template expressions.",
+                  "type": "boolean"
+                },
+                "allowRegExp": {
+                  "description": "Whether to allow `regexp` typed values in template expressions.",
+                  "type": "boolean"
+                },
+                "allowNever": {
+                  "description": "Whether to allow `never` typed values in template expressions.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce template literal expressions to be of `string` type\nhttps://typescript-eslint.io/rules/restrict-template-expressions"
+    },
+    "typescript-eslint/return-await": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent returning of awaited values\nhttps://typescript-eslint.io/rules/return-await"
+    },
+    "typescript-eslint/semi": {
+      "description": "Require or disallow semicolons instead of ASI\nhttps://typescript-eslint.io/rules/semi"
+    },
+    "typescript-eslint/sort-type-constituents": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "checkIntersections": {
+                  "description": "Whether to check intersection types.",
+                  "type": "boolean"
+                },
+                "checkUnions": {
+                  "description": "Whether to check union types.",
+                  "type": "boolean"
+                },
+                "groupOrder": {
+                  "description": "Ordering of the groups.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "conditional",
+                      "function",
+                      "import",
+                      "intersection",
+                      "keyword",
+                      "nullish",
+                      "literal",
+                      "named",
+                      "object",
+                      "operator",
+                      "tuple",
+                      "union"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce constituents of a type union/intersection to be sorted alphabetically\nhttps://typescript-eslint.io/rules/sort-type-constituents"
+    },
+    "typescript-eslint/space-before-blocks": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing before blocks\nhttps://typescript-eslint.io/rules/space-before-blocks"
+    },
+    "typescript-eslint/space-before-function-paren": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          ]
+        }
+      ],
+      "description": "Enforce consistent spacing before function parenthesis\nhttps://typescript-eslint.io/rules/space-before-function-paren"
+    },
+    "typescript-eslint/space-infix-ops": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "int32Hint": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require spacing around infix operators\nhttps://typescript-eslint.io/rules/space-infix-ops"
+    },
+    "typescript-eslint/strict-boolean-expressions": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "allowString": {
+                  "type": "boolean"
+                },
+                "allowNumber": {
+                  "type": "boolean"
+                },
+                "allowNullableObject": {
+                  "type": "boolean"
+                },
+                "allowNullableBoolean": {
+                  "type": "boolean"
+                },
+                "allowNullableString": {
+                  "type": "boolean"
+                },
+                "allowNullableNumber": {
+                  "type": "boolean"
+                },
+                "allowNullableEnum": {
+                  "type": "boolean"
+                },
+                "allowAny": {
+                  "type": "boolean"
+                },
+                "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow certain types in boolean expressions\nhttps://typescript-eslint.io/rules/strict-boolean-expressions"
+    },
+    "typescript-eslint/switch-exhaustiveness-check": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "requireDefaultForNonUnion": {
+                  "description": "If 'true', require a 'default' clause for switches on non-union types.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require switch-case statements to be exhaustive\nhttps://typescript-eslint.io/rules/switch-exhaustiveness-check"
+    },
+    "typescript-eslint/triple-slash-reference": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "lib": {
+                  "type": "string",
+                  "enum": ["always", "never"]
+                },
+                "path": {
+                  "type": "string",
+                  "enum": ["always", "never"]
+                },
+                "types": {
+                  "type": "string",
+                  "enum": ["always", "never", "prefer-import"]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow certain triple slash directives in favor of ES6-style import declarations\nhttps://typescript-eslint.io/rules/triple-slash-reference"
+    },
+    "typescript-eslint/type-annotation-spacing": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "before": {
+                  "type": "boolean"
+                },
+                "after": {
+                  "type": "boolean"
+                },
+                "overrides": {
+                  "type": "object",
+                  "properties": {
+                    "colon": {},
+                    "arrow": {},
+                    "variable": {},
+                    "parameter": {},
+                    "property": {},
+                    "returnType": {}
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require consistent spacing around type annotations\nhttps://typescript-eslint.io/rules/type-annotation-spacing"
+    },
+    "typescript-eslint/typedef": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "arrayDestructuring": {
+                  "type": "boolean"
+                },
+                "arrowParameter": {
+                  "type": "boolean"
+                },
+                "memberVariableDeclaration": {
+                  "type": "boolean"
+                },
+                "objectDestructuring": {
+                  "type": "boolean"
+                },
+                "parameter": {
+                  "type": "boolean"
+                },
+                "propertyDeclaration": {
+                  "type": "boolean"
+                },
+                "variableDeclaration": {
+                  "type": "boolean"
+                },
+                "variableDeclarationIgnoreFunction": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Require type annotations in certain places\nhttps://typescript-eslint.io/rules/typedef"
+    },
+    "typescript-eslint/unbound-method": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreStatic": {
+                  "description": "Whether to skip checking whether `static` methods are correctly bound.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Enforce unbound methods are called with their expected scope\nhttps://typescript-eslint.io/rules/unbound-method"
+    },
+    "typescript-eslint/unified-signatures": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ruleNumber"
+        },
+        {
+          "$ref": "#/definitions/ruleString"
+        },
+        {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/ruleNumber"
+                },
+                {
+                  "$ref": "#/definitions/ruleString"
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignoreDifferentlyNamedParameters": {
+                  "description": "Whether two parameters with different names at the same index should be considered different even if their types are the same.",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Disallow two overloads that could be unified into one with a union or an optional/rest parameter\nhttps://typescript-eslint.io/rules/unified-signatures"
+    }
+  }
+}

--- a/src/schemas/json/prettierrc.json
+++ b/src/schemas/json/prettierrc.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/prettierrc.json",
   "definitions": {
     "optionsDefinition": {
       "type": "object",
@@ -382,7 +383,6 @@
       }
     }
   },
-  "id": "https://json.schemastore.org/prettierrc.json",
   "oneOf": [
     {
       "type": "object",

--- a/src/schemas/json/semantic-release.json
+++ b/src/schemas/json/semantic-release.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/semantic-release.json",
   "definitions": {
     "branch-object": {
       "type": "object",
@@ -28,7 +29,6 @@
       }
     }
   },
-  "id": "https://json.schemastore.org/semantic-release.json",
   "properties": {
     "extends": {
       "description": "List of modules or file paths containing a shareable configuration. If multiple shareable configurations are set, they will be imported in the order defined with each configuration option taking precedence over the options defined in a previous shareable configuration",

--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/stylelintrc.json",
   "definitions": {
     "allRules": {
       "type": "object",
@@ -3139,7 +3140,6 @@
       }
     }
   },
-  "id": "https://json.schemastore.org/stylelintrc.json",
   "properties": {
     "extends": {
       "$ref": "#/definitions/simpleStringOrArrayStringRule",


### PR DESCRIPTION
This adds schemas to "rules" from the following ESLint plugins:

```js
[
	{
		id: 'angular-eslint',
		requireDir: './node_modules/@angular-eslint/eslint-plugin',
	},
	{
		id: 'eslint-plugin-import',
		requireDir: './node_modules/eslint-plugin-import',
	},
	{
		id: 'eslint-plugin-unicorn',
		requireDir: './node_modules/eslint-plugin-unicorn',
	},
	{
		id: 'eslint-plugin-vue',
		requireDir: './node_modules/eslint-plugin-vue',
	},
	{
		id: 'typescript-eslint',
		requireDir: './node_modules/@typescript-eslint/eslint-plugin/dist',
	},
]
```

**Notes:**

I Had to update some schemas from `draft-04` to `draft-07`. Schemas for ESLint plugins must be in `draft-07`. As a result, the main ESLint schema must be draft 7 as well. Since the ESLint schema is `$ref`ed in `package.json`, the `package.json` schema must be draft 07 as well. All other schemas `$ref`ed in `package.json` must be draft-07 as well (ex. ava.json), or the build will fail with:

```
>> compile              | schemas/json/package.json (unknown)(NotStrictMode)
>> Error: no schema with key or ref "http://json-schema.org/draft-04/schema#"`.
```

Source code to generate this is from [jsonschema-extractor](https://github.com/fox-projects/jsonschema-extractor). More extracted schemas will come!