### PR TITLE
Introduce monoweave schema (remote)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2887,6 +2887,18 @@
       "url": "https://raw.githubusercontent.com/software-t-rex/monospace/main/apps/monospace/schemas/monospace.schema.json"
     },
     {
+      "name": "Monoweave Configuration",
+      "description": "Monoweave configuration file (Yarn package publishing)",
+      "fileMatch": [
+        "monoweave.config.json",
+        "monoweave.config.jsonc",
+        "monoweave.config.json5",
+        "monoweave.config.yaml",
+        "monoweave.config.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/monoweave/monoweave/main/packages/types/schema.json"
+    },
+    {
       "name": "MS2Rescore Configuration",
       "description": "MS2Rescore configuration file",
       "fileMatch": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

This pull request introduces a configuration for https://monoweave.github.io/monoweave/ ([GitHub Link](https://github.com/monoweave/monoweave)] which is a Yarn-based npm package publishing project.

It's a recent "official" fork of https://github.com/tophat/monodeploy hence the low usage at the moment.

We point to the main branch so it's always serving the latest schema.
