### PR TITLE
chore: update for scikit-build-core 0.8

### DIFF
--- a/src/schemas/json/partial-scikit-build.json
+++ b/src/schemas/json/partial-scikit-build.json
@@ -19,22 +19,32 @@
       "additionalProperties": false,
       "properties": {
         "python-version": {
-          "type": "string"
+          "type": "string",
+          "description": "The two-digit Python version. Takes a specifier set."
         },
         "implementation-name": {
-          "type": "string"
+          "type": "string",
+          "description": "The value of `sys.implementation.name`. Takes a regex"
         },
         "implementation-version": {
-          "type": "string"
+          "type": "string",
+          "description": "Derived from `sys.implementation.version`, following PEP 508. Takes a specifier set."
         },
         "platform-system": {
-          "type": "string"
+          "type": "string",
+          "description": "The value of `sys.platform`. Takes a regex."
         },
         "platform-machine": {
-          "type": "string"
+          "type": "string",
+          "description": "The value of `platform.machine()`. Takes a regex."
         },
         "platform-node": {
-          "type": "string"
+          "type": "string",
+          "description": "The value of `platform.node()`. Takes a regex."
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of the build, one of `sdist`, `wheel`, `editable`, `metadata_wheel`, and `metadata_editable`. Takes a regex."
         },
         "env": {
           "type": "object",
@@ -51,7 +61,8 @@
             }
           },
           "additionalProperties": false,
-          "minProperties": 1
+          "minProperties": 1,
+          "description": "A table of environment variables mapped to either string regexs, or booleans. Valid 'truthy' environment variables are case insensitive `true`, `on`, `yes`, `y`, `t`, or a number more than 0."
         }
       }
     }
@@ -66,8 +77,13 @@
       "properties": {
         "minimum-version": {
           "type": "string",
-          "default": "3.15",
-          "description": "The minimum version of CMake to use. If CMake is not present on the system or is older than this, it will be downloaded via PyPI if possible. An empty string will disable this check."
+          "description": "DEPRECATED in 0.8; use version instead.",
+          "deprecated": true
+        },
+        "version": {
+          "type": "string",
+          "default": ">=3.15",
+          "description": "The versions of CMake to allow. If CMake is not present on the system or does not pass this specifier, it will be downloaded via PyPI if possible. An empty string will disable this check."
         },
         "args": {
           "type": "array",
@@ -82,10 +98,35 @@
             ".+": {
               "oneOf": [
                 {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
                 },
                 {
-                  "type": "boolean"
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["env"],
+                  "properties": {
+                    "env": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "default": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "boolean"
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }
@@ -122,8 +163,13 @@
       "properties": {
         "minimum-version": {
           "type": "string",
-          "default": "1.5",
-          "description": "The minimum version of Ninja to use. If Ninja is not present on the system or is older than this, it will be downloaded via PyPI if possible. An empty string will disable this check."
+          "description": "DEPRECATED in 0.8; use version instead.",
+          "deprecated": true
+        },
+        "version": {
+          "type": "string",
+          "default": ">=1.5",
+          "description": "The versions of Ninja to allow. If Ninja is not present on the system or does not pass this specifier, it will be downloaded via PyPI if possible. An empty string will disable this check."
         },
         "make-fallback": {
           "type": "boolean",
@@ -221,6 +267,11 @@
             "type": "string"
           },
           "description": "A set of patterns to exclude from the wheel. This is additive to the SDist exclude patterns. This applies to the source files, not the final paths. Editable installs may not respect this exclusion."
+        },
+        "build-tag": {
+          "type": "string",
+          "default": "",
+          "description": "The build tag to use for the wheel. If empty, no build tag is used."
         }
       }
     },
@@ -397,6 +448,7 @@
     },
     "overrides": {
       "type": "array",
+      "description": "A list of overrides to apply to the settings, based on the `if` selector.",
       "items": {
         "type": "object",
         "required": ["if"],


### PR DESCRIPTION

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Update for 0.8, released today.
