### PR TITLE
Update `github-funding.json` to support Polar option

### DIFF
--- a/src/schemas/json/github-funding.json
+++ b/src/schemas/json/github-funding.json
@@ -88,6 +88,12 @@
       "description": "Project name on LFX Crowdfunding.",
       "minLength": 1
     },
+    "polar": {
+      "$ref": "#/definitions/github_username",
+      "title": "Polar",
+      "description": "Username on Polar.",
+      "minLength": 1
+    },
     "custom": {
       "title": "Custom URL",
       "description": "Link or links where funding is accepted on external locations.",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

GitHub just added support for Polar as an official sponsor option:

* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#about-funding-files
* https://github.com/orgs/community/discussions/106700

This PR adds this new option to the corresponding schema, `github-funding.json`.
