### PR TITLE
rename rtx -> mise

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3528,12 +3528,6 @@
       "url": "https://json.schemastore.org/resjson.json"
     },
     {
-      "name": "rtx",
-      "description": "rtx config, a polyglot dev tool manager",
-      "fileMatch": [".rtx.toml", ".rtx.*.toml", "**/rtx/config.toml"],
-      "url": "https://rtx.pub/schema/rtx.json"
-    },
-    {
       "name": "Ruff",
       "description": "Ruff, a fast Python linter",
       "fileMatch": ["ruff.toml", ".ruff.toml"],
@@ -4557,6 +4551,12 @@
       "description": "mirrord",
       "fileMatch": ["*.mirrord.+(toml|json|y?(a)ml)"],
       "url": "https://raw.githubusercontent.com/metalbear-co/mirrord/main/mirrord-schema.json"
+    },
+    {
+      "name": "mise",
+      "description": "mise config, a polyglot dev tool manager",
+      "fileMatch": [".mise.toml", ".mise.*.toml", "**/mise/config.toml"],
+      "url": "https://mise.jdx.dev/schema/mise.json"
     },
     {
       "name": "mta.yaml",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
This project has been renamed: https://mise.jdx.dev/rtx.html