### PR TITLE
Add hyperupcall to CODEOWNERs for all files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,7 @@
 #
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
-* @madskristensen
-# * @hyperupcall
+* @madskristensen @hyperupcall
 
 # Managed by Ansible DevTools Team members:
 src/schemas/json/ansible-* @ssbarnea @webknjaz


### PR DESCRIPTION
This adds myself to the CODEOWNERS file. This makes it more clear to contributors that I help maintain and am able to merge their PRs.