### PR TITLE
Fill out `steps` property for Google's `cloudbuild.json` schema

### DIFF
--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -18,9 +18,9 @@
         "allowExitCodes": {
           "description": "Specify that a build step failure can be ignored when that step returns a particular exit code.",
           "type": "array",
-            "items": {
-              "type": "number"
-            }
+          "items": {
+            "type": "number"
+          }
         },
         "waitFor": {
           "description": "The ID(s) of the step(s) that this build step depends on.\nThis build step will not start until all the build steps in `wait_for`\nhave completed successfully. If `wait_for` is empty, this build step will\nstart when all previous build steps in the `Build.Steps` list have\ncompleted successfully.",

--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -5,10 +5,22 @@
     "BuildStep": {
       "description": "A step in the build pipeline.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "name": {
           "description": "Required. The name of the container image that will run this particular\nbuild step.\n\nIf the image is available in the host's Docker daemon's cache, it\nwill be run directly. If not, the host will attempt to pull the image\nfirst, using the builder service account's credentials if necessary.\n\nThe Docker daemon's cache will already have the latest versions of all of\nthe officially supported build steps\n([https://github.com/GoogleCloudPlatform/cloud-builders](https://github.com/GoogleCloudPlatform/cloud-builders)).\nThe Docker daemon will also have cached many of the layers for some popular\nimages, like \"ubuntu\", \"debian\", but they will be refreshed at the time you\nattempt to use them.\n\nIf you built an image in a previous build step, it will be stored in the\nhost's Docker daemon's cache and is available to use as the name for a\nlater build step.",
           "type": "string"
+        },
+        "allowFailure": {
+          "description": "In a build step, if you set the value of the allowFailure field to true, and the build step fails, then the build succeeds as long as all other build steps in that build succeed.",
+          "type": "boolean"
+        },
+        "allowExitCodes": {
+          "description": "Specify that a build step failure can be ignored when that step returns a particular exit code.",
+          "type": "array",
+            "items": {
+              "type": "number"
+            }
         },
         "waitFor": {
           "description": "The ID(s) of the step(s) that this build step depends on.\nThis build step will not start until all the build steps in `wait_for`\nhave completed successfully. If `wait_for` is empty, this build step will\nstart when all previous build steps in the `Build.Steps` list have\ncompleted successfully.",
@@ -26,6 +38,10 @@
         },
         "entrypoint": {
           "description": "Entrypoint to be used instead of the build step image's default entrypoint.\nIf unset, the image's default entrypoint is used.",
+          "type": "string"
+        },
+        "script": {
+          "description": "Specify a shell script to execute in the step.\nIf you specify script in a build step, you cannot specify args or entrypoint in the same step.",
           "type": "string"
         },
         "volumes": {


### PR DESCRIPTION
This fills out the Google Cloud Build schema's `steps` property. 

Added properties:

- `allowFailure`
- `allowExitCodes`
- `script`

With this PR, all the possible values for `steps` has been filled out (see [Build configuration file schema](https://cloud.google.com/build/docs/build-config-file-schema#structure_of_a_build_config_file)), so I've added `"additionalProperties": false` for the `BuildStep` definition to catch misspelled or incorrect properties for `steps`.