### PR TITLE
site: Update serving stat

### DIFF
--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -94,7 +94,7 @@
     <h3 id="sponsor">Sponsorships <span style="color:mediumvioletred">♡</span></h3>
     <p>
         <img src="/img/sponsor.png" width="160" height="192" alt="Sponsor SchemaStore.org now" class="right" />
-		Over 700 GB of JSON schema files are served each day from SchemaStore.org. It's a big effort to maintain
+		Over 1 TB of JSON Schema files are served each day from SchemaStore.org. It's a big effort to maintain
 		and keep running, and it's all done by JSON Schema loving volunteers.
 
         If your business gets value from SchemaStore.org, please consider sponsoring to keep the project alive and healthy.


### PR DESCRIPTION
Recently looked at the site again, remembering about [this comment](https://github.com/SchemaStore/schemastore/issues/3303#issuecomment-1758208822) about serving over 1TB of traffic per day