### PR TITLE
Add Clawject configuration schema to catalogue

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -965,10 +965,7 @@
     {
       "name": "Clawject config",
       "description": "Clawject configuration file",
-      "fileMatch": [
-        ".clawjectrc",
-        ".clawjectrc.json"
-      ],
+      "fileMatch": [".clawjectrc", ".clawjectrc.json"],
       "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -963,6 +963,15 @@
       "url": "https://raw.githubusercontent.com/SFDO-Tooling/CumulusCI/main/cumulusci/schema/cumulusci.jsonschema.json"
     },
     {
+      "name": "Clawject config",
+      "description": "Clawject configuration file",
+      "fileMatch": [
+        ".clawjectrc",
+        ".clawjectrc.json"
+      ],
+      "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
+    },
+    {
       "name": "DataYoga Connections",
       "description": "Collection of defined source and target connections used within DataYoga jobs",
       "fileMatch": ["connections.dy.yaml"],


### PR DESCRIPTION
This PR adds external schema file for typescript dependency injection framework - Clawject https://clawject.com
