### PR TITLE
add bioimagio JSON schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5961,8 +5961,8 @@
       "url": "https://raw.githubusercontent.com/Nuitka/Nuitka/develop/misc/nuitka-package-config-schema.json"
     },
     {
-      "name": "bioimageio JSON schema",
-      "description": "Bioimage.io community specifications JSON, may be produced or consumed by bioimage.io-compatible consumers",
+      "name": "bioimageio json",
+      "description": "Bioimage.io community specifications json, may be produced or consumed by bioimage.io-compatible consumers",
       "fileMatch": [],
       "url": "https://github.com/bioimage-io/spec-bioimage-io/raw/gh-pages/bioimageio_schema_latest.json"
     }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5959,6 +5959,12 @@
         "*.nuitka-package.config.yaml"
       ],
       "url": "https://raw.githubusercontent.com/Nuitka/Nuitka/develop/misc/nuitka-package-config-schema.json"
+    },
+    {
+      "name": "bioimageio JSON schema",
+      "description": "Bioimage.io community specifications JSON, may be produced or consumed by bioimage.io-compatible consumers",
+      "fileMatch": [],
+      "url": "https://github.com/bioimage-io/spec-bioimage-io/raw/gh-pages/bioimageio_schema_latest.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5964,7 +5964,7 @@
       "name": "bioimageio json",
       "description": "Bioimage.io community specifications json, may be produced or consumed by bioimage.io-compatible consumers",
       "fileMatch": [],
-      "url": "https://github.com/bioimage-io/spec-bioimage-io/raw/gh-pages/bioimageio_schema_latest.json"
+      "url": "https://bioimage-io.github.io/spec-bioimage-io/bioimageio_schema_latest.json"
     }
   ]
 }


### PR DESCRIPTION
Hello,

we (@fynnbe) would like to add JSON specifications for [bioimage.io](https://github.com/bioimage-io/spec-bioimage-io/tree/gh-pages) to SchemaStore. I added the URL links to the schema catalog (as is in the [example PR](https://github.com/SchemaStore/schemastore/pull/1211/files)). And the grunt checks went through smoothly.

The current linked schema (latest) does encompass all released descriptions (all types and their format versions).

Thank you
Martin
