### PR TITLE
add versions for bottom's config file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -438,7 +438,11 @@
       "name": "bottom configuration",
       "description": "Configuration file for bottom",
       "fileMatch": ["bottom.toml"],
-      "url": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/nightly/bottom.json"
+      "url": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v1.0/bottom.json",
+      "versions": {
+        "nightly": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/nightly/bottom.json",
+        "1.0": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v1.0/bottom.json"
+      }
     },
     {
       "name": "buf.yaml",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Adds versioning scheme for bottom, and changes the base URL to point to a stable version instead rather than the nightly version, which is subject to more frequent change.
