### PR TITLE
Add SDMX (ISO 17369) from the SDMX TWG repository

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3853,6 +3853,33 @@
       "url": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json"
     },
     {
+      "name": "SDMX structure message",
+      "description": "Statistical Data and Metadata eXchange (ISO 17369) structure message",
+      "url": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+      "versions": {
+        "1.0": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+        "2.0.0": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json"
+      }
+    },
+    {
+      "name": "SDMX metadata message",
+      "description": "Statistical Data and Metadata eXchange (ISO 17369) metadata message",
+      "url": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/metadata-message/tools/schemas/2.0.0/sdmx-json-metadata-schema.json",
+      "versions": {
+        "1.0": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/metadata-message/tools/schemas/1.0/sdmx-json-metadata-schema.json",
+        "2.0.0": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/metadata-message/tools/schemas/2.0.0/sdmx-json-metadata-schema.json"
+      }
+    },
+    {
+      "name": "SDMX data message",
+      "description": "Statistical Data and Metadata eXchange (ISO 17369) data message",
+      "url": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/data-message/tools/schemas/2.0.0/sdmx-json-data-schema.json",
+      "versions": {
+        "1.0": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/data-message/tools/schemas/1.0/sdmx-json-data-schema.json",
+        "2.0.0": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/data-message/tools/schemas/2.0.0/sdmx-json-data-schema.json"
+      }
+    },
+    {
       "name": "Semantic Data Fabric (SDF) file",
       "description": "SDF blocks",
       "fileMatch": ["*.sdf.yml"],


### PR DESCRIPTION
SDMX, Statistical Data and Metadata eXchange, is an ISO Standard with the official schemas hosted on GitHub. This adds them as per [CONTRIBUTING.md](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md).