### PR TITLE
Add support for Elgato Stream Deck plugin manifest (#3439)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1721,6 +1721,15 @@
       "url": "https://raw.githubusercontent.com/weaveworks/eksctl/main/pkg/apis/eksctl.io/v1alpha5/assets/schema.json"
     },
     {
+      "name": "Elgato Stream Deck",
+      "description": "Elgato Stream Deck plugin manifest file",
+      "fileMatch": [
+        "elgato-stream-deck-plugin.yml",
+        "elgato-stream-deck-plugin.yaml"
+      ],
+      "url": "https://json.schemastore.org/elgato-stream-deck-plugin.json"
+    },
+    {
       "name": ".esmrc.json",
       "description": "Configuration files for the esm module/package in Node.js",
       "fileMatch": [

--- a/src/schemas/json/elgato-stream-deck-plugin.json
+++ b/src/schemas/json/elgato-stream-deck-plugin.json
@@ -1,0 +1,365 @@
+{
+  "$id": "https://json.schemastore.org/elgato-stream-deck-plugin.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "title": "Elgato Stream Deck Manifest",
+  "description": "Manifest files for plugins built for the Elgato Stream Deck SDK",
+  "$comment": "Used as reference: https://docs.elgato.com/sdk/plugins/manifest",
+  "type": "object",
+  "properties": {
+    "Author": {
+      "description": "The author of the plugin. This string is displayed to the user in the Stream Deck store.",
+      "type": "string"
+    },
+    "CodePath": {
+      "type": "string",
+      "description": "The relative path to the HTML/binary file containing the plugin code."
+    },
+    "Description": {
+      "type": "string",
+      "description": "Provides a general description of what the plugin does. This string is displayed to the user in the Stream Deck store."
+    },
+    "Icon": {
+      "type": "string",
+      "description": "The relative path to an image without the extension. This image is displayed in the Stream Deck marketplace. SVGs are preferred. If not, the PNG image should be 288 x 288 px, and you should provide @1x and @2x (288 x 288 px & 576 x 576 px respectively). The Stream Deck application takes care of loading the appropriate version of the image."
+    },
+    "Name": {
+      "type": "string",
+      "description": "The name of the plugin. This string is displayed to the user in the Stream Deck store."
+    },
+    "Version": {
+      "type": "string",
+      "description": "Plugin's semantic version (1.0.0)."
+    },
+    "SDKVersion": {
+      "type": "number",
+      "minimum": 1,
+      "description": "The current SDK version is 2."
+    },
+    "OS": {
+      "type": "array",
+      "description": "The list of operating systems & versions supported by the plugin.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "Platform": {
+            "enum": ["mac", "windows"]
+          },
+          "MinimumVersion": {
+            "type": "string",
+            "description": "The minimum version of the operating system that the plugin requires. Example: For Windows 10, you can use `10`. For macOS 10.11, you can use `10.11`.",
+            "examples": ["10", "10.11"],
+            "pattern": "^\\d+(\\.\\d+)*$"
+          }
+        },
+        "required": ["Platform", "MinimumVersion"]
+      }
+    },
+    "Software": {
+      "type": "object",
+      "description": "Indicates which version of the Stream Deck application is required to install the plugin.",
+      "properties": {
+        "MinimumVersion": {
+          "type": "string",
+          "description": "The minimum version of the operating system that the plugin requires. For Windows 10, you can use “10”. For macOS 10.11, you can use “10.11”.",
+          "pattern": "^\\d+(\\.\\d+)*$"
+        }
+      }
+    },
+    "Category": {
+      "type": "string",
+      "description": "The name of the custom category in which the actions should be listed. This string is visible to the user in the actions list. If you don't provide a category, the actions will appear inside a \"Custom\" category."
+    },
+    "CategoryIcon": {
+      "type": "string",
+      "description": "The relative path to a PNG image without the .png extension. This image is used in the actions list. The PNG image should be a 28pt x 28pt image. You should provide @1x and @2x versions of the image. The Stream Deck application takes care of loading the appropriate version of the image."
+    },
+    "CodePathMac": {
+      "type": "string",
+      "description": "Override CodePath for macOS."
+    },
+    "CodePathWin": {
+      "type": "string",
+      "description": "Override CodePath for Windows."
+    },
+    "Profiles": {
+      "type": "array",
+      "description": "Specifies an array of profiles. A plugin can have one or more profiles proposed to the user on installation. This lets you create full screen plugins.",
+      "items": {
+        "type": "object",
+        "required": ["Name", "DeviceType"],
+        "properties": {
+          "Name": {
+            "type": "string",
+            "description": "The filename of the profile."
+          },
+          "DeviceType": {
+            "description": "Type of device.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 7
+          },
+          "Readonly": {
+            "type": "boolean",
+            "default": false,
+            "description": "Boolean to mark the profile as read-only."
+          },
+          "DontAutoSwitchWhenInstalled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Boolean to prevent Stream Deck from automatically switching to this profile when installed."
+          }
+        }
+      }
+    },
+    "PropertyInspectorPath": {
+      "type": "string",
+      "description": "The relative path to the Property Inspector HTML file if your plugin wants to display some custom settings in the Property Inspector. If missing, the plugin will have an empty Property Inspector."
+    },
+    "DefaultWindowSize": {
+      "type": "array",
+      "description": "Specify the default window size when a Javascript plugin or Property Inspector opens a window using window.open(). The default value is [500, 650].",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "URL": {
+      "type": "string",
+      "description": "A site to provide more information about the plugin."
+    },
+    "ApplicationsToMonitor": {
+      "type": "object",
+      "description": "List of application identifiers to monitor (applications launched or terminated). See the `applicationDidLaunch` and `applicationDidTerminate` events.",
+      "properties": {
+        "mac": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "windows": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Actions": {
+      "description": "Specifies an array of actions. A plugin can indeed have one or multiple actions. For example, the “Game Capture” plugin has six actions: Scene, Record, Screenshot, Flashback Recording, Stream, Live Commentary.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["UUID", "Name", "States"],
+        "oneOf": [
+          {
+            "required": ["Icon"],
+            "properties": {
+              "Icon": {
+                "type": "string",
+                "description": "The relative path to a PNG image without the .png extension. This image is displayed in the actions list. The PNG image should be a 20pt x 20pt image. You should provide @1x and @2x versions of the image. The Stream Deck application takes care of loading the appropriate version of the image. This icon is not required for actions not visible in the actions list (`VisibleInActionsList` set to false)."
+              }
+            }
+          },
+          {
+            "required": ["VisibleInActionsList"],
+            "properties": {
+              "VisibleInActionsList": {
+                "const": false,
+                "description": "Boolean to hide the action in the actions list. This can be used for a plugin that only works with a specific profile."
+              }
+            }
+          }
+        ],
+        "properties": {
+          "UUID": {
+            "type": "string",
+            "pattern": "^[a-z0-9\\-.]",
+            "description": "The unique identifier of the action. It must be a uniform type identifier (UTI) that contains only lowercase alphanumeric characters (a-z, 0-9), hyphen (-), and period (.). The string must be in reverse-DNS format. For example, if your domain is `elgato.com` and you create a plugin named `Hello` with the action `My Action`, you could assign the string `com.elgato.hello.myaction` as your action's Unique Identifier."
+          },
+          "Name": {
+            "type": "string",
+            "description": "The name of the action. This string is visible to the user in the actions list."
+          },
+          "Icon": {
+            "type": "string",
+            "description": "The relative path to a PNG image without the .png extension. This image is displayed in the actions list. The PNG image should be a 20pt x 20pt image. You should provide @1x and @2x versions of the image. The Stream Deck application takes care of loading the appropriate version of the image. This icon is not required for actions not visible in the actions list (`VisibleInActionsList` set to false)."
+          },
+          "States": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["Image"],
+              "properties": {
+                "Image": {
+                  "type": "string",
+                  "description": "The default image for the state. When a user sets a custom image on the primary state, Stream Deck will automatically set the secondary state to a darker version of the same icon."
+                },
+                "MultiActionImage": {
+                  "type": "string",
+                  "description": "This can be used if you want to provide a different image for the state when the action is displayed in a Multi-Action."
+                },
+                "Name": {
+                  "type": "string",
+                  "description": "Displayed in the dropdown menu in the Multi-action. For example, the Game Capture Record action has Start and Stop. If the name is not provided, the state will not appear in the Multi-Action."
+                },
+                "Title": {
+                  "type": "string",
+                  "description": "Default title."
+                },
+                "ShowTitle": {
+                  "type": "string",
+                  "description": "Boolean to show or hide the title"
+                },
+                "TitleColor": {
+                  "type": "string",
+                  "description": "Default title color."
+                },
+                "FontFamily": {
+                  "type": "string",
+                  "enum": [
+                    "Arial",
+                    "Arial Black",
+                    "Comic Sans MS",
+                    "Courier",
+                    "Courier New",
+                    "Georgia",
+                    "Impact",
+                    "Microsoft Sans Serif",
+                    "Symbol",
+                    "Tahoma",
+                    "Times New Roman",
+                    "Trebuchet MS",
+                    "Verdana",
+                    "Webdings",
+                    "Wingdings"
+                  ],
+                  "description": "Default font family for the title."
+                },
+                "Title Alignment": {
+                  "type": "string",
+                  "enum": ["top", "bottom", "middle"],
+                  "description": "Default title vertical alignment."
+                },
+                "FontStyle": {
+                  "type": "string",
+                  "enum": ["Regular", "Bold", "Italic", "Bold Italic"],
+                  "description": "Default font style for the title. Note that some fonts might not support all values."
+                },
+                "FontSize": {
+                  "type": "string",
+                  "description": "Default font size for the title."
+                },
+                "FontUnderline": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Boolean to have an underline under the title."
+                }
+              }
+            }
+          },
+          "PropertyInspectorPath": {
+            "type": "string",
+            "description": "This can override PropertyInspectorPath member from the plugin if you wish to have a different PropertyInspectorPath based on the action. The relative path to the Property Inspector HTML file if your plugin wants to display some custom settings in the Property Inspector."
+          },
+          "SupportedInMultiActions": {
+            "type": "boolean",
+            "default": true,
+            "description": "Boolean to prevent the action from being used in a Multi Action."
+          },
+          "Tooltip": {
+            "type": "string",
+            "description": "The string is displayed as a tooltip when the user leaves the mouse over your action in the actions list."
+          },
+          "DisableCaching": {
+            "type": "boolean",
+            "default": false,
+            "description": "Boolean to disable image caching."
+          },
+          "DisableAutomaticStates": {
+            "type": "boolean",
+            "default": false,
+            "description": "Determines whether the state of the action should automatically toggle when the user presses the action; only applies to actions that have two states defined."
+          },
+          "VisibleInActionsList": {
+            "type": "boolean",
+            "default": true,
+            "description": "Boolean to hide the action in the actions list. This can be used for a plugin that only works with a specific profile."
+          },
+          "UserTitleEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Boolean to disable the title field for users in the property inspector."
+          },
+          "Controllers": {
+            "type": "array",
+            "description": "Specifies an array of controllers.",
+            "items": {
+              "type": "string",
+              "enum": ["Keypad", "Encoder"]
+            },
+            "default": ["Keypad"]
+          },
+          "Encoder": {
+            "type": "object",
+            "description": "Used to describe and configure the dial and display segment on Stream Deck +.",
+            "properties": {
+              "background": {
+                "type": "string",
+                "description": "The default background image for the encoders touch display slot."
+              },
+              "Icon": {
+                "type": "string",
+                "description": "The default icon found in the property inspector, dial stack image, and the layout. If no icon is set Stream Deck will use the action list icon."
+              },
+              "layout": {
+                "type": "string",
+                "description": "A string containing the name of a built-in layout or the partial path to a JSON file with a custom layout definition. You can dynamically change the layout with with setFeedbackLayout event. The default layout is the Icon Layout ($X1)."
+              },
+              "StackColor": {
+                "type": "string",
+                "description": "The color that will be used in the dial stack as background color."
+              },
+              "TriggerDescription": {
+                "type": "object",
+                "description": "Used to describe encoder actions in the property inspector.",
+                "properties": {
+                  "Rotate": {
+                    "description": "Describe the rotation.",
+                    "type": "string"
+                  },
+                  "Push": {
+                    "description": "Describe the encoder push.",
+                    "type": "string"
+                  },
+                  "Touch": {
+                    "description": "Describe the touch.",
+                    "type": "string"
+                  },
+                  "LongTouch": {
+                    "description": "Describe the long touch.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "Actions",
+    "CodePath",
+    "Description",
+    "Icon",
+    "Name",
+    "Version",
+    "SDKVersion",
+    "OS",
+    "Software"
+  ]
+}

--- a/src/schemas/json/elgato-stream-deck-plugin.json
+++ b/src/schemas/json/elgato-stream-deck-plugin.json
@@ -1,10 +1,10 @@
 {
-  "$id": "https://json.schemastore.org/elgato-stream-deck-plugin.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/elgato-stream-deck-plugin.json",
+  "$comment": "Used as reference: https://docs.elgato.com/sdk/plugins/manifest",
   "additionalProperties": true,
   "title": "Elgato Stream Deck Manifest",
   "description": "Manifest files for plugins built for the Elgato Stream Deck SDK",
-  "$comment": "Used as reference: https://docs.elgato.com/sdk/plugins/manifest",
   "type": "object",
   "properties": {
     "Author": {

--- a/src/schemas/json/elgato-stream-deck-plugin.json
+++ b/src/schemas/json/elgato-stream-deck-plugin.json
@@ -239,7 +239,7 @@
                   ],
                   "description": "Default font family for the title."
                 },
-                "Title Alignment": {
+                "TitleAlignment": {
                   "type": "string",
                   "enum": ["top", "bottom", "middle"],
                   "description": "Default title vertical alignment."

--- a/src/test/elgato-stream-deck-plugin/barraider-sample-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/barraider-sample-plugin.json
@@ -1,0 +1,41 @@
+{
+  "Actions": [
+    {
+      "Icon": "Images/icon",
+      "Name": "SDTools Test",
+      "States": [
+        {
+          "Image": "Images/pluginAction",
+          "TitleAlignment": "middle",
+          "FontSize": "12"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Sample Plugin to Test SDTools",
+      "UUID": "com.test.sdtools.sampleplugin",
+      "PropertyInspectorPath": "PropertyInspector/Sample.html"
+    }
+  ],
+  "Author": "BarRaider",
+  "Description": "Sample Plugin to test SDTools",
+  "Name": "SDTools Sample Plugin",
+  "Icon": "Images/pluginIcon",
+  "URL": "https://barraider.com/",
+  "Version": "0.1",
+  "CodePath": "com.test.sdtools",
+  "Category": "Test",
+  "CategoryIcon": "Images/categoryIcon",
+  "OS": [
+    {
+      "Platform": "windows",
+      "MinimumVersion": "10"
+    }
+  ],
+  "SDKVersion": 2,
+  "Software": {
+    "MinimumVersion": "4.4.1"
+  },
+  "ApplicationsToMonitor": {
+    "windows": ["notepad.exe", "calc.exe"]
+  }
+}

--- a/src/test/elgato-stream-deck-plugin/barraider-sample-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/barraider-sample-plugin.json
@@ -3,39 +3,39 @@
     {
       "Icon": "Images/icon",
       "Name": "SDTools Test",
+      "PropertyInspectorPath": "PropertyInspector/Sample.html",
       "States": [
         {
+          "FontSize": "12",
           "Image": "Images/pluginAction",
-          "TitleAlignment": "middle",
-          "FontSize": "12"
+          "TitleAlignment": "middle"
         }
       ],
       "SupportedInMultiActions": true,
       "Tooltip": "Sample Plugin to Test SDTools",
-      "UUID": "com.test.sdtools.sampleplugin",
-      "PropertyInspectorPath": "PropertyInspector/Sample.html"
+      "UUID": "com.test.sdtools.sampleplugin"
     }
   ],
+  "ApplicationsToMonitor": {
+    "windows": ["notepad.exe", "calc.exe"]
+  },
   "Author": "BarRaider",
-  "Description": "Sample Plugin to test SDTools",
-  "Name": "SDTools Sample Plugin",
-  "Icon": "Images/pluginIcon",
-  "URL": "https://barraider.com/",
-  "Version": "0.1",
-  "CodePath": "com.test.sdtools",
   "Category": "Test",
   "CategoryIcon": "Images/categoryIcon",
+  "CodePath": "com.test.sdtools",
+  "Description": "Sample Plugin to test SDTools",
+  "Icon": "Images/pluginIcon",
+  "Name": "SDTools Sample Plugin",
   "OS": [
     {
-      "Platform": "windows",
-      "MinimumVersion": "10"
+      "MinimumVersion": "10",
+      "Platform": "windows"
     }
   ],
   "SDKVersion": 2,
   "Software": {
     "MinimumVersion": "4.4.1"
   },
-  "ApplicationsToMonitor": {
-    "windows": ["notepad.exe", "calc.exe"]
-  }
+  "URL": "https://barraider.com/",
+  "Version": "0.1"
 }

--- a/src/test/elgato-stream-deck-plugin/dim-stream-deck-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/dim-stream-deck-plugin.json
@@ -1,0 +1,219 @@
+{
+  "Name": "DIM Stream Deck",
+  "Author": "fcannizzaro",
+  "Description": "Use Destiny Item Manager from your Stream Deck! Equip Loadouts, Pull Items, Search and much more",
+  "Icon": "icons/pluginIcon",
+  "Version": "2.0.3",
+  "SDKVersion": 2,
+  "URL": "https://dimstreamdeck.vercel.app",
+  "uuid": "com.dim.streamdeck",
+  "Software": {
+    "MinimumVersion": "5.0"
+  },
+  "OS": [
+    {
+      "Platform": "windows",
+      "MinimumVersion": "10"
+    },
+    {
+      "Platform": "mac",
+      "MinimumVersion": "10.11"
+    }
+  ],
+  "Category": "Destiny Item Manager",
+  "CategoryIcon": "icons/category",
+  "CodePath": "com.dim.streamdeck.exe",
+  "CodePathWin": "com.dim.streamdeck.exe",
+  "CodePathMac": "com.dim.streamdeck",
+  "PropertyInspectorPath": "pi/index.html",
+  "Profiles": [
+    {
+      "Name": "DIM-Enhanced",
+      "ReadOnly": true,
+      "DeviceType": 0,
+      "DontAutoSwitchWhenInstalled": true
+    },
+    {
+      "Name": "DIM-EnhancedMini",
+      "ReadOnly": true,
+      "DeviceType": 1,
+      "DontAutoSwitchWhenInstalled": true
+    },
+    {
+      "Name": "DIM-EnhancedXL",
+      "ReadOnly": true,
+      "DeviceType": 2,
+      "DontAutoSwitchWhenInstalled": true
+    },
+    {
+      "Name": "DIM-Enhanced",
+      "ReadOnly": true,
+      "DeviceType": 3,
+      "DontAutoSwitchWhenInstalled": true
+    }
+  ],
+  "Actions": [
+    {
+      "Icon": "icons/equipItemIcon",
+      "Name": "Pull/Equip Item",
+      "States": [
+        {
+          "Image": "icons/equipItemState"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Pull or equip a pre-selected item",
+      "UUID": "com.dim.streamdeck.pull-item"
+    },
+    {
+      "Icon": "icons/loadoutIcon",
+      "Name": "Equip Loadout",
+      "States": [
+        {
+          "Image": "icons/loadoutState"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Allow to switch Destiny 2 Loadout",
+      "UUID": "com.dim.streamdeck.loadout"
+    },
+    {
+      "Icon": "icons/searchIcon",
+      "Name": "Search",
+      "States": [
+        {
+          "Image": "icons/searchState"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Search with a specific query",
+      "UUID": "com.dim.streamdeck.search"
+    },
+    {
+      "Icon": "icons/refreshIcon",
+      "Name": "Refresh DIM",
+      "States": [
+        {
+          "Image": "icons/refreshState"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Refresh DIM",
+      "UUID": "com.dim.streamdeck.refresh"
+    },
+    {
+      "Icon": "icons/randomIcon",
+      "Name": "Randomize Character",
+      "States": [
+        {
+          "Image": "icons/randomState"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Randomize a specific character",
+      "UUID": "com.dim.streamdeck.randomize"
+    },
+    {
+      "Icon": "icons/appIcon",
+      "Name": "Open DIM",
+      "States": [
+        {
+          "Image": "icons/appState"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Open DIM on the browser",
+      "UUID": "com.dim.streamdeck.app"
+    },
+    {
+      "Icon": "icons/vaultIcon",
+      "Name": "Vault",
+      "States": [
+        {
+          "Image": "icons/vaultState",
+          "TitleAlignment": "bottom"
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "Tooltip": "Show a specific param from the vault",
+      "UUID": "com.dim.streamdeck.vault"
+    },
+    {
+      "Icon": "icons/postmasterIcon",
+      "Name": "Postmaster",
+      "States": [
+        {
+          "Image": "icons/postmasterState"
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "Tooltip": "Show the used percentage of the current character postmaster",
+      "UUID": "com.dim.streamdeck.postmaster"
+    },
+    {
+      "Icon": "icons/metricsIcon",
+      "Name": "Metrics",
+      "States": [
+        {
+          "Image": "icons/metricsState",
+          "TitleAlignment": "bottom"
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "Tooltip": "Show a specific game metric",
+      "UUID": "com.dim.streamdeck.metrics"
+    },
+    {
+      "Icon": "icons/maxPowerIcon",
+      "Name": "Max Power",
+      "States": [
+        {
+          "Image": "icons/maxPowerState"
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "Tooltip": "Show the current character Max Power and tap to apply",
+      "UUID": "com.dim.streamdeck.power"
+    },
+    {
+      "Icon": "icons/farmingIcon",
+      "Name": "Farming Mode",
+      "States": [
+        {
+          "Image": "icons/farming-mode-off"
+        },
+        {
+          "Image": "icons/farming-mode-on"
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "Tooltip": "Turn on/off the DIM Farming mode",
+      "UUID": "com.dim.streamdeck.farming-mode"
+    },
+    {
+      "Icon": "icons/rotationIcon",
+      "Name": "Rotation",
+      "States": [
+        {
+          "Image": "icons/rotationState"
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "VisibleInActionsList": true,
+      "UUID": "com.dim.streamdeck.rotation"
+    },
+    {
+      "Name": "Tile",
+      "States": [
+        {
+          "Image": "icons/pageState",
+          "TitleAlignment": "middle",
+          "FontSize": "16"
+        }
+      ],
+      "SupportedInMultiActions": false,
+      "VisibleInActionsList": false,
+      "UUID": "com.dim.streamdeck.page"
+    }
+  ]
+}

--- a/src/test/elgato-stream-deck-plugin/dim-stream-deck-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/dim-stream-deck-plugin.json
@@ -1,57 +1,4 @@
 {
-  "Name": "DIM Stream Deck",
-  "Author": "fcannizzaro",
-  "Description": "Use Destiny Item Manager from your Stream Deck! Equip Loadouts, Pull Items, Search and much more",
-  "Icon": "icons/pluginIcon",
-  "Version": "2.0.3",
-  "SDKVersion": 2,
-  "URL": "https://dimstreamdeck.vercel.app",
-  "uuid": "com.dim.streamdeck",
-  "Software": {
-    "MinimumVersion": "5.0"
-  },
-  "OS": [
-    {
-      "Platform": "windows",
-      "MinimumVersion": "10"
-    },
-    {
-      "Platform": "mac",
-      "MinimumVersion": "10.11"
-    }
-  ],
-  "Category": "Destiny Item Manager",
-  "CategoryIcon": "icons/category",
-  "CodePath": "com.dim.streamdeck.exe",
-  "CodePathWin": "com.dim.streamdeck.exe",
-  "CodePathMac": "com.dim.streamdeck",
-  "PropertyInspectorPath": "pi/index.html",
-  "Profiles": [
-    {
-      "Name": "DIM-Enhanced",
-      "ReadOnly": true,
-      "DeviceType": 0,
-      "DontAutoSwitchWhenInstalled": true
-    },
-    {
-      "Name": "DIM-EnhancedMini",
-      "ReadOnly": true,
-      "DeviceType": 1,
-      "DontAutoSwitchWhenInstalled": true
-    },
-    {
-      "Name": "DIM-EnhancedXL",
-      "ReadOnly": true,
-      "DeviceType": 2,
-      "DontAutoSwitchWhenInstalled": true
-    },
-    {
-      "Name": "DIM-Enhanced",
-      "ReadOnly": true,
-      "DeviceType": 3,
-      "DontAutoSwitchWhenInstalled": true
-    }
-  ],
   "Actions": [
     {
       "Icon": "icons/equipItemIcon",
@@ -199,21 +146,74 @@
         }
       ],
       "SupportedInMultiActions": false,
-      "VisibleInActionsList": true,
-      "UUID": "com.dim.streamdeck.rotation"
+      "UUID": "com.dim.streamdeck.rotation",
+      "VisibleInActionsList": true
     },
     {
       "Name": "Tile",
       "States": [
         {
+          "FontSize": "16",
           "Image": "icons/pageState",
-          "TitleAlignment": "middle",
-          "FontSize": "16"
+          "TitleAlignment": "middle"
         }
       ],
       "SupportedInMultiActions": false,
-      "VisibleInActionsList": false,
-      "UUID": "com.dim.streamdeck.page"
+      "UUID": "com.dim.streamdeck.page",
+      "VisibleInActionsList": false
     }
-  ]
+  ],
+  "Author": "fcannizzaro",
+  "Category": "Destiny Item Manager",
+  "CategoryIcon": "icons/category",
+  "CodePath": "com.dim.streamdeck.exe",
+  "CodePathMac": "com.dim.streamdeck",
+  "CodePathWin": "com.dim.streamdeck.exe",
+  "Description": "Use Destiny Item Manager from your Stream Deck! Equip Loadouts, Pull Items, Search and much more",
+  "Icon": "icons/pluginIcon",
+  "Name": "DIM Stream Deck",
+  "OS": [
+    {
+      "MinimumVersion": "10",
+      "Platform": "windows"
+    },
+    {
+      "MinimumVersion": "10.11",
+      "Platform": "mac"
+    }
+  ],
+  "Profiles": [
+    {
+      "DeviceType": 0,
+      "DontAutoSwitchWhenInstalled": true,
+      "Name": "DIM-Enhanced",
+      "ReadOnly": true
+    },
+    {
+      "DeviceType": 1,
+      "DontAutoSwitchWhenInstalled": true,
+      "Name": "DIM-EnhancedMini",
+      "ReadOnly": true
+    },
+    {
+      "DeviceType": 2,
+      "DontAutoSwitchWhenInstalled": true,
+      "Name": "DIM-EnhancedXL",
+      "ReadOnly": true
+    },
+    {
+      "DeviceType": 3,
+      "DontAutoSwitchWhenInstalled": true,
+      "Name": "DIM-Enhanced",
+      "ReadOnly": true
+    }
+  ],
+  "PropertyInspectorPath": "pi/index.html",
+  "SDKVersion": 2,
+  "Software": {
+    "MinimumVersion": "5.0"
+  },
+  "URL": "https://dimstreamdeck.vercel.app",
+  "Version": "2.0.3",
+  "uuid": "com.dim.streamdeck"
 }

--- a/src/test/elgato-stream-deck-plugin/home-assistant-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/home-assistant-plugin.json
@@ -1,0 +1,66 @@
+{
+  "Actions": [
+    {
+      "Icon": "images/actionImage",
+      "Name": "Entity (generic)",
+      "PropertyInspectorPath": "pi.html",
+      "States": [
+        {
+          "Image": "images/ha-button",
+          "TitleAlignment": "bottom",
+          "FontSize": "9"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "UUID": "de.perdoctus.streamdeck.homeassistant.entity",
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "layout": "$A0",
+        "StackColor": "#AABBCC"
+      }
+    },
+
+    {
+      "Icon": "images/actionImage",
+      "Name": "Entity (custom icons)",
+      "PropertyInspectorPath": "pi.html",
+      "States": [
+        {
+          "Image": "images/ha-button-off",
+          "TitleAlignment": "bottom",
+          "FontSize": "9"
+        },
+        {
+          "Image": "images/ha-button-on",
+          "TitleAlignment": "bottom",
+          "FontSize": "9"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "UUID": "de.perdoctus.streamdeck.homeassistant.dual-state-entity"
+    }
+  ],
+  "Category": "Home Assistant",
+  "CategoryIcon": "images/category",
+  "SDKVersion": 2,
+  "Author": "Christoph Giesche",
+  "CodePath": "plugin.html",
+  "Description": "Control your Home Assistant entities with stream deck.",
+  "Name": "Home Assistant",
+  "Icon": "images/plugin/plugin",
+  "URL": "https://github.com/cgiesche/streamdeck-homeassistant",
+  "Version": "100.2.1",
+  "OS": [
+    {
+      "Platform": "mac",
+      "MinimumVersion": "10.11"
+    },
+    {
+      "Platform": "windows",
+      "MinimumVersion": "10"
+    }
+  ],
+  "Software": {
+    "MinimumVersion": "4.1"
+  }
+}

--- a/src/test/elgato-stream-deck-plugin/home-assistant-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/home-assistant-plugin.json
@@ -1,23 +1,23 @@
 {
   "Actions": [
     {
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "StackColor": "#AABBCC",
+        "layout": "$A0"
+      },
       "Icon": "images/actionImage",
       "Name": "Entity (generic)",
       "PropertyInspectorPath": "pi.html",
       "States": [
         {
+          "FontSize": "9",
           "Image": "images/ha-button",
-          "TitleAlignment": "bottom",
-          "FontSize": "9"
+          "TitleAlignment": "bottom"
         }
       ],
       "SupportedInMultiActions": true,
-      "UUID": "de.perdoctus.streamdeck.homeassistant.entity",
-      "Controllers": ["Keypad", "Encoder"],
-      "Encoder": {
-        "layout": "$A0",
-        "StackColor": "#AABBCC"
-      }
+      "UUID": "de.perdoctus.streamdeck.homeassistant.entity"
     },
 
     {
@@ -26,41 +26,41 @@
       "PropertyInspectorPath": "pi.html",
       "States": [
         {
+          "FontSize": "9",
           "Image": "images/ha-button-off",
-          "TitleAlignment": "bottom",
-          "FontSize": "9"
+          "TitleAlignment": "bottom"
         },
         {
+          "FontSize": "9",
           "Image": "images/ha-button-on",
-          "TitleAlignment": "bottom",
-          "FontSize": "9"
+          "TitleAlignment": "bottom"
         }
       ],
       "SupportedInMultiActions": true,
       "UUID": "de.perdoctus.streamdeck.homeassistant.dual-state-entity"
     }
   ],
+  "Author": "Christoph Giesche",
   "Category": "Home Assistant",
   "CategoryIcon": "images/category",
-  "SDKVersion": 2,
-  "Author": "Christoph Giesche",
   "CodePath": "plugin.html",
   "Description": "Control your Home Assistant entities with stream deck.",
-  "Name": "Home Assistant",
   "Icon": "images/plugin/plugin",
-  "URL": "https://github.com/cgiesche/streamdeck-homeassistant",
-  "Version": "100.2.1",
+  "Name": "Home Assistant",
   "OS": [
     {
-      "Platform": "mac",
-      "MinimumVersion": "10.11"
+      "MinimumVersion": "10.11",
+      "Platform": "mac"
     },
     {
-      "Platform": "windows",
-      "MinimumVersion": "10"
+      "MinimumVersion": "10",
+      "Platform": "windows"
     }
   ],
+  "SDKVersion": 2,
   "Software": {
     "MinimumVersion": "4.1"
-  }
+  },
+  "URL": "https://github.com/cgiesche/streamdeck-homeassistant",
+  "Version": "100.2.1"
 }

--- a/src/test/elgato-stream-deck-plugin/logitech-litra-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/logitech-litra-plugin.json
@@ -1,0 +1,41 @@
+{
+  "Actions": [
+    {
+      "Icon": "icons/setLightsAction",
+      "Name": "Set Litra Lights",
+      "States": [
+        {
+          "Image": "icons/counterState",
+          "TitleAlignment": "middle",
+          "FontSize": "24"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Set your lights",
+      "UUID": "ca.michaelabon.logitech-litra-lights.set"
+    }
+  ],
+  "Author": "Michael Abon",
+  "CodePath": "streamdeck-logitech-litra.exe",
+  "CodePathMac": "streamdeck-logitech-litra",
+  "Description": "Control your Logitech Litra lights",
+  "Icon": "icons/pluginIcon",
+  "Name": "Logitech Litra",
+  "OS": [
+    {
+      "MinimumVersion": "10.11",
+      "Platform": "mac"
+    },
+    {
+      "MinimumVersion": "10",
+      "Platform": "windows"
+    }
+  ],
+  "PropertyInspectorPath": "propertyInspector/pi.html",
+  "SDKVersion": 2,
+  "Software": {
+    "MinimumVersion": "5.0"
+  },
+  "URL": "https://github.com/michaelabon/streamdeck-logitech-litra-lights",
+  "Version": "0.3"
+}

--- a/src/test/elgato-stream-deck-plugin/logitech-litra-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/logitech-litra-plugin.json
@@ -5,9 +5,9 @@
       "Name": "Set Litra Lights",
       "States": [
         {
+          "FontSize": "24",
           "Image": "icons/counterState",
-          "TitleAlignment": "middle",
-          "FontSize": "24"
+          "TitleAlignment": "middle"
         }
       ],
       "SupportedInMultiActions": true,

--- a/src/test/elgato-stream-deck-plugin/stream-deck-phillips-hue-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/stream-deck-phillips-hue-plugin.json
@@ -39,6 +39,14 @@
       "UUID": "com.elgato.philips-hue.cycle"
     },
     {
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "TriggerDescription": {
+          "Rotate": "Adjust Brightness",
+          "Touch": "Toggle Light on/off"
+        },
+        "layout": "$B1"
+      },
       "Icon": "plugin/images/actions/brightness",
       "Name": "Brightness",
       "States": [
@@ -46,18 +54,18 @@
           "Image": "plugin/images/icons/brightness"
         }
       ],
-      "Controllers": ["Keypad", "Encoder"],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust Brightness",
-          "Touch": "Toggle Light on/off"
-        }
-      },
       "Tooltip": "Set the brightness of your light.",
       "UUID": "com.elgato.philips-hue.brightness"
     },
     {
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "TriggerDescription": {
+          "Rotate": "Adjust Temperature",
+          "Touch": "Toggle Light on/off"
+        },
+        "layout": "$B1"
+      },
       "Icon": "plugin/images/actions/temperature",
       "Name": "Temperature",
       "States": [
@@ -65,14 +73,6 @@
           "Image": "plugin/images/icons/temperature"
         }
       ],
-      "Controllers": ["Keypad", "Encoder"],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust Temperature",
-          "Touch": "Toggle Light on/off"
-        }
-      },
       "Tooltip": "Set the temperature of your light.",
       "UUID": "com.elgato.philips-hue.temperature"
     },
@@ -99,29 +99,29 @@
       "UUID": "com.elgato.philips-hue.scene"
     }
   ],
-  "SDKVersion": 2,
   "Author": "Elgato",
-  "CodePath": "plugin/index.html",
-  "Description": "Control your Philips Hue lights.",
-  "Name": "Philips Hue",
-  "Icon": "plugin/images/icons/plugin",
   "Category": "Philips Hue",
   "CategoryIcon": "plugin/images/actions/category",
-  "PropertyInspectorPath": "pi/index.html",
-  "URL": "https://www.elgato.com/gaming/stream-deck",
-  "Version": "1.6.5",
+  "CodePath": "plugin/index.html",
   "DefaultWindowSize": [500, 650],
+  "Description": "Control your Philips Hue lights.",
+  "Icon": "plugin/images/icons/plugin",
+  "Name": "Philips Hue",
   "OS": [
     {
-      "Platform": "mac",
-      "MinimumVersion": "10.11"
+      "MinimumVersion": "10.11",
+      "Platform": "mac"
     },
     {
-      "Platform": "windows",
-      "MinimumVersion": "10"
+      "MinimumVersion": "10",
+      "Platform": "windows"
     }
   ],
+  "PropertyInspectorPath": "pi/index.html",
+  "SDKVersion": 2,
   "Software": {
     "MinimumVersion": "5.0"
-  }
+  },
+  "URL": "https://www.elgato.com/gaming/stream-deck",
+  "Version": "1.6.5"
 }

--- a/src/test/elgato-stream-deck-plugin/stream-deck-phillips-hue-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/stream-deck-phillips-hue-plugin.json
@@ -1,0 +1,127 @@
+{
+  "Actions": [
+    {
+      "Icon": "plugin/images/actions/power",
+      "Name": "On / Off",
+      "States": [
+        {
+          "Image": "plugin/images/icons/on",
+          "Name": "On"
+        },
+        {
+          "Image": "plugin/images/icons/off",
+          "Name": "Off"
+        }
+      ],
+      "Tooltip": "Turn lights on or off.",
+      "UUID": "com.elgato.philips-hue.power"
+    },
+    {
+      "Icon": "plugin/images/actions/color",
+      "Name": "Color",
+      "States": [
+        {
+          "Image": "plugin/images/icons/color"
+        }
+      ],
+      "Tooltip": "Set the color of your light.",
+      "UUID": "com.elgato.philips-hue.color"
+    },
+    {
+      "Icon": "plugin/images/actions/cycle",
+      "Name": "Color Cycle",
+      "States": [
+        {
+          "Image": "plugin/images/icons/cycle"
+        }
+      ],
+      "Tooltip": "Cycle between colors of your light.",
+      "UUID": "com.elgato.philips-hue.cycle"
+    },
+    {
+      "Icon": "plugin/images/actions/brightness",
+      "Name": "Brightness",
+      "States": [
+        {
+          "Image": "plugin/images/icons/brightness"
+        }
+      ],
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Adjust Brightness",
+          "Touch": "Toggle Light on/off"
+        }
+      },
+      "Tooltip": "Set the brightness of your light.",
+      "UUID": "com.elgato.philips-hue.brightness"
+    },
+    {
+      "Icon": "plugin/images/actions/temperature",
+      "Name": "Temperature",
+      "States": [
+        {
+          "Image": "plugin/images/icons/temperature"
+        }
+      ],
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Rotate": "Adjust Temperature",
+          "Touch": "Toggle Light on/off"
+        }
+      },
+      "Tooltip": "Set the temperature of your light.",
+      "UUID": "com.elgato.philips-hue.temperature"
+    },
+    {
+      "Icon": "plugin/images/actions/brightness",
+      "Name": "Brightness Relative",
+      "States": [
+        {
+          "Image": "plugin/images/icons/brightness"
+        }
+      ],
+      "Tooltip": "Set the brightness of your light.",
+      "UUID": "com.elgato.philips-hue.brightness-rel"
+    },
+    {
+      "Icon": "plugin/images/actions/scene",
+      "Name": "Scene",
+      "States": [
+        {
+          "Image": "plugin/images/icons/scene"
+        }
+      ],
+      "Tooltip": "Set a scene.",
+      "UUID": "com.elgato.philips-hue.scene"
+    }
+  ],
+  "SDKVersion": 2,
+  "Author": "Elgato",
+  "CodePath": "plugin/index.html",
+  "Description": "Control your Philips Hue lights.",
+  "Name": "Philips Hue",
+  "Icon": "plugin/images/icons/plugin",
+  "Category": "Philips Hue",
+  "CategoryIcon": "plugin/images/actions/category",
+  "PropertyInspectorPath": "pi/index.html",
+  "URL": "https://www.elgato.com/gaming/stream-deck",
+  "Version": "1.6.5",
+  "DefaultWindowSize": [500, 650],
+  "OS": [
+    {
+      "Platform": "mac",
+      "MinimumVersion": "10.11"
+    },
+    {
+      "Platform": "windows",
+      "MinimumVersion": "10"
+    }
+  ],
+  "Software": {
+    "MinimumVersion": "5.0"
+  }
+}

--- a/src/test/elgato-stream-deck-plugin/voice-meeter-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/voice-meeter-plugin.json
@@ -1,0 +1,175 @@
+{
+  "Actions": [
+    {
+      "Icon": "Images/icon",
+      "Name": "Modify Setting",
+      "States": [
+        {
+          "Image": "Images/vmTop",
+          "TitleAlignment": "bottom",
+          "FontSize": "11"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "DisableCaching": true,
+      "UserTitleEnabled": false,
+      "Tooltip": "Modify Setting - Allows you to easily modify various VoiceMeeter settings.",
+      "UUID": "com.barraider.vmmodify",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/Modify.html"
+    },
+    {
+      "Icon": "Images/icon",
+      "Name": "Mute/Unmute",
+      "States": [
+        {
+          "Image": "Images/vm",
+          "TitleAlignment": "bottom",
+          "FontSize": "11"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "DisableCaching": true,
+      "UserTitleEnabled": false,
+      "Tooltip": "Mute/Unmute - See a live indication of the current status on Stream Deck (never forget your microphone on again!).",
+      "UUID": "com.barraider.vmmicrophone",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/Microphone.html"
+    },
+    {
+      "Icon": "Images/icon",
+      "Name": "Advanced Press/Long-Press",
+      "States": [
+        {
+          "Image": "Images/vmTop",
+          "TitleAlignment": "bottom",
+          "FontSize": "11"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "DisableCaching": true,
+      "UserTitleEnabled": false,
+      "Tooltip": "Advanced Press/Long-Press - Directly access any setting through text. Supports both Press and Long-Press (allows you to change between two preset list of settings).",
+      "UUID": "com.barraider.vmadvanced",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedKeypress.html"
+    },
+    {
+      "Icon": "Images/icon",
+      "Name": "Advanced Toggle",
+      "States": [
+        {
+          "Image": "Images/vmTop",
+          "TitleAlignment": "bottom",
+          "FontSize": "11"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "DisableCaching": true,
+      "UserTitleEnabled": false,
+      "Tooltip": "Advanced Toggle - Focused on toggling between two modes (versus click and long click in the VoiceMeeter Advanced Click/Long-Click).",
+      "UUID": "com.barraider.vmadvancedtoggle",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedToggle.html"
+    },
+    {
+      "Icon": "Images/icon",
+      "Name": "Advanced PTT",
+      "States": [
+        {
+          "Image": "Images/vmTop",
+          "TitleAlignment": "bottom",
+          "FontSize": "11"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "DisableCaching": true,
+      "UserTitleEnabled": false,
+      "Tooltip": "Advanced PTT - Enable settings until you release the button",
+      "UUID": "com.barraider.vmadvancedptt",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedPTT.html"
+    },
+    {
+      "Icon": "Images/icon",
+      "Name": "MacroButton Toggle",
+      "States": [
+        {
+          "Image": "Images/buttonDisabled",
+          "TitleAlignment": "middle",
+          "FontSize": "11"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "DisableCaching": true,
+      "UserTitleEnabled": false,
+      "Tooltip": "MacroButton Toggle - Enable/Disable a VoiceMeeter MacroButton",
+      "UUID": "com.barraider.vmmacrotoggle",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/MacroToggle.html"
+    },
+    {
+      "Icon": "Images/volumeIcon",
+      "Name": "Gain Adjust",
+      "States": [
+        {
+          "Image": "Images/volumeAction",
+          "TitleAlignment": "middle",
+          "FontSize": "13"
+        }
+      ],
+      "Controllers": ["Encoder"],
+      "Encoder": {
+        "layout": "gainAdjustDialLayout.json",
+        "TriggerDescription": {
+          "Rotate": "Increase/Decrease",
+          "Push": "Toggle mute"
+        }
+      },
+      "SupportedInMultiActions": false,
+      "DisableCaching": true,
+      "UserTitleEnabled": false,
+      "Tooltip": "Adjusts the gain of a Strip/Bus",
+      "UUID": "com.barraider.gainadjust",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/GainAdjustDial.html"
+    },
+    {
+      "Icon": "Images/settingAdjustIcon",
+      "Name": "Setting Adjust",
+      "States": [
+        {
+          "Image": "Images/settingAdjustAction",
+          "TitleAlignment": "middle",
+          "FontSize": "13"
+        }
+      ],
+      "Controllers": ["Encoder"],
+      "Encoder": {
+        "layout": "settingAdjustDialLayout.json",
+        "TriggerDescription": {
+          "Rotate": "Increase/Decrease",
+          "Push": "Disable"
+        }
+      },
+      "SupportedInMultiActions": false,
+      "DisableCaching": true,
+      "UserTitleEnabled": false,
+      "Tooltip": "Adjusts one of the knobs of a Strip/Bus",
+      "UUID": "com.barraider.settingadjust",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdjustSettingDial.html"
+    }
+  ],
+  "Author": "BarRaider",
+  "Description": "VoiceMeeter integration and live feedback. Includes Dials, Hotkey and MIDI Support",
+  "Name": "VoiceMeeter Integration",
+  "Icon": "Images/pluginIcon",
+  "URL": "https://BarRaider.com/",
+  "Version": "2.2",
+  "CodePath": "com.barraider.voicemeeter.exe",
+  "Category": "VoiceMeeter [BarRaider]",
+  "CategoryIcon": "Images/categoryIcon",
+  "OS": [
+    {
+      "Platform": "windows",
+      "MinimumVersion": "10"
+    }
+  ],
+  "SDKVersion": 2,
+  "Software": {
+    "MinimumVersion": "6.0"
+  }
+}

--- a/src/test/elgato-stream-deck-plugin/voice-meeter-plugin.json
+++ b/src/test/elgato-stream-deck-plugin/voice-meeter-plugin.json
@@ -1,175 +1,175 @@
 {
   "Actions": [
     {
+      "DisableCaching": true,
       "Icon": "Images/icon",
       "Name": "Modify Setting",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/Modify.html",
       "States": [
         {
+          "FontSize": "11",
           "Image": "Images/vmTop",
-          "TitleAlignment": "bottom",
-          "FontSize": "11"
+          "TitleAlignment": "bottom"
         }
       ],
       "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "UserTitleEnabled": false,
       "Tooltip": "Modify Setting - Allows you to easily modify various VoiceMeeter settings.",
       "UUID": "com.barraider.vmmodify",
-      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/Modify.html"
+      "UserTitleEnabled": false
     },
     {
+      "DisableCaching": true,
       "Icon": "Images/icon",
       "Name": "Mute/Unmute",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/Microphone.html",
       "States": [
         {
+          "FontSize": "11",
           "Image": "Images/vm",
-          "TitleAlignment": "bottom",
-          "FontSize": "11"
+          "TitleAlignment": "bottom"
         }
       ],
       "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "UserTitleEnabled": false,
       "Tooltip": "Mute/Unmute - See a live indication of the current status on Stream Deck (never forget your microphone on again!).",
       "UUID": "com.barraider.vmmicrophone",
-      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/Microphone.html"
+      "UserTitleEnabled": false
     },
     {
+      "DisableCaching": true,
       "Icon": "Images/icon",
       "Name": "Advanced Press/Long-Press",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedKeypress.html",
       "States": [
         {
+          "FontSize": "11",
           "Image": "Images/vmTop",
-          "TitleAlignment": "bottom",
-          "FontSize": "11"
+          "TitleAlignment": "bottom"
         }
       ],
       "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "UserTitleEnabled": false,
       "Tooltip": "Advanced Press/Long-Press - Directly access any setting through text. Supports both Press and Long-Press (allows you to change between two preset list of settings).",
       "UUID": "com.barraider.vmadvanced",
-      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedKeypress.html"
+      "UserTitleEnabled": false
     },
     {
+      "DisableCaching": true,
       "Icon": "Images/icon",
       "Name": "Advanced Toggle",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedToggle.html",
       "States": [
         {
+          "FontSize": "11",
           "Image": "Images/vmTop",
-          "TitleAlignment": "bottom",
-          "FontSize": "11"
+          "TitleAlignment": "bottom"
         }
       ],
       "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "UserTitleEnabled": false,
       "Tooltip": "Advanced Toggle - Focused on toggling between two modes (versus click and long click in the VoiceMeeter Advanced Click/Long-Click).",
       "UUID": "com.barraider.vmadvancedtoggle",
-      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedToggle.html"
+      "UserTitleEnabled": false
     },
     {
+      "DisableCaching": true,
       "Icon": "Images/icon",
       "Name": "Advanced PTT",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedPTT.html",
       "States": [
         {
+          "FontSize": "11",
           "Image": "Images/vmTop",
-          "TitleAlignment": "bottom",
-          "FontSize": "11"
+          "TitleAlignment": "bottom"
         }
       ],
       "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "UserTitleEnabled": false,
       "Tooltip": "Advanced PTT - Enable settings until you release the button",
       "UUID": "com.barraider.vmadvancedptt",
-      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdvancedPTT.html"
+      "UserTitleEnabled": false
     },
     {
+      "DisableCaching": true,
       "Icon": "Images/icon",
       "Name": "MacroButton Toggle",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/MacroToggle.html",
       "States": [
         {
+          "FontSize": "11",
           "Image": "Images/buttonDisabled",
-          "TitleAlignment": "middle",
-          "FontSize": "11"
+          "TitleAlignment": "middle"
         }
       ],
       "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "UserTitleEnabled": false,
       "Tooltip": "MacroButton Toggle - Enable/Disable a VoiceMeeter MacroButton",
       "UUID": "com.barraider.vmmacrotoggle",
-      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/MacroToggle.html"
+      "UserTitleEnabled": false
     },
     {
+      "Controllers": ["Encoder"],
+      "DisableCaching": true,
+      "Encoder": {
+        "TriggerDescription": {
+          "Push": "Toggle mute",
+          "Rotate": "Increase/Decrease"
+        },
+        "layout": "gainAdjustDialLayout.json"
+      },
       "Icon": "Images/volumeIcon",
       "Name": "Gain Adjust",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/GainAdjustDial.html",
       "States": [
         {
+          "FontSize": "13",
           "Image": "Images/volumeAction",
-          "TitleAlignment": "middle",
-          "FontSize": "13"
+          "TitleAlignment": "middle"
         }
       ],
-      "Controllers": ["Encoder"],
-      "Encoder": {
-        "layout": "gainAdjustDialLayout.json",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease",
-          "Push": "Toggle mute"
-        }
-      },
       "SupportedInMultiActions": false,
-      "DisableCaching": true,
-      "UserTitleEnabled": false,
       "Tooltip": "Adjusts the gain of a Strip/Bus",
       "UUID": "com.barraider.gainadjust",
-      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/GainAdjustDial.html"
+      "UserTitleEnabled": false
     },
     {
+      "Controllers": ["Encoder"],
+      "DisableCaching": true,
+      "Encoder": {
+        "TriggerDescription": {
+          "Push": "Disable",
+          "Rotate": "Increase/Decrease"
+        },
+        "layout": "settingAdjustDialLayout.json"
+      },
       "Icon": "Images/settingAdjustIcon",
       "Name": "Setting Adjust",
+      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdjustSettingDial.html",
       "States": [
         {
+          "FontSize": "13",
           "Image": "Images/settingAdjustAction",
-          "TitleAlignment": "middle",
-          "FontSize": "13"
+          "TitleAlignment": "middle"
         }
       ],
-      "Controllers": ["Encoder"],
-      "Encoder": {
-        "layout": "settingAdjustDialLayout.json",
-        "TriggerDescription": {
-          "Rotate": "Increase/Decrease",
-          "Push": "Disable"
-        }
-      },
       "SupportedInMultiActions": false,
-      "DisableCaching": true,
-      "UserTitleEnabled": false,
       "Tooltip": "Adjusts one of the knobs of a Strip/Bus",
       "UUID": "com.barraider.settingadjust",
-      "PropertyInspectorPath": "PropertyInspector/VoiceMeeter/AdjustSettingDial.html"
+      "UserTitleEnabled": false
     }
   ],
   "Author": "BarRaider",
-  "Description": "VoiceMeeter integration and live feedback. Includes Dials, Hotkey and MIDI Support",
-  "Name": "VoiceMeeter Integration",
-  "Icon": "Images/pluginIcon",
-  "URL": "https://BarRaider.com/",
-  "Version": "2.2",
-  "CodePath": "com.barraider.voicemeeter.exe",
   "Category": "VoiceMeeter [BarRaider]",
   "CategoryIcon": "Images/categoryIcon",
+  "CodePath": "com.barraider.voicemeeter.exe",
+  "Description": "VoiceMeeter integration and live feedback. Includes Dials, Hotkey and MIDI Support",
+  "Icon": "Images/pluginIcon",
+  "Name": "VoiceMeeter Integration",
   "OS": [
     {
-      "Platform": "windows",
-      "MinimumVersion": "10"
+      "MinimumVersion": "10",
+      "Platform": "windows"
     }
   ],
   "SDKVersion": 2,
   "Software": {
     "MinimumVersion": "6.0"
-  }
+  },
+  "URL": "https://BarRaider.com/",
+  "Version": "2.2"
 }


### PR DESCRIPTION
Elgato publishes a specification on their website: https://docs.elgato.com/sdk/plugins/manifest

I copied that mostly exactly into a schema file.
I also sourced several published manifest.json files as positive test samples, trying to cover as many other different properties as possible.

This is a redo of the reverted #3439, with the feedback addressed.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
