### PR TITLE
ci: Update code-owner-self-merge ref

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
       - name: 'Run Codeowners merge check'
-        uses: 'fox-forks/code-owner-self-merge@8b5015c0e9a2dc8401cb3cde1bce517b044a99af'
+        uses: 'fox-forks/code-owner-self-merge@hyperupcall-feat-ownernopings'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
           merge_method: 'squash'
           ownerNoPings: '["@hyperupcall"]'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

To reduce maintenance burden and custom CI code, I'm upstreaming the `ownerNoPings` option that I added to my `code-owner-self-merge` fork. I'm switching the `ref` to the specific branch that'll serve as the basis for the upstream PR. Doing this will "test" the code.

This is tracked upstream at https://github.com/OSS-Docs-Tools/code-owner-self-merge/issues/42.

Once this is merged upstream, then I'll make another PR that updates the same workflow to use the upstream project instead of my fork.