### PR TITLE
add defaultLibraryPrefix to nest-cli.json

### DIFF
--- a/src/schemas/json/nest-cli.json
+++ b/src/schemas/json/nest-cli.json
@@ -486,6 +486,11 @@
         "$ref": "#/definitions/ProjectConfiguration"
       },
       "default": {}
+    },
+    "defaultLibraryPrefix": {
+      "type": "string",
+      "description": "Default import prefix for newly generated libraries.",
+      "default": "@app"
     }
   },
   "title": "Nest CLI configuration",

--- a/src/test/nest-cli/.nest.json
+++ b/src/test/nest-cli/.nest.json
@@ -7,6 +7,7 @@
     "webpack": false,
     "webpackConfigPath": "webpack.config.js"
   },
+  "defaultLibraryPrefix": "@app",
   "entryFile": "main",
   "generateOptions": {},
   "language": "ts",

--- a/src/test/nest-cli/nest-cli-generateOptions.json
+++ b/src/test/nest-cli/nest-cli-generateOptions.json
@@ -24,6 +24,7 @@
     "tsConfigPath": "apps/my-project/tsconfig.app.json",
     "webpack": true
   },
+  "defaultLibraryPrefix": "@app",
   "generateOptions": {
     "flat": false,
     "spec": {

--- a/src/test/nest-cli/nest-cli.json
+++ b/src/test/nest-cli/nest-cli.json
@@ -25,6 +25,7 @@
     "tsConfigPath": "apps/my-project/tsconfig.app.json",
     "typeCheck": true
   },
+  "defaultLibraryPrefix": "@app",
   "monorepo": true,
   "projects": {
     "my-app": {


### PR DESCRIPTION
[In January 2024 NestJS has added a `defaultLibraryPrefix` option to `nest-cli.json`](https://github.com/nestjs/schematics/pull/1563), but this doesn't seem to have been added to its schema yet.