### PR TITLE
cron test for 1st and 3rd wednesday

### DIFF
--- a/src/test/github-workflow/cron-every-1st-and-3rd-wednesday.yaml
+++ b/src/test/github-workflow/cron-every-1st-and-3rd-wednesday.yaml
@@ -1,0 +1,8 @@
+name: PR review reminders
+on:
+  schedule:
+    # Every 1st and 3rd Wednesday of every month
+    - cron: '45 1 1-7,15-21 * 3'
+jobs:
+  check_run:
+    runs-on: ubuntu-latest


### PR DESCRIPTION
Failing Test case for github-workflow schema, faulty regex for cron expression

Related to https://github.com/SchemaStore/schemastore/issues/1162

Issue link - https://github.com/SchemaStore/schemastore/issues/3504