### PR TITLE
add Enterprise Contract policy Spec schema.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1735,6 +1735,11 @@
       "url": "https://json.schemastore.org/elgato-stream-deck-plugin.json"
     },
     {
+      "name": "Enterprise Contract Policy Spec",
+      "description": "Policy file for use with Enterprise Contract",
+      "url": "https://enterprisecontract.dev/enterprise-contract-controller/schema/policy_spec.json"
+    },
+    {
       "name": ".esmrc.json",
       "description": "Configuration files for the esm module/package in Node.js",
       "fileMatch": [


### PR DESCRIPTION
This PR adds a reference to the Enterprise Contract policy spec. For more information about Enterprise Contract, visit the [website](https://enterprisecontract.dev)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
