### PR TITLE
Add mypy no implicit optional no implicit reexport

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -578,6 +578,12 @@
           "implicit_optional": {
             "$ref": "#/properties/implicit_optional"
           },
+          "no_implicit_optional": {
+            "$ref": "#/properties/no_implicit_optional"
+          },
+          "no_implicit_reexport": {
+            "$ref": "#/properties/no_implicit_reexport"
+          },
           "strict_optional": {
             "$ref": "#/properties/strict_optional"
           },

--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -93,7 +93,12 @@
       "description": "Directs what to do with imports when the imported module is found as a ``.py`` file and not part of the files, modules and packages provided on the command line.",
       "default": "normal",
       "type": "string",
-      "enum": ["normal", "silent", "skip", "error"]
+      "enum": [
+        "normal",
+        "silent",
+        "skip",
+        "error"
+      ]
     },
     "follow_imports_for_stubs": {
       "description": "Determines whether to respect the :confval:`follow_imports` setting even for stub (``.pyi``) files.",
@@ -221,6 +226,16 @@
     },
     "implicit_optional": {
       "description": "Causes mypy to treat arguments with a ``None`` default value as having an implicit :py:data:`~typing.Optional` type.",
+      "default": false,
+      "type": "boolean"
+    },
+    "no_implicit_optional": {
+      "description": "Inverse of implicit_optional.",
+      "default": true,
+      "type": "boolean"
+    },
+    "no_implicit_reexport": {
+      "description": "By default, imported values to a module are treated as exported and mypy allows other modules to import them. This flag changes the behavior to not re-export unless the item is imported using from-as or is included in __all__. Note this is always treated as enabled for stub files.",
       "default": false,
       "type": "boolean"
     },
@@ -487,7 +502,9 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["module"],
+        "required": [
+          "module"
+        ],
         "minProperties": 2,
         "properties": {
           "module": {

--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -93,12 +93,7 @@
       "description": "Directs what to do with imports when the imported module is found as a ``.py`` file and not part of the files, modules and packages provided on the command line.",
       "default": "normal",
       "type": "string",
-      "enum": [
-        "normal",
-        "silent",
-        "skip",
-        "error"
-      ]
+      "enum": ["normal", "silent", "skip", "error"]
     },
     "follow_imports_for_stubs": {
       "description": "Determines whether to respect the :confval:`follow_imports` setting even for stub (``.pyi``) files.",
@@ -502,9 +497,7 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "module"
-        ],
+        "required": ["module"],
         "minProperties": 2,
         "properties": {
           "module": {


### PR DESCRIPTION
Fixes #3470 

TBH I wasn't able to test in on a real file (despite reading the contributing guide). I couldn't quickly figure out how to make the grunt tests run against `mypy-01.toml`  , it doesn't seem like they are triggered against pyproject schema + pyproject schema itself is referencing the catalog URI and changing it to a local file didn't work for me.

If someone can help figure out how test it, would be great. but hopefully it is a simple enough fix to just work
