### PR TITLE
[Azure Functions] Add new property 'sendCanceledInvocationsToWorker'

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -1382,6 +1382,11 @@
             }
           },
           "additionalProperties": false
+        },
+        "sendCanceledInvocationsToWorker": {
+          "description": "Where the language worker supports 'Cancellation', send canceled invocations to the worker. If not set, defaults to true.",
+          "type": "boolean",
+          "default": true
         }
       },
       "required": ["version"],

--- a/src/test/host/host.v2.json
+++ b/src/test/host/host.v2.json
@@ -192,6 +192,7 @@
     "maxRetryCount": 5,
     "delayInterval": "00:00:05"
   },
+  "sendCanceledInvocationsToWorker": true,
   "singleton": {
     "lockPeriod": "00:00:15",
     "listenerLockPeriod": "00:01:00",
@@ -201,6 +202,5 @@
   },
   "version": "2.0",
   "watchDirectories": ["Shared", "Test"],
-  "watchFiles": ["myFile.txt"],
-  "sendCanceledInvocationsToWorker": true
+  "watchFiles": ["myFile.txt"]
 }

--- a/src/test/host/host.v2.json
+++ b/src/test/host/host.v2.json
@@ -201,5 +201,6 @@
   },
   "version": "2.0",
   "watchDirectories": ["Shared", "Test"],
-  "watchFiles": ["myFile.txt"]
+  "watchFiles": ["myFile.txt"],
+  "sendCanceledInvocationsToWorker": true
 }


### PR DESCRIPTION
Adding new host property that has been added via this PR: https://github.com/Azure/azure-functions-host/pull/9523

`sendCanceledInvocationsToWorker` is a new configuration property for handling pre-cancelled invocation requests in Azure Function.

- If a worker supports CancellationTokens, cancelled invocations will now be sent to the worker by default
    - Customers can opt-out of this behavior by setting `SendCanceledInvocationsToWorker` to `false` in host.json
- If a worker does not support CancellationTokens, cancelled invocations will not be sent to the worker