### PR TITLE
add Custom Machinery Machine and Recipe schemas to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5900,7 +5900,7 @@
     {
       "name": "Custom Machinery Recipe",
       "description": "Custom machinery recipes specification",
-      "fileMatch": ["**/data/*/recipes/*.json"],
+      "fileMatch": ["**/data/*/recipes/**/*.json"],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_recipe.json"
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5890,6 +5890,23 @@
       "description": "Card Game Simulator (CGS) custom card game specification",
       "fileMatch": ["CardGameDef.json"],
       "url": "https://www.cardgamesimulator.com/schema/CardGameDef.json"
+    },
+    {
+      "name": "Custom Machinery Machine",
+      "description": "Custom machinery machine specification",
+      "fileMatch": [
+        "**/data/*/machines/*.json",
+        "**/data/*/machine/*.json"
+      ],
+      "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_machine.json"
+    },
+    {
+      "name": "Custom Machinery Recipe",
+      "description": "Custom machinery recipes specification",
+      "fileMatch": [
+        "**/data/*/recipes/*.json"
+      ],
+      "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_recipe.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5893,13 +5893,13 @@
     },
     {
       "name": "Custom Machinery Machine",
-      "description": "Custom machinery machine specification",
+      "description": "Custom machinery machine specification (Minecraft mod)",
       "fileMatch": ["**/data/*/machines/*.json", "**/data/*/machine/*.json"],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_machine.json"
     },
     {
       "name": "Custom Machinery Recipe",
-      "description": "Custom machinery recipes specification",
+      "description": "Custom machinery recipes specification (Minecraft mod)",
       "fileMatch": ["**/data/*/recipes/**/*.json"],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_recipe.json"
     }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5894,18 +5894,13 @@
     {
       "name": "Custom Machinery Machine",
       "description": "Custom machinery machine specification",
-      "fileMatch": [
-        "**/data/*/machines/*.json",
-        "**/data/*/machine/*.json"
-      ],
+      "fileMatch": ["**/data/*/machines/*.json", "**/data/*/machine/*.json"],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_machine.json"
     },
     {
       "name": "Custom Machinery Recipe",
       "description": "Custom machinery recipes specification",
-      "fileMatch": [
-        "**/data/*/recipes/*.json"
-      ],
+      "fileMatch": ["**/data/*/recipes/*.json"],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_recipe.json"
     }
   ]


### PR DESCRIPTION
This PR adds a reference to the machine and recipe schema of [Custom Machinery](https://github.com/Frinn38/Custom-Machinery)