### PR TITLE
Add Gitea/Forgejo config files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2010,7 +2010,11 @@
       "description": "YAML GitHub issue forms",
       "fileMatch": [
         "**/.github/ISSUE_TEMPLATE/**.yml",
-        "**/.github/ISSUE_TEMPLATE/**.yaml"
+        "**/.github/ISSUE_TEMPLATE/**.yaml",
+        "**/.gitea/ISSUE_TEMPLATE/**.yml",
+        "**/.gitea/ISSUE_TEMPLATE/**.yaml",
+        "**/.forgejo/ISSUE_TEMPLATE/**.yml",
+        "**/.forgejo/ISSUE_TEMPLATE/**.yaml"
       ],
       "url": "https://json.schemastore.org/github-issue-forms.json"
     },
@@ -2019,7 +2023,11 @@
       "description": "YAML configuring GitHub Issue Templates",
       "fileMatch": [
         "**/.github/ISSUE_TEMPLATE/config.yml",
-        "**/.github/ISSUE_TEMPLATE/config.yaml"
+        "**/.github/ISSUE_TEMPLATE/config.yaml",
+        "**/.gitea/ISSUE_TEMPLATE/config.yml",
+        "**/.gitea/ISSUE_TEMPLATE/config.yaml",
+        "**/.forgejo/ISSUE_TEMPLATE/config.yml",
+        "**/.forgejo/ISSUE_TEMPLATE/config.yaml"
       ],
       "url": "https://json.schemastore.org/github-issue-config.json"
     },
@@ -2028,7 +2036,11 @@
       "description": "YAML GitHub Workflow",
       "fileMatch": [
         "**/.github/workflows/*.yml",
-        "**/.github/workflows/*.yaml"
+        "**/.github/workflows/*.yaml",
+        "**/.gitea/workflows/*.yml",
+        "**/.gitea/workflows/*.yaml",
+        "**/.forgejo/workflows/*.yml",
+        "**/.forgejo/workflows/*.yaml"
       ],
       "url": "https://json.schemastore.org/github-workflow.json"
     },


### PR DESCRIPTION
I would like to update the patterns for GitHub workflows and issue templates to add support for the open source code hosting platforms Gitea and Forgejo. They use the same config file format, but allow placing the config files in different folders (`.gitea` and `.forgejo`).

Sources:
https://docs.gitea.com/next/usage/actions/overview
https://docs.gitea.com/next/usage/issue-pull-request-templates#syntax-for-yaml-template