### PR TITLE
Add dependency cruiser schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -957,6 +957,12 @@
       "url": "https://json.schemastore.org/dein.json"
     },
     {
+      "name": "Dependency cruiser",
+      "description": "Configuration file for Dependency cruiser",
+      "fileMatch": ["dependency-cruiser.config.json"],
+      "url": "https://raw.githubusercontent.com/sverweij/dependency-cruiser/main/src/schema/configuration.schema.json"
+    },
+    {
       "name": "Deta Spacefile",
       "description": "Configuration file for Space Apps",
       "fileMatch": ["Spacefile"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

As mentioned in [CONTRIBUTING.md](https://github.com/SchemaStore/schemastore/blob/143792728278ac9da8214a08431b6204f06bd253/CONTRIBUTING.md) I used https://github.com/SchemaStore/schemastore/pull/1211 as a blue print to add the [configuration schema](https://github.com/sverweij/dependency-cruiser/blob/26dac1191e95905bc36a24f71b71117f9432aebc/src/schema/configuration.schema.json) of [dependency cruiser](https://github.com/sverweij/dependency-cruiser).