### PR TITLE
ci: Fix labeler configuration for v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,53 +1,68 @@
 # Asp.Net files must not be updated.
 WARNING_AspNetFiles:
-  - 'src/bin/**/*'
-  - 'src/css/**/*'
-  - 'src/img/**/*'
-  - 'src/js/**/*'
-  - '**/*.sln'
-  - '**/*.cshtml'
-  - '**/*.config'
-  - '**/*.webinfo'
-  - '**/*.ico'
-  - '**/*.txt'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/bin/**/*'
+          - 'src/css/**/*'
+          - 'src/img/**/*'
+          - 'src/js/**/*'
+          - '**/*.sln'
+          - '**/*.cshtml'
+          - '**/*.config'
+          - '**/*.webinfo'
+          - '**/*.ico'
+          - '**/*.txt'
 
 # code change
-gruntfile.cjs:
-  - 'src/Gruntfile.cjs'
+gruntfile:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/Gruntfile.cjs'
 
 # schema setting change
 schema-validation.json:
-  - 'src/schema-validation.json'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/schema-validation.json'
 
 # possible code change
-GitHub_ci_folder:
-  - '.github/**/*'
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**/*'
 
 # possible code change
-makefile:
-  - 'Makefile'
-
-# possible code change
-NodeJs:
-  - 'src/package.json'
-  - 'src/package-lock.json'
+NodeJS:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**/*'
+          - 'src/package.json'
+          - 'src/package-lock.json'
 
 # possible URL change
-doc_md:
-  - '**/*.md'
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
 
 # formatting change
 editorconfig:
-  - '.editorconfig'
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.editorconfig'
 
 # lint change
 eslintrcjson:
-  - 'src/.eslintrc.json'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/.eslintrc.json'
 
 # .gitignore change
 gitignore:
-  - '.gitignore'
-  - '.gitattributes'
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.gitignore'
+          - '.gitattributes'
 # Do not add "api", "schema" and "test" directories.
 # Those are the usual commit. No need for extra attention.
 # src/api/**/*

--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -5,7 +5,7 @@ on:
   pull_request_review: { types: [submitted] }
 
 jobs:
-  build:
+  codeowners-merge:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

- Update labeler config for v5
- Remove configuration from no-longer existing files (Makefile)
- Improve name of some labels (ie. docs_md -> documentation)