### PR TITLE
Update schema appsettings.json - Allow null as MethodCallReferenceItem in Serilog

### DIFF
--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -884,7 +884,7 @@
           "required": ["Name"]
         },
         "MethodCallReferenceItem": {
-          "type": ["string", "object"],
+          "type": ["string", "object", "null"],
           "oneOf": [
             {
               "$ref": "#/definitions/Serilog/definitions/CSharpMethodName"


### PR DESCRIPTION
Allow "null" as MethodCallReferenceItem in Serilog to enable clearing previously set values in overrides.

## The problem

Take the following setup

```jsonc
// appsettings.json
{
  "Serilog": {
    "WriteTo": [
      "SomeLoggerSink",
      "SomeOtherSink"
    ]
  }
}

// appsettings.Development.json
{
  "Serilog": {
    "WriteTo": [
      "Console"
    ]
  }
}
```

I have 2 entries in WriteTo in appsettings.json, but only one in appsettings.Development.json. Due to the way appsettings.json files get merged, I'm only overriding `WriteTo:0`, whereas `WriteTo:1` remains unchanged at "SomeOtherSink", since it's inheriting the value.

In my case, this is undesired, so I want to override the second value with something that prevents it from being populated.

## The solution, allow `null`

There are applicable nullchecks in Serilog allowing the MethodCallReferenceItem to be null, so my suggestion is to allow it to be null in the schema, enabling clearing previously set values by overriding them with `null`

```jsonc
// appsettings.json
{
  "Serilog": {
    "WriteTo": [
      "SomeLoggerSink",
      "SomeOtherSink"
    ]
  }
}

// appsettings.Development.json
{
  "Serilog": {
    "WriteTo": [
      "Console",
      null
    ]
  }
}
```