### PR TITLE
Add JSON Schema for Atmos Stack Manifests to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -344,7 +344,7 @@
     },
     {
       "name": "Atmos Manifests",
-      "description": "JSON Schema for Atmos Stack Manifests. https://atmos.tools",
+      "description": "Atmos Stack Manifests. https://atmos.tools",
       "fileMatch": [
         "*.yaml",
         "*.yml"

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -343,6 +343,15 @@
       "url": "https://raw.githubusercontent.com/asyncapi/website/master/scripts/tools/tools-schema.json"
     },
     {
+      "name": "Atmos Manifests",
+      "description": "JSON Schema for Atmos Stack Manifests. https://atmos.tools",
+      "fileMatch": [
+        "*.yaml",
+        "*.yml"
+      ],
+      "url": "https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json"
+    },
+    {
       "name": "Aurora Agile Meta-Framework",
       "description": "Aurora Agile Meta-Framework",
       "fileMatch": ["*.aurora.yaml", "*.aurora.yml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -345,10 +345,7 @@
     {
       "name": "Atmos Manifests",
       "description": "Atmos Stack Manifests. https://atmos.tools",
-      "fileMatch": [
-        "*.yaml",
-        "*.yml"
-      ],
+      "fileMatch": ["*.yaml", "*.yml"],
       "url": "https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -345,7 +345,7 @@
     {
       "name": "Atmos Manifests",
       "description": "Atmos Stack Manifests. https://atmos.tools",
-      "fileMatch": ["*.yaml", "*.yml"],
+      "fileMatch": [],
       "url": "https://atmos.tools/schemas/atmos/atmos-manifest/1.0/atmos-manifest.json"
     },
     {


### PR DESCRIPTION
## what
* Add JSON Schema for Atmos Stack Manifests to the catalog

## why
* Atmos Manifest JSON Schema can be used to validate [Atmos](https://atmos.tools) stack manifests and provide auto-completion

## references
* https://atmos.tools
* https://atmos.tools/reference/schemas
* https://atmos.tools/cli/commands/validate/stacks
* https://atmos.tools/core-concepts/stacks/validation
* https://atmos.tools/core-concepts/components/validation

