### PR TITLE
Add schema for `dotnet-tools.json` manifest file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1597,6 +1597,12 @@
       "url": "https://json.schemastore.org/dotnet-releases-index.json"
     },
     {
+      "name": "dotnet-tools.json",
+      "description": ".NET tools manifest file",
+      "fileMatch": ["dotnet-tools.json"],
+      "url": "https://json.schemastore.org/dotnet-tools.json"
+    },
+    {
       "name": "dotnetcli.host.json",
       "description": ".NET CLI template host files",
       "fileMatch": ["dotnetcli.host.json"],

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -467,6 +467,11 @@
       }
     },
     {
+      "dotnet-tools.json": {
+        "unknownKeywords": ["allowTrailingCommas"]
+      }
+    },
+    {
       "drone.json": {
         "unknownKeywords": [
           "x-kubernetes-patch-strategy",

--- a/src/schemas/json/dotnet-tools.json
+++ b/src/schemas/json/dotnet-tools.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/dotnet-tools.json",
+  "allowTrailingCommas": false,
+  "type": "object",
+  "required": ["version", "isRoot", "tools"],
+  "additionalProperties": true,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "title": ".NET Tools Manifest Version",
+      "description": "Specifies the version of the local tool manifest file format."
+    },
+    "isRoot": {
+      "type": "boolean",
+      "title": "Root/Top-Most Manifest File Indicator",
+      "description": "Indicates whether this is the root manifest file. If true, dotnet will not continue to search parent directories for additional dotnet-tools.json files."
+    },
+    "tools": {
+      "type": "object",
+      "title": "Local Tools",
+      "description": "Mappings of .NET CLI tools that are available locally for the project. Each entry specifies a tool accessible by its NuGet package ID.",
+      "patternProperties": {
+        "^.*$": {
+          "type": "object",
+          "title": "Tool Configuration",
+          "description": "Represents a single .NET CLI tool with its specific settings and commands.",
+          "required": ["version", "commands"],
+          "additionalProperties": true,
+          "properties": {
+            "version": {
+              "type": ["string", "null"],
+              "title": "Tool NuGet Version",
+              "description": "Specifies the version of the NuGet package of the tool. If null, the latest version will be used."
+            },
+            "commands": {
+              "type": ["array", "null"],
+              "title": "Available Tool Commands",
+              "description": "Lists all of the available commands provided by this tool. The way to invoke a command depends on the naming format of its executable. If the command is in the format `dotnet-<toolName>`, it should be invoked using 'dotnet <toolName>'. If the command is in the format '<toolName>', it can be directly invoked using just '<toolName>'. If null, no specific commands are specified.",
+              "items": {
+                "type": ["string", "null"],
+                "title": "Tool Command",
+                "description": "A command made available by this tool which can be invoked according to the naming convention of its executable. If the command is in the format `dotnet-<toolName>`, it should be invoked using 'dotnet <toolName>'. If the command is in the format '<toolName>', it can be directly invoked using just '<toolName>'. If null, no specific commands are specified."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/dotnet-tools/dotnet-tools.json
+++ b/src/test/dotnet-tools/dotnet-tools.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "commands": ["dotnet-ef"],
+      "version": "8.0.1"
+    }
+  }
+}

--- a/src/test/dotnet-tools/dotnet-tools.json
+++ b/src/test/dotnet-tools/dotnet-tools.json
@@ -1,10 +1,10 @@
 {
-  "version": 1,
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
       "commands": ["dotnet-ef"],
       "version": "8.0.1"
     }
-  }
+  },
+  "version": 1
 }


### PR DESCRIPTION
Adds a schema file for the `dotnet-tools.json` manifest file which is created by the `dotnet tool` command as described [here in the docs](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-local-tool).

As far as I can tell, there isn't an existing schema file for the `dotnet-tools.json` manifest file, so this schema was hand written by me. Since the doc's don't mention any other properties, I  am assuming there aren't any.

Thanks!