### PR TITLE
Dependabot: Add "Europe/Kyiv" as a valid timezone

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -451,6 +451,7 @@
         "Europe/Kaliningrad",
         "Europe/Kiev",
         "Europe/Kirov",
+        "Europe/Kyiv",
         "Europe/Lisbon",
         "Europe/Ljubljana",
         "Europe/London",


### PR DESCRIPTION
This adds "Europe/Kyiv" as a valid timezone to the Dependabot schema.

Closes #3508

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
