### PR TITLE
Remove "overrides" in partial-pyright.json

### DIFF
--- a/src/schemas/json/partial-pyright.json
+++ b/src/schemas/json/partial-pyright.json
@@ -779,9 +779,6 @@
           }
         }
       }
-    },
-    "overrides": {
-      "$comment": "This field is included in the original schema but not in the configuration documentation file."
     }
   }
 }


### PR DESCRIPTION
I'm not sure why I thought it was there in [the original schema](https://github.com/microsoft/pyright/blob/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json); the commit history made it clear that I hallucinated it somehow. Anyway, it is unnecessary at best and should be removed.