### PR TITLE
add DataYoga connections schema to the catalog 

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -949,7 +949,7 @@
       "description": "Collection of defined source and target connections used within DataYoga jobs",
       "fileMatch": ["connections.dy.yaml"],
       "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/connections.schema.json"
-    },    
+    },
     {
       "name": "DataYoga Job",
       "description": "Declarative definition of sequential pipeline steps within a DataYoga job",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -945,9 +945,15 @@
       "url": "https://raw.githubusercontent.com/SFDO-Tooling/CumulusCI/main/cumulusci/schema/cumulusci.jsonschema.json"
     },
     {
+      "name": "DataYoga Connections",
+      "description": "Collection of defined source and target connections used within DataYoga jobs",
+      "fileMatch": ["connections.dy.yaml"],
+      "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/connections.schema.json"
+    },    
+    {
       "name": "DataYoga Job",
-      "description": "DataYoga job configurations",
-      "fileMatch": ["*.dy.yaml", "*.dy.yml"],
+      "description": "Declarative definition of sequential pipeline steps within a DataYoga job",
+      "fileMatch": ["*.dy.yaml"],
       "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/job.schema.json"
     },
     {


### PR DESCRIPTION
- also changed descriptions to better describe the purpose of each file.
- changed the fileMatch of DataYoga job to `*.dy.yaml` only, as `*.dy.yml` is not supported.