### PR TITLE
Cloud Build Config improvements

### DIFF
--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -24,10 +24,11 @@
           }
         },
         "waitFor": {
-          "description": "The ID(s) of the step(s) that this build step depends on.\nThis build step will not start until all the build steps in `wait_for`\nhave completed successfully. If `wait_for` is empty, this build step will\nstart when all previous build steps in the `Build.Steps` list have\ncompleted successfully.",
+          "description": "The ID(s) of the step(s) that this build step depends on.\nThis build step will not start until all the build steps in `waitFor`\nhave completed successfully. If `waitFor` is empty, this build step will\nstart when all previous build steps in the `Build.Steps` list have\ncompleted successfully.\nIf `waitFor` is set to `'-'`, the step runs immediately when the build starts.",
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "examples": [["-"], ["terraform-init", "terraform-apply"]]
           }
         },
         "env": {
@@ -42,7 +43,7 @@
           "type": "string"
         },
         "script": {
-          "description": "Specify a shell script to execute in the step.\nIf you specify script in a build step, you cannot specify args or entrypoint in the same step.",
+          "description": "Specify a shell script to execute in the step.\nIf you specify script in a build step, you cannot specify `args` or `entrypoint` in the same step.",
           "type": "string"
         },
         "volumes": {
@@ -53,7 +54,7 @@
           }
         },
         "args": {
-          "description": "A list of arguments that will be presented to the step when it is started.\n\nIf the image used to run the step's container has an entrypoint, the `args`\nare used as arguments to that entrypoint. If the image does not define\nan entrypoint, the first element in args is used as the entrypoint,\nand the remainder will be used as arguments.",
+          "description": "A list of arguments that will be presented to the step when it is started.\n\nIf the image used to run the step's container has an entrypoint, the `args`\nare used as arguments to that entrypoint. If the image does not define\nan entrypoint, the first element in `args` is used as the entrypoint,\nand the remainder will be used as arguments.",
           "type": "array",
           "items": {
             "type": "string"
@@ -87,46 +88,23 @@
       "properties": {
         "machineType": {
           "enum": [
-            "E2_HIGHCPU_2",
-            "E2_HIGHCPU_4",
             "E2_HIGHCPU_8",
-            "E2_HIGHCPU_16",
             "E2_HIGHCPU_32",
-            "E2_HIGHMEM_2",
-            "E2_HIGHMEM_4",
-            "E2_HIGHMEM_8",
-            "E2_HIGHMEM_16",
             "E2_MEDIUM",
-            "E2_STANDARD_2",
-            "E2_STANDARD_4",
-            "E2_STANDARD_8",
-            "E2_STANDARD_16",
-            "E2_STANDARD_32",
             "N1_HIGHCPU_8",
             "N1_HIGHCPU_32",
             "UNSPECIFIED"
           ],
           "description": "Compute Engine machine type on which to run the build.",
+          "default": "UNSPECIFIED",
           "type": "string",
           "enumDescriptions": [
-            "e2 HighCPU: 2 vCPUs, 2GB RAM",
-            "e2 HighCPU: 4 vCPUs, 4GB RAM",
             "e2 HighCPU: 8 vCPUs, 8GB RAM",
-            "e2 HighCPU: 16 vCPUs, 16GB RAM",
             "e2 HighCPU: 32 vCPUs, 32GB RAM",
-            "e2 HighMem: 2 vCPUs, 16GB RAM",
-            "e2 HighMem: 4 vCPUs, 32GB RAM",
-            "e2 HighMem: 8 vCPUs, 64GB RAM",
-            "e2 HighMem: 16 vCPUs, 128GB RAM",
             "e2 Medium: 1 vCPU, 4GB RAM",
-            "e2 Standard: 2 vCPU, 8GB RAM",
-            "e2 Standard: 4 vCPU, 16GB RAM",
-            "e2 Standard: 8 vCPU, 32GB RAM",
-            "e2 Standard: 16 vCPU, 64GB RAM",
-            "e2 Standard: 32 vCPU, 128GB RAM",
             "n1 HighCPU: 8 vCPUs, 7.2GB RAM",
             "n1 HighCPU: 32 vCPUs, 28.8GB RAM",
-            "e2 Medium: 1 vCPU, 4GB RAM"
+            "e2 Standard: 2 vCPU, 8GB RAM"
           ]
         },
         "volumes": {
@@ -160,7 +138,7 @@
           "required": ["name"]
         },
         "env": {
-          "description": "A list of global environment variable definitions that will exist for all\nbuild steps in this build. If a variable is defined in both globally and in\na build step, the variable will use the build step value.\n\nThe elements are of the form \"KEY=VALUE\" for the environment variable \"KEY\"\nbeing given the value \"VALUE\".",
+          "description": "A list of global environment variable definitions that will exist for all\nbuild steps in this build. If a variable is defined both globally and in\na build step, the variable will use the build step value.\n\nThe elements are of the form \"KEY=VALUE\" for the environment variable \"KEY\"\nbeing given the value \"VALUE\".",
           "type": "array",
           "items": {
             "type": "string"
@@ -188,9 +166,13 @@
           "description": "Configure Cloud Build to create a default logs bucket within your own project in the same region as your build.",
           "type": "string",
           "enumDescriptions": [
-            "Configure Cloud Build to use regionalized, user-owned logs"
+            "Unspecified",
+            "Configure Cloud Build to use regionalized, user-owned logs."
           ],
-          "enum": ["REGIONAL_USER_OWNED_BUCKET"]
+          "enum": [
+            "DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED",
+            "REGIONAL_USER_OWNED_BUCKET"
+          ]
         },
         "requestedVerifyOption": {
           "description": "Requested verifiability options.",
@@ -215,8 +197,12 @@
           "type": "boolean"
         },
         "diskSizeGb": {
-          "description": "Requested disk size for the VM that runs the build. Note that this is *NOT*\n\"disk free\"; some of the space will be used by the operating system and\nbuild utilities. Also note that this is the minimum disk size that will be\nallocated for the build -- the build may run with a larger disk than\nrequested. At present, the maximum disk size is 1000GB; builds that request\nmore than the maximum are rejected with an error.",
-          "type": "integer"
+          "description": "Requested disk size for the VM that runs the build. Note that this is *NOT*\n\"disk free\"; some of the space will be used by the operating system and\nbuild utilities. Also note that this is the minimum disk size that will be\nallocated for the build -- the build may run with a larger disk than\nrequested. At present, the maximum disk size is 2000GB; builds that request\nmore than the maximum are rejected with an error.",
+          "type": ["integer", "string"],
+          "pattern": "^([1-9]|[1-9][0-9]|[1-9][0-9][0-9]|[1][0-9][0-9][0-9]|2000)$",
+          "maximum": 2000,
+          "minimum": 1,
+          "examples": [30, 50, "100", 200, "300"]
         },
         "secretEnv": {
           "description": "A list of global environment variables, which are encrypted using a Cloud\nKey Management Service crypto key. These values must be specified in the\nbuild's `Secret`. These variables will be available to all build steps\nin this build.",
@@ -231,7 +217,7 @@
             "Use a sha256 hash.",
             "Use a md5 hash."
           ],
-          "description": "Requested hash for SourceProvenance.",
+          "description": "Requested hash for `SourceProvenance`.",
           "type": "array",
           "items": {
             "enum": ["NONE", "SHA256", "MD5"],
@@ -254,69 +240,6 @@
             "type": "string"
           },
           "description": "Map of environment variable name to its encrypted value.\n\nSecret environment variables must be unique across all of a build's\nsecrets, and must be used by at least one build step. Values can be at most\n64 KB in size. There can be at most 100 secret values across all of a\nbuild's secrets."
-        }
-      }
-    },
-    "Source": {
-      "description": "Location of the source in a supported storage service.",
-      "type": "object",
-      "properties": {
-        "storageSource": {
-          "$ref": "#/definitions/StorageSource",
-          "description": "If provided, get the source from this location in Google Cloud Storage."
-        },
-        "repoSource": {
-          "$ref": "#/definitions/RepoSource",
-          "description": "If provided, get the source from this location in a Cloud Source\nRepository."
-        }
-      }
-    },
-    "StorageSource": {
-      "$id": "StorageSource",
-      "description": "Location of the source in an archive file in Google Cloud Storage.",
-      "type": "object",
-      "properties": {
-        "generation": {
-          "type": "string",
-          "description": "Google Cloud Storage generation for the object. If the generation is\nomitted, the latest generation will be used."
-        },
-        "bucket": {
-          "description": "Google Cloud Storage bucket containing the source (see\n[Bucket Name\nRequirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).",
-          "type": "string"
-        },
-        "object": {
-          "description": "Google Cloud Storage object containing the source.\n\nThis object must be a gzipped archive file (`.tar.gz`) containing source to\nbuild.",
-          "type": "string"
-        }
-      }
-    },
-    "RepoSource": {
-      "description": "Location of the source in a Google Cloud Source Repository.",
-      "type": "object",
-      "properties": {
-        "tagName": {
-          "description": "Name of the tag to build.",
-          "type": "string"
-        },
-        "projectId": {
-          "description": "ID of the project that owns the Cloud Source Repository. If omitted, the\nproject ID requesting the build is assumed.",
-          "type": "string"
-        },
-        "repoName": {
-          "description": "Name of the Cloud Source Repository. If omitted, the name \"default\" is\nassumed.",
-          "type": "string"
-        },
-        "commitSha": {
-          "description": "Explicit commit SHA to build.",
-          "type": "string"
-        },
-        "dir": {
-          "description": "Directory, relative to the source root, in which to run the build.\n\nThis must be a relative path. If a step's `dir` is specified and is an\nabsolute path, this value is ignored for that step's execution.",
-          "type": "string"
-        },
-        "branchName": {
-          "description": "Name of the branch to build.",
-          "type": "string"
         }
       }
     },
@@ -343,7 +266,7 @@
           }
         },
         "npmPackages": {
-          "description": "Uploads your built NPM packages to supported repositories..",
+          "description": "Uploads your built NPM packages to supported repositories.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/NpmPackages"
@@ -449,7 +372,7 @@
       "type": "string",
       "description": "Time limit for executing the build or particular build step. The `timeout` field of a build step specifies the amount of time the step is allowed to run,\nand the `timeout` field of a build specifies the amount of time the build is allowed to run.",
       "pattern": "^\\d+(\\.\\d{0,9})?s$",
-      "examples": ["3.5s"]
+      "examples": ["3.5s", "120s"]
     }
   },
   "description": "A build resource in the Cloud Build API.\n\nAt a high level, a `Build` describes where to find source code, how to build\nit (for example, the builder image to run on the source), and where to store\nthe built artifacts.\n\nFields can include the following variables, which will be expanded when the\nbuild is created:\n\n- $PROJECT_ID: the project ID of the build.\n- $BUILD_ID: the autogenerated ID of the build.\n- $REPO_NAME: the source repository name specified by RepoSource.\n- $BRANCH_NAME: the branch name specified by RepoSource.\n- $TAG_NAME: the tag name specified by RepoSource.\n- $REVISION_ID or $COMMIT_SHA: the commit SHA specified by RepoSource or\n  resolved from the specified branch or tag.\n- $SHORT_SHA: first 7 characters of $REVISION_ID or $COMMIT_SHA.",
@@ -490,10 +413,6 @@
       "$ref": "#/definitions/BuildOptions",
       "description": "Special options for this build."
     },
-    "source": {
-      "$ref": "#/definitions/Source",
-      "description": "The location of the source files to build."
-    },
     "artifacts": {
       "$ref": "#/definitions/Artifacts",
       "description": "Artifacts produced by the build that should be uploaded upon\nsuccessful completion of all build steps."
@@ -519,7 +438,7 @@
       "description": "Specifies the amount of time a build can be queued.\nIf a build is in the queue for longer than the value set in `queueTtl`, the build expires and the build status is set to `EXPIRED`.",
       "type": "string",
       "pattern": "^\\d+(\\.\\d{0,9})?s$",
-      "examples": ["3.5s"],
+      "examples": ["3.5s", "120s"],
       "default": "3600s"
     }
   },

--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -198,10 +198,17 @@
         },
         "diskSizeGb": {
           "description": "Requested disk size for the VM that runs the build. Note that this is *NOT*\n\"disk free\"; some of the space will be used by the operating system and\nbuild utilities. Also note that this is the minimum disk size that will be\nallocated for the build -- the build may run with a larger disk than\nrequested. At present, the maximum disk size is 2000GB; builds that request\nmore than the maximum are rejected with an error.",
-          "type": ["integer", "string"],
-          "pattern": "^(?:[1-9]\\d{0,2}|1\\d{3}|2000)$",
-          "maximum": 2000,
-          "minimum": 1,
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2000
+            },
+            {
+              "type": "string",
+              "pattern": "^(?:[1-9]\\d{0,2}|1\\d{3}|2000)$"
+            }
+          ],
           "examples": [30, 50, "100", 200, "300"]
         },
         "secretEnv": {

--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -198,7 +198,7 @@
         },
         "diskSizeGb": {
           "description": "Requested disk size for the VM that runs the build. Note that this is *NOT*\n\"disk free\"; some of the space will be used by the operating system and\nbuild utilities. Also note that this is the minimum disk size that will be\nallocated for the build -- the build may run with a larger disk than\nrequested. At present, the maximum disk size is 2000GB; builds that request\nmore than the maximum are rejected with an error.",
-          "anyOf": [
+          "oneOf": [
             {
               "type": "integer",
               "minimum": 1,

--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -199,7 +199,7 @@
         "diskSizeGb": {
           "description": "Requested disk size for the VM that runs the build. Note that this is *NOT*\n\"disk free\"; some of the space will be used by the operating system and\nbuild utilities. Also note that this is the minimum disk size that will be\nallocated for the build -- the build may run with a larger disk than\nrequested. At present, the maximum disk size is 2000GB; builds that request\nmore than the maximum are rejected with an error.",
           "type": ["integer", "string"],
-          "pattern": "^([1-9]|[1-9][0-9]|[1-9][0-9][0-9]|[1][0-9][0-9][0-9]|2000)$",
+          "pattern": "^(?:[1-9]\\d{0,2}|1\\d{3}|2000)$",
           "maximum": 2000,
           "minimum": 1,
           "examples": [30, 50, "100", 200, "300"]


### PR DESCRIPTION
I am almost done going through this file making improvements. 

- Removes several `machineType`s that are no longer (or were maybe never) supported for use in a Cloud Build config file
- Removes several `Source` definitions that are no longer (or were maybe never)  supported for use in a Cloud Build config file
- Updates `diskSizeGb` with better validation that accounts for Cloud Build's max values and acceptance of `string` and `integer` `type`s for the value
- Minor updates to some `examples` and `description`s