### PR TITLE
Add `devcontainers` as a supported Dependabot ecosystem

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -651,6 +651,7 @@
         "bundler",
         "cargo",
         "composer",
+        "devcontainers",
         "docker",
         "elm",
         "gitsubmodule",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
Support was added in https://github.com/dependabot/dependabot-core/pull/8445
