### PR TITLE
appveyor: Add type key to artifacts

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -700,6 +700,18 @@
               },
               "name": {
                 "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "Auto",
+                  "WebDeployPackage",
+                  "NuGetPackage",
+                  "AzureCloudService",
+                  "AzureCloudServiceConfig",
+                  "SsdtPackage",
+                  "Zip",
+                  "File"
+                ]
               }
             },
             "required": ["path"]

--- a/src/test/appveyor/appveyor2.yml
+++ b/src/test/appveyor/appveyor2.yml
@@ -253,6 +253,8 @@ artifacts:
 
   # pushing entire folder as a zip archive
   - path: logs
+    name: test logs
+    type: Zip
 
   # pushing all *.nupkg files in build directory recursively
   - path: '**\*.nupkg'


### PR DESCRIPTION
For some reason, this key is not documented on the appveyor.yml reference [1], but is documented in the Packaging Artifacts page [2].

[1] https://www.appveyor.com/docs/appveyor-yml/
[2] https://www.appveyor.com/docs/packaging-artifacts/#basics

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
