### PR TITLE
Add `merge_group` to `event` enum

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -267,6 +267,7 @@
         "issue_comment",
         "issues",
         "label",
+        "merge_group",
         "member",
         "milestone",
         "page_build",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

`merge_group` was added in https://github.com/SchemaStore/schemastore/pull/2455 but not the `event.enum`
