### PR TITLE
feat: add rockcraft schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3661,7 +3661,7 @@
     {
       "name": "rockcraft",
       "description": "rockcraft project (https://canonical-rockcraft.readthedocs-hosted.com)",
-      "fileMatch": ["rockcraft.y*ml"],
+      "fileMatch": ["rockcraft.yaml", "rockcraft.yml"],
       "url": "https://raw.githubusercontent.com/canonical/rockcraft/main/schema/rockcraft.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3659,6 +3659,12 @@
       }
     },
     {
+      "name": "rockcraft",
+      "description": "rockcraft project (https://canonical-rockcraft.readthedocs-hosted.com)",
+      "fileMatch": ["rockcraft.y*ml"],
+      "url": "https://raw.githubusercontent.com/canonical/rockcraft/main/schema/rockcraft.json"
+    },
+    {
       "name": "rustfmt",
       "description": "fustfmt, a tool to format Rust code",
       "fileMatch": ["rustfmt.toml"],


### PR DESCRIPTION
This add rockcraft schema for [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com) yaml files.
Note that the generation of this schema is generated by [a script hosted on the rockcraft repo](https://github.com/canonical/rockcraft/blob/main/tools/schema/schema.py).
