### PR TITLE
fix: allow arbitrary paths in any permalink (#3483)

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -56,7 +56,7 @@
         "/:categories/:year/:week/:short_day/:title:output_ext",
         "/:categories/:title:output_ext"
       ],
-      "pattern": "^((/(:(year|short_year|month|i_month|short_month|long_month|day|i_day|y_day|w_year|week|w_day|short_day|long_day|hour|minute|second|title|slug|categories|slugified_categories|output_ext))+)+|date|pretty|ordinal|weekdate|none)(/?)$"
+      "pattern": "^((.*(:(year|short_year|month|i_month|short_month|long_month|day|i_day|y_day|w_year|week|w_day|short_day|long_day|hour|minute|second|title|slug|categories|slugified_categories|output_ext))+)+|date|pretty|ordinal|weekdate|none)(/?)$"
     },
     "collection-permalink": {
       "description": "The collection permalink format\nhttps://jekyllrb.com/docs/permalinks/#collections",

--- a/src/test/jekyll/_config.yaml
+++ b/src/test/jekyll/_config.yaml
@@ -64,7 +64,18 @@ timezone: null
 
 quiet: false
 verbose: false
-defaults: []
+defaults:
+  - scope:
+      path: ''          # An empty string here means all files in the project
+      type: posts
+    values:
+      layout: post
+      comments: true    # Enable comments in posts.
+      toc: true         # Display TOC column in posts.
+      # DO NOT modify the following parameter unless you are confident enough
+      # to update the code of all other post links in this project.
+      #permalink: /posts/:title/
+      permalink: /posts/:year/:month/:day/:title/
 
 liquid:
   error_mode: warn

--- a/src/test/jekyll/_config.yaml
+++ b/src/test/jekyll/_config.yaml
@@ -66,12 +66,12 @@ quiet: false
 verbose: false
 defaults:
   - scope:
-      path: ''          # An empty string here means all files in the project
+      path: '' # An empty string here means all files in the project
       type: posts
     values:
       layout: post
-      comments: true    # Enable comments in posts.
-      toc: true         # Display TOC column in posts.
+      comments: true # Enable comments in posts.
+      toc: true # Display TOC column in posts.
       # DO NOT modify the following parameter unless you are confident enough
       # to update the code of all other post links in this project.
       #permalink: /posts/:title/


### PR DESCRIPTION
Allow "global" (non-collection) permalinks to contain arbitrary prefixes, such that /posts/:year/:month/:day/:title/ is considered valid.

Fixes https://github.com/SchemaStore/schemastore/issues/3483
