### PR TITLE
feat(flagd): add targeting, update schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -529,9 +529,10 @@
         "*.flagd.yaml",
         "*.flagd.yml"
       ],
-      "url": "https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json",
+      "url": "https://flagd.dev/schema/v0/flags.json",
       "versions": {
-        "0.1.1": "https://raw.githubusercontent.com/open-feature/schemas/json/json-schema-v0.1.1/json/flagd-definitions.json"
+        "0.1.1": "https://raw.githubusercontent.com/open-feature/flagd-schemas/json/json-schema-v0.1.1/json/flagd-definitions.json",
+        "0.2.0": "https://raw.githubusercontent.com/open-feature/flagd-schemas/json/json-schema-v0.2.0/json/flags.json"
       }
     },
     {


### PR DESCRIPTION
Updates to latest flagd schema (hosted at flagd.dev: https://flagd.dev/schema/v0/flags.json)