### PR TITLE
Add dotnet-isolated:8.0 into staticwebapp schema

### DIFF
--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -604,6 +604,7 @@
             "dotnet:6.0",
             "dotnet-isolated:6.0",
             "dotnet-isolated:7.0",
+            "dotnet-isolated:8.0",
             "node:12",
             "node:14",
             "node:16",


### PR DESCRIPTION
Add dotnet-isolated:8.0 to sync with Azure Functions (https://learn.microsoft.com/en-us/azure/static-web-apps/languages-runtimes#api). The schema is used by swa-cli, and this change is to solve the issue: https://github.com/Azure/static-web-apps/issues/1394.