### PR TITLE
Add buy_me_a_coffee to GitHub funding schema

### DIFF
--- a/src/schemas/json/github-funding.json
+++ b/src/schemas/json/github-funding.json
@@ -94,6 +94,12 @@
       "description": "Username on Polar.",
       "minLength": 1
     },
+    "buy_me_a_coffee": {
+      "$ref": "#/definitions/nullable_string",
+      "title": "Buy Me a Coffee",
+      "description": "Username on Buy Me a Coffee.",
+      "minLength": 1
+    },
     "custom": {
       "title": "Custom URL",
       "description": "Link or links where funding is accepted on external locations.",


### PR DESCRIPTION
GitHub sponsors now support "Buy Me a Coffee"

Ref:

- https://github.blog/changelog/2024-03-14-sponsors-now-supports-polar-and-buy-me-a-coffee-as-funding-platform-options/
- https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

