### PR TITLE
sublime-syntax: Fix types in `clear_scopes` keyword 

### DIFF
--- a/src/schemas/json/sublime-syntax.json
+++ b/src/schemas/json/sublime-syntax.json
@@ -38,7 +38,7 @@
         },
         "clear_scopes": {
           "description": "This setting allows removing scope names from the current stack. It can be an integer, or the value true to remove all scope names. It is applied before meta_scope and meta_content_scope. This is typically only used when one syntax is embedding another.",
-          "type": "boolean"
+          "anyOf": [{ "type": "integer" }, { "type": "boolean" }]
         },
         "meta_prepend": {
           "description": "A boolean, controlling context name conflict resolution during inheritance. If this is specified, the rules in this context will be inserted before any existing rules from a context with the same name in an ancestor syntax definition.",

--- a/src/test/sublime-syntax/Manpage.sublime-syntax.yaml
+++ b/src/test/sublime-syntax/Manpage.sublime-syntax.yaml
@@ -169,3 +169,9 @@ contexts:
     - match: \[
       scope: punctuation.section.brackets.begin.man
       push: command-line-option-or-pipe
+
+  test_clear_scopes_1:
+    - clear_scopes: 2
+
+  test_clear_scopes_2:
+    - clear_scopes: true


### PR DESCRIPTION
Hi! I'm getting an error in [cmd-help.sublime-syntax](https://github.com/victor-gp/cmd-help-sublime-syntax) even though I'm using an allowed value:

![false positive in cmd-help.sublime-syntax](https://github.com/SchemaStore/schemastore/assets/43856183/d6aa0aca-ab26-4a4f-8163-7545eeb500e3)

`clear_scopes` can be an integer or a boolean, as its description indicates.