### PR TITLE
Add "x-intellij-html-description" fields for partial-pyright.json

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -836,7 +836,11 @@
           "poetry.json",
           "ruff.json"
         ],
-        "unknownKeywords": ["x-taplo", "x-taplo-info"],
+        "unknownKeywords": [
+          "x-taplo",
+          "x-taplo-info",
+          "x-intellij-html-description"
+        ],
         "unknownFormat": [
           "uint16",
           "uint8",

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -1030,6 +1030,11 @@
       }
     },
     {
+      "partial-pyright.json": {
+        "unknownKeywords": ["x-intellij-html-description"]
+      }
+    },
+    {
       "rudder-techniques.json": {
         "unknownFormat": ["markdown"],
         "unknownKeywords": ["defaultSnippets", "markdownDescription"]

--- a/src/schemas/json/partial-pyright.json
+++ b/src/schemas/json/partial-pyright.json
@@ -28,7 +28,8 @@
         "type": "string",
         "description": "File or directory to include in type analysis",
         "pattern": "^(.*)$"
-      }
+      },
+      "x-intellij-html-description": "Paths of directories or files that should be included. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no include paths are specified, the root path for the workspace is assumed."
     },
     "exclude": {
       "$id": "#/properties/exclude",
@@ -40,7 +41,8 @@
         "type": "string",
         "title": "File or directory to exclude from type analysis",
         "pattern": "^(.*)$"
-      }
+      },
+      "x-intellij-html-description": "Paths of directories or files that should not be included. These override the includes directories, allowing specific subdirectories to be ignored. Note that files in the exclude paths may still be included in the analysis if they are referenced (imported) by source files that are not excluded. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no exclude paths are specified, Pyright automatically excludes the following: <code>**/node_modules</code>, <code>**/__pycache__</code>, <code>**/.*</code> and any virtual environment directories."
     },
     "ignore": {
       "$id": "#/properties/ignore",
@@ -52,7 +54,8 @@
         "type": "string",
         "title": "File or directory where diagnostics should be suppressed",
         "pattern": "^(.*)$"
-      }
+      },
+      "x-intellij-html-description": "Paths of directories or files whose diagnostic output (errors and warnings) should be suppressed even if they are an included file or within the transitive closure of an included file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character)."
     },
     "strict": {
       "$id": "#/properties/strict",
@@ -64,7 +67,8 @@
         "type": "string",
         "title": "File or directory that should use \"strict\" type checking rules",
         "pattern": "^(.*)$"
-      }
+      },
+      "x-intellij-html-description": "Paths of directories or files that should use &quot;strict&quot; analysis if they are included. This is the same as manually adding a <code># pyright: strict</code> comment. In strict mode, most type-checking rules are enabled. Refer to this table for details about which rules are enabled in strict mode. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character)."
     },
     "defineConstant": {
       "$id": "#/properties/defineConstant",
@@ -75,7 +79,8 @@
       "additionalProperties": {
         "type": ["string", "boolean"],
         "title": "Value of constant (boolean or string)"
-      }
+      },
+      "x-intellij-html-description": "Set of identifiers that should be assumed to contain a constant value wherever used within this program. For example, <code>{ &quot;DEBUG&quot;: true }</code> indicates that pyright should assume that the identifier <code>DEBUG</code> will always be equal to <code>True</code>. If this identifier is used within a conditional expression (such as <code>if not DEBUG:</code>) pyright will use the indicated value to determine whether the guarded block is reachable or not. Member expressions that reference one of these constants (e.g. <code>my_module.DEBUG</code>) are also supported."
     },
     "typeCheckingMode": {
       "$id": "#/properties/typeCheckingMode",
@@ -83,7 +88,8 @@
       "enum": ["off", "basic", "standard", "strict"],
       "title": "Specifies the default rule set to use for type checking",
       "description": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to `off`, all type-checking rules are disabled, but Python syntax and semantic errors are still reported.",
-      "default": "standard"
+      "default": "standard",
+      "x-intellij-html-description": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to <code>off</code>, all type-checking rules are disabled, but Python syntax and semantic errors are still reported."
     },
     "useLibraryCodeForTypes": {
       "$id": "#/properties/useLibraryCodeForTypes",
@@ -96,9 +102,10 @@
       "$id": "#/properties/typeshedPath",
       "type": "string",
       "title": "Path to directory containing `typeshed` type stub files",
-      "description": "Path to a directory that contains `typeshed` type stub files. Pyright ships with a bundled copy of `typeshed` type stubs. If you want to use a different version of `typeshed` stubs, you can clone the `typeshed` GitHub repo (https://github.com/python/typeshed) to a local directory and reference the location with this path. This option is useful if you’re actively contributing updates to `typeshed`.",
+      "description": "Path to a directory that contains `typeshed` type stub files. Pyright ships with a bundled copy of `typeshed` type stubs. If you want to use a different version of `typeshed` stubs, you can clone the `typeshed` GitHub repo (https://github.com/python/typeshed) to a local directory and reference the location with this path. This option is useful if you're actively contributing updates to `typeshed`.",
       "default": "",
-      "pattern": "^(.*)$"
+      "pattern": "^(.*)$",
+      "x-intellij-html-description": "Path to a directory that contains <code>typeshed</code> type stub files. Pyright ships with a bundled copy of <code>typeshed</code> type stubs. If you want to use a different version of <code>typeshed</code> stubs, you can clone <a href=\"https://github.com/python/typeshed\">the <code>typeshed</code> GitHub repo</a> to a local directory and reference the location with this path. This option is useful if you&#39;re actively contributing updates to <code>typeshed</code>."
     },
     "stubPath": {
       "$id": "#/properties/stubPath",
@@ -108,35 +115,40 @@
       "description": "Path to a directory that contains custom type stubs. Each package's type stub file(s) are expected to be in its own subdirectory. The default value of this setting is `./typings` (`typingsPath` is now deprecated).",
       "default": "",
       "examples": ["src/typestubs"],
-      "pattern": "^(.*)$"
+      "pattern": "^(.*)$",
+      "x-intellij-html-description": "Path to a directory that contains custom type stubs. Each package&#39;s type stub file(s) are expected to be in its own subdirectory. The default value of this setting is <code>./typings</code> (<code>typingsPath</code> is now deprecated)."
     },
     "disableBytesTypePromotions": {
       "$id": "#/properties/disableBytesTypePromotions",
       "type": "boolean",
       "title": "Do not treat `bytearray` and `memoryview` as implicit subtypes of `bytes`",
       "description": "Disables legacy behavior where `bytearray` and `memoryview` are considered subtypes of bytes. PEP 688 deprecates this behavior, but this switch is provided to restore the older behavior.",
-      "default": false
+      "default": false,
+      "x-intellij-html-description": "Disables legacy behavior where <code>bytearray</code> and <code>memoryview</code> are considered subtypes of bytes. <a href=\"https://peps.python.org/pep-0688/\">PEP 688</a> deprecates this behavior, but this switch is provided to restore the older behavior."
     },
     "strictListInference": {
       "$id": "#/properties/strictListInference",
       "type": "boolean",
       "title": "Infer strict types for list expressions",
       "description": "When inferring the type of a list, use strict type assumptions. For example, the expression `[1, 'a', 3.4]` could be inferred to be of type `list[Any]` or `list[int | str | float]`. If this setting is `true`, it will use the latter (stricter) type.",
-      "default": false
+      "default": false,
+      "x-intellij-html-description": "When inferring the type of a list, use strict type assumptions. For example, the expression <code>[1, &#39;a&#39;, 3.4]</code> could be inferred to be of type <code>list[Any]</code> or <code>list[int | str | float]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type."
     },
     "strictSetInference": {
       "$id": "#/properties/strictSetInference",
       "type": "boolean",
       "title": "Infer strict types for set expressions",
       "description": "When inferring the type of a set, use strict type assumptions. For example, the expression `{1, 'a', 3.4}` could be inferred to be of type `set[Any]` or `set[int | str | float]`. If this setting is `true`, it will use the latter (stricter) type.",
-      "default": false
+      "default": false,
+      "x-intellij-html-description": "When inferring the type of a set, use strict type assumptions. For example, the expression <code>{1, &#39;a&#39;, 3.4}</code> could be inferred to be of type <code>set[Any]</code> or <code>set[int | str | float]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type."
     },
     "strictDictionaryInference": {
       "$id": "#/properties/strictDictionaryInference",
       "type": "boolean",
       "title": "Infer strict types for dictionary expressions",
-      "description": "When inferring the type of a dictionary’s keys and values, use strict type assumptions. For example, the expression `{'a': 1, 'b': 'a'}` could be inferred to be of type `dict[str, Any]` or `dict[str, int | str]`. If this setting is `true`, it will use the latter (stricter) type.",
-      "default": false
+      "description": "When inferring the type of a dictionary's keys and values, use strict type assumptions. For example, the expression `{'a': 1, 'b': 'a'}` could be inferred to be of type `dict[str, Any]` or `dict[str, int | str]`. If this setting is `true`, it will use the latter (stricter) type.",
+      "default": false,
+      "x-intellij-html-description": "When inferring the type of a dictionary&#39;s keys and values, use strict type assumptions. For example, the expression <code>{&#39;a&#39;: 1, &#39;b&#39;: &#39;a&#39;}</code> could be inferred to be of type <code>dict[str, Any]</code> or <code>dict[str, int | str]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type."
     },
     "analyzeUnannotatedFunctions": {
       "$id": "#/properties/analyzeUnannotatedFunctions",
@@ -150,7 +162,8 @@
       "type": "boolean",
       "title": "Allow implicit Optional when default parameter value is None",
       "description": "PEP 484 indicates that when a function parameter is assigned a default value of `None`, its type should implicitly be `Optional` even if the explicit type is not. When enabled, this rule requires that parameter type annotations use `Optional` explicitly in this case.",
-      "default": true
+      "default": true,
+      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0484/\">PEP 484</a> indicates that when a function parameter is assigned a default value of <code>None</code>, its type should implicitly be <code>Optional</code> even if the explicit type is not. When enabled, this rule requires that parameter type annotations use <code>Optional</code> explicitly in this case."
     },
     "enableExperimentalFeatures": {
       "$id": "#/properties/enableExperimentalFeatures",
@@ -164,14 +177,16 @@
       "type": "boolean",
       "title": "Allow `# type: ignore` comments",
       "description": "PEP 484 defines support for `# type: ignore` comments. This switch enables or disables support for these comments. This does not affect `# pyright: ignore` comments.",
-      "default": true
+      "default": true,
+      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0484/\">PEP 484</a> defines support for <code># type: ignore</code> comments. This switch enables or disables support for these comments. This does not affect <code># pyright: ignore</code> comments."
     },
     "deprecateTypingAliases": {
       "$id": "#/properties/deprecateTypingAliases",
       "type": "boolean",
       "title": "Treat typing-specific aliases to standard types as deprecated",
       "description": "PEP 585 indicates that aliases to types in standard collections that were introduced solely to support generics are deprecated as of Python 3.9. This switch controls whether these are treated as deprecated. This applies only when `pythonVersion` is 3.9 or newer. The default value for this setting is `false` but may be switched to `true` in the future.",
-      "default": false
+      "default": false,
+      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0585/\">PEP 585</a> indicates that aliases to types in standard collections that were introduced solely to support generics are deprecated as of Python 3.9. This switch controls whether these are treated as deprecated. This applies only when <code>pythonVersion</code> is 3.9 or newer. The default value for this setting is <code>false</code> but may be switched to <code>true</code> in the future."
     },
     "reportGeneralTypeIssues": {
       "$id": "#/properties/reportGeneralTypeIssues",
@@ -269,49 +284,56 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to subscript (index) a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to subscript (index) a variable with an `Optional` type.",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to subscript (index) a variable with an <code>Optional</code> type."
     },
     "reportOptionalMemberAccess": {
       "$id": "#/properties/reportOptionalMemberAccess",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to access a member of a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to access a member of a variable with an `Optional` type.",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to access a member of a variable with an <code>Optional</code> type."
     },
     "reportOptionalCall": {
       "$id": "#/properties/reportOptionalCall",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to call a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to call a variable with an `Optional` type.",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to call a variable with an <code>Optional</code> type."
     },
     "reportOptionalIterable": {
       "$id": "#/properties/reportOptionalIterable",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as an iterable value",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as an iterable value (e.g. within a `for` statement).",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as an iterable value (e.g. within a <code>for</code> statement)."
     },
     "reportOptionalContextManager": {
       "$id": "#/properties/reportOptionalContextManager",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as a parameter to a `with` statement",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as a context manager (as a parameter to a `with` statement).",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as a context manager (as a parameter to a <code>with</code> statement)."
     },
     "reportOptionalOperand": {
       "$id": "#/properties/reportOptionalOperand",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as an operand for a binary or unary operator",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as an operand to a unary operator (like `~` or `not`) or the left-hand operator of a binary operator (like `*`, `==`, `or`).",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as an operand to a unary operator (like <code>~</code> or <code>not</code>) or the left-hand operator of a binary operator (like <code>*</code>, <code>==</code>, <code>or</code>)."
     },
     "reportTypedDictNotRequiredAccess": {
       "$id": "#/properties/reportTypedDictNotRequiredAccess",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to access a non-required key in a `TypedDict` without a check for its presence",
       "description": "Generate or suppress diagnostics for an attempt to access a non-required field within a `TypedDict` without first checking whether it is present.",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to access a non-required field within a <code>TypedDict</code> without first checking whether it is present."
     },
     "reportUntypedFunctionDecorator": {
       "$id": "#/properties/reportUntypedFunctionDecorator",
@@ -339,14 +361,16 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of a named tuple definition that does not contain type information",
       "description": "Generate or suppress diagnostics when `namedtuple` is used rather than `NamedTuple`. The former contains no type information, whereas the latter does.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics when <code>namedtuple</code> is used rather than <code>NamedTuple</code>. The former contains no type information, whereas the latter does."
     },
     "reportPrivateUsage": {
       "$id": "#/properties/reportPrivateUsage",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of private variables and functions used outside of the owning class or module and usage of protected members outside of subclasses",
       "description": "Generate or suppress diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore (`_`) and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore (<code>_</code>) and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module."
     },
     "reportTypeCommentUsage": {
       "$id": "#/properties/reportTypeCommentUsage",
@@ -360,7 +384,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of improper usage of symbol imported from a `py.typed` module that is not re-exported from that module",
       "description": "Generate or suppress diagnostics for use of a symbol from a `py.typed` module that is not meant to be exported from that module.",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for use of a symbol from a <code>py.typed</code> module that is not meant to be exported from that module."
     },
     "reportConstantRedefinition": {
       "$id": "#/properties/reportConstantRedefinition",
@@ -395,7 +420,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `__init__` and `__new__` methods whose signatures are inconsistent",
       "description": "Generate or suppress diagnostics when an `__init__` method signature is inconsistent with a `__new__` signature.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics when an <code>__init__</code> method signature is inconsistent with a <code>__new__</code> signature."
     },
     "reportOverlappingOverload": {
       "$id": "#/properties/reportOverlappingOverload",
@@ -409,14 +435,16 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of missing call to parent class for inherited `__init__` methods",
       "description": "Generate or suppress diagnostics for `__init__`, `__init_subclass__`, `__enter__` and `__exit__` methods in a subclass that fail to call through to the same-named method on a base class.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>__init__</code>, <code>__init_subclass__</code>, <code>__enter__</code> and <code>__exit__</code> methods in a subclass that fail to call through to the same-named method on a base class."
     },
     "reportUninitializedInstanceVariable": {
       "$id": "#/properties/reportUninitializedInstanceVariable",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of instance variables that are not initialized in the constructor",
       "description": "Generate or suppress diagnostics for instance variables within a class that are not initialized or declared within the class body or the `__init__` method.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for instance variables within a class that are not initialized or declared within the class body or the <code>__init__</code> method."
     },
     "reportInvalidStringEscapeSequence": {
       "$id": "#/properties/reportInvalidStringEscapeSequence",
@@ -465,7 +493,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting input parameters that are missing a type annotation",
       "description": "Generate or suppress diagnostics for input parameters for functions or methods that are missing a type annotation. The `self` and `cls` parameters used within methods are exempt from this check.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for input parameters for functions or methods that are missing a type annotation. The <code>self</code> and <code>cls</code> parameters used within methods are exempt from this check."
     },
     "reportMissingTypeArgument": {
       "$id": "#/properties/reportMissingTypeArgument",
@@ -479,7 +508,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting improper use of type variables within function signatures",
       "description": "Generate or suppress diagnostics when a `TypeVar` is used inappropriately (e.g. if a `TypeVar` appears only once) within a generic function signature.",
-      "default": "warning"
+      "default": "warning",
+      "x-intellij-html-description": "Generate or suppress diagnostics when a <code>TypeVar</code> is used inappropriately (e.g. if a <code>TypeVar</code> appears only once) within a generic function signature."
     },
     "reportCallInDefaultInitializer": {
       "$id": "#/properties/reportCallInDefaultInitializer",
@@ -493,42 +523,48 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting calls to `isinstance` or `issubclass` where the result is statically determined to be always true",
       "description": "Generate or suppress diagnostics for `isinstance` or `issubclass` calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>isinstance</code> or <code>issubclass</code> calls where the result is statically determined to be always true. Such calls are often indicative of a programming error."
     },
     "reportUnnecessaryCast": {
       "$id": "#/properties/reportUnnecessaryCast",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting calls to `cast` that are unnecessary",
       "description": "Generate or suppress diagnostics for `cast` calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>cast</code> calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error."
     },
     "reportUnnecessaryComparison": {
       "$id": "#/properties/reportUnnecessaryComparison",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting the use of `==` or `!=` comparisons that are unnecessary",
       "description": "Generate or suppress diagnostics for `==` or `!=` comparisons or other conditional expressions that are statically determined to always evaluate to `False` or `True`. Such comparisons are sometimes indicative of a programming error.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>==</code> or <code>!=</code> comparisons or other conditional expressions that are statically determined to always evaluate to <code>False</code> or <code>True</code>. Such comparisons are sometimes indicative of a programming error."
     },
     "reportUnnecessaryContains": {
       "$id": "#/properties/reportUnnecessaryContains",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting the use of `in` operations that are unnecessary",
       "description": "Generate or suppress diagnostics for `in` operations that are statically determined to always evaluate to `False` or `True`. Such operations are sometimes indicative of a programming error.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>in</code> operations that are statically determined to always evaluate to <code>False</code> or <code>True</code>. Such operations are sometimes indicative of a programming error."
     },
     "reportAssertAlwaysTrue": {
       "$id": "#/properties/reportAssertAlwaysTrue",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting `assert` expressions that will always evaluate to `True`",
       "description": "Generate or suppress diagnostics for `assert` statement that will provably always assert. This can be indicative of a programming error.",
-      "default": "warning"
+      "default": "warning",
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>assert</code> statement that will provably always assert. This can be indicative of a programming error."
     },
     "reportSelfClsParameterName": {
       "$id": "#/properties/reportSelfClsParameterName",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting missing or misnamed `self` parameters",
       "description": "Generate or suppress diagnostics for a missing or misnamed `self` parameter in instance methods and `cls` parameter in class methods. Instance methods in metaclasses (classes that derive from `type`) are allowed to use `cls` for instance methods.",
-      "default": "warning"
+      "default": "warning",
+      "x-intellij-html-description": "Generate or suppress diagnostics for a missing or misnamed <code>self</code> parameter in instance methods and <code>cls</code> parameter in class methods. Instance methods in metaclasses (classes that derive from <code>type</code>) are allowed to use <code>cls</code> for instance methods."
     },
     "reportImplicitStringConcatenation": {
       "$id": "#/properties/reportImplicitStringConcatenation",
@@ -563,28 +599,32 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of incomplete type stubs that declare a module-level `__getattr__` function",
       "description": "Generate or suppress diagnostics for a module-level `__getattr__` call in a type stub file, indicating that it is incomplete.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for a module-level <code>__getattr__</code> call in a type stub file, indicating that it is incomplete."
     },
     "reportUnsupportedDunderAll": {
       "$id": "#/properties/reportUnsupportedDunderAll",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of unsupported operations performed on `__all__`",
       "description": "Generate or suppress diagnostics for statements that define or manipulate `__all__` in a way that is not allowed by a static type checker, thus rendering the contents of `__all__` to be unknown or incorrect. Also reports names within the `__all__` list that are not present in the module namespace.",
-      "default": "warning"
+      "default": "warning",
+      "x-intellij-html-description": "Generate or suppress diagnostics for statements that define or manipulate <code>__all__</code> in a way that is not allowed by a static type checker, thus rendering the contents of <code>__all__</code> to be unknown or incorrect. Also reports names within the <code>__all__</code> list that are not present in the module namespace."
     },
     "reportUnusedCallResult": {
       "$id": "#/properties/reportUnusedCallResult",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of call expressions whose results are not consumed",
       "description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is not `None`.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is not <code>None</code>."
     },
     "reportUnusedCoroutine": {
       "$id": "#/properties/reportUnusedCoroutine",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of call expressions that returns `Coroutine` whose results are not consumed",
       "description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is a `Coroutine`. This identifies a common error where an `await` keyword is mistakenly omitted.",
-      "default": "error"
+      "default": "error",
+      "x-intellij-html-description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is a <code>Coroutine</code>. This identifies a common error where an <code>await</code> keyword is mistakenly omitted."
     },
     "reportUnusedExpression": {
       "$id": "#/properties/reportUnusedExpression",
@@ -598,14 +638,16 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `# type: ignore` comments that have no effect",
       "description": "Generate or suppress diagnostics for a `# type: ignore` or `# pyright: ignore` comment that would have no effect if removed.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for a <code># type: ignore</code> or <code># pyright: ignore</code> comment that would have no effect if removed."
     },
     "reportMatchNotExhaustive": {
       "$id": "#/properties/reportMatchNotExhaustive",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `match` statements that do not exhaustively match all possible values",
       "description": "Generate or suppress diagnostics for a `match` statement that does not provide cases that exhaustively match against all potential types of the target expression.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for a <code>match</code> statement that does not provide cases that exhaustively match against all potential types of the target expression."
     },
     "reportShadowedImports": {
       "$id": "#/properties/reportShadowedImports",
@@ -619,7 +661,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting overridden methods that are missing an `@override` decorator",
       "description": "Generate or suppress diagnostics for overridden methods in a class that are missing an explicit `@override` decorator.",
-      "default": "none"
+      "default": "none",
+      "x-intellij-html-description": "Generate or suppress diagnostics for overridden methods in a class that are missing an explicit <code>@override</code> decorator."
     },
     "extraPaths": {
       "$id": "#/properties/extraPaths",
@@ -641,7 +684,8 @@
       "description": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. `3.0` or `3.6`). If a version is provided, pyright will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version. If no version is specified, pyright will use the version of the current python interpreter, if one is present.",
       "default": "",
       "examples": ["3.7"],
-      "pattern": "^3\\.[0-9]+$"
+      "pattern": "^3\\.[0-9]+$",
+      "x-intellij-html-description": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format <code>M.m</code> where <code>M</code> is the major version and <code>m</code> is the minor (e.g. <code>3.0</code> or <code>3.6</code>). If a version is provided, pyright will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version. If no version is specified, pyright will use the version of the current python interpreter, if one is present."
     },
     "pythonPlatform": {
       "$id": "#/properties/pythonPlatform",
@@ -650,15 +694,17 @@
       "description": "Specifies the target platform that will be used to execute the source code. Should be one of `Windows`, `Darwin`, `Linux`, or `All`. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
       "default": "",
       "examples": ["Linux"],
-      "pattern": "^(Linux|Windows|Darwin|All)$"
+      "pattern": "^(Linux|Windows|Darwin|All)$",
+      "x-intellij-html-description": "Specifies the target platform that will be used to execute the source code. Should be one of <code>Windows</code>, <code>Darwin</code>, <code>Linux</code>, or <code>All</code>. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform."
     },
     "venvPath": {
       "$id": "#/properties/venvPath",
       "type": "string",
       "title": "Path to directory containing a folder of virtual environments",
-      "description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a `venv` setting, pyright will search for imports in the virtual environment’s site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
+      "description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a `venv` setting, pyright will search for imports in the virtual environment's site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
       "default": "",
-      "pattern": "^(.*)$"
+      "pattern": "^(.*)$",
+      "x-intellij-html-description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a <code>venv</code> setting, pyright will search for imports in the virtual environment&#39;s site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting."
     },
     "venv": {
       "$id": "#/properties/venv",
@@ -667,7 +713,8 @@
       "description": "Used in conjunction with the `venvPath`, specifies the virtual environment to use.",
       "default": "",
       "examples": ["python37"],
-      "pattern": "^(.*)$"
+      "pattern": "^(.*)$",
+      "x-intellij-html-description": "Used in conjunction with the <code>venvPath</code>, specifies the virtual environment to use."
     },
     "verboseOutput": {
       "$id": "#/properties/verboseOutput",
@@ -699,14 +746,15 @@
             "$id": "#/properties/executionEnvironments/items/properties/extraPaths",
             "type": "array",
             "title": "Additional import search resolution paths",
-            "description": "Additional search paths (in addition to the root path) that will be used when searching for modules imported by files within this execution environment. If specified, this overrides the default `extraPaths` setting when resolving imports for files within this execution environment. Note that each file’s execution environment mapping is independent, so if file A is in one execution environment and imports a second file B within a second execution environment, any imports from B will use the `extraPaths` in the second execution environment.",
+            "description": "Additional search paths (in addition to the root path) that will be used when searching for modules imported by files within this execution environment. If specified, this overrides the default `extraPaths` setting when resolving imports for files within this execution environment. Note that each file's execution environment mapping is independent, so if file A is in one execution environment and imports a second file B within a second execution environment, any imports from B will use the `extraPaths` in the second execution environment.",
             "items": {
               "$id": "#/properties/executionEnvironments/items/properties/extraPaths/items",
               "type": "string",
               "title": "Additional import search resolution path",
               "default": "",
               "pattern": "^(.*)$"
-            }
+            },
+            "x-intellij-html-description": "Additional search paths (in addition to the root path) that will be used when searching for modules imported by files within this execution environment. If specified, this overrides the default <code>extraPaths</code> setting when resolving imports for files within this execution environment. Note that each file&#39;s execution environment mapping is independent, so if file A is in one execution environment and imports a second file B within a second execution environment, any imports from B will use the <code>extraPaths</code> in the second execution environment."
           },
           "pythonVersion": {
             "$id": "#/properties/executionEnvironments/items/properties/pythonVersion",
@@ -715,7 +763,8 @@
             "description": "The version of Python used for this execution environment. If not specified, the global `pythonVersion` setting is used instead.",
             "default": "",
             "examples": ["3.7"],
-            "pattern": "^3\\.[0-9]+$"
+            "pattern": "^3\\.[0-9]+$",
+            "x-intellij-html-description": "The version of Python used for this execution environment. If not specified, the global <code>pythonVersion</code> setting is used instead."
           },
           "pythonPlatform": {
             "$id": "#/properties/executionEnvironments/items/properties/pythonPlatform",
@@ -724,7 +773,8 @@
             "description": "Specifies the target platform that will be used for this execution environment. If not specified, the global `pythonPlatform` setting is used instead.",
             "default": "",
             "examples": ["Linux"],
-            "pattern": "^(Linux|Windows|Darwin|All)$"
+            "pattern": "^(Linux|Windows|Darwin|All)$",
+            "x-intellij-html-description": "Specifies the target platform that will be used for this execution environment. If not specified, the global <code>pythonPlatform</code> setting is used instead."
           }
         }
       }


### PR DESCRIPTION
This [helps](https://www.jetbrains.com/help/pycharm/json.html#ws_json_show_doc_in_html) PyCharm render descriptions in rich format. Mostly [automatically generated](https://gist.github.com/InSyncWithFoo/76daad64f08114c48f8476067bebab43) from existing `description`s.