### PR TITLE
ci: Do not run codeowners merge workflow on draft PRs

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   codeowners-merge:
-    if: github.repository == 'SchemaStore/schemastore'
+    if: "github.repository == 'SchemaStore/schemastore' && github.event.pull_request.draft == false"
     runs-on: ubuntu-latest
     steps:
       - uses: 'actions/checkout@v4'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

title. only ping when PR is actually ready.
