### PR TITLE
golangci-lint: update configuration

### DIFF
--- a/src/schemas/json/golangci-lint.json
+++ b/src/schemas/json/golangci-lint.json
@@ -456,6 +456,21 @@
           "type": "boolean",
           "default": false
         },
+        "allow-serial-runners": {
+          "description": "Allow multiple golangci-lint instances running, but serialize them around a lock.",
+          "type": "boolean",
+          "default": false
+        },
+        "print-resources-usage": {
+          "description": "Print avg and max memory usage of golangci-lint and total time.",
+          "type": "boolean",
+          "default": false
+        },
+        "show-stats": {
+          "description": "Show statistics per linter.",
+          "type": "boolean",
+          "default": false
+        },
         "go": {
           "description": "Targeted Go version.",
           "type": "string",
@@ -696,8 +711,7 @@
                   "type": "object",
                   "properties": {
                     "list-mode": {
-                      "description": "Used to determine the package matching priority.\nThere are three different modes: `original`, `strict`, and `lax`.\nDefault: \"original\"",
-                      "type": "string",
+                      "description": "Used to determine the package matching priority.",
                       "enum": ["original", "strict", "lax"],
                       "default": "original"
                     },
@@ -871,6 +885,11 @@
             },
             "explicit-exhaustive-map": {
               "description": "Only run exhaustive check on map literals with \"//exhaustive:enforce\" comment.",
+              "type": "boolean",
+              "default": false
+            },
+            "default-case-required": {
+              "description": "Switch statement requires default case even if exhaustive.",
               "type": "boolean",
               "default": false
             },
@@ -1111,6 +1130,10 @@
               "description": "Ignore when constant is not used as function argument",
               "type": "boolean",
               "default": true
+            },
+            "ignore-strings": {
+              "description": "Exclude strings matching the given regular expression",
+              "type": "string"
             },
             "numbers": {
               "description": "Search also for duplicated numbers.",
@@ -1816,6 +1839,17 @@
             }
           }
         },
+        "inamedparam": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "skip-single-param": {
+              "description": "Skips check for interface methods with only a single parameter.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
         "ireturn": {
           "type": "object",
           "additionalProperties": false,
@@ -1973,6 +2007,11 @@
               "items": {
                 "type": "string"
               }
+            },
+            "mode": {
+              "description": "Mode of the analysis.",
+              "enum": ["restricted", "", "default"],
+              "default": ""
             }
           }
         },
@@ -2117,6 +2156,32 @@
             }
           }
         },
+        "perfsprint": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "int-conversion": {
+              "description": "Optimizes even if it requires an int or uint type cast.",
+              "type": "boolean",
+              "default": true
+            },
+            "err-error": {
+              "description": "Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.",
+              "type": "boolean",
+              "default": false
+            },
+            "errorf": {
+              "description": "Optimizes `fmt.Errorf`.",
+              "type": "boolean",
+              "default": true
+            },
+            "sprintf1": {
+              "description": "Optimizes `fmt.Sprintf` with only one argument.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
         "prealloc": {
           "description": "We do not recommend using this linter before doing performance profiling.\nFor most programs usage of `prealloc` will be premature optimization.",
           "type": "object",
@@ -2173,6 +2238,36 @@
                   "UnitAbbreviations"
                 ]
               }
+            }
+          }
+        },
+        "protogetter": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "skip-generated-by": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "examples": ["protoc-gen-go-my-own-generator"]
+              }
+            },
+            "skip-files": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "examples": ["*.pb.go"]
+              }
+            },
+            "skip-any-generated": {
+              "description": "Skip any generated files from the checking.",
+              "type": "boolean",
+              "default": false
+            },
+            "replace-first-arg-in-append": {
+              "description": "Skip first argument of append function.",
+              "type": "boolean",
+              "default": false
             }
           }
         },
@@ -2269,6 +2364,25 @@
               "type": "boolean",
               "default": false
             },
+            "no-mixed-args": {
+              "description": "Enforce not mixing key-value pairs and attributes.",
+              "type": "boolean",
+              "default": true
+            },
+            "context-only": {
+              "description": "Enforce using methods that accept a context.",
+              "type": "boolean",
+              "default": false
+            },
+            "static-msg": {
+              "description": "Enforce using static values for log messages.",
+              "type": "boolean",
+              "default": false
+            },
+            "key-naming-case": {
+              "description": "Enforce a single key naming convention.",
+              "enum": ["snake", "kebab", "camel", "pascal"]
+            },
             "attr-only": {
               "description": "Enforce using attributes only (incompatible with kv-only).",
               "type": "boolean",
@@ -2283,6 +2397,26 @@
               "description": "Enforce putting arguments on separate lines.",
               "type": "boolean",
               "default": false
+            }
+          }
+        },
+        "spancheck": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "checks": {
+              "description": "Checks to enable.",
+              "type": "array",
+              "items": {
+                "enum": ["end", "record-error", "set-status"]
+              }
+            },
+            "ignore-check-signatures": {
+              "description": "A list of regexes for function signatures that silence `record-error` and `set-status` reports if found in the call path to a returned error.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },
@@ -2570,23 +2704,56 @@
               "type": "boolean",
               "default": false
             },
+            "disable-all": {
+              "description": "Disable all checkers.",
+              "type": "boolean",
+              "default": false
+            },
             "enable": {
               "description": "Enable specific checkers.",
               "type": "array",
               "items": {
                 "enum": [
+                  "blank-import",
                   "bool-compare",
                   "compares",
                   "empty",
                   "error-is-as",
                   "error-nil",
                   "expected-actual",
+                  "go-require",
                   "float-compare",
                   "len",
+                  "nil-compare",
                   "require-error",
                   "suite-dont-use-pkg",
                   "suite-extra-assert-call",
-                  "suite-thelper"
+                  "suite-thelper",
+                  "useless-assert"
+                ]
+              }
+            },
+            "disable": {
+              "description": "Enable specific checkers.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "blank-import",
+                  "bool-compare",
+                  "compares",
+                  "empty",
+                  "error-is-as",
+                  "error-nil",
+                  "expected-actual",
+                  "go-require",
+                  "float-compare",
+                  "len",
+                  "nil-compare",
+                  "require-error",
+                  "suite-dont-use-pkg",
+                  "suite-extra-assert-call",
+                  "suite-thelper",
+                  "useless-assert"
                 ]
               }
             },
@@ -2595,6 +2762,16 @@
               "additionalProperties": false,
               "properties": {
                 "pattern": {
+                  "description": "Regexp for expected variable name.",
+                  "type": "string"
+                }
+              }
+            },
+            "require-error": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "fn-pattern": {
                   "description": "Regexp for expected variable name.",
                   "type": "string"
                 }
@@ -3222,7 +3399,12 @@
         "fix": {
           "description": "Fix found issues (if it's supported by the linter).",
           "type": "boolean",
-          "default": true
+          "default": false
+        },
+        "whole-files": {
+          "description": "Show issues in any part of update files (requires new-from-rev or new-from-patch).",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/src/test/golangci-lint/example-values.json
+++ b/src/test/golangci-lint/example-values.json
@@ -48,7 +48,8 @@
     "max-same-issues": 0,
     "new": true,
     "new-from-patch": "path/to/patch/file",
-    "new-from-rev": "HEAD"
+    "new-from-rev": "HEAD",
+    "whole-files": true
   },
   "linters": {
     "disable": [
@@ -141,6 +142,7 @@
       "rowserrcheck",
       "scopelint",
       "sloglint",
+      "spancheck",
       "sqlclosecheck",
       "staticcheck",
       "structcheck",
@@ -257,6 +259,7 @@
       "rowserrcheck",
       "scopelint",
       "sloglint",
+      "spancheck",
       "sqlclosecheck",
       "staticcheck",
       "structcheck",
@@ -353,17 +356,7 @@
               "pkg": "github.com/pkg/errors"
             }
           ],
-          "files": ["$all", "!**/*_a _file.go"],
-          "list-mode": "strict"
-        },
-        "tests": {
-          "deny": [
-            {
-              "desc": "Please use standard library for tests",
-              "pkg": "github.com/stretchr/testify"
-            }
-          ],
-          "files": ["$test"],
+          "files": ["!**/*_a _file.go"],
           "list-mode": "lax"
         }
       }
@@ -403,6 +396,7 @@
     "exhaustive": {
       "check": ["switch", "map"],
       "check-generated": true,
+      "default-case-required": true,
       "default-signifies-exhaustive": true,
       "explicit-exhaustive-map": true,
       "explicit-exhaustive-switch": true,
@@ -414,9 +408,9 @@
       "struct-patterns": ["*.Test", "example.com/package.ExampleStruct"]
     },
     "exhaustruct": {
-      "exclude": ["cobra\\.Command$"],
+      "exclude": [".+/cobra\\.Command$"],
       "include": [
-        ".*\\.Test",
+        ".+\\.Test",
         "example\\.com/package\\.ExampleStruct[\\d]{1,2}"
       ]
     },
@@ -450,7 +444,8 @@
         "default",
         "prefix(github.com/org/project)",
         "blank",
-        "dot"
+        "dot",
+        "alias"
       ],
       "skip-generated": false
     },
@@ -469,6 +464,7 @@
     },
     "goconst": {
       "ignore-calls": false,
+      "ignore-strings": "foo.+",
       "ignore-tests": true,
       "match-constant": false,
       "max": 2,
@@ -503,11 +499,17 @@
         "captLocal": {
           "paramsOnly": false
         },
+        "commentedOutCode": {
+          "minLength": 50
+        },
         "elseif": {
           "skipBalanced": false
         },
         "hugeParam": {
           "sizeThreshold": 70
+        },
+        "ifElseChain": {
+          "minThreshold": 4
         },
         "nestingReduce": {
           "bodyWidth": 4
@@ -897,6 +899,9 @@
       "no-extra-aliases": true,
       "no-unaliased": true
     },
+    "inamedparam": {
+      "skip-single-param": true
+    },
     "interfacebloat": {
       "max": 5
     },
@@ -932,7 +937,8 @@
     },
     "misspell": {
       "ignore-words": ["someword"],
-      "locale": "US"
+      "locale": "US",
+      "mode": "restricted"
     },
     "musttag": {
       "functions": [
@@ -968,6 +974,12 @@
       "ignore-missing": true,
       "ignore-missing-subtests": true
     },
+    "perfsprint": {
+      "err-error": true,
+      "errorf": false,
+      "int-conversion": false,
+      "sprintf1": false
+    },
     "prealloc": {
       "for-loops": true,
       "range-loops": false,
@@ -989,6 +1001,12 @@
         "UnitAbbreviations"
       ],
       "strict": true
+    },
+    "protogetter": {
+      "replace-first-arg-in-append": true,
+      "skip-any-generated": true,
+      "skip-files": ["*.pb.go", "*/vendor/*", "/full/path/to/file.go"],
+      "skip-generated-by": ["protoc-gen-go-my-own-generator"]
     },
     "reassign": {
       "patterns": [".*"]
@@ -1143,6 +1161,18 @@
           "arguments": ["make"],
           "disabled": false,
           "name": "enforce-map-style",
+          "severity": "warning"
+        },
+        {
+          "arguments": ["short"],
+          "disabled": false,
+          "name": "enforce-repeated-arg-type-style",
+          "severity": "warning"
+        },
+        {
+          "arguments": ["make"],
+          "disabled": false,
+          "name": "enforce-slice-style",
           "severity": "warning"
         },
         {
@@ -1440,8 +1470,16 @@
     "sloglint": {
       "args-on-sep-lines": true,
       "attr-only": true,
+      "context-only": true,
+      "key-naming-case": "snake",
       "kv-only": true,
-      "no-raw-keys": true
+      "no-mixed-args": false,
+      "no-raw-keys": true,
+      "static-msg": true
+    },
+    "spancheck": {
+      "checks": ["end", "record-error", "set-status"],
+      "ignore-check-signatures": ["telemetry.RecordError"]
     },
     "staticcheck": {
       "checks": ["all"],
@@ -1538,23 +1576,49 @@
       "all": false
     },
     "testifylint": {
-      "enable": [
+      "disable": [
+        "blank-import",
         "bool-compare",
         "compares",
         "empty",
         "error-is-as",
         "error-nil",
         "expected-actual",
+        "go-require",
         "float-compare",
         "len",
+        "nil-compare",
         "require-error",
         "suite-dont-use-pkg",
         "suite-extra-assert-call",
-        "suite-thelper"
+        "suite-thelper",
+        "useless-assert"
+      ],
+      "disable-all": true,
+      "enable": [
+        "blank-import",
+        "bool-compare",
+        "compares",
+        "empty",
+        "error-is-as",
+        "error-nil",
+        "expected-actual",
+        "go-require",
+        "float-compare",
+        "len",
+        "nil-compare",
+        "require-error",
+        "suite-dont-use-pkg",
+        "suite-extra-assert-call",
+        "suite-thelper",
+        "useless-assert"
       ],
       "enable-all": true,
       "expected-actual": {
         "pattern": "^expected"
+      },
+      "require-error": {
+        "fn-pattern": "^(Errorf?|NoErrorf?)$"
       },
       "suite-extra-assert-call": {
         "mode": "require"
@@ -1648,6 +1712,7 @@
         ".Errorf(",
         "errors.New(",
         "errors.Unwrap(",
+        "errors.Join(",
         ".Wrap(",
         ".Wrapf(",
         ".WithMessage(",
@@ -1676,16 +1741,19 @@
     "path-prefix": "",
     "print-issued-lines": false,
     "print-linter-name": false,
-    "sort-results": false,
+    "sort-results": true,
     "uniq-by-line": false
   },
   "run": {
     "allow-parallel-runners": false,
+    "allow-serial-runners": true,
     "build-tags": ["mytag"],
     "concurrency": 4,
     "go": "1.19",
     "issues-exit-code": 2,
     "modules-download-mode": "readonly",
+    "print-resources-usage": true,
+    "show-stats": true,
     "skip-dirs": ["src/external_libs", "autogenerated_by_my_lib"],
     "skip-dirs-use-default": false,
     "skip-files": [".*\\.my\\.go$", "lib/bad.go"],


### PR DESCRIPTION
Update schema with new configuration options.

Related to the new release v1.56.0
https://github.com/golangci/golangci-lint/releases/tag/v1.56.0
