### PR TITLE
feat: add listMode to depguard for golangci-lint

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -695,6 +695,12 @@
                   "additionalProperties": false,
                   "type": "object",
                   "properties": {
+                    "listMode": {
+                      "description": "Used to determine the package matching priority.\nThere are three different modes: `original`, `strict`, and `lax`.\nDefault: \"original\"",
+                      "type": "string",
+                      "enum": ["original", "strict", "lax"],
+                      "default": "original"
+                    },
                     "files": {
                       "description": "List of file globs that will match this list of settings to compare against.",
                       "additionalProperties": false,

--- a/src/test/golangci-lint/example-values.json
+++ b/src/test/golangci-lint/example-values.json
@@ -335,7 +335,8 @@
     "depguard": {
       "rules": {
         "main": {
-          "files": ["!**/*_a _file.go"],
+          "listMode": "strict",
+          "files": ["$all", "!**/*_a _file.go"],
           "allow": ["$gostd", "github.com/OpenPeeDeeP"],
           "deny": [
             {
@@ -345,6 +346,16 @@
             {
               "pkg": "github.com/pkg/errors",
               "desc": "Should be replaced by standard lib errors package"
+            }
+          ]
+        },
+        "tests": {
+          "listMode": "lax",
+          "files": ["$test"],
+          "deny": [
+            {
+              "pkg": "github.com/stretchr/testify",
+              "desc": "Please use standard library for tests"
             }
           ]
         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

These modes were added recently to [depguard](https://github.com/OpenPeeDeeP/depguard) and are supported by [the linter](https://golangci-lint.run/usage/linters/#depguard).
