### PR TITLE
ci: Do not run labeler and CODEOWNERS GitHub Actions in forks

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   codeowners-merge:
+    if: github.repository == 'SchemaStore/schemastore'
     runs-on: ubuntu-latest
-
     steps:
       - uses: 'actions/checkout@v4'
       - name: 'Run Codeowners merge check'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   triage:
+    if: github.repository == 'SchemaStore/schemastore'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5


### PR DESCRIPTION
Somehow, I have been getting notifications from the [CODEOWNERS self merge bot](https://github.com/OSS-Docs-Tools/code-owner-self-merge) from PRS https://github.com/Olympic1/schemastore/pull/9 and https://github.com/Uncodedtech/schemastore/pull/56.

I haven't been able to reproduce, but, the issue is that when a PR is made in a fork (ex. from a fork's branch to that fork's `master` branch), our workflows are ran. This is only an issue now because the code owners merge self bot `@mentions` people that are in CODEOWNERS. This fixes the YAML to account for that