### PR TITLE
Remove `version` from required cargo package fields

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -278,9 +278,9 @@
     },
     "Package": {
       "title": "Package",
-      "description": "The only fields required by Cargo are [`name`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field) and\n[`version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field). If publishing to a registry, the registry may\nrequire additional fields. See the notes below and [the publishing chapter](https://doc.rust-lang.org/cargo/reference/publishing.html) for requirements for publishing to [crates.io](https://crates.io/).",
+      "description": "The only field required by Cargo is [`name`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field).\n If publishing to a registry, the registry may\nrequire additional fields. See the notes below and [the publishing chapter](https://doc.rust-lang.org/cargo/reference/publishing.html) for requirements for publishing to [crates.io](https://crates.io/).",
       "type": "object",
-      "required": ["name", "version"],
+      "required": ["name"],
       "properties": {
         "authors": {
           "anyOf": [


### PR DESCRIPTION
Since Rust 1.75.0 the `version` field is optional. It defaults to `0.0.0` now. But `schemastore` still lists it as a required field, giving me errors in my IDE schema evaluation. This PR aims to fix that.

https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28

This fixes https://github.com/tamasfe/taplo/issues/530