### PR TITLE
Update dbt Project URL in catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -972,7 +972,7 @@
       "name": "dbt Project",
       "description": "dbt project configurations",
       "fileMatch": ["dbt_project.yml"],
-      "url": "https://github.com/dbt-labs/dbt-jsonschema/raw/main/schemas/latest/dbt_project-latest.json"
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dbt_project-latest.json"
     },
     {
       "name": "Dein Config",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -972,7 +972,7 @@
       "name": "dbt Project",
       "description": "dbt project configurations",
       "fileMatch": ["dbt_project.yml"],
-      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/dbt_project.json"
+      "url": "https://github.com/dbt-labs/dbt-jsonschema/raw/main/schemas/latest/dbt_project-latest.json"
     },
     {
       "name": "Dein Config",


### PR DESCRIPTION
Linking to the latest version of the dbt project schema

The old version was missing the `dbt-cloud` property, specifically