### PR TITLE
Add another guideline for creating `partial-` "subschemas"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,5 +390,7 @@ A subschema should be extracted to its own file based on the following rules:
   - Same with [Prettier](https://prettier.io). It reads from `.prettierrc.json` (among other files) and `package.json`'s `prettier` key.
 - If the schema cannot be its own file, then extracting the subschema may be an improvement
   - For example, [Poetry](https://python-poetry.org) reads configuration _only_ from `pyproject.toml`'s `tool.poetry` key. Because the Poetry subschema is relatively complex and a large project, it has been extracted to its own file, `partial-poetry.json`.
+- If the schema must exist locally to workaround issue #2731, then the subschema should be extracted
+  - In a top-level `$comment`, you must add the date at which you copied the original. See #3526 for an example
 
 Use your best judgement; if the project or schema is small, then the drawbacks of extracting the subschema to its own file likely outweigh the benefits.


### PR DESCRIPTION
In some places, a subschema cannot be added because it is a remote schema. See https://github.com/SchemaStore/schemastore/issues/2731 for details. In nearly all cases, such a schema would be helpful for autocomplete, even if it is a bit oudated. (If a schema author does not want the oudated schema to fail validation because the schema was out of date, they can use `"oneOf"` and add an empty object to the set.) The `partial-` convention is a good way to workaround the issue. This adds guidance for how to do so.