### PR TITLE
Fix: regex for git URLs in pyproject.toml poetry section

### DIFF
--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -134,7 +134,7 @@
               "format": "uri"
             },
             {
-              "pattern": "^([A-Za-z0-9\\-]+@|https:\/\/|http:\/\/)[A-Za-z][A-Za-z0-9+.-]*(:|\/)[A-Za-z0-9\\-]+\/[A-Za-z0-9\\-_]+\\.git$"
+              "pattern": "^([A-Za-z0-9\\-]+@|https://|http://)[A-Za-z][A-Za-z0-9+.-]*(:|/)[A-Za-z0-9\\-]+/[A-Za-z0-9\\-_]+\\.git$"
             }
           ]
         },

--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -134,7 +134,7 @@
               "format": "uri"
             },
             {
-              "pattern": "^([A-Za-z0-9\\-]+@|https://|http://)[A-Za-z0-9\\-]+\\.[A-Za-z0-9\\-]+(:|/)[A-Za-z0-9\\-]+/[A-Za-z0-9\\-]+\\.git$"
+              "pattern": "^([A-Za-z0-9\\-]+@|https:\/\/|http:\/\/)[A-Za-z][A-Za-z0-9+.-]*(:|\/)[A-Za-z0-9\\-]+\/[A-Za-z0-9\\-_]+\\.git$"
             }
           ]
         },

--- a/src/test/pyproject/3616.toml
+++ b/src/test/pyproject/3616.toml
@@ -1,0 +1,9 @@
+[tool.poetry]
+name = "myotherlib"
+version = "0.1.0"
+description = "foo"
+authors = ["Waylon Peng <waylon@berkeley.edu>"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+mylib = { git = "git@git.my.domain.com:pandaxtc/mylib.git" }


### PR DESCRIPTION
Updates regex for git dependencies in pyproject.toml poetry sections. Fixes #3575 
