### PR TITLE
Update GitHub labeler action to v5

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3454,7 +3454,11 @@
       "name": "Pull Request Labeler",
       "description": "A GitHub Action for automatically labelling pull requests",
       "fileMatch": ["**/.github/labeler.yml"],
-      "url": "https://json.schemastore.org/pull-request-labeler.json"
+      "url": "https://json.schemastore.org/pull-request-labeler.json",
+      "versions": {
+        "4": "https://json.schemastore.org/pull-request-labeler.json",
+        "5": "https://json.schemastore.org/pull-request-labeler-5.json"
+      }
     },
     {
       "name": ".putout.json",

--- a/src/negative_test/pull-request-labeler-5/bad-changed-files.yml
+++ b/src/negative_test/pull-request-labeler-5/bad-changed-files.yml
@@ -1,0 +1,5 @@
+---
+apps:
+  - changed-files:
+      # This entry is typoed; it should be any-glob-to-any-file.
+      - any-globs-to-any-files: ['compose/*', 'compose/**/*']

--- a/src/negative_test/pull-request-labeler-5/bad-toplevel.yml
+++ b/src/negative_test/pull-request-labeler-5/bad-toplevel.yml
@@ -1,0 +1,4 @@
+---
+apps:
+  - changing-file:
+      - any-glob-to-any-file: ['compose/*', 'compose/**/*']

--- a/src/negative_test/pull-request-labeler-5/bad-type.yml
+++ b/src/negative_test/pull-request-labeler-5/bad-type.yml
@@ -1,0 +1,4 @@
+---
+apps:
+  changed-files:
+    - any-glob-to-any-file: ['compose/*', 'compose/**/*']

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -164,6 +164,7 @@
     "prometheus.json",
     "proxies.json",
     "pull-request-labeler.json",
+    "pull-request-labeler-5.json",
     "putout.json",
     "pyrseas-0.8.json",
     "rehyperc.json",

--- a/src/schemas/json/pull-request-labeler-5.json
+++ b/src/schemas/json/pull-request-labeler-5.json
@@ -26,9 +26,15 @@
             "type": "object",
             "properties": {
               "any-glob-to-any-file": { "$ref": "#/$defs/stringOrStringArray" },
-              "any-glob-to-all-files": { "$ref": "#/$defs/stringOrStringArray" },
-              "all-globs-to-any-file": { "$ref": "#/$defs/stringOrStringArray" },
-              "all-globs-to-all-files": { "$ref": "#/$defs/stringOrStringArray" }
+              "any-glob-to-all-files": {
+                "$ref": "#/$defs/stringOrStringArray"
+              },
+              "all-globs-to-any-file": {
+                "$ref": "#/$defs/stringOrStringArray"
+              },
+              "all-globs-to-all-files": {
+                "$ref": "#/$defs/stringOrStringArray"
+              }
             },
             "oneOf": [
               { "required": ["any-glob-to-any-file"] },

--- a/src/schemas/json/pull-request-labeler-5.json
+++ b/src/schemas/json/pull-request-labeler-5.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/pull-request-labeler-5.json",
+  "$comment": "https://github.com/actions/labeler",
+  "$defs": {
+    "stringOrStringArray": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "match": {
+      "title": "Match",
+      "type": "object",
+      "properties": {
+        "changed-files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "any-glob-to-any-file": { "$ref": "#/$defs/stringOrStringArray" },
+              "any-glob-to-all-files": { "$ref": "#/$defs/stringOrStringArray" },
+              "all-globs-to-any-file": { "$ref": "#/$defs/stringOrStringArray" },
+              "all-globs-to-all-files": { "$ref": "#/$defs/stringOrStringArray" }
+            },
+            "oneOf": [
+              { "required": ["any-glob-to-any-file"] },
+              { "required": ["any-glob-to-all-files"] },
+              { "required": ["all-globs-to-any-file"] },
+              { "required": ["all-globs-to-all-files"] }
+            ],
+            "additionalProperties": false
+          }
+        },
+        "base-branch": { "$ref": "#/$defs/stringOrStringArray" },
+        "head-branch": { "$ref": "#/$defs/stringOrStringArray" }
+      },
+      "oneOf": [
+        { "required": ["changed-files"] },
+        { "required": ["base-branch"] },
+        { "required": ["head-branch"] }
+      ],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": {
+    "title": "Label",
+    "type": "array",
+    "items": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "all": {
+              "title": "All",
+              "type": "array",
+              "items": { "$ref": "#/$defs/match" }
+            }
+          },
+          "additionalProperties": false,
+          "required": ["all"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "any": {
+              "title": "Any",
+              "type": "array",
+              "items": { "$ref": "#/$defs/match" }
+            }
+          },
+          "additionalProperties": false,
+          "required": ["any"]
+        },
+        { "$ref": "#/$defs/match" }
+      ]
+    }
+  },
+  "description": "A GitHub Action for automatically labelling pull requests.",
+  "title": "Pull Request Labeler",
+  "type": "object"
+}

--- a/src/test/pull-request-labeler-5/examples.yml
+++ b/src/test/pull-request-labeler-5/examples.yml
@@ -1,0 +1,57 @@
+---
+# Add 'root' label to any root file changes.
+root:
+  - changed-files:
+      - any-glob-to-any-file: '*'
+
+# Add 'AnyChange' label to any changes within the entire repository.
+AnyChange:
+  - changed-files:
+      - any-glob-to-any-file: '**'
+
+# Add 'Documentation0' label to any changes within 'docs' folder or any
+# subfolders.
+Documentation0:
+  - changed-files:
+      - any-glob-to-any-file: docs/**
+
+# Add 'Documentation1' label to any file changes within 'docs' folder.
+Documentation1:
+  - changed-files:
+      - any-glob-to-any-file: docs/*
+
+# Add 'Documentation2' label to any file changes within 'docs' or 'guides'
+# folders.
+Documentation2:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/*
+          - guides/*
+
+## Equivalent of the above mentioned configuration using another syntax.
+Documentation3:
+  - changed-files:
+      - any-glob-to-any-file: ['docs/*', 'guides/*']
+
+# Add 'Documentation4' label to any change to .md files within the entire
+# repository.
+Documentation4:
+  - changed-files:
+      - any-glob-to-any-file: '**/*.md'
+
+# Add 'source' label to any change to src files within the source dir EXCEPT
+# for the docs sub-folder.
+source:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: 'src/**/*'
+          - all-globs-to-all-files: '!src/docs/*'
+
+# Add 'feature' label to any PR where the head branch name starts with
+# `feature` or has a `feature` section in the name.
+feature:
+  - head-branch: ['^feature', 'feature']
+
+# Add 'release' label to any PR that is opened against the `main` branch.
+release:
+  - base-branch: 'main'


### PR DESCRIPTION
As the original schema did not have a version in the name, I'm a bit unsure whether I should add the version to the new one, the old one, or both, and/or make the non-versioned one the latest or vice-versa.

I also need to write up some tests.
