### PR TITLE
Narrow the fileMatch of DataYoga job

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -953,7 +953,7 @@
     {
       "name": "DataYoga Job",
       "description": "Declarative definition of sequential pipeline steps within a DataYoga job",
-      "fileMatch": ["*.dy.yaml"],
+      "fileMatch": ["**/jobs/*.dy.yaml"],
       "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/job.schema.json"
     },
     {


### PR DESCRIPTION
To avoid conflicts with `connections.dy.yaml` that uses a different schema, see:
https://github.com/SchemaStore/schemastore/pull/3642#issuecomment-1996885064