### PR TITLE
Add markdownDescription and x-intellij-html-description to partial-mypy

### DIFF
--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -1039,12 +1039,18 @@
     },
     {
       "partial-mypy.json": {
-        "unknownKeywords": ["markdownDescription", "x-intellij-html-description"]
+        "unknownKeywords": [
+          "markdownDescription",
+          "x-intellij-html-description"
+        ]
       }
     },
     {
       "partial-pyright.json": {
-        "unknownKeywords": ["markdownDescription", "x-intellij-html-description"]
+        "unknownKeywords": [
+          "markdownDescription",
+          "x-intellij-html-description"
+        ]
       }
     },
     {

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -840,6 +840,7 @@
           "ruff.json"
         ],
         "unknownKeywords": [
+          "markdownDescription",
           "x-taplo",
           "x-taplo-info",
           "x-intellij-html-description"
@@ -1037,8 +1038,13 @@
       }
     },
     {
+      "partial-mypy.json": {
+        "unknownKeywords": ["markdownDescription", "x-intellij-html-description"]
+      }
+    },
+    {
       "partial-pyright.json": {
-        "unknownKeywords": ["x-intellij-html-description"]
+        "unknownKeywords": ["markdownDescription", "x-intellij-html-description"]
       }
     },
     {

--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -1,11 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/partial-mypy.json",
+  "$comment": "The descriptions are derived from the documentation (https://mypy.readthedocs.io/en/stable/config_file.html), which is licensed under MIT.",
   "additionalProperties": false,
   "type": "object",
   "properties": {
     "mypy_path": {
-      "description": "Specifies the paths to use, after trying the paths from ``MYPYPATH`` environment variable.  Useful if you'd like to keep stubs in your repo, along with the config file. Multiple paths are always separated with a ``:`` or ``,`` regardless of the platform. User home directory and environment variables will be expanded.",
+      "description": "Specifies the paths to use, after trying the paths from `MYPYPATH` environment variable. Useful if you'd like to keep stubs in your repo, along with the config file. Multiple paths are always separated with a `:` or `,` regardless of the platform. User home directory and environment variables will be expanded.",
+      "x-intellij-html-description": "Specifies the paths to use, after trying the paths from <code>MYPYPATH</code> environment variable. Useful if you&#39;d like to keep stubs in your repo, along with the config file. Multiple paths are always separated with a <code>:</code> or <code>,</code> regardless of the platform. User home directory and environment variables will be expanded.",
       "oneOf": [
         {
           "type": "string"
@@ -19,7 +21,9 @@
       ]
     },
     "files": {
-      "description": "A comma-separated list of paths which should be checked by mypy if none are given on the command line. Supports recursive file globbing using :py:mod:`glob`, where ``*`` (e.g. ``*.py``) matches files in the current directory and ``**/`` (e.g. ``**/*.py``) matches files in any directories below the current one. User home directory and environment variables will be expanded.",
+      "description": "A comma-separated list of paths which should be checked by mypy if none are given on the command line. Supports recursive file globbing using `glob`, where `*` (e.g. `*.py`) matches files in the current directory and `**/` (e.g. `**/*.py`) matches files in any directories below the current one. User home directory and environment variables will be expanded.",
+      "markdownDescription": "A comma-separated list of paths which should be checked by mypy if none are given on the command line. Supports recursive file globbing using [`glob`](https://docs.python.org/3/library/glob.html), where `*` (e.g. `*.py`) matches files in the current directory and `**/` (e.g. `**/*.py`) matches files in any directories below the current one. User home directory and environment variables will be expanded.",
+      "x-intellij-html-description": "A comma-separated list of paths which should be checked by mypy if none are given on the command line. Supports recursive file globbing using <a href=\"https://docs.python.org/3/library/glob.html\"><code>glob</code></a>, where <code>*</code> (e.g. <code>*.py</code>) matches files in the current directory and <code>**/</code> (e.g. <code>**/*.py</code>) matches files in any directories below the current one. User home directory and environment variables will be expanded.",
       "oneOf": [
         {
           "type": "string"
@@ -33,7 +37,9 @@
       ]
     },
     "modules": {
-      "description": "A comma-separated list of packages which should be checked by mypy if none are given on the command line. Mypy *will not* recursively type check any submodules of the provided module.",
+      "description": "A comma-separated list of packages which should be checked by mypy if none are given on the command line. Mypy WILL NOT recursively type check any submodules of the provided module.",
+      "markdownDescription": "A comma-separated list of packages which should be checked by mypy if none are given on the command line. Mypy *will not* recursively type check any submodules of the provided module.",
+      "x-intellij-html-description": "A comma-separated list of packages which should be checked by mypy if none are given on the command line. Mypy <em>will not</em> recursively type check any submodules of the provided module.",
       "oneOf": [
         {
           "type": "string"
@@ -47,7 +53,9 @@
       ]
     },
     "packages": {
-      "description": "A comma-separated list of packages which should be checked by mypy if none are given on the command line.  Mypy *will* recursively type check any submodules of the provided package. This flag is identical to :confval:`modules` apart from this behavior.",
+      "description": "A comma-separated list of packages which should be checked by mypy if none are given on the command line. Mypy WILL recursively type check any submodules of the provided package. This flag is identical to `modules` apart from this behavior.",
+      "markdownDescription": "A comma-separated list of packages which should be checked by mypy if none are given on the command line. Mypy *will* recursively type check any submodules of the provided package. This flag is identical to `modules` apart from this behavior.",
+      "x-intellij-html-description": "A comma-separated list of packages which should be checked by mypy if none are given on the command line. Mypy <em>will</em> recursively type check any submodules of the provided package. This flag is identical to <code>modules</code> apart from this behavior.",
       "oneOf": [
         {
           "type": "string"
@@ -61,7 +69,8 @@
       ]
     },
     "exclude": {
-      "description": "A regular expression that matches file names, directory names and paths which mypy should ignore while recursively discovering files to check. Use forward slashes (``/``) as directory separators on all platforms.",
+      "description": "A regular expression that matches file names, directory names and paths which mypy should ignore while recursively discovering files to check. Use forward slashes (`/`) as directory separators on all platforms.",
+      "x-intellij-html-description": "A regular expression that matches file names, directory names and paths which mypy should ignore while recursively discovering files to check. Use forward slashes (<code>/</code>) as directory separators on all platforms.",
       "oneOf": [
         {
           "type": "string"
@@ -75,12 +84,16 @@
       ]
     },
     "namespace_packages": {
-      "description": "Enables :pep:`420` style namespace packages.  See the corresponding flag :option:`--no-namespace-packages <mypy --no-namespace-packages>` for more information.",
+      "description": "Enables PEP 420 style namespace packages. See the corresponding flag `--no-namespace-packages` (https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-namespace-packages) for more information.",
+      "markdownDescription": "Enables [PEP 420](https://peps.python.org/pep-0420/) style namespace packages. See the corresponding flag [`--no-namespace-packages`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-namespace-packages) for more information.",
+      "x-intellij-html-description": "Enables <a href=\"https://peps.python.org/pep-0420/\">PEP 420</a> style namespace packages. See the corresponding flag <a href=\"https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-namespace-packages\"><code>--no-namespace-packages</code></a> for more information.",
       "default": true,
       "type": "boolean"
     },
     "explicit_package_bases": {
-      "description": "This flag tells mypy that top-level packages will be based in either the current directory, or a member of the ``MYPYPATH`` environment variable or :confval:`mypy_path` config option. This option is only useful in the absence of `__init__.py`. See :ref:`Mapping file paths to modules <mapping-paths-to-modules>` for details.",
+      "description": "This flag tells mypy that top-level packages will be based in either the current directory, or a member of the `MYPYPATH` environment variable or `mypy_path` config option. This option is only useful in the absence of `__init__.py`. See Mapping file paths to modules (https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-paths-to-modules) for details.",
+      "markdownDescription": "This flag tells mypy that top-level packages will be based in either the current directory, or a member of the `MYPYPATH` environment variable or `mypy_path` config option. This option is only useful in the absence of `__init__.py`. See <i>[Mapping file paths to modules](https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-paths-to-modules)</i> for details.",
+      "x-intellij-html-description": "This flag tells mypy that top-level packages will be based in either the current directory, or a member of the <code>MYPYPATH</code> environment variable or <code>mypy_path</code> config option. This option is only useful in the absence of <code>__init__.py</code>. See <i><a href=\"https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-paths-to-modules\">Mapping file paths to modules</a></i> for details.",
       "default": false,
       "type": "boolean"
     },
@@ -90,36 +103,47 @@
       "type": "boolean"
     },
     "follow_imports": {
-      "description": "Directs what to do with imports when the imported module is found as a ``.py`` file and not part of the files, modules and packages provided on the command line.",
+      "description": "Directs what to do with imports when the imported module is found as a `.py` file and not part of the files, modules and packages provided on the command line.",
+      "x-intellij-html-description": "Directs what to do with imports when the imported module is found as a <code>.py</code> file and not part of the files, modules and packages provided on the command line.",
       "default": "normal",
       "type": "string",
       "enum": ["normal", "silent", "skip", "error"]
     },
     "follow_imports_for_stubs": {
-      "description": "Determines whether to respect the :confval:`follow_imports` setting even for stub (``.pyi``) files.",
+      "description": "Determines whether to respect the `follow_imports` setting even for stub (`.pyi`) files.",
+      "x-intellij-html-description": "Determines whether to respect the <code>follow_imports</code> setting even for stub (<code>.pyi</code>) files.",
       "default": false,
       "type": "boolean"
     },
     "python_executable": {
-      "description": "Specifies the path to the Python executable to inspect to collect a list of available :ref:`PEP 561 packages <installed-packages>`. User home directory and environment variables will be expanded. Defaults to the executable used to run mypy.",
+      "description": "Specifies the path to the Python executable to inspect to collect a list of available PEP 561 packages (https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages). User home directory and environment variables will be expanded. Defaults to the executable used to run mypy.",
+      "markdownDescription": "Specifies the path to the Python executable to inspect to collect a list of available [PEP 561 packages](https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages). User home directory and environment variables will be expanded. Defaults to the executable used to run mypy.",
+      "x-intellij-html-description": "Specifies the path to the Python executable to inspect to collect a list of available <a href=\"https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages\">PEP 561 packages</a>. User home directory and environment variables will be expanded. Defaults to the executable used to run mypy.",
       "type": "string"
     },
     "no_site_packages": {
-      "description": "Disables using type information in installed packages (see :pep:`561`). This will also disable searching for a usable Python executable. This acts the same as :option:`--no-site-packages <mypy --no-site-packages>` command line flag.",
+      "description": "Disables using type information in installed packages (see PEP 561). This will also disable searching for a usable Python executable. This acts the same as :option:`--no-site-packages <mypy --no-site-packages>` command line flag.",
+      "markdownDescription": "Disables using type information in installed packages (see [PEP 561](https://peps.python.org/pep-0561/)). This will also disable searching for a usable Python executable. This acts the same as [`--no-site-packages`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-site-packages) command line flag.",
+      "x-intellij-html-description": "Disables using type information in installed packages (see <a href=\"https://peps.python.org/pep-0561/\">PEP 561</a>). This will also disable searching for a usable Python executable. This acts the same as <a href=\"https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-site-packages\"><code>--no-site-packages</code></a> command line flag.",
       "default": false,
       "type": "boolean"
     },
     "no_silence_site_packages": {
-      "description": "Enables reporting error messages generated within installed packages (see :pep:`561` for more details on distributing type information). Those error messages are suppressed by default, since you are usually not able to control errors in 3rd party code.",
+      "description": "Enables reporting error messages generated within installed packages (see PEP 561 for more details on distributing type information). Those error messages are suppressed by default, since you are usually not able to control errors in 3rd party code.",
+      "markdownDescription": "Enables reporting error messages generated within installed packages (see [PEP 561](https://peps.python.org/pep-0561/) for more details on distributing type information). Those error messages are suppressed by default, since you are usually not able to control errors in 3rd party code.",
+      "x-intellij-html-description": "Enables reporting error messages generated within installed packages (see <a href=\"https://peps.python.org/pep-0561/\">PEP 561</a> for more details on distributing type information). Those error messages are suppressed by default, since you are usually not able to control errors in 3rd party code.",
       "default": false,
       "type": "boolean"
     },
     "python_version": {
-      "description": "Specifies the Python version used to parse and check the target program.  The string should be in the format ``MAJOR.MINOR`` -- for example ``2.7``.  The default is the version of the Python interpreter used to run mypy.",
+      "description": "Specifies the Python version used to parse and check the target program. The string should be in the format `MAJOR.MINOR` (for example, `2.7`). The default is the version of the Python interpreter used to run mypy.",
+      "x-intellij-html-description": "Specifies the Python version used to parse and check the target program. The string should be in the format <code>MAJOR.MINOR</code> (for example, <code>2.7</code>). The default is the version of the Python interpreter used to run mypy.",
       "type": "string"
     },
     "platform": {
-      "description": "Specifies the OS platform for the target program, for example ``darwin`` or ``win32`` (meaning OS X or Windows, respectively). The default is the current platform as revealed by Python's :py:data:`sys.platform` variable.",
+      "description": "Specifies the OS platform for the target program, for example `darwin` or `win32` (meaning OS X or Windows, respectively). The default is the current platform as revealed by Python's `sys.platform` variable.",
+      "markdownDescription": "Specifies the OS platform for the target program, for example `darwin` or `win32` (meaning OS X or Windows, respectively). The default is the current platform as revealed by Python's [`sys.platform`](https://docs.python.org/3/library/sys.html#sys.platform) variable.",
+      "x-intellij-html-description": "Specifies the OS platform for the target program, for example <code>darwin</code> or <code>win32</code> (meaning OS X or Windows, respectively). The default is the current platform as revealed by Python&#39;s <a href=\"https://docs.python.org/3/library/sys.html#sys.platform\"><code>sys.platform</code></a> variable.",
       "type": "string"
     },
     "always_true": {
@@ -151,22 +175,26 @@
       ]
     },
     "disallow_any_unimported": {
-      "description": "Disallows usage of types that come from unfollowed imports (anything imported from an unfollowed import is automatically given a type of ``Any``).",
+      "description": "Disallows usage of types that come from unfollowed imports (anything imported from an unfollowed import is automatically given a type of `Any`).",
+      "x-intellij-html-description": "Disallows usage of types that come from unfollowed imports (anything imported from an unfollowed import is automatically given a type of <code>Any</code>).",
       "default": false,
       "type": "boolean"
     },
     "disallow_any_expr": {
-      "description": "Disallows all expressions in the module that have type ``Any``.",
+      "description": "Disallows all expressions in the module that have type `Any`.",
+      "x-intellij-html-description": "Disallows all expressions in the module that have type <code>Any</code>.",
       "default": false,
       "type": "boolean"
     },
     "disallow_any_decorated": {
-      "description": "Disallows functions that have ``Any`` in their signature after decorator transformation.",
+      "description": "Disallows functions that have `Any` in their signature after decorator transformation.",
+      "x-intellij-html-description": "Disallows functions that have <code>Any</code> in their signature after decorator transformation.",
       "default": false,
       "type": "boolean"
     },
     "disallow_any_explicit": {
-      "description": "Disallows explicit ``Any`` in type positions such as type annotations and generic type parameters.",
+      "description": "Disallows explicit `Any` in type positions such as type annotations and generic type parameters.",
+      "x-intellij-html-description": "Disallows explicit <code>Any</code> in type positions such as type annotations and generic type parameters.",
       "default": false,
       "type": "boolean"
     },
@@ -176,17 +204,21 @@
       "type": "boolean"
     },
     "disallow_subclassing_any": {
-      "description": "Disallows subclassing a value of type ``Any``.",
+      "description": "Disallows subclassing a value of type `Any`.",
+      "x-intellij-html-description": "Disallows subclassing a value of type <code>Any</code>.",
       "default": false,
       "type": "boolean"
     },
     "disallow_untyped_calls": {
-      "description": "Disallows calling functions without type annotations from functions with type annotations. Note that when used in per-module options, it enables/disables this check **inside** the module(s) specified, not for functions that come from that module(s), for example config like this:",
+      "description": "Disallows calling functions without type annotations from functions with type annotations. Note that when used in per-module options, it enables/disables this check INSIDE the module(s) specified, not for functions that come from that module(s).",
+      "markdownDescription": "Disallows calling functions without type annotations from functions with type annotations. Note that when used in per-module options, it enables/disables this check **inside** the module(s) specified, not for functions that come from that module(s).",
+      "x-intellij-html-description": "Disallows calling functions without type annotations from functions with type annotations. Note that when used in per-module options, it enables/disables this check <strong>inside</strong> the module(s) specified, not for functions that come from that module(s).",
       "default": false,
       "type": "boolean"
     },
     "untyped_calls_exclude": {
-      "description": "Selectively excludes functions and methods defined in specific packages, modules, and classes from action of :confval:`disallow_untyped_calls`. This also applies to all submodules of packages (i.e. everything inside a given prefix). Note, this option does not support per-file configuration, the exclusions list is defined globally for all your code.",
+      "description": "Selectively excludes functions and methods defined in specific packages, modules, and classes from action of `disallow_untyped_calls`. This also applies to all submodules of packages (i.e. everything inside a given prefix). Note, this option does not support per-file configuration, the exclusions list is defined globally for all your code.",
+      "x-intellij-html-description": "Selectively excludes functions and methods defined in specific packages, modules, and classes from action of <code>disallow_untyped_calls</code>. This also applies to all submodules of packages (i.e. everything inside a given prefix). Note, this option does not support per-file configuration, the exclusions list is defined globally for all your code.",
       "oneOf": [
         {
           "type": "string"
@@ -200,7 +232,8 @@
       ]
     },
     "disallow_untyped_defs": {
-      "description": "Disallows defining functions without type annotations or with incomplete type annotations (a superset of :confval:`disallow_incomplete_defs`).",
+      "description": "Disallows defining functions without type annotations or with incomplete type annotations (a superset of `disallow_incomplete_defs`).",
+      "x-intellij-html-description": "Disallows defining functions without type annotations or with incomplete type annotations (a superset of <code>disallow_incomplete_defs</code>).",
       "default": false,
       "type": "boolean"
     },
@@ -220,7 +253,9 @@
       "type": "boolean"
     },
     "implicit_optional": {
-      "description": "Causes mypy to treat arguments with a ``None`` default value as having an implicit :py:data:`~typing.Optional` type.",
+      "description": "Causes mypy to treat arguments with a `None` default value as having an implicit `typing.Optional` type.",
+      "markdownDescription": "Causes mypy to treat arguments with a `None` default value as having an implicit [`Optional`](https://docs.python.org/3/library/typing.html#typing.Optional) type.",
+      "x-intellij-html-description": "Causes mypy to treat arguments with a <code>None</code> default value as having an implicit <a href=\"https://docs.python.org/3/library/typing.html#typing.Optional\"><code>Optional</code></a> type.",
       "default": false,
       "type": "boolean"
     },
@@ -230,12 +265,14 @@
       "type": "boolean"
     },
     "no_implicit_reexport": {
-      "description": "By default, imported values to a module are treated as exported and mypy allows other modules to import them. This flag changes the behavior to not re-export unless the item is imported using from-as or is included in __all__. Note this is always treated as enabled for stub files.",
+      "description": "By default, imported values to a module are treated as exported and mypy allows other modules to import them. This flag changes the behavior to not re-export unless the item is imported using from-as or is included in `__all__`. Note this is always treated as enabled for stub files.",
+      "x-intellij-html-description": "By default, imported values to a module are treated as exported and mypy allows other modules to import them. This flag changes the behavior to not re-export unless the item is imported using from-as or is included in <code>__all__</code>. Note this is always treated as enabled for stub files.",
       "default": false,
       "type": "boolean"
     },
     "strict_optional": {
-      "description": "Enables or disables strict Optional checks. If False, mypy treats ``None`` as compatible with every type.",
+      "description": "Enables or disables strict `Optional` checks. If `False`, mypy treats `None` as compatible with every type.",
+      "x-intellij-html-description": "Enables or disables strict <code>Optional</code> checks. If <code>False</code>, mypy treats <code>None</code> as compatible with every type.",
       "default": true,
       "type": "boolean"
     },
@@ -245,7 +282,8 @@
       "type": "boolean"
     },
     "warn_unused_ignores": {
-      "description": "Warns about unneeded ``# type: ignore`` comments.",
+      "description": "Warns about unneeded `# type: ignore` comments.",
+      "x-intellij-html-description": "Warns about unneeded <code># type: ignore</code> comments.",
       "default": false,
       "type": "boolean"
     },
@@ -255,7 +293,8 @@
       "type": "boolean"
     },
     "warn_return_any": {
-      "description": "Shows a warning when returning a value with type ``Any`` from a function declared with a non- ``Any`` return type.",
+      "description": "Shows a warning when returning a value with type `Any` from a function declared with a non-`Any` return type.",
+      "x-intellij-html-description": "Shows a warning when returning a value with type <code>Any</code> from a function declared with a non-<code>Any</code> return type.",
       "default": false,
       "type": "boolean"
     },
@@ -275,12 +314,14 @@
       "type": "boolean"
     },
     "allow_redefinition": {
-      "description": "Allows variables to be redefined with an arbitrary type, as long as the redefinition is in the same block and nesting level as the original definition. Example where this can be useful:",
+      "description": "Allows variables to be redefined with an arbitrary type, as long as the redefinition is in the same block and nesting level as the original definition.",
       "default": false,
       "type": "boolean"
     },
     "local_partial_types": {
-      "description": "Disallows inferring variable type for ``None`` from two assignments in different scopes. This is always implicitly enabled when using the :ref:`mypy daemon <mypy_daemon>`.",
+      "description": "Disallows inferring variable type for `None` from two assignments in different scopes. This is always implicitly enabled when using the mypy daemon (https://mypy.readthedocs.io/en/stable/mypy_daemon.html).",
+      "markdownDescription": "Disallows inferring variable type for `None` from two assignments in different scopes. This is always implicitly enabled when using [the mypy daemon](https://mypy.readthedocs.io/en/stable/mypy_daemon.html).",
+      "x-intellij-html-description": "Disallows inferring variable type for <code>None</code> from two assignments in different scopes. This is always implicitly enabled when using <a href=\"https://mypy.readthedocs.io/en/stable/mypy_daemon.html\">the mypy daemon</a>.",
       "default": false,
       "type": "boolean"
     },
@@ -313,12 +354,14 @@
       ]
     },
     "implicit_reexport": {
-      "description": "By default, imported values to a module are treated as exported and mypy allows other modules to import them. When false, mypy will not re-export unless the item is imported using from-as or is included in ``__all__``. Note that mypy treats stub files as if this is always disabled. For example:",
+      "description": "By default, imported values to a module are treated as exported and mypy allows other modules to import them. When false, mypy will not re-export unless the item is imported using from-as or is included in `__all__`. Note that mypy treats stub files as if this is always disabled.",
+      "x-intellij-html-description": "By default, imported values to a module are treated as exported and mypy allows other modules to import them. When false, mypy will not re-export unless the item is imported using from-as or is included in <code>__all__</code>. Note that mypy treats stub files as if this is always disabled.",
       "default": true,
       "type": "boolean"
     },
     "strict_concatenate": {
-      "description": "Make arguments prepended via ``Concatenate`` be truly positional-only.",
+      "description": "Make arguments prepended via `Concatenate` be truly positional-only.",
+      "x-intellij-html-description": "Make arguments prepended via <code>Concatenate</code> be truly positional-only.",
       "default": false,
       "type": "boolean"
     },
@@ -328,12 +371,13 @@
       "type": "boolean"
     },
     "strict_equality": {
-      "description": "",
+      "description": "Prohibit equality checks, identity checks, and container checks between non-overlapping types.",
       "default": false,
       "type": "boolean"
     },
     "strict": {
-      "description": "",
+      "description": "Enable all optional error checking flags. You can see the list of flags enabled by strict mode in the full `mypy --help` output. The exact list of flags enabled by `strict` may change over time.",
+      "x-intellij-html-description": "Enable all optional error checking flags. You can see the list of flags enabled by strict mode in the full <code>mypy --help</code> output. The exact list of flags enabled by <code>strict</code> may change over time.",
       "default": false,
       "type": "boolean"
     },
@@ -348,7 +392,9 @@
       "type": "boolean"
     },
     "hide_error_codes": {
-      "description": "Hides error codes in error messages. See :ref:`error-codes` for more information.",
+      "description": "Hides error codes (https://mypy.readthedocs.io/en/stable/error_codes.html#error-codes) in error messages.",
+      "markdownDescription": "Hides error codes in error messages. See <i>[Error codes](https://mypy.readthedocs.io/en/stable/error_codes.html#error-codes)</i> for more information.",
+      "x-intellij-html-description": "Hides error codes in error messages. See <i><a href=\"https://mypy.readthedocs.io/en/stable/error_codes.html#error-codes\">Error codes</a></i> for more information.",
       "default": false,
       "type": "boolean"
     },
@@ -373,32 +419,39 @@
       "type": "boolean"
     },
     "force_uppercase_builtins": {
-      "description": "Always use ``List`` instead of ``list`` in error messages, even on Python 3.9+.",
+      "description": "Always use `List` instead of `list` in error messages, even on Python 3.9+.",
+      "x-intellij-html-description": "Always use <code>List</code> instead of <code>list</code> in error messages, even on Python 3.9+.",
       "default": false,
       "type": "boolean"
     },
     "force_union_syntax": {
-      "description": "Always use ``Union[]`` and ``Optional[]`` for union types in error messages (instead of the ``|`` operator), even on Python 3.10+.",
+      "description": "Always use `Union[]` and `Optional[]` for union types in error messages (instead of the `|` operator), even on Python 3.10+.",
+      "x-intellij-html-description": "Always use <code>Union[]</code> and <code>Optional[]</code> for union types in error messages (instead of the <code>|</code> operator), even on Python 3.10+.",
       "default": false,
       "type": "boolean"
     },
     "incremental": {
-      "description": "Enables :ref:`incremental mode <incremental>`.",
+      "description": "Enables incremental mode (https://mypy.readthedocs.io/en/stable/command_line.html#incremental).",
+      "markdownDescription": "Enables [incremental mode](https://mypy.readthedocs.io/en/stable/command_line.html#incremental).",
+      "x-intellij-html-description": "Enables <a href=\"https://mypy.readthedocs.io/en/stable/command_line.html#incremental\">incremental mode</a>.",
       "default": true,
       "type": "boolean"
     },
     "cache_dir": {
-      "description": "Specifies the location where mypy stores incremental cache info. User home directory and environment variables will be expanded. This setting will be overridden by the ``MYPY_CACHE_DIR`` environment variable.",
+      "description": "Specifies the location where mypy stores incremental cache info. User home directory and environment variables will be expanded. This setting will be overridden by the `MYPY_CACHE_DIR` environment variable.",
+      "x-intellij-html-description": "Specifies the location where mypy stores incremental cache info. User home directory and environment variables will be expanded. This setting will be overridden by the <code>MYPY_CACHE_DIR</code> environment variable.",
       "default": ".mypy_cache",
       "type": "string"
     },
     "sqlite_cache": {
-      "description": "Use an `SQLite`_ database to store the cache.",
+      "description": "Use an SQLite database to store the cache.",
       "default": false,
       "type": "boolean"
     },
     "cache_fine_grained": {
-      "description": "Include fine-grained dependency information in the cache for the mypy daemon.",
+      "description": "Include fine-grained dependency information in the cache for the mypy daemon (https://mypy.readthedocs.io/en/stable/mypy_daemon.html).",
+      "markdownDescription": "Include fine-grained dependency information in the cache for [the mypy daemon](https://mypy.readthedocs.io/en/stable/mypy_daemon.html).",
+      "x-intellij-html-description": "Include fine-grained dependency information in the cache for <a href=\"https://mypy.readthedocs.io/en/stable/mypy_daemon.html\">the mypy daemon</a>.",
       "default": false,
       "type": "boolean"
     },
@@ -413,7 +466,9 @@
       "type": "boolean"
     },
     "plugins": {
-      "description": "A comma-separated list of mypy plugins. See :ref:`extending-mypy-using-plugins`.",
+      "description": "A comma-separated list of mypy plugins.",
+      "markdownDescription": "A comma-separated list of mypy plugins. See <i>[Extending mypy using plugins](https://mypy.readthedocs.io/en/stable/extending_mypy.html#extending-mypy-using-plugins)</i>.",
+      "x-intellij-html-description": "A comma-separated list of mypy plugins. See <i><a href=\"https://mypy.readthedocs.io/en/stable/extending_mypy.html#extending-mypy-using-plugins\">Extending mypy using plugins</a></i>.",
       "oneOf": [
         {
           "type": "string"
@@ -427,7 +482,9 @@
       ]
     },
     "pdb": {
-      "description": "Invokes :mod:`pdb` on fatal error.",
+      "description": "Invokes `pdb` (https://docs.python.org/3/library/pdb.html) on fatal error.",
+      "markdownDescription": "Invokes [`pdb`](https://docs.python.org/3/library/pdb.html) on fatal error.",
+      "x-intellij-html-description": "Invokes <a href=\"https://docs.python.org/3/library/pdb.html\"><code>pdb</code></a> on fatal error.",
       "default": false,
       "type": "boolean"
     },
@@ -442,20 +499,24 @@
       "type": "boolean"
     },
     "custom_typing_module": {
-      "description": "Specifies a custom module to use as a substitute for the :py:mod:`typing` module.",
+      "description": "Specifies a custom module to use as a substitute for the `typing` module.",
+      "markdownDescription": "Specifies a custom module to use as a substitute for the `typing` module.",
+      "x-intellij-html-description": "Specifies a custom module to use as a substitute for the <code>typing</code> module.",
       "type": "string"
     },
     "custom_typeshed_dir": {
-      "description": "This specifies the directory where mypy looks for standard library typeshed stubs, instead of the typeshed that ships with mypy.  This is primarily intended to make it easier to test typeshed changes before submitting them upstream, but also allows you to use a forked version of typeshed.",
+      "description": "This specifies the directory where mypy looks for standard library typeshed stubs, instead of the typeshed that ships with mypy. This is primarily intended to make it easier to test typeshed changes before submitting them upstream, but also allows you to use a forked version of typeshed.",
       "type": "string"
     },
     "warn_incomplete_stub": {
-      "description": "Warns about missing type annotations in typeshed.  This is only relevant in combination with :confval:`disallow_untyped_defs` or :confval:`disallow_incomplete_defs`.",
+      "description": "Warns about missing type annotations in typeshed. This is only relevant in combination with `disallow_untyped_defs` or `disallow_incomplete_defs`.",
+      "x-intellij-html-description": "Warns about missing type annotations in typeshed. This is only relevant in combination with <code>disallow_untyped_defs</code> or <code>disallow_incomplete_defs</code>.",
       "default": false,
       "type": "boolean"
     },
     "any_exprs_report": {
-      "description": "Causes mypy to generate a text file report documenting how many expressions of type ``Any`` are present within your codebase.",
+      "description": "Causes mypy to generate a text file report documenting how many expressions of type `Any` are present within your codebase.",
+      "x-intellij-html-description": "Causes mypy to generate a text file report documenting how many expressions of type <code>Any</code> are present within your codebase.",
       "type": "string"
     },
     "cobertura_xml_report": {
@@ -468,6 +529,7 @@
     },
     "linecoverage_report": {
       "description": "Causes mypy to generate a JSON file that maps each source file's absolute filename to a list of line numbers that belong to typed functions in that file.",
+      "x-intellij-html-description": "Causes mypy to generate a JSON file that maps each source file&#39;s absolute filename to a list of line numbers that belong to typed functions in that file.",
       "type": "string"
     },
     "lineprecision_report": {
@@ -483,17 +545,20 @@
       "type": "string"
     },
     "scripts_are_modules": {
-      "description": "Makes script ``x`` become module ``x`` instead of ``__main__``.  This is useful when checking multiple scripts in a single run.",
+      "description": "Makes script `x` become module `x` instead of `__main__`. This is useful when checking multiple scripts in a single run.",
+      "x-intellij-html-description": "Makes script <code>x</code> become module <code>x</code> instead of <code>__main__</code>. This is useful when checking multiple scripts in a single run.",
       "default": false,
       "type": "boolean"
     },
     "warn_unused_configs": {
-      "description": "Warns about per-module sections in the config file that do not match any files processed when invoking mypy. (This requires turning off incremental mode using :confval:`incremental = False <incremental>`.)",
+      "description": "Warns about per-module sections in the config file that do not match any files processed when invoking mypy. (This requires turning off incremental mode using `incremental = False`.)",
+      "markdownDescription": "Warns about per-module sections in the config file that do not match any files processed when invoking mypy. (This requires turning off incremental mode using [`incremental = False`](https://mypy.readthedocs.io/en/stable/command_line.html#incremental).)",
+      "x-intellij-html-description": "Warns about per-module sections in the config file that do not match any files processed when invoking mypy. (This requires turning off incremental mode using <a href=\"https://mypy.readthedocs.io/en/stable/command_line.html#incremental\"><code>incremental = False</code></a>.)",
       "default": false,
       "type": "boolean"
     },
     "verbosity": {
-      "description": "Controls how much debug output will be generated.  Higher numbers are more verbose.",
+      "description": "Controls how much debug output will be generated. Higher numbers are more verbose.",
       "default": 0,
       "type": "integer"
     },
@@ -501,6 +566,7 @@
       "type": "boolean",
       "default": true,
       "description": "DEPRECATED and UNDOCUMENTED: Now defaults to true, use `hide_error_codes` if you need to disable error codes instead.",
+      "x-intellij-html-description": "DEPRECATED and UNDOCUMENTED: Now defaults to true, use <code>hide_error_codes</code> if you need to disable error codes instead.",
       "deprecated": true
     },
     "show_error_code_links": {

--- a/src/schemas/json/partial-pyright.json
+++ b/src/schemas/json/partial-pyright.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/partial-pyright.json",
-  "$comment": "This file was copied from Pyright's repository, which is licensed under MIT, on 2024-01-17.",
+  "$comment": "This file was originallycopied from Pyright's repository, which is licensed under MIT, on 2024-01-17. The markdownDescription fields are for VSCode and x-intellij-html-description ones are for PyCharm.",
   "description": "Pyright Configuration Schema",
   "type": "object",
   "definitions": {
@@ -23,64 +23,64 @@
       "type": "array",
       "title": "Files and directories included in type analysis",
       "description": "Paths of directories or files that should be included. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character). If no include paths are specified, the root path for the workspace is assumed.",
+      "x-intellij-html-description": "Paths of directories or files that should be included. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no include paths are specified, the root path for the workspace is assumed.",
       "items": {
         "$id": "#/properties/include/items",
         "type": "string",
         "description": "File or directory to include in type analysis",
         "pattern": "^(.*)$"
-      },
-      "x-intellij-html-description": "Paths of directories or files that should be included. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no include paths are specified, the root path for the workspace is assumed."
+      }
     },
     "exclude": {
       "$id": "#/properties/exclude",
       "type": "array",
       "title": "Files and directories excluded from type analysis",
       "description": "Paths of directories or files that should not be included. These override the includes directories, allowing specific subdirectories to be ignored. Note that files in the exclude paths may still be included in the analysis if they are referenced (imported) by source files that are not excluded. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character). If no exclude paths are specified, Pyright automatically excludes the following: `**/node_modules`, `**/__pycache__`, `**/.*` and any virtual environment directories.",
+      "x-intellij-html-description": "Paths of directories or files that should not be included. These override the includes directories, allowing specific subdirectories to be ignored. Note that files in the exclude paths may still be included in the analysis if they are referenced (imported) by source files that are not excluded. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no exclude paths are specified, Pyright automatically excludes the following: <code>**/node_modules</code>, <code>**/__pycache__</code>, <code>**/.*</code> and any virtual environment directories.",
       "items": {
         "$id": "#/properties/exclude/items",
         "type": "string",
         "title": "File or directory to exclude from type analysis",
         "pattern": "^(.*)$"
-      },
-      "x-intellij-html-description": "Paths of directories or files that should not be included. These override the includes directories, allowing specific subdirectories to be ignored. Note that files in the exclude paths may still be included in the analysis if they are referenced (imported) by source files that are not excluded. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no exclude paths are specified, Pyright automatically excludes the following: <code>**/node_modules</code>, <code>**/__pycache__</code>, <code>**/.*</code> and any virtual environment directories."
+      }
     },
     "ignore": {
       "$id": "#/properties/ignore",
       "type": "array",
       "title": "Files and directories whose diagnostics are suppressed",
       "description": "Paths of directories or files whose diagnostic output (errors and warnings) should be suppressed even if they are an included file or within the transitive closure of an included file. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character).",
+      "x-intellij-html-description": "Paths of directories or files whose diagnostic output (errors and warnings) should be suppressed even if they are an included file or within the transitive closure of an included file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character).",
       "items": {
         "$id": "#/properties/ignore/items",
         "type": "string",
         "title": "File or directory where diagnostics should be suppressed",
         "pattern": "^(.*)$"
-      },
-      "x-intellij-html-description": "Paths of directories or files whose diagnostic output (errors and warnings) should be suppressed even if they are an included file or within the transitive closure of an included file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character)."
+      }
     },
     "strict": {
       "$id": "#/properties/strict",
       "type": "array",
       "title": "Files and directories that should use \"strict\" type checking rules",
       "description": "Paths of directories or files that should use \"strict\" analysis if they are included. This is the same as manually adding a `# pyright: strict` comment. In strict mode, most type-checking rules are enabled. Refer to this table for details about which rules are enabled in strict mode. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character).",
+      "x-intellij-html-description": "Paths of directories or files that should use &quot;strict&quot; analysis if they are included. This is the same as manually adding a <code># pyright: strict</code> comment. In strict mode, most type-checking rules are enabled. Refer to this table for details about which rules are enabled in strict mode. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character).",
       "items": {
         "$id": "#/properties/strict/items",
         "type": "string",
         "title": "File or directory that should use \"strict\" type checking rules",
         "pattern": "^(.*)$"
-      },
-      "x-intellij-html-description": "Paths of directories or files that should use &quot;strict&quot; analysis if they are included. This is the same as manually adding a <code># pyright: strict</code> comment. In strict mode, most type-checking rules are enabled. Refer to this table for details about which rules are enabled in strict mode. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character)."
+      }
     },
     "defineConstant": {
       "$id": "#/properties/defineConstant",
       "type": "object",
       "title": "Identifiers that should be treated as constants",
       "description": "Set of identifiers that should be assumed to contain a constant value wherever used within this program. For example, `{ \"DEBUG\": true }` indicates that pyright should assume that the identifier `DEBUG` will always be equal to `True`. If this identifier is used within a conditional expression (such as `if not DEBUG:`) pyright will use the indicated value to determine whether the guarded block is reachable or not. Member expressions that reference one of these constants (e.g. `my_module.DEBUG`) are also supported.",
+      "x-intellij-html-description": "Set of identifiers that should be assumed to contain a constant value wherever used within this program. For example, <code>{ &quot;DEBUG&quot;: true }</code> indicates that pyright should assume that the identifier <code>DEBUG</code> will always be equal to <code>True</code>. If this identifier is used within a conditional expression (such as <code>if not DEBUG:</code>) pyright will use the indicated value to determine whether the guarded block is reachable or not. Member expressions that reference one of these constants (e.g. <code>my_module.DEBUG</code>) are also supported.",
       "properties": {},
       "additionalProperties": {
         "type": ["string", "boolean"],
         "title": "Value of constant (boolean or string)"
-      },
-      "x-intellij-html-description": "Set of identifiers that should be assumed to contain a constant value wherever used within this program. For example, <code>{ &quot;DEBUG&quot;: true }</code> indicates that pyright should assume that the identifier <code>DEBUG</code> will always be equal to <code>True</code>. If this identifier is used within a conditional expression (such as <code>if not DEBUG:</code>) pyright will use the indicated value to determine whether the guarded block is reachable or not. Member expressions that reference one of these constants (e.g. <code>my_module.DEBUG</code>) are also supported."
+      }
     },
     "typeCheckingMode": {
       "$id": "#/properties/typeCheckingMode",
@@ -88,8 +88,8 @@
       "enum": ["off", "basic", "standard", "strict"],
       "title": "Specifies the default rule set to use for type checking",
       "description": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to `off`, all type-checking rules are disabled, but Python syntax and semantic errors are still reported.",
-      "default": "standard",
-      "x-intellij-html-description": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to <code>off</code>, all type-checking rules are disabled, but Python syntax and semantic errors are still reported."
+      "x-intellij-html-description": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to <code>off</code>, all type-checking rules are disabled, but Python syntax and semantic errors are still reported.",
+      "default": "standard"
     },
     "useLibraryCodeForTypes": {
       "$id": "#/properties/useLibraryCodeForTypes",
@@ -103,9 +103,10 @@
       "type": "string",
       "title": "Path to directory containing `typeshed` type stub files",
       "description": "Path to a directory that contains `typeshed` type stub files. Pyright ships with a bundled copy of `typeshed` type stubs. If you want to use a different version of `typeshed` stubs, you can clone the `typeshed` GitHub repo (https://github.com/python/typeshed) to a local directory and reference the location with this path. This option is useful if you're actively contributing updates to `typeshed`.",
+      "markdownDescription": "Path to a directory that contains `typeshed` type stub files. Pyright ships with a bundled copy of `typeshed` type stubs. If you want to use a different version of `typeshed` stubs, you can clone [the `typeshed` GitHub repo](https://github.com/python/typeshed) to a local directory and reference the location with this path. This option is useful if you're actively contributing updates to `typeshed`.",
+      "x-intellij-html-description": "Path to a directory that contains <code>typeshed</code> type stub files. Pyright ships with a bundled copy of <code>typeshed</code> type stubs. If you want to use a different version of <code>typeshed</code> stubs, you can clone <a href=\"https://github.com/python/typeshed\">the <code>typeshed</code> GitHub repo</a> to a local directory and reference the location with this path. This option is useful if you&#39;re actively contributing updates to <code>typeshed</code>.",
       "default": "",
-      "pattern": "^(.*)$",
-      "x-intellij-html-description": "Path to a directory that contains <code>typeshed</code> type stub files. Pyright ships with a bundled copy of <code>typeshed</code> type stubs. If you want to use a different version of <code>typeshed</code> stubs, you can clone <a href=\"https://github.com/python/typeshed\">the <code>typeshed</code> GitHub repo</a> to a local directory and reference the location with this path. This option is useful if you&#39;re actively contributing updates to <code>typeshed</code>."
+      "pattern": "^(.*)$"
     },
     "stubPath": {
       "$id": "#/properties/stubPath",
@@ -113,42 +114,42 @@
       "type": "string",
       "title": "Path to directory containing custom type stub files",
       "description": "Path to a directory that contains custom type stubs. Each package's type stub file(s) are expected to be in its own subdirectory. The default value of this setting is `./typings` (`typingsPath` is now deprecated).",
+      "x-intellij-html-description": "Path to a directory that contains custom type stubs. Each package&#39;s type stub file(s) are expected to be in its own subdirectory. The default value of this setting is <code>./typings</code> (<code>typingsPath</code> is now deprecated).",
       "default": "",
       "examples": ["src/typestubs"],
-      "pattern": "^(.*)$",
-      "x-intellij-html-description": "Path to a directory that contains custom type stubs. Each package&#39;s type stub file(s) are expected to be in its own subdirectory. The default value of this setting is <code>./typings</code> (<code>typingsPath</code> is now deprecated)."
+      "pattern": "^(.*)$"
     },
     "disableBytesTypePromotions": {
       "$id": "#/properties/disableBytesTypePromotions",
       "type": "boolean",
       "title": "Do not treat `bytearray` and `memoryview` as implicit subtypes of `bytes`",
       "description": "Disables legacy behavior where `bytearray` and `memoryview` are considered subtypes of bytes. PEP 688 deprecates this behavior, but this switch is provided to restore the older behavior.",
-      "default": false,
-      "x-intellij-html-description": "Disables legacy behavior where <code>bytearray</code> and <code>memoryview</code> are considered subtypes of bytes. <a href=\"https://peps.python.org/pep-0688/\">PEP 688</a> deprecates this behavior, but this switch is provided to restore the older behavior."
+      "x-intellij-html-description": "Disables legacy behavior where <code>bytearray</code> and <code>memoryview</code> are considered subtypes of bytes. <a href=\"https://peps.python.org/pep-0688/\">PEP 688</a> deprecates this behavior, but this switch is provided to restore the older behavior.",
+      "default": false
     },
     "strictListInference": {
       "$id": "#/properties/strictListInference",
       "type": "boolean",
       "title": "Infer strict types for list expressions",
       "description": "When inferring the type of a list, use strict type assumptions. For example, the expression `[1, 'a', 3.4]` could be inferred to be of type `list[Any]` or `list[int | str | float]`. If this setting is `true`, it will use the latter (stricter) type.",
-      "default": false,
-      "x-intellij-html-description": "When inferring the type of a list, use strict type assumptions. For example, the expression <code>[1, &#39;a&#39;, 3.4]</code> could be inferred to be of type <code>list[Any]</code> or <code>list[int | str | float]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type."
+      "x-intellij-html-description": "When inferring the type of a list, use strict type assumptions. For example, the expression <code>[1, &#39;a&#39;, 3.4]</code> could be inferred to be of type <code>list[Any]</code> or <code>list[int | str | float]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type.",
+      "default": false
     },
     "strictSetInference": {
       "$id": "#/properties/strictSetInference",
       "type": "boolean",
       "title": "Infer strict types for set expressions",
       "description": "When inferring the type of a set, use strict type assumptions. For example, the expression `{1, 'a', 3.4}` could be inferred to be of type `set[Any]` or `set[int | str | float]`. If this setting is `true`, it will use the latter (stricter) type.",
-      "default": false,
-      "x-intellij-html-description": "When inferring the type of a set, use strict type assumptions. For example, the expression <code>{1, &#39;a&#39;, 3.4}</code> could be inferred to be of type <code>set[Any]</code> or <code>set[int | str | float]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type."
+      "x-intellij-html-description": "When inferring the type of a set, use strict type assumptions. For example, the expression <code>{1, &#39;a&#39;, 3.4}</code> could be inferred to be of type <code>set[Any]</code> or <code>set[int | str | float]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type.",
+      "default": false
     },
     "strictDictionaryInference": {
       "$id": "#/properties/strictDictionaryInference",
       "type": "boolean",
       "title": "Infer strict types for dictionary expressions",
       "description": "When inferring the type of a dictionary's keys and values, use strict type assumptions. For example, the expression `{'a': 1, 'b': 'a'}` could be inferred to be of type `dict[str, Any]` or `dict[str, int | str]`. If this setting is `true`, it will use the latter (stricter) type.",
-      "default": false,
-      "x-intellij-html-description": "When inferring the type of a dictionary&#39;s keys and values, use strict type assumptions. For example, the expression <code>{&#39;a&#39;: 1, &#39;b&#39;: &#39;a&#39;}</code> could be inferred to be of type <code>dict[str, Any]</code> or <code>dict[str, int | str]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type."
+      "x-intellij-html-description": "When inferring the type of a dictionary&#39;s keys and values, use strict type assumptions. For example, the expression <code>{&#39;a&#39;: 1, &#39;b&#39;: &#39;a&#39;}</code> could be inferred to be of type <code>dict[str, Any]</code> or <code>dict[str, int | str]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type.",
+      "default": false
     },
     "analyzeUnannotatedFunctions": {
       "$id": "#/properties/analyzeUnannotatedFunctions",
@@ -162,8 +163,8 @@
       "type": "boolean",
       "title": "Allow implicit Optional when default parameter value is None",
       "description": "PEP 484 indicates that when a function parameter is assigned a default value of `None`, its type should implicitly be `Optional` even if the explicit type is not. When enabled, this rule requires that parameter type annotations use `Optional` explicitly in this case.",
-      "default": true,
-      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0484/\">PEP 484</a> indicates that when a function parameter is assigned a default value of <code>None</code>, its type should implicitly be <code>Optional</code> even if the explicit type is not. When enabled, this rule requires that parameter type annotations use <code>Optional</code> explicitly in this case."
+      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0484/\">PEP 484</a> indicates that when a function parameter is assigned a default value of <code>None</code>, its type should implicitly be <code>Optional</code> even if the explicit type is not. When enabled, this rule requires that parameter type annotations use <code>Optional</code> explicitly in this case.",
+      "default": true
     },
     "enableExperimentalFeatures": {
       "$id": "#/properties/enableExperimentalFeatures",
@@ -177,16 +178,16 @@
       "type": "boolean",
       "title": "Allow `# type: ignore` comments",
       "description": "PEP 484 defines support for `# type: ignore` comments. This switch enables or disables support for these comments. This does not affect `# pyright: ignore` comments.",
-      "default": true,
-      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0484/\">PEP 484</a> defines support for <code># type: ignore</code> comments. This switch enables or disables support for these comments. This does not affect <code># pyright: ignore</code> comments."
+      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0484/\">PEP 484</a> defines support for <code># type: ignore</code> comments. This switch enables or disables support for these comments. This does not affect <code># pyright: ignore</code> comments.",
+      "default": true
     },
     "deprecateTypingAliases": {
       "$id": "#/properties/deprecateTypingAliases",
       "type": "boolean",
       "title": "Treat typing-specific aliases to standard types as deprecated",
       "description": "PEP 585 indicates that aliases to types in standard collections that were introduced solely to support generics are deprecated as of Python 3.9. This switch controls whether these are treated as deprecated. This applies only when `pythonVersion` is 3.9 or newer. The default value for this setting is `false` but may be switched to `true` in the future.",
-      "default": false,
-      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0585/\">PEP 585</a> indicates that aliases to types in standard collections that were introduced solely to support generics are deprecated as of Python 3.9. This switch controls whether these are treated as deprecated. This applies only when <code>pythonVersion</code> is 3.9 or newer. The default value for this setting is <code>false</code> but may be switched to <code>true</code> in the future."
+      "x-intellij-html-description": "<a href=\"https://peps.python.org/pep-0585/\">PEP 585</a> indicates that aliases to types in standard collections that were introduced solely to support generics are deprecated as of Python 3.9. This switch controls whether these are treated as deprecated. This applies only when <code>pythonVersion</code> is 3.9 or newer. The default value for this setting is <code>false</code> but may be switched to <code>true</code> in the future.",
+      "default": false
     },
     "reportGeneralTypeIssues": {
       "$id": "#/properties/reportGeneralTypeIssues",
@@ -284,56 +285,56 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to subscript (index) a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to subscript (index) a variable with an `Optional` type.",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to subscript (index) a variable with an <code>Optional</code> type."
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to subscript (index) a variable with an <code>Optional</code> type.",
+      "default": "error"
     },
     "reportOptionalMemberAccess": {
       "$id": "#/properties/reportOptionalMemberAccess",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to access a member of a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to access a member of a variable with an `Optional` type.",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to access a member of a variable with an <code>Optional</code> type."
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to access a member of a variable with an <code>Optional</code> type.",
+      "default": "error"
     },
     "reportOptionalCall": {
       "$id": "#/properties/reportOptionalCall",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to call a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to call a variable with an `Optional` type.",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to call a variable with an <code>Optional</code> type."
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to call a variable with an <code>Optional</code> type.",
+      "default": "error"
     },
     "reportOptionalIterable": {
       "$id": "#/properties/reportOptionalIterable",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as an iterable value",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as an iterable value (e.g. within a `for` statement).",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as an iterable value (e.g. within a <code>for</code> statement)."
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as an iterable value (e.g. within a <code>for</code> statement).",
+      "default": "error"
     },
     "reportOptionalContextManager": {
       "$id": "#/properties/reportOptionalContextManager",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as a parameter to a `with` statement",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as a context manager (as a parameter to a `with` statement).",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as a context manager (as a parameter to a <code>with</code> statement)."
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as a context manager (as a parameter to a <code>with</code> statement).",
+      "default": "error"
     },
     "reportOptionalOperand": {
       "$id": "#/properties/reportOptionalOperand",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as an operand for a binary or unary operator",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as an operand to a unary operator (like `~` or `not`) or the left-hand operator of a binary operator (like `*`, `==`, `or`).",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as an operand to a unary operator (like <code>~</code> or <code>not</code>) or the left-hand operator of a binary operator (like <code>*</code>, <code>==</code>, <code>or</code>)."
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as an operand to a unary operator (like <code>~</code> or <code>not</code>) or the left-hand operator of a binary operator (like <code>*</code>, <code>==</code>, <code>or</code>).",
+      "default": "error"
     },
     "reportTypedDictNotRequiredAccess": {
       "$id": "#/properties/reportTypedDictNotRequiredAccess",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to access a non-required key in a `TypedDict` without a check for its presence",
       "description": "Generate or suppress diagnostics for an attempt to access a non-required field within a `TypedDict` without first checking whether it is present.",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to access a non-required field within a <code>TypedDict</code> without first checking whether it is present."
+      "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to access a non-required field within a <code>TypedDict</code> without first checking whether it is present.",
+      "default": "error"
     },
     "reportUntypedFunctionDecorator": {
       "$id": "#/properties/reportUntypedFunctionDecorator",
@@ -361,16 +362,16 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of a named tuple definition that does not contain type information",
       "description": "Generate or suppress diagnostics when `namedtuple` is used rather than `NamedTuple`. The former contains no type information, whereas the latter does.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics when <code>namedtuple</code> is used rather than <code>NamedTuple</code>. The former contains no type information, whereas the latter does."
+      "x-intellij-html-description": "Generate or suppress diagnostics when <code>namedtuple</code> is used rather than <code>NamedTuple</code>. The former contains no type information, whereas the latter does.",
+      "default": "none"
     },
     "reportPrivateUsage": {
       "$id": "#/properties/reportPrivateUsage",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of private variables and functions used outside of the owning class or module and usage of protected members outside of subclasses",
       "description": "Generate or suppress diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore (`_`) and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore (<code>_</code>) and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module."
+      "x-intellij-html-description": "Generate or suppress diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore (<code>_</code>) and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
+      "default": "none"
     },
     "reportTypeCommentUsage": {
       "$id": "#/properties/reportTypeCommentUsage",
@@ -384,8 +385,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of improper usage of symbol imported from a `py.typed` module that is not re-exported from that module",
       "description": "Generate or suppress diagnostics for use of a symbol from a `py.typed` module that is not meant to be exported from that module.",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for use of a symbol from a <code>py.typed</code> module that is not meant to be exported from that module."
+      "x-intellij-html-description": "Generate or suppress diagnostics for use of a symbol from a <code>py.typed</code> module that is not meant to be exported from that module.",
+      "default": "error"
     },
     "reportConstantRedefinition": {
       "$id": "#/properties/reportConstantRedefinition",
@@ -420,8 +421,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `__init__` and `__new__` methods whose signatures are inconsistent",
       "description": "Generate or suppress diagnostics when an `__init__` method signature is inconsistent with a `__new__` signature.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics when an <code>__init__</code> method signature is inconsistent with a <code>__new__</code> signature."
+      "x-intellij-html-description": "Generate or suppress diagnostics when an <code>__init__</code> method signature is inconsistent with a <code>__new__</code> signature.",
+      "default": "none"
     },
     "reportOverlappingOverload": {
       "$id": "#/properties/reportOverlappingOverload",
@@ -435,16 +436,16 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of missing call to parent class for inherited `__init__` methods",
       "description": "Generate or suppress diagnostics for `__init__`, `__init_subclass__`, `__enter__` and `__exit__` methods in a subclass that fail to call through to the same-named method on a base class.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for <code>__init__</code>, <code>__init_subclass__</code>, <code>__enter__</code> and <code>__exit__</code> methods in a subclass that fail to call through to the same-named method on a base class."
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>__init__</code>, <code>__init_subclass__</code>, <code>__enter__</code> and <code>__exit__</code> methods in a subclass that fail to call through to the same-named method on a base class.",
+      "default": "none"
     },
     "reportUninitializedInstanceVariable": {
       "$id": "#/properties/reportUninitializedInstanceVariable",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of instance variables that are not initialized in the constructor",
       "description": "Generate or suppress diagnostics for instance variables within a class that are not initialized or declared within the class body or the `__init__` method.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for instance variables within a class that are not initialized or declared within the class body or the <code>__init__</code> method."
+      "x-intellij-html-description": "Generate or suppress diagnostics for instance variables within a class that are not initialized or declared within the class body or the <code>__init__</code> method.",
+      "default": "none"
     },
     "reportInvalidStringEscapeSequence": {
       "$id": "#/properties/reportInvalidStringEscapeSequence",
@@ -493,8 +494,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting input parameters that are missing a type annotation",
       "description": "Generate or suppress diagnostics for input parameters for functions or methods that are missing a type annotation. The `self` and `cls` parameters used within methods are exempt from this check.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for input parameters for functions or methods that are missing a type annotation. The <code>self</code> and <code>cls</code> parameters used within methods are exempt from this check."
+      "x-intellij-html-description": "Generate or suppress diagnostics for input parameters for functions or methods that are missing a type annotation. The <code>self</code> and <code>cls</code> parameters used within methods are exempt from this check.",
+      "default": "none"
     },
     "reportMissingTypeArgument": {
       "$id": "#/properties/reportMissingTypeArgument",
@@ -508,8 +509,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting improper use of type variables within function signatures",
       "description": "Generate or suppress diagnostics when a `TypeVar` is used inappropriately (e.g. if a `TypeVar` appears only once) within a generic function signature.",
-      "default": "warning",
-      "x-intellij-html-description": "Generate or suppress diagnostics when a <code>TypeVar</code> is used inappropriately (e.g. if a <code>TypeVar</code> appears only once) within a generic function signature."
+      "x-intellij-html-description": "Generate or suppress diagnostics when a <code>TypeVar</code> is used inappropriately (e.g. if a <code>TypeVar</code> appears only once) within a generic function signature.",
+      "default": "warning"
     },
     "reportCallInDefaultInitializer": {
       "$id": "#/properties/reportCallInDefaultInitializer",
@@ -523,48 +524,48 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting calls to `isinstance` or `issubclass` where the result is statically determined to be always true",
       "description": "Generate or suppress diagnostics for `isinstance` or `issubclass` calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for <code>isinstance</code> or <code>issubclass</code> calls where the result is statically determined to be always true. Such calls are often indicative of a programming error."
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>isinstance</code> or <code>issubclass</code> calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
+      "default": "none"
     },
     "reportUnnecessaryCast": {
       "$id": "#/properties/reportUnnecessaryCast",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting calls to `cast` that are unnecessary",
       "description": "Generate or suppress diagnostics for `cast` calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for <code>cast</code> calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error."
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>cast</code> calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
+      "default": "none"
     },
     "reportUnnecessaryComparison": {
       "$id": "#/properties/reportUnnecessaryComparison",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting the use of `==` or `!=` comparisons that are unnecessary",
       "description": "Generate or suppress diagnostics for `==` or `!=` comparisons or other conditional expressions that are statically determined to always evaluate to `False` or `True`. Such comparisons are sometimes indicative of a programming error.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for <code>==</code> or <code>!=</code> comparisons or other conditional expressions that are statically determined to always evaluate to <code>False</code> or <code>True</code>. Such comparisons are sometimes indicative of a programming error."
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>==</code> or <code>!=</code> comparisons or other conditional expressions that are statically determined to always evaluate to <code>False</code> or <code>True</code>. Such comparisons are sometimes indicative of a programming error.",
+      "default": "none"
     },
     "reportUnnecessaryContains": {
       "$id": "#/properties/reportUnnecessaryContains",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting the use of `in` operations that are unnecessary",
       "description": "Generate or suppress diagnostics for `in` operations that are statically determined to always evaluate to `False` or `True`. Such operations are sometimes indicative of a programming error.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for <code>in</code> operations that are statically determined to always evaluate to <code>False</code> or <code>True</code>. Such operations are sometimes indicative of a programming error."
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>in</code> operations that are statically determined to always evaluate to <code>False</code> or <code>True</code>. Such operations are sometimes indicative of a programming error.",
+      "default": "none"
     },
     "reportAssertAlwaysTrue": {
       "$id": "#/properties/reportAssertAlwaysTrue",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting `assert` expressions that will always evaluate to `True`",
       "description": "Generate or suppress diagnostics for `assert` statement that will provably always assert. This can be indicative of a programming error.",
-      "default": "warning",
-      "x-intellij-html-description": "Generate or suppress diagnostics for <code>assert</code> statement that will provably always assert. This can be indicative of a programming error."
+      "x-intellij-html-description": "Generate or suppress diagnostics for <code>assert</code> statement that will provably always assert. This can be indicative of a programming error.",
+      "default": "warning"
     },
     "reportSelfClsParameterName": {
       "$id": "#/properties/reportSelfClsParameterName",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting missing or misnamed `self` parameters",
       "description": "Generate or suppress diagnostics for a missing or misnamed `self` parameter in instance methods and `cls` parameter in class methods. Instance methods in metaclasses (classes that derive from `type`) are allowed to use `cls` for instance methods.",
-      "default": "warning",
-      "x-intellij-html-description": "Generate or suppress diagnostics for a missing or misnamed <code>self</code> parameter in instance methods and <code>cls</code> parameter in class methods. Instance methods in metaclasses (classes that derive from <code>type</code>) are allowed to use <code>cls</code> for instance methods."
+      "x-intellij-html-description": "Generate or suppress diagnostics for a missing or misnamed <code>self</code> parameter in instance methods and <code>cls</code> parameter in class methods. Instance methods in metaclasses (classes that derive from <code>type</code>) are allowed to use <code>cls</code> for instance methods.",
+      "default": "warning"
     },
     "reportImplicitStringConcatenation": {
       "$id": "#/properties/reportImplicitStringConcatenation",
@@ -599,32 +600,32 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of incomplete type stubs that declare a module-level `__getattr__` function",
       "description": "Generate or suppress diagnostics for a module-level `__getattr__` call in a type stub file, indicating that it is incomplete.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for a module-level <code>__getattr__</code> call in a type stub file, indicating that it is incomplete."
+      "x-intellij-html-description": "Generate or suppress diagnostics for a module-level <code>__getattr__</code> call in a type stub file, indicating that it is incomplete.",
+      "default": "none"
     },
     "reportUnsupportedDunderAll": {
       "$id": "#/properties/reportUnsupportedDunderAll",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of unsupported operations performed on `__all__`",
       "description": "Generate or suppress diagnostics for statements that define or manipulate `__all__` in a way that is not allowed by a static type checker, thus rendering the contents of `__all__` to be unknown or incorrect. Also reports names within the `__all__` list that are not present in the module namespace.",
-      "default": "warning",
-      "x-intellij-html-description": "Generate or suppress diagnostics for statements that define or manipulate <code>__all__</code> in a way that is not allowed by a static type checker, thus rendering the contents of <code>__all__</code> to be unknown or incorrect. Also reports names within the <code>__all__</code> list that are not present in the module namespace."
+      "x-intellij-html-description": "Generate or suppress diagnostics for statements that define or manipulate <code>__all__</code> in a way that is not allowed by a static type checker, thus rendering the contents of <code>__all__</code> to be unknown or incorrect. Also reports names within the <code>__all__</code> list that are not present in the module namespace.",
+      "default": "warning"
     },
     "reportUnusedCallResult": {
       "$id": "#/properties/reportUnusedCallResult",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of call expressions whose results are not consumed",
       "description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is not `None`.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is not <code>None</code>."
+      "x-intellij-html-description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is not <code>None</code>.",
+      "default": "none"
     },
     "reportUnusedCoroutine": {
       "$id": "#/properties/reportUnusedCoroutine",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of call expressions that returns `Coroutine` whose results are not consumed",
       "description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is a `Coroutine`. This identifies a common error where an `await` keyword is mistakenly omitted.",
-      "default": "error",
-      "x-intellij-html-description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is a <code>Coroutine</code>. This identifies a common error where an <code>await</code> keyword is mistakenly omitted."
+      "x-intellij-html-description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is a <code>Coroutine</code>. This identifies a common error where an <code>await</code> keyword is mistakenly omitted.",
+      "default": "error"
     },
     "reportUnusedExpression": {
       "$id": "#/properties/reportUnusedExpression",
@@ -638,16 +639,16 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `# type: ignore` comments that have no effect",
       "description": "Generate or suppress diagnostics for a `# type: ignore` or `# pyright: ignore` comment that would have no effect if removed.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for a <code># type: ignore</code> or <code># pyright: ignore</code> comment that would have no effect if removed."
+      "x-intellij-html-description": "Generate or suppress diagnostics for a <code># type: ignore</code> or <code># pyright: ignore</code> comment that would have no effect if removed.",
+      "default": "none"
     },
     "reportMatchNotExhaustive": {
       "$id": "#/properties/reportMatchNotExhaustive",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `match` statements that do not exhaustively match all possible values",
       "description": "Generate or suppress diagnostics for a `match` statement that does not provide cases that exhaustively match against all potential types of the target expression.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for a <code>match</code> statement that does not provide cases that exhaustively match against all potential types of the target expression."
+      "x-intellij-html-description": "Generate or suppress diagnostics for a <code>match</code> statement that does not provide cases that exhaustively match against all potential types of the target expression.",
+      "default": "none"
     },
     "reportShadowedImports": {
       "$id": "#/properties/reportShadowedImports",
@@ -661,8 +662,8 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting overridden methods that are missing an `@override` decorator",
       "description": "Generate or suppress diagnostics for overridden methods in a class that are missing an explicit `@override` decorator.",
-      "default": "none",
-      "x-intellij-html-description": "Generate or suppress diagnostics for overridden methods in a class that are missing an explicit <code>@override</code> decorator."
+      "x-intellij-html-description": "Generate or suppress diagnostics for overridden methods in a class that are missing an explicit <code>@override</code> decorator.",
+      "default": "none"
     },
     "extraPaths": {
       "$id": "#/properties/extraPaths",
@@ -682,39 +683,39 @@
       "type": "string",
       "title": "Python version to assume during type analysis",
       "description": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. `3.0` or `3.6`). If a version is provided, pyright will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version. If no version is specified, pyright will use the version of the current python interpreter, if one is present.",
+      "x-intellij-html-description": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format <code>M.m</code> where <code>M</code> is the major version and <code>m</code> is the minor (e.g. <code>3.0</code> or <code>3.6</code>). If a version is provided, pyright will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version. If no version is specified, pyright will use the version of the current python interpreter, if one is present.",
       "default": "",
       "examples": ["3.7"],
-      "pattern": "^3\\.[0-9]+$",
-      "x-intellij-html-description": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format <code>M.m</code> where <code>M</code> is the major version and <code>m</code> is the minor (e.g. <code>3.0</code> or <code>3.6</code>). If a version is provided, pyright will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version. If no version is specified, pyright will use the version of the current python interpreter, if one is present."
+      "pattern": "^3\\.[0-9]+$"
     },
     "pythonPlatform": {
       "$id": "#/properties/pythonPlatform",
       "type": "string",
       "title": "Python platform to assume during type analysis",
       "description": "Specifies the target platform that will be used to execute the source code. Should be one of `Windows`, `Darwin`, `Linux`, or `All`. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
+      "x-intellij-html-description": "Specifies the target platform that will be used to execute the source code. Should be one of <code>Windows</code>, <code>Darwin</code>, <code>Linux</code>, or <code>All</code>. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
       "default": "",
       "examples": ["Linux"],
-      "pattern": "^(Linux|Windows|Darwin|All)$",
-      "x-intellij-html-description": "Specifies the target platform that will be used to execute the source code. Should be one of <code>Windows</code>, <code>Darwin</code>, <code>Linux</code>, or <code>All</code>. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform."
+      "pattern": "^(Linux|Windows|Darwin|All)$"
     },
     "venvPath": {
       "$id": "#/properties/venvPath",
       "type": "string",
       "title": "Path to directory containing a folder of virtual environments",
       "description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a `venv` setting, pyright will search for imports in the virtual environment's site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
+      "x-intellij-html-description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a <code>venv</code> setting, pyright will search for imports in the virtual environment&#39;s site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
       "default": "",
-      "pattern": "^(.*)$",
-      "x-intellij-html-description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a <code>venv</code> setting, pyright will search for imports in the virtual environment&#39;s site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting."
+      "pattern": "^(.*)$"
     },
     "venv": {
       "$id": "#/properties/venv",
       "type": "string",
       "title": "Name of virtual environment subdirectory within `venvPath`",
       "description": "Used in conjunction with the `venvPath`, specifies the virtual environment to use.",
+      "x-intellij-html-description": "Used in conjunction with the <code>venvPath</code>, specifies the virtual environment to use.",
       "default": "",
       "examples": ["python37"],
-      "pattern": "^(.*)$",
-      "x-intellij-html-description": "Used in conjunction with the <code>venvPath</code>, specifies the virtual environment to use."
+      "pattern": "^(.*)$"
     },
     "verboseOutput": {
       "$id": "#/properties/verboseOutput",
@@ -747,34 +748,34 @@
             "type": "array",
             "title": "Additional import search resolution paths",
             "description": "Additional search paths (in addition to the root path) that will be used when searching for modules imported by files within this execution environment. If specified, this overrides the default `extraPaths` setting when resolving imports for files within this execution environment. Note that each file's execution environment mapping is independent, so if file A is in one execution environment and imports a second file B within a second execution environment, any imports from B will use the `extraPaths` in the second execution environment.",
+            "x-intellij-html-description": "Additional search paths (in addition to the root path) that will be used when searching for modules imported by files within this execution environment. If specified, this overrides the default <code>extraPaths</code> setting when resolving imports for files within this execution environment. Note that each file&#39;s execution environment mapping is independent, so if file A is in one execution environment and imports a second file B within a second execution environment, any imports from B will use the <code>extraPaths</code> in the second execution environment.",
             "items": {
               "$id": "#/properties/executionEnvironments/items/properties/extraPaths/items",
               "type": "string",
               "title": "Additional import search resolution path",
               "default": "",
               "pattern": "^(.*)$"
-            },
-            "x-intellij-html-description": "Additional search paths (in addition to the root path) that will be used when searching for modules imported by files within this execution environment. If specified, this overrides the default <code>extraPaths</code> setting when resolving imports for files within this execution environment. Note that each file&#39;s execution environment mapping is independent, so if file A is in one execution environment and imports a second file B within a second execution environment, any imports from B will use the <code>extraPaths</code> in the second execution environment."
+            }
           },
           "pythonVersion": {
             "$id": "#/properties/executionEnvironments/items/properties/pythonVersion",
             "type": "string",
             "title": "Python version to assume during type analysis",
             "description": "The version of Python used for this execution environment. If not specified, the global `pythonVersion` setting is used instead.",
+            "x-intellij-html-description": "The version of Python used for this execution environment. If not specified, the global <code>pythonVersion</code> setting is used instead.",
             "default": "",
             "examples": ["3.7"],
-            "pattern": "^3\\.[0-9]+$",
-            "x-intellij-html-description": "The version of Python used for this execution environment. If not specified, the global <code>pythonVersion</code> setting is used instead."
+            "pattern": "^3\\.[0-9]+$"
           },
           "pythonPlatform": {
             "$id": "#/properties/executionEnvironments/items/properties/pythonPlatform",
             "type": "string",
             "title": "Python platform to assume during type analysis",
             "description": "Specifies the target platform that will be used for this execution environment. If not specified, the global `pythonPlatform` setting is used instead.",
+            "x-intellij-html-description": "Specifies the target platform that will be used for this execution environment. If not specified, the global <code>pythonPlatform</code> setting is used instead.",
             "default": "",
             "examples": ["Linux"],
-            "pattern": "^(Linux|Windows|Darwin|All)$",
-            "x-intellij-html-description": "Specifies the target platform that will be used for this execution environment. If not specified, the global <code>pythonPlatform</code> setting is used instead."
+            "pattern": "^(Linux|Windows|Darwin|All)$"
           }
         }
       }


### PR DESCRIPTION
Add [`markdownDescription`](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings) and [`x-intellij-html-description`](https://www.jetbrains.com/help/pycharm/json.html#ws_json_show_doc_in_html) to `partial-mypy.json`. This provides better, tailored support for VSCode and PyCharm, correspondingly.