### PR TITLE
fix: Update titleCaseSytle in hugo.json

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -3617,8 +3617,8 @@
     "titleCaseStyle": {
       "description": "The title case style\nhttps://gohugo.io/getting-started/configuration/#titlecasestyle",
       "type": "string",
-      "default": "AP",
-      "enum": ["AP", "Chicago", "Go"]
+      "default": "ap",
+      "enum": ["ap", "chicago", "go", "firstupper", "none"]
     },
     "uglyURLs": {
       "description": "Enable/disable adding file extensions to urls\nhttps://gohugo.io/getting-started/configuration/#uglyurls",


### PR DESCRIPTION
update enum base on latest (v0.122.0) doc

> https://gohugo.io/getting-started/configuration/#configure-title-case

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
