### PR TITLE
Add Conventional Changelog Configuration file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4375,11 +4375,7 @@
     {
       "name": ".versionrc.json",
       "description": "Conventional Changelog Configuration file",
-      "fileMatch": [
-        ".versionrc",
-        ".versionrc.json",
-        ".versionrc.js"
-      ],
+      "fileMatch": [".versionrc", ".versionrc.json", ".versionrc.js"],
       "url": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.2.0/schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/1.0.0/schema.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4373,6 +4373,22 @@
       "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
+      "name": ".versionrc.json",
+      "description": "Conventional Changelog Configuration file",
+      "fileMatch": [
+        ".versionrc",
+        ".versionrc.json",
+        ".versionrc.js"
+      ],
+      "url": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.2.0/schema.json",
+      "versions": {
+        "1.0.0": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/1.0.0/schema.json",
+        "2.0.0": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.0.0/schema.json",
+        "2.1.0": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.1.0/schema.json",
+        "2.2.0": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.2.0/schema.json"
+      }
+    },
+    {
       "name": "vim-addon-info",
       "description": "vim plugin addon-info.json metadata files",
       "fileMatch": ["**/*vim*/addon-info.json"],


### PR DESCRIPTION
This commit adds the JSON schema for the **Conventional Changelog Configuration** file. It is used by tools like [standard-version](https://github.com/conventional-changelog/standard-version) and its newer fork [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) to generate change logs. The configuration file that these tools recognize and that utilize this schema, is usually named `.versionrc`, `.versionrc.json` or `.versionrc.js`.

The JSON schema is directly linked from the [conventional-changelog/conventional-changelog-config-spec](https://github.com/conventional-changelog/conventional-changelog-config-spec) repository. The various versions of the schemas are located [here](https://github.com/conventional-changelog/conventional-changelog-config-spec/tree/master/versions).

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
