### PR TITLE
Use `code-owner-self-merge` fork that supports optional pinging

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -11,8 +11,9 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
       - name: 'Run Codeowners merge check'
-        uses: 'OSS-Docs-Tools/code-owner-self-merge@1.6.5'
+        uses: 'fox-forks/code-owner-self-merge@8b5015c0e9a2dc8401cb3cde1bce517b044a99af'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           merge_method: 'squash'
+          ownerNoPings: '["@hyperupcall"]'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

The upstream `OSS-Docs-Tools/code-owner-self-merge` is useful, but I thought it was missing a feature in which it would not ping certain CODEOWNERS. This is useful when a CODEOWNER watches the repositories (for pull requests) and would recieve a notification anyways, on a PR. This is helpful when prioritizing PRs in the notification page: it will show as a notification of type "review quested" instead of "mentioned".

When `ownerNoPings` is configured, it looks like this:

![image](https://github.com/SchemaStore/schemastore/assets/24364012/053bc46f-939e-49b7-951f-9be12d832df1)
