### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -40,12 +40,26 @@
     "DocstringCodeLineWidth": {
       "anyOf": [
         {
-          "$ref": "#/definitions/LineWidth"
+          "description": "Wrap docstring code examples at a fixed line width.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LineWidth"
+            }
+          ]
         },
         {
-          "type": "null"
+          "description": "Respect the line length limit setting for the surrounding Python code.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Dynamic"
+            }
+          ]
         }
       ]
+    },
+    "Dynamic": {
+      "type": "string",
+      "const": "dynamic"
     },
     "Flake8AnnotationsOptions": {
       "type": "object",
@@ -1366,6 +1380,12 @@
           "format": "uint",
           "minimum": 0.0
         },
+        "max-nested-blocks": {
+          "description": "Maximum number of nested blocks allowed within a function or method body (see: `PLR1702`).",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0.0
+        },
         "max-positional-args": {
           "description": "Maximum number of positional arguments allowed for a function or method definition (see: `PLR0917`).\n\nIf not specified, defaults to the value of `max-args`.",
           "type": ["integer", "null"],
@@ -2114,6 +2134,7 @@
         "PLR17",
         "PLR170",
         "PLR1701",
+        "PLR1702",
         "PLR1704",
         "PLR1706",
         "PLR171",


### PR DESCRIPTION
This updates ruff's JSON schema to [5fe0fdd0a877b05846595459c822c7c73c1adab2](https://github.com/astral-sh/ruff/commit/5fe0fdd0a877b05846595459c822c7c73c1adab2)

Sorr for two updates in one week -- we fixed a bug in the schema.