### PR TITLE
Add missing types

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1257,6 +1257,8 @@
                       "ready_for_review",
                       "locked",
                       "unlocked",
+                      "milestoned",
+                      "demilestoned",
                       "review_requested",
                       "review_request_removed",
                       "auto_merge_enabled",
@@ -1636,7 +1638,7 @@
                   "$ref": "#/definitions/types",
                   "items": {
                     "type": "string",
-                    "enum": ["requested", "completed"]
+                    "enum": ["requested", "completed", "in_progress"]
                   },
                   "default": ["requested", "completed"]
                 },


### PR DESCRIPTION
Add missing types in pull_request and workflow_run events according to documentation.
Only the `pull_request` one was required for me but I had a look to all of them and suggested a modification on `workflow_run` as well.
We might want to add `repository_dispatch` to the list of events.
Thanks in advance

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
