### PR TITLE
Fix format to comply with GA id specs

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -719,7 +719,7 @@
       "description": "The Google Analytics tracking ID\nhttps://gohugo.io/getting-started/configuration/#googleanalytics",
       "type": "string",
       "default": "",
-      "pattern": "(UA-\\d{6}-\\d)|(G-\\w+)"
+      "pattern": "(UA-\\d{4,9}-\\d)|(G-\\w+)"
     },
     "hasCJKLanguage": {
       "description": "Enable/disable auto-detecting Chinese/Japanese/Korean Languages in the content\nhttps://gohugo.io/getting-started/configuration/#hascjklanguage",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

The regex pattern falsely flags my UA id (which has 8 characters between UA- and -1). After doing some research the range seems to be between 4-9 digits for now. 
