### PR TITLE
Support array `skip` in linkinator-config.json

### DIFF
--- a/src/schemas/json/linkinator-config.json
+++ b/src/schemas/json/linkinator-config.json
@@ -18,7 +18,17 @@
     },
     "skip": {
       "description": "List of urls in regexy form to not include in the check.",
-      "type": "string",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ],
       "default": "www.googleapis.com"
     },
     "format": {

--- a/src/test/linkinator-config/skip-array-config.json
+++ b/src/test/linkinator-config/skip-array-config.json
@@ -1,0 +1,3 @@
+{
+  "skip": ["fake.local", "fake2.local"]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Supported `skip` field types https://github.com/JustinBeckwith/linkinator/blob/501fc4c/src/config.ts#L9

Copied test from https://github.com/JustinBeckwith/linkinator/blob/501fc4c/test/fixtures/config/skip-array-config.json