### PR TITLE
Added CWL json schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6070,9 +6070,7 @@
     {
       "name": "CWL",
       "description": "The Common Workflow Language Configuration",
-      "fileMatch": [
-        "*.cwl"
-      ],
+      "fileMatch": ["*.cwl"],
       "url": "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.json"
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6066,6 +6066,14 @@
       "description": "Bioimage.io resource descriptions may be produced or consumed by bioimage.io-compatible software",
       "fileMatch": ["bioimageio.yaml", "*.bioimageio.yaml"],
       "url": "https://bioimage-io.github.io/spec-bioimage-io/bioimageio_schema_latest.json"
+    },
+    {
+      "name": "CWL",
+      "description": "The Common Workflow Language Configuration",
+      "fileMatch": [
+        "*.cwl"
+      ],
+      "url": "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.json"
     }
   ]
 }


### PR DESCRIPTION
Added the CWL Json schema to the Catalog - 

Related PRs - https://github.com/common-workflow-lab/cwl-ts-auto/pull/28

Tests are done through https://github.com/common-workflow-lab/cwl-ts-auto/blob/1290fb1aa0aad1dc81ca68db2ea4c6de4af8edce/.github/scripts/validate_schema.py when PR is made via GH actions
