### PR TITLE
circleci: allow 'machine: default' for machine executor

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -397,6 +397,7 @@
           "properties": {
             "machine": {
               "oneOf": [
+                { "const": "default" },
                 { "const": true },
                 {
                   "type": "object",

--- a/src/test/circleciconfig/machine-default.yaml
+++ b/src/test/circleciconfig/machine-default.yaml
@@ -1,0 +1,6 @@
+version: 2.1
+jobs:
+  prepare:
+    machine: default
+    steps:
+      - run: echo "Hello world!"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Add support for `machine: default` executor in circleci YAMLs.