### PR TITLE
Improve cloudbuild json schema's serviceAccount field pattern

### DIFF
--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -439,7 +439,7 @@
     "serviceAccount": {
       "description": "Use this field to specify the IAM service account to use at build time.",
       "type": "string",
-      "pattern": "^projects/[\\w-]+/serviceAccounts/[\\w-.]+@[\\w-.]+$"
+      "pattern": "^projects/[\\w\\-]+/serviceAccounts/[\\w\\-.]+@[\\w\\-.]+$"
     },
     "queueTtl": {
       "description": "Specifies the amount of time a build can be queued.\nIf a build is in the queue for longer than the value set in `queueTtl`, the build expires and the build status is set to `EXPIRED`.",

--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -439,7 +439,7 @@
     "serviceAccount": {
       "description": "Use this field to specify the IAM service account to use at build time.",
       "type": "string",
-      "pattern": "^projects/\\w+/serviceAccounts/\\w+$"
+      "pattern": "^projects/[\\w-]+/serviceAccounts/[\\w-.]+@[\\w-.]+$"
     },
     "queueTtl": {
       "description": "Specifies the amount of time a build can be queued.\nIf a build is in the queue for longer than the value set in `queueTtl`, the build expires and the build status is set to `EXPIRED`.",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
Thank you for your great contribution of this project.

Now, Cloud Build allows us to use a user-specified Service Account (SA) instead of the default Service Account (SA).
In order to use the user-specified SA in the job definition, we need to add the serviceAccount field to the job definition.
As stated in [the documentation](https://cloud.google.com/build/docs/securing-builds/configure-user-specified-service-accounts#running_builds_from_the_command_line), specify `PROJECT_ID` and `SERVICE_ACCOUNT_NAME` as follows.

```
serviceAccount: 'projects/project-id/serviceAccounts/service-account-name@project-id.iam.gserviceaccount.com'
```

Then, `PROJECT_ID` and `SERVICE_ACCOUNT_NAME` are specified as `\w+` in [the Cloud Build json shema file](https://github.com/SchemaStore/schemastore/blob/d9516961f8a5b0e65a457808070147b5a866f60b/src/schemas/json/cloudbuild.json#L442).
However, `\w+` matches strings containing only lowercase letters, numbers, and underscores, so we cannot specify values that include `-`, `@`, or `.`.
Official documentation provides examples using these symbols and should be supported.

`PROJECT_ID` should support strings including `-` in addition to lowercase letters and numbers. Also, `SERVICE_ACCOUNT_NAME` should support strings containing `-`, `@`, and `.` in addition to lowercase letters, numbers, and underscores.

I would appreciate your comments on this improvement. Thank you.