### PR TITLE
Dependabot: Allow `updates.registries` to be the string `"*"`

### DIFF
--- a/src/negative_test/dependabot-2.0/registries-string-other-than-asterisk.json
+++ b/src/negative_test/dependabot-2.0/registries-string-other-than-asterisk.json
@@ -9,17 +9,9 @@
   },
   "updates": [
     {
-      "directory": "/1",
+      "directory": "/",
       "package-ecosystem": "npm",
-      "registries": ["my-custom-registry"],
-      "schedule": {
-        "interval": "daily"
-      }
-    },
-    {
-      "directory": "/2",
-      "package-ecosystem": "npm",
-      "registries": "*",
+      "registries": "not *",
       "schedule": {
         "interval": "daily"
       }

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -890,13 +890,22 @@
           "default": "auto"
         },
         "registries": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "uniqueItems": true,
-          "minItems": 1
+          "$comment": "'registries' must be either an array of strings, or the string constant '*'.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "uniqueItems": true,
+              "minItems": 1
+            },
+            {
+              "type": "string",
+              "const": "*"
+            }
+          ]
         },
         "reviewers": {
           "type": "array",


### PR DESCRIPTION
This PR resolves an oversight in the Dependabot 2.0 schema. According to [the Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#registries), the `updates.registries` key should be either an array of strings or:

> You can allow all of the defined registries to be used by setting `registries` to `"*"`

The schema now aligns with the Dependabot documentation and examples.

Fixes #3502 