### PR TITLE
Add GitLab Agent for Kubernetes configuration file schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5848,6 +5848,12 @@
       "description": "Squid manifest for Subsquid Cloud deployments",
       "fileMatch": ["squid.yaml", "*.squid.yaml", "squid.yml", "*.squid.yml"],
       "url": "https://cdn.subsquid.io/schemas/squid_manifest.json"
+    },
+    {
+      "name": "GitLab Agent for Kubernetes configuration",
+      "description": "GitLab Agent for Kubernetes configuration file",
+      "fileMatch": [".gitlab/agents/*/config.yaml"],
+      "url": "https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/raw/master/pkg/agentcfg/agentcfg_schemas/ConfigurationFile.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5852,7 +5852,7 @@
     {
       "name": "GitLab Agent for Kubernetes configuration",
       "description": "GitLab Agent for Kubernetes configuration file",
-      "fileMatch": [".gitlab/agents/*/config.yaml"],
+      "fileMatch": ["**/.gitlab/agents/*/config.yaml"],
       "url": "https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/raw/master/pkg/agentcfg/agentcfg_schemas/ConfigurationFile.json"
     }
   ]


### PR DESCRIPTION
Add GitLab Agent for Kubernetes configuration file schema to the catalog.