### PR TITLE
Add the extra_checks option to mypy's schema

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -322,6 +322,11 @@
       "default": false,
       "type": "boolean"
     },
+    "extra_checks": {
+      "description": "Enable additional checks that are technically correct but impractical.",
+      "default": false,
+      "type": "boolean"
+    },
     "strict_equality": {
       "description": "",
       "default": false,


### PR DESCRIPTION
This option has existed since `mypy` [1.5.0](https://mypy-lang.blogspot.com/2023/08/mypy-15-released.html) and subsumes the now-deprecated `strict_concatenate` option, although that option still exists as of `mypy` 1.8.0.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
