### PR TITLE
Allow null values in TypeScript configuration files

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -46,10 +46,11 @@
       "properties": {
         "files": {
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
-          "type": "array",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         }
       }
@@ -58,10 +59,11 @@
       "properties": {
         "exclude": {
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
-          "type": "array",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         }
       }
@@ -70,10 +72,11 @@
       "properties": {
         "include": {
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
-          "type": "array",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         }
       }
@@ -82,7 +85,7 @@
       "properties": {
         "compileOnSave": {
           "description": "Enable Compile-on-Save for this project.",
-          "type": "boolean"
+          "type": ["boolean", "null"]
         }
       }
     },
@@ -112,36 +115,42 @@
           "properties": {
             "dry": {
               "description": "~",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false
             },
             "force": {
               "description": "Build all projects, including those that appear to be up to date",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Build all projects, including those that appear to be up to date\n\nSee more: https://www.typescriptlang.org/tsconfig#force"
             },
             "verbose": {
               "description": "Enable verbose logging",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable verbose logging\n\nSee more: https://www.typescriptlang.org/tsconfig#verbose"
             },
             "incremental": {
               "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "traceResolution": {
               "description": "Log paths used during the `moduleResolution` process.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Log paths used during the `moduleResolution` process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
             }
@@ -152,48 +161,55 @@
     "watchOptionsDefinition": {
       "properties": {
         "watchOptions": {
-          "type": "object",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["object", "null"],
           "description": "Settings for the watch mode in TypeScript.",
           "properties": {
             "force": {
               "description": "~",
-              "type": "string"
+              "type": ["string", "null"]
             },
             "watchFile": {
               "description": "Specify how the TypeScript watch mode works.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify how the TypeScript watch mode works.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchFile"
             },
             "watchDirectory": {
               "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify how directories are watched on systems that lack recursive file-watching functionality.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchDirectory"
             },
             "fallbackPolling": {
               "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify what approach the watcher should use if the system runs out of native file watchers.\n\nSee more: https://www.typescriptlang.org/tsconfig#fallbackPolling"
             },
             "synchronousWatchDirectory": {
               "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.\n\nSee more: https://www.typescriptlang.org/tsconfig#synchronousWatchDirectory"
             },
             "excludeFiles": {
               "description": "Remove a list of files from the watch mode's processing.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Remove a list of files from the watch mode's processing.\n\nSee more: https://www.typescriptlang.org/tsconfig#excludeFiles"
             },
             "excludeDirectories": {
               "description": "Remove a list of directories from the watch process.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Remove a list of directories from the watch process.\n\nSee more: https://www.typescriptlang.org/tsconfig#excludeDirectories"
             }
@@ -204,86 +220,100 @@
     "compilerOptionsDefinition": {
       "properties": {
         "compilerOptions": {
-          "type": "object",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["object", "null"],
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "allowArbitraryExtensions": {
               "description": "Enable importing files with any extension, provided a declaration file is present.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enable importing files with any extension, provided a declaration file is present.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "allowImportingTsExtensions": {
               "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "charset": {
               "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
               "description": "Enable constraints that allow a TypeScript project to be used with project references.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable constraints that allow a TypeScript project to be used with project references.\n\nSee more: https://www.typescriptlang.org/tsconfig#composite"
             },
             "customConditions": {
               "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Conditions to set in addition to the resolver-specific defaults when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#customConditions"
             },
             "declaration": {
               "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Generate .d.ts files from TypeScript and JavaScript files in your project.\n\nSee more: https://www.typescriptlang.org/tsconfig#declaration"
             },
             "declarationDir": {
               "description": "Specify the output directory for generated declaration files.",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
               "description": "Output compiler performance information after building.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
               "description": "Reduce the number of projects loaded automatically by TypeScript.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Reduce the number of projects loaded automatically by TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad"
             },
             "noPropertyAccessFromIndexSignature": {
               "description": "Enforces using indexed accessors for keys declared using an indexed type",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enforces using indexed accessors for keys declared using an indexed type\n\nSee more: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature"
             },
             "emitBOM": {
               "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitBOM"
             },
             "emitDeclarationOnly": {
               "description": "Only output d.ts files and not JavaScript files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Only output d.ts files and not JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDeclarationOnly"
             },
             "exactOptionalPropertyTypes": {
               "description": "Differentiate between undefined and not present when type checking",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Differentiate between undefined and not present when type checking\n\nSee more: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes"
             },
             "incremental": {
               "description": "Enable incremental compilation. Requires TypeScript version 3.4 or later.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "tsBuildInfoFile": {
               "$comment": "The value of 'null' is UNDOCUMENTED.",
@@ -294,13 +324,15 @@
             },
             "inlineSourceMap": {
               "description": "Include sourcemap files inside the emitted JavaScript.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include sourcemap files inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSourceMap"
             },
             "inlineSources": {
               "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include source code in the sourcemaps inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSources"
             },
@@ -316,42 +348,49 @@
             },
             "reactNamespace": {
               "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "React",
               "markdownDescription": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.\n\nSee more: https://www.typescriptlang.org/tsconfig#reactNamespace"
             },
             "jsxFactory": {
               "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "React.createElement",
               "markdownDescription": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFactory"
             },
             "jsxFragmentFactory": {
               "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "React.Fragment",
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
               "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "react",
               "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
               "description": "Print all of the files read during the compilation.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print all of the files read during the compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listFiles"
             },
             "mapRoot": {
               "description": "Specify the location where debugger should locate map files instead of generated locations.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify the location where debugger should locate map files instead of generated locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#mapRoot"
             },
             "module": {
               "description": "Specify what module code is generated.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "anyOf": [
                 {
                   "enum": [
@@ -378,7 +417,8 @@
             },
             "moduleResolution": {
               "description": "Specify how TypeScript looks up a file from a given module specifier.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "anyOf": [
                 {
                   "enum": ["classic", "node", "node16", "nodenext", "bundler"]
@@ -392,7 +432,8 @@
             },
             "newLine": {
               "description": "Set the newline character for emitting files.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "anyOf": [
                 {
                   "enum": ["crlf", "lf"]
@@ -405,161 +446,189 @@
             },
             "noEmit": {
               "description": "Disable emitting file from a compilation.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting file from a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmit"
             },
             "noEmitHelpers": {
               "description": "Disable generating custom helper functions like `__extends` in compiled output.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable generating custom helper functions like `__extends` in compiled output.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitHelpers"
             },
             "noEmitOnError": {
               "description": "Disable emitting files if any type checking errors are reported.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting files if any type checking errors are reported.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitOnError"
             },
             "noImplicitAny": {
               "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
             },
             "noImplicitThis": {
               "description": "Enable error reporting when `this` is given the type `any`.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting when `this` is given the type `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitThis"
             },
             "noUnusedLocals": {
               "description": "Enable error reporting when a local variables aren't read.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting when a local variables aren't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
               "description": "Raise an error when a function parameter isn't read",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Raise an error when a function parameter isn't read\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedParameters"
             },
             "noLib": {
               "description": "Disable including any library files, including the default lib.d.ts.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable including any library files, including the default lib.d.ts.\n\nSee more: https://www.typescriptlang.org/tsconfig#noLib"
             },
             "noResolve": {
               "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.\n\nSee more: https://www.typescriptlang.org/tsconfig#noResolve"
             },
             "noStrictGenericChecks": {
               "description": "Disable strict checking of generic signatures in function types.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
             },
             "skipDefaultLibCheck": {
               "description": "Skip type checking .d.ts files that are included with TypeScript.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking .d.ts files that are included with TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck"
             },
             "skipLibCheck": {
               "description": "Skip type checking all .d.ts files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
               "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
               "description": "Specify an output folder for all emitted files.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify an output folder for all emitted files.\n\nSee more: https://www.typescriptlang.org/tsconfig#outDir"
             },
             "preserveConstEnums": {
               "description": "Disable erasing `const enum` declarations in generated code.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable erasing `const enum` declarations in generated code.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveConstEnums"
             },
             "preserveSymlinks": {
               "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveSymlinks"
             },
             "preserveValueImports": {
               "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Preserve unused imported values in the JavaScript output that would otherwise be removed\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveValueImports"
             },
             "preserveWatchOutput": {
               "description": "Disable wiping the console in watch mode",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable wiping the console in watch mode\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveWatchOutput"
             },
             "pretty": {
               "description": "Enable color and formatting in output to make compiler errors easier to read",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable color and formatting in output to make compiler errors easier to read\n\nSee more: https://www.typescriptlang.org/tsconfig#pretty"
             },
             "removeComments": {
               "description": "Disable emitting comments.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#removeComments"
             },
             "rootDir": {
               "description": "Specify the root folder within your source files.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify the root folder within your source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDir"
             },
             "isolatedModules": {
               "description": "Ensure that each file can be safely transpiled without relying on other imports.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that each file can be safely transpiled without relying on other imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedModules"
             },
             "sourceMap": {
               "description": "Create source map files for emitted JavaScript files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create source map files for emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceMap"
             },
             "sourceRoot": {
               "description": "Specify the root path for debuggers to find the reference source code.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify the root path for debuggers to find the reference source code.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceRoot"
             },
             "suppressExcessPropertyErrors": {
               "description": "Disable reporting of excess property errors during the creation of object literals.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
               "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
               "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable emitting declarations that have `@internal` in their JSDoc comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#stripInternal"
             },
             "target": {
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "ES3",
               "anyOf": [
                 {
@@ -587,13 +656,14 @@
             },
             "useUnknownInCatchVariables": {
               "description": "Default catch clause variables as `unknown` instead of `any`.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Default catch clause variables as `unknown` instead of `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables"
             },
             "watch": {
               "description": "Watch input files.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "fallbackPolling": {
               "description": "Specify the polling strategy to use when the system runs out of or doesn't support native file watchers. Requires TypeScript version 3.8 or later.",
@@ -631,72 +701,86 @@
             },
             "experimentalDecorators": {
               "description": "Enable experimental support for TC39 stage 2 draft decorators.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enable experimental support for TC39 stage 2 draft decorators.\n\nSee more: https://www.typescriptlang.org/tsconfig#experimentalDecorators"
             },
             "emitDecoratorMetadata": {
               "description": "Emit design-type metadata for decorated declarations in source files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata"
             },
             "allowUnusedLabels": {
               "description": "Disable error reporting for unused labels.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unused labels.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnusedLabels"
             },
             "noImplicitReturns": {
               "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for codepaths that do not explicitly return in a function.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitReturns"
             },
             "noUncheckedIndexedAccess": {
               "description": "Add `undefined` to a type when accessed using an index.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Add `undefined` to a type when accessed using an index.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess"
             },
             "noFallthroughCasesInSwitch": {
               "description": "Enable error reporting for fallthrough cases in switch statements.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for fallthrough cases in switch statements.\n\nSee more: https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch"
             },
             "noImplicitOverride": {
               "description": "Ensure overriding members in derived classes are marked with an override modifier.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure overriding members in derived classes are marked with an override modifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitOverride"
             },
             "allowUnreachableCode": {
               "description": "Disable error reporting for unreachable code.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unreachable code.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnreachableCode"
             },
             "forceConsistentCasingInFileNames": {
               "description": "Ensure that casing is correct in imports.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
               "description": "Emit a v8 CPU profile of the compiler run for debugging.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "profile.cpuprofile",
               "markdownDescription": "Emit a v8 CPU profile of the compiler run for debugging.\n\nSee more: https://www.typescriptlang.org/tsconfig#generateCpuProfile"
             },
             "baseUrl": {
               "description": "Specify the base directory to resolve non-relative module names.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify the base directory to resolve non-relative module names.\n\nSee more: https://www.typescriptlang.org/tsconfig#baseUrl"
             },
             "paths": {
               "description": "Specify a set of entries that re-map imports to additional lookup locations.",
-              "type": "object",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["object", "null"],
               "additionalProperties": {
-                "type": "array",
+                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "type": ["array", "null"],
                 "uniqueItems": true,
                 "items": {
-                  "type": "string",
+                  "$comment": "The value of 'null' is UNDOCUMENTED.",
+                  "type": ["string", "null"],
                   "description": "Path mapping to be computed relative to baseUrl option."
                 }
               },
@@ -704,13 +788,15 @@
             },
             "plugins": {
               "description": "Specify a list of language service plugins to include.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "items": {
-                "type": "object",
+                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "type": ["object", "null"],
                 "properties": {
                   "name": {
                     "description": "Plugin name.",
-                    "type": "string"
+                    "type": ["string", "null"]
                   }
                 }
               },
@@ -718,77 +804,89 @@
             },
             "rootDirs": {
               "description": "Allow multiple folders to be treated as one when resolving modules.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Allow multiple folders to be treated as one when resolving modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDirs"
             },
             "typeRoots": {
               "description": "Specify multiple folders that act like `./node_modules/@types`.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Specify multiple folders that act like `./node_modules/@types`.\n\nSee more: https://www.typescriptlang.org/tsconfig#typeRoots"
             },
             "types": {
               "description": "Specify type package names to be included without being referenced in a source file.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Specify type package names to be included without being referenced in a source file.\n\nSee more: https://www.typescriptlang.org/tsconfig#types"
             },
             "traceResolution": {
               "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false
             },
             "allowJs": {
               "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowJs"
             },
             "noErrorTruncation": {
               "description": "Disable truncating types in error messages.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
               "description": "Allow 'import x from y' when a module doesn't have a default export.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Allow 'import x from y' when a module doesn't have a default export.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports"
             },
             "noImplicitUseStrict": {
               "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable adding 'use strict' directives in emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitUseStrict"
             },
             "listEmittedFiles": {
               "description": "Print the names of emitted files after a compilation.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print the names of emitted files after a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listEmittedFiles"
             },
             "disableSizeLimit": {
               "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSizeLimit"
             },
             "lib": {
               "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string",
+                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "type": ["string", "null"],
                 "anyOf": [
                   {
                     "enum": [
@@ -905,19 +1003,22 @@
             },
             "strictNullChecks": {
               "description": "When type checking, take into account `null` and `undefined`.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
               "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
-              "type": "number",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["number", "null"],
               "default": 0,
               "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
               "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow importing helper functions from tslib once per project, instead of including them per-file.\n\nSee more: https://www.typescriptlang.org/tsconfig#importHelpers"
             },
@@ -928,120 +1029,139 @@
             },
             "alwaysStrict": {
               "description": "Ensure 'use strict' is always emitted.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Ensure 'use strict' is always emitted.\n\nSee more: https://www.typescriptlang.org/tsconfig#alwaysStrict"
             },
             "strict": {
               "description": "Enable all strict type checking options.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable all strict type checking options.\n\nSee more: https://www.typescriptlang.org/tsconfig#strict"
             },
             "strictBindCallApply": {
               "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBindCallApply"
             },
             "downlevelIteration": {
               "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit more compliant, but verbose and less performant JavaScript for iteration.\n\nSee more: https://www.typescriptlang.org/tsconfig#downlevelIteration"
             },
             "checkJs": {
               "description": "Enable error reporting in type-checked JavaScript files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
             },
             "strictFunctionTypes": {
               "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictFunctionTypes"
             },
             "strictPropertyInitialization": {
               "description": "Check for class properties that are declared but not set in the constructor.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
               "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
               "description": "Allow accessing UMD globals from modules.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow accessing UMD globals from modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUmdGlobalAccess"
             },
             "keyofStringsOnly": {
               "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {
               "description": "Emit ECMAScript-standard-compliant class fields.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit ECMAScript-standard-compliant class fields.\n\nSee more: https://www.typescriptlang.org/tsconfig#useDefineForClassFields"
             },
             "declarationMap": {
               "description": "Create sourcemaps for d.ts files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create sourcemaps for d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationMap"
             },
             "resolveJsonModule": {
               "description": "Enable importing .json files",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable importing .json files\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
               "description": "Use the package.json 'exports' field when resolving package imports.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
               "description": "Use the package.json 'imports' field when resolving imports.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'imports' field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it. Requires TypeScript version 3.8 or later.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "extendedDiagnostics": {
               "description": "Output more detailed compiler performance information after building.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Output more detailed compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#extendedDiagnostics"
             },
             "listFilesOnly": {
               "description": "Print names of files that are part of the compilation and then stop processing.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "disableSourceOfProjectReferenceRedirect": {
               "description": "Disable preferring source files instead of declaration files when referencing composite projects",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable preferring source files instead of declaration files when referencing composite projects\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSourceOfProjectReferenceRedirect"
             },
             "disableSolutionSearching": {
               "description": "Opt a project out of multi-project reference checking when editing.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Opt a project out of multi-project reference checking when editing.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSolutionSearching"
             },
             "verbatimModuleSyntax": {
               "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.\n\nSee more: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax"
             }
           }
@@ -1051,28 +1171,32 @@
     "typeAcquisitionDefinition": {
       "properties": {
         "typeAcquisition": {
-          "type": "object",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["object", "null"],
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
           "properties": {
             "enable": {
               "description": "Enable auto type acquisition",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false
             },
             "include": {
               "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               }
             },
             "exclude": {
               "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               }
             }
           }
@@ -1082,15 +1206,18 @@
     "referencesDefinition": {
       "properties": {
         "references": {
-          "type": "array",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["array", "null"],
           "uniqueItems": true,
           "description": "Referenced projects. Requires TypeScript version 3.0 or later.",
           "items": {
-            "type": "object",
+            "$comment": "The value of 'null' is UNDOCUMENTED.",
+            "type": ["object", "null"],
             "description": "Project reference.",
             "properties": {
               "path": {
-                "type": "string",
+                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "type": ["string", "null"],
                 "description": "Path to referenced tsconfig or to folder containing tsconfig."
               }
             }

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -45,8 +45,8 @@
     "filesDefinition": {
       "properties": {
         "files": {
-          "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+          "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -58,8 +58,8 @@
     "excludeDefinition": {
       "properties": {
         "exclude": {
-          "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+          "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -71,8 +71,8 @@
     "includeDefinition": {
       "properties": {
         "include": {
-          "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+          "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -114,42 +114,42 @@
         "buildOptions": {
           "properties": {
             "dry": {
-              "description": "~",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "~",
               "type": ["boolean", "null"],
               "default": false
             },
             "force": {
-              "description": "Build all projects, including those that appear to be up to date",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Build all projects, including those that appear to be up to date",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Build all projects, including those that appear to be up to date\n\nSee more: https://www.typescriptlang.org/tsconfig#force"
             },
             "verbose": {
-              "description": "Enable verbose logging",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable verbose logging",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable verbose logging\n\nSee more: https://www.typescriptlang.org/tsconfig#verbose"
             },
             "incremental": {
-              "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
-              "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "traceResolution": {
-              "description": "Log paths used during the `moduleResolution` process.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Log paths used during the `moduleResolution` process.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Log paths used during the `moduleResolution` process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
@@ -170,32 +170,32 @@
               "type": ["string", "null"]
             },
             "watchFile": {
-              "description": "Specify how the TypeScript watch mode works.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify how the TypeScript watch mode works.",
               "type": ["string", "null"],
               "markdownDescription": "Specify how the TypeScript watch mode works.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchFile"
             },
             "watchDirectory": {
-              "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
               "type": ["string", "null"],
               "markdownDescription": "Specify how directories are watched on systems that lack recursive file-watching functionality.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchDirectory"
             },
             "fallbackPolling": {
-              "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
               "type": ["string", "null"],
               "markdownDescription": "Specify what approach the watcher should use if the system runs out of native file watchers.\n\nSee more: https://www.typescriptlang.org/tsconfig#fallbackPolling"
             },
             "synchronousWatchDirectory": {
-              "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
               "type": ["boolean", "null"],
               "markdownDescription": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.\n\nSee more: https://www.typescriptlang.org/tsconfig#synchronousWatchDirectory"
             },
             "excludeFiles": {
-              "description": "Remove a list of files from the watch mode's processing.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Remove a list of files from the watch mode's processing.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -204,8 +204,8 @@
               "markdownDescription": "Remove a list of files from the watch mode's processing.\n\nSee more: https://www.typescriptlang.org/tsconfig#excludeFiles"
             },
             "excludeDirectories": {
-              "description": "Remove a list of directories from the watch process.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Remove a list of directories from the watch process.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -225,33 +225,33 @@
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "allowArbitraryExtensions": {
-              "description": "Enable importing files with any extension, provided a declaration file is present.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable importing files with any extension, provided a declaration file is present.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable importing files with any extension, provided a declaration file is present.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "allowImportingTsExtensions": {
-              "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "charset": {
-              "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
               "type": ["string", "null"],
               "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
-              "description": "Enable constraints that allow a TypeScript project to be used with project references.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable constraints that allow a TypeScript project to be used with project references.",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable constraints that allow a TypeScript project to be used with project references.\n\nSee more: https://www.typescriptlang.org/tsconfig#composite"
             },
             "customConditions": {
-              "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -260,53 +260,53 @@
               "markdownDescription": "Conditions to set in addition to the resolver-specific defaults when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#customConditions"
             },
             "declaration": {
-              "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Generate .d.ts files from TypeScript and JavaScript files in your project.\n\nSee more: https://www.typescriptlang.org/tsconfig#declaration"
             },
             "declarationDir": {
-              "description": "Specify the output directory for generated declaration files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the output directory for generated declaration files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
-              "description": "Output compiler performance information after building.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Output compiler performance information after building.",
               "type": ["boolean", "null"],
               "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
-              "description": "Reduce the number of projects loaded automatically by TypeScript.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Reduce the number of projects loaded automatically by TypeScript.",
               "type": ["boolean", "null"],
               "markdownDescription": "Reduce the number of projects loaded automatically by TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad"
             },
             "noPropertyAccessFromIndexSignature": {
-              "description": "Enforces using indexed accessors for keys declared using an indexed type",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enforces using indexed accessors for keys declared using an indexed type",
               "type": ["boolean", "null"],
               "markdownDescription": "Enforces using indexed accessors for keys declared using an indexed type\n\nSee more: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature"
             },
             "emitBOM": {
-              "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitBOM"
             },
             "emitDeclarationOnly": {
-              "description": "Only output d.ts files and not JavaScript files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Only output d.ts files and not JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Only output d.ts files and not JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDeclarationOnly"
             },
             "exactOptionalPropertyTypes": {
-              "description": "Differentiate between undefined and not present when type checking",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Differentiate between undefined and not present when type checking",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Differentiate between undefined and not present when type checking\n\nSee more: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes"
@@ -323,15 +323,15 @@
               "markdownDescription": "Specify the folder for .tsbuildinfo incremental compilation files.\n\nSee more: https://www.typescriptlang.org/tsconfig#tsBuildInfoFile"
             },
             "inlineSourceMap": {
-              "description": "Include sourcemap files inside the emitted JavaScript.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Include sourcemap files inside the emitted JavaScript.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include sourcemap files inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSourceMap"
             },
             "inlineSources": {
-              "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include source code in the sourcemaps inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSources"
@@ -347,49 +347,49 @@
               ]
             },
             "reactNamespace": {
-              "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
               "type": ["string", "null"],
               "default": "React",
               "markdownDescription": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.\n\nSee more: https://www.typescriptlang.org/tsconfig#reactNamespace"
             },
             "jsxFactory": {
-              "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
               "type": ["string", "null"],
               "default": "React.createElement",
               "markdownDescription": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFactory"
             },
             "jsxFragmentFactory": {
-              "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
               "type": ["string", "null"],
               "default": "React.Fragment",
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
-              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
               "type": ["string", "null"],
               "default": "react",
               "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
-              "description": "Print all of the files read during the compilation.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Print all of the files read during the compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print all of the files read during the compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listFiles"
             },
             "mapRoot": {
-              "description": "Specify the location where debugger should locate map files instead of generated locations.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the location where debugger should locate map files instead of generated locations.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the location where debugger should locate map files instead of generated locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#mapRoot"
             },
             "module": {
-              "description": "Specify what module code is generated.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify what module code is generated.",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -416,8 +416,8 @@
               "markdownDescription": "Specify what module code is generated.\n\nSee more: https://www.typescriptlang.org/tsconfig#module"
             },
             "moduleResolution": {
-              "description": "Specify how TypeScript looks up a file from a given module specifier.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify how TypeScript looks up a file from a given module specifier.",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -431,8 +431,8 @@
               "markdownDescription": "Specify how TypeScript looks up a file from a given module specifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleResolution"
             },
             "newLine": {
-              "description": "Set the newline character for emitting files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Set the newline character for emitting files.",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -445,189 +445,189 @@
               "markdownDescription": "Set the newline character for emitting files.\n\nSee more: https://www.typescriptlang.org/tsconfig#newLine"
             },
             "noEmit": {
-              "description": "Disable emitting file from a compilation.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable emitting file from a compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting file from a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmit"
             },
             "noEmitHelpers": {
-              "description": "Disable generating custom helper functions like `__extends` in compiled output.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable generating custom helper functions like `__extends` in compiled output.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable generating custom helper functions like `__extends` in compiled output.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitHelpers"
             },
             "noEmitOnError": {
-              "description": "Disable emitting files if any type checking errors are reported.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable emitting files if any type checking errors are reported.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting files if any type checking errors are reported.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitOnError"
             },
             "noImplicitAny": {
-              "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
             },
             "noImplicitThis": {
-              "description": "Enable error reporting when `this` is given the type `any`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting when `this` is given the type `any`.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting when `this` is given the type `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitThis"
             },
             "noUnusedLocals": {
-              "description": "Enable error reporting when a local variables aren't read.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting when a local variables aren't read.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting when a local variables aren't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
-              "description": "Raise an error when a function parameter isn't read",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Raise an error when a function parameter isn't read",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Raise an error when a function parameter isn't read\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedParameters"
             },
             "noLib": {
-              "description": "Disable including any library files, including the default lib.d.ts.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable including any library files, including the default lib.d.ts.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable including any library files, including the default lib.d.ts.\n\nSee more: https://www.typescriptlang.org/tsconfig#noLib"
             },
             "noResolve": {
-              "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.\n\nSee more: https://www.typescriptlang.org/tsconfig#noResolve"
             },
             "noStrictGenericChecks": {
-              "description": "Disable strict checking of generic signatures in function types.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable strict checking of generic signatures in function types.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
             },
             "skipDefaultLibCheck": {
-              "description": "Skip type checking .d.ts files that are included with TypeScript.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Skip type checking .d.ts files that are included with TypeScript.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking .d.ts files that are included with TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck"
             },
             "skipLibCheck": {
-              "description": "Skip type checking all .d.ts files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Skip type checking all .d.ts files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
-              "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
               "type": ["string", "null"],
               "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
-              "description": "Specify an output folder for all emitted files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify an output folder for all emitted files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify an output folder for all emitted files.\n\nSee more: https://www.typescriptlang.org/tsconfig#outDir"
             },
             "preserveConstEnums": {
-              "description": "Disable erasing `const enum` declarations in generated code.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable erasing `const enum` declarations in generated code.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable erasing `const enum` declarations in generated code.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveConstEnums"
             },
             "preserveSymlinks": {
-              "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveSymlinks"
             },
             "preserveValueImports": {
-              "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Preserve unused imported values in the JavaScript output that would otherwise be removed\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveValueImports"
             },
             "preserveWatchOutput": {
-              "description": "Disable wiping the console in watch mode",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable wiping the console in watch mode",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable wiping the console in watch mode\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveWatchOutput"
             },
             "pretty": {
-              "description": "Enable color and formatting in output to make compiler errors easier to read",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable color and formatting in output to make compiler errors easier to read",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable color and formatting in output to make compiler errors easier to read\n\nSee more: https://www.typescriptlang.org/tsconfig#pretty"
             },
             "removeComments": {
-              "description": "Disable emitting comments.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable emitting comments.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#removeComments"
             },
             "rootDir": {
-              "description": "Specify the root folder within your source files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the root folder within your source files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root folder within your source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDir"
             },
             "isolatedModules": {
-              "description": "Ensure that each file can be safely transpiled without relying on other imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Ensure that each file can be safely transpiled without relying on other imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that each file can be safely transpiled without relying on other imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedModules"
             },
             "sourceMap": {
-              "description": "Create source map files for emitted JavaScript files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Create source map files for emitted JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create source map files for emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceMap"
             },
             "sourceRoot": {
-              "description": "Specify the root path for debuggers to find the reference source code.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the root path for debuggers to find the reference source code.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root path for debuggers to find the reference source code.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceRoot"
             },
             "suppressExcessPropertyErrors": {
-              "description": "Disable reporting of excess property errors during the creation of object literals.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable reporting of excess property errors during the creation of object literals.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
-              "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
-              "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable emitting declarations that have `@internal` in their JSDoc comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#stripInternal"
             },
             "target": {
-              "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": ["string", "null"],
               "default": "ES3",
               "anyOf": [
@@ -655,8 +655,8 @@
               "markdownDescription": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.\n\nSee more: https://www.typescriptlang.org/tsconfig#target"
             },
             "useUnknownInCatchVariables": {
-              "description": "Default catch clause variables as `unknown` instead of `any`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Default catch clause variables as `unknown` instead of `any`.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Default catch clause variables as `unknown` instead of `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables"
@@ -700,79 +700,79 @@
               "default": "useFsEvents"
             },
             "experimentalDecorators": {
-              "description": "Enable experimental support for TC39 stage 2 draft decorators.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable experimental support for TC39 stage 2 draft decorators.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable experimental support for TC39 stage 2 draft decorators.\n\nSee more: https://www.typescriptlang.org/tsconfig#experimentalDecorators"
             },
             "emitDecoratorMetadata": {
-              "description": "Emit design-type metadata for decorated declarations in source files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit design-type metadata for decorated declarations in source files.",
               "type": ["boolean", "null"],
               "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata"
             },
             "allowUnusedLabels": {
-              "description": "Disable error reporting for unused labels.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable error reporting for unused labels.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unused labels.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnusedLabels"
             },
             "noImplicitReturns": {
-              "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for codepaths that do not explicitly return in a function.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitReturns"
             },
             "noUncheckedIndexedAccess": {
-              "description": "Add `undefined` to a type when accessed using an index.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Add `undefined` to a type when accessed using an index.",
               "type": ["boolean", "null"],
               "markdownDescription": "Add `undefined` to a type when accessed using an index.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess"
             },
             "noFallthroughCasesInSwitch": {
-              "description": "Enable error reporting for fallthrough cases in switch statements.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting for fallthrough cases in switch statements.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for fallthrough cases in switch statements.\n\nSee more: https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch"
             },
             "noImplicitOverride": {
-              "description": "Ensure overriding members in derived classes are marked with an override modifier.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Ensure overriding members in derived classes are marked with an override modifier.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure overriding members in derived classes are marked with an override modifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitOverride"
             },
             "allowUnreachableCode": {
-              "description": "Disable error reporting for unreachable code.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable error reporting for unreachable code.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unreachable code.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnreachableCode"
             },
             "forceConsistentCasingInFileNames": {
-              "description": "Ensure that casing is correct in imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Ensure that casing is correct in imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
-              "description": "Emit a v8 CPU profile of the compiler run for debugging.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit a v8 CPU profile of the compiler run for debugging.",
               "type": ["string", "null"],
               "default": "profile.cpuprofile",
               "markdownDescription": "Emit a v8 CPU profile of the compiler run for debugging.\n\nSee more: https://www.typescriptlang.org/tsconfig#generateCpuProfile"
             },
             "baseUrl": {
-              "description": "Specify the base directory to resolve non-relative module names.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the base directory to resolve non-relative module names.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the base directory to resolve non-relative module names.\n\nSee more: https://www.typescriptlang.org/tsconfig#baseUrl"
             },
             "paths": {
-              "description": "Specify a set of entries that re-map imports to additional lookup locations.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify a set of entries that re-map imports to additional lookup locations.",
               "type": ["object", "null"],
               "additionalProperties": {
                 "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -787,8 +787,8 @@
               "markdownDescription": "Specify a set of entries that re-map imports to additional lookup locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#paths"
             },
             "plugins": {
-              "description": "Specify a list of language service plugins to include.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify a list of language service plugins to include.",
               "type": ["array", "null"],
               "items": {
                 "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -803,8 +803,8 @@
               "markdownDescription": "Specify a list of language service plugins to include.\n\nSee more: https://www.typescriptlang.org/tsconfig#plugins"
             },
             "rootDirs": {
-              "description": "Allow multiple folders to be treated as one when resolving modules.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow multiple folders to be treated as one when resolving modules.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -813,8 +813,8 @@
               "markdownDescription": "Allow multiple folders to be treated as one when resolving modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDirs"
             },
             "typeRoots": {
-              "description": "Specify multiple folders that act like `./node_modules/@types`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify multiple folders that act like `./node_modules/@types`.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -823,8 +823,8 @@
               "markdownDescription": "Specify multiple folders that act like `./node_modules/@types`.\n\nSee more: https://www.typescriptlang.org/tsconfig#typeRoots"
             },
             "types": {
-              "description": "Specify type package names to be included without being referenced in a source file.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify type package names to be included without being referenced in a source file.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -833,55 +833,55 @@
               "markdownDescription": "Specify type package names to be included without being referenced in a source file.\n\nSee more: https://www.typescriptlang.org/tsconfig#types"
             },
             "traceResolution": {
-              "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
               "type": ["boolean", "null"],
               "default": false
             },
             "allowJs": {
-              "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowJs"
             },
             "noErrorTruncation": {
-              "description": "Disable truncating types in error messages.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable truncating types in error messages.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
-              "description": "Allow 'import x from y' when a module doesn't have a default export.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow 'import x from y' when a module doesn't have a default export.",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow 'import x from y' when a module doesn't have a default export.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports"
             },
             "noImplicitUseStrict": {
-              "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable adding 'use strict' directives in emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitUseStrict"
             },
             "listEmittedFiles": {
-              "description": "Print the names of emitted files after a compilation.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Print the names of emitted files after a compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print the names of emitted files after a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listEmittedFiles"
             },
             "disableSizeLimit": {
-              "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSizeLimit"
             },
             "lib": {
-              "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -1002,22 +1002,22 @@
               "markdownDescription": "Specify a set of bundled library declaration files that describe the target runtime environment.\n\nSee more: https://www.typescriptlang.org/tsconfig#lib"
             },
             "strictNullChecks": {
-              "description": "When type checking, take into account `null` and `undefined`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "When type checking, take into account `null` and `undefined`.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
-              "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
               "type": ["number", "null"],
               "default": 0,
               "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
-              "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow importing helper functions from tslib once per project, instead of including them per-file.\n\nSee more: https://www.typescriptlang.org/tsconfig#importHelpers"
@@ -1028,105 +1028,105 @@
               "enum": ["remove", "preserve", "error"]
             },
             "alwaysStrict": {
-              "description": "Ensure 'use strict' is always emitted.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Ensure 'use strict' is always emitted.",
               "type": ["boolean", "null"],
               "markdownDescription": "Ensure 'use strict' is always emitted.\n\nSee more: https://www.typescriptlang.org/tsconfig#alwaysStrict"
             },
             "strict": {
-              "description": "Enable all strict type checking options.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable all strict type checking options.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable all strict type checking options.\n\nSee more: https://www.typescriptlang.org/tsconfig#strict"
             },
             "strictBindCallApply": {
-              "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBindCallApply"
             },
             "downlevelIteration": {
-              "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit more compliant, but verbose and less performant JavaScript for iteration.\n\nSee more: https://www.typescriptlang.org/tsconfig#downlevelIteration"
             },
             "checkJs": {
-              "description": "Enable error reporting in type-checked JavaScript files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting in type-checked JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
             },
             "strictFunctionTypes": {
-              "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictFunctionTypes"
             },
             "strictPropertyInitialization": {
-              "description": "Check for class properties that are declared but not set in the constructor.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Check for class properties that are declared but not set in the constructor.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
-              "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
-              "description": "Allow accessing UMD globals from modules.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow accessing UMD globals from modules.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow accessing UMD globals from modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUmdGlobalAccess"
             },
             "keyofStringsOnly": {
-              "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {
-              "description": "Emit ECMAScript-standard-compliant class fields.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit ECMAScript-standard-compliant class fields.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit ECMAScript-standard-compliant class fields.\n\nSee more: https://www.typescriptlang.org/tsconfig#useDefineForClassFields"
             },
             "declarationMap": {
-              "description": "Create sourcemaps for d.ts files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Create sourcemaps for d.ts files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create sourcemaps for d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationMap"
             },
             "resolveJsonModule": {
-              "description": "Enable importing .json files",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable importing .json files",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable importing .json files\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
-              "description": "Use the package.json 'exports' field when resolving package imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Use the package.json 'exports' field when resolving package imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
-              "description": "Use the package.json 'imports' field when resolving imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Use the package.json 'imports' field when resolving imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'imports' field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
@@ -1136,8 +1136,8 @@
               "type": ["boolean", "null"]
             },
             "extendedDiagnostics": {
-              "description": "Output more detailed compiler performance information after building.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Output more detailed compiler performance information after building.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Output more detailed compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#extendedDiagnostics"
@@ -1147,20 +1147,20 @@
               "type": ["boolean", "null"]
             },
             "disableSourceOfProjectReferenceRedirect": {
-              "description": "Disable preferring source files instead of declaration files when referencing composite projects",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable preferring source files instead of declaration files when referencing composite projects",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable preferring source files instead of declaration files when referencing composite projects\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSourceOfProjectReferenceRedirect"
             },
             "disableSolutionSearching": {
-              "description": "Opt a project out of multi-project reference checking when editing.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Opt a project out of multi-project reference checking when editing.",
               "type": ["boolean", "null"],
               "markdownDescription": "Opt a project out of multi-project reference checking when editing.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSolutionSearching"
             },
             "verbatimModuleSyntax": {
-              "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
               "type": ["boolean", "null"],
               "markdownDescription": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.\n\nSee more: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax"
             }
@@ -1176,14 +1176,14 @@
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
           "properties": {
             "enable": {
-              "description": "Enable auto type acquisition",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable auto type acquisition",
               "type": ["boolean", "null"],
               "default": false
             },
             "include": {
-              "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -1191,8 +1191,8 @@
               }
             },
             "exclude": {
-              "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {

--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -46,7 +46,7 @@
       "properties": {
         "files": {
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -59,7 +59,7 @@
       "properties": {
         "exclude": {
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -72,7 +72,7 @@
       "properties": {
         "include": {
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -115,41 +115,41 @@
           "properties": {
             "dry": {
               "description": "~",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false
             },
             "force": {
               "description": "Build all projects, including those that appear to be up to date",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Build all projects, including those that appear to be up to date\n\nSee more: https://www.typescriptlang.org/tsconfig#force"
             },
             "verbose": {
               "description": "Enable verbose logging",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable verbose logging\n\nSee more: https://www.typescriptlang.org/tsconfig#verbose"
             },
             "incremental": {
               "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "traceResolution": {
               "description": "Log paths used during the `moduleResolution` process.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Log paths used during the `moduleResolution` process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
@@ -161,7 +161,7 @@
     "watchOptionsDefinition": {
       "properties": {
         "watchOptions": {
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Settings for the watch mode in TypeScript.",
           "properties": {
@@ -171,31 +171,31 @@
             },
             "watchFile": {
               "description": "Specify how the TypeScript watch mode works.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify how the TypeScript watch mode works.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchFile"
             },
             "watchDirectory": {
               "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify how directories are watched on systems that lack recursive file-watching functionality.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchDirectory"
             },
             "fallbackPolling": {
               "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify what approach the watcher should use if the system runs out of native file watchers.\n\nSee more: https://www.typescriptlang.org/tsconfig#fallbackPolling"
             },
             "synchronousWatchDirectory": {
               "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.\n\nSee more: https://www.typescriptlang.org/tsconfig#synchronousWatchDirectory"
             },
             "excludeFiles": {
               "description": "Remove a list of files from the watch mode's processing.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -205,7 +205,7 @@
             },
             "excludeDirectories": {
               "description": "Remove a list of directories from the watch process.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -220,38 +220,38 @@
     "compilerOptionsDefinition": {
       "properties": {
         "compilerOptions": {
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "allowArbitraryExtensions": {
               "description": "Enable importing files with any extension, provided a declaration file is present.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable importing files with any extension, provided a declaration file is present.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "allowImportingTsExtensions": {
               "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "charset": {
               "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
               "description": "Enable constraints that allow a TypeScript project to be used with project references.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable constraints that allow a TypeScript project to be used with project references.\n\nSee more: https://www.typescriptlang.org/tsconfig#composite"
             },
             "customConditions": {
               "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -261,52 +261,52 @@
             },
             "declaration": {
               "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Generate .d.ts files from TypeScript and JavaScript files in your project.\n\nSee more: https://www.typescriptlang.org/tsconfig#declaration"
             },
             "declarationDir": {
               "description": "Specify the output directory for generated declaration files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
               "description": "Output compiler performance information after building.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
               "description": "Reduce the number of projects loaded automatically by TypeScript.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Reduce the number of projects loaded automatically by TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad"
             },
             "noPropertyAccessFromIndexSignature": {
               "description": "Enforces using indexed accessors for keys declared using an indexed type",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enforces using indexed accessors for keys declared using an indexed type\n\nSee more: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature"
             },
             "emitBOM": {
               "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitBOM"
             },
             "emitDeclarationOnly": {
               "description": "Only output d.ts files and not JavaScript files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Only output d.ts files and not JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDeclarationOnly"
             },
             "exactOptionalPropertyTypes": {
               "description": "Differentiate between undefined and not present when type checking",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Differentiate between undefined and not present when type checking\n\nSee more: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes"
@@ -316,7 +316,7 @@
               "type": ["boolean", "null"]
             },
             "tsBuildInfoFile": {
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the folder for .tsbuildinfo incremental compilation files.",
               "default": ".tsbuildinfo",
               "type": ["string", "null"],
@@ -324,14 +324,14 @@
             },
             "inlineSourceMap": {
               "description": "Include sourcemap files inside the emitted JavaScript.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include sourcemap files inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSourceMap"
             },
             "inlineSources": {
               "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include source code in the sourcemaps inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSources"
@@ -348,48 +348,48 @@
             },
             "reactNamespace": {
               "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "React",
               "markdownDescription": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.\n\nSee more: https://www.typescriptlang.org/tsconfig#reactNamespace"
             },
             "jsxFactory": {
               "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "React.createElement",
               "markdownDescription": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFactory"
             },
             "jsxFragmentFactory": {
               "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "React.Fragment",
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
               "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "react",
               "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
               "description": "Print all of the files read during the compilation.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print all of the files read during the compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listFiles"
             },
             "mapRoot": {
               "description": "Specify the location where debugger should locate map files instead of generated locations.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the location where debugger should locate map files instead of generated locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#mapRoot"
             },
             "module": {
               "description": "Specify what module code is generated.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -417,7 +417,7 @@
             },
             "moduleResolution": {
               "description": "Specify how TypeScript looks up a file from a given module specifier.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -432,7 +432,7 @@
             },
             "newLine": {
               "description": "Set the newline character for emitting files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -446,188 +446,188 @@
             },
             "noEmit": {
               "description": "Disable emitting file from a compilation.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting file from a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmit"
             },
             "noEmitHelpers": {
               "description": "Disable generating custom helper functions like `__extends` in compiled output.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable generating custom helper functions like `__extends` in compiled output.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitHelpers"
             },
             "noEmitOnError": {
               "description": "Disable emitting files if any type checking errors are reported.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting files if any type checking errors are reported.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitOnError"
             },
             "noImplicitAny": {
               "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
             },
             "noImplicitThis": {
               "description": "Enable error reporting when `this` is given the type `any`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting when `this` is given the type `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitThis"
             },
             "noUnusedLocals": {
               "description": "Enable error reporting when a local variables aren't read.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting when a local variables aren't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
               "description": "Raise an error when a function parameter isn't read",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Raise an error when a function parameter isn't read\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedParameters"
             },
             "noLib": {
               "description": "Disable including any library files, including the default lib.d.ts.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable including any library files, including the default lib.d.ts.\n\nSee more: https://www.typescriptlang.org/tsconfig#noLib"
             },
             "noResolve": {
               "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.\n\nSee more: https://www.typescriptlang.org/tsconfig#noResolve"
             },
             "noStrictGenericChecks": {
               "description": "Disable strict checking of generic signatures in function types.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
             },
             "skipDefaultLibCheck": {
               "description": "Skip type checking .d.ts files that are included with TypeScript.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking .d.ts files that are included with TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck"
             },
             "skipLibCheck": {
               "description": "Skip type checking all .d.ts files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
               "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
               "description": "Specify an output folder for all emitted files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify an output folder for all emitted files.\n\nSee more: https://www.typescriptlang.org/tsconfig#outDir"
             },
             "preserveConstEnums": {
               "description": "Disable erasing `const enum` declarations in generated code.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable erasing `const enum` declarations in generated code.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveConstEnums"
             },
             "preserveSymlinks": {
               "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveSymlinks"
             },
             "preserveValueImports": {
               "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Preserve unused imported values in the JavaScript output that would otherwise be removed\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveValueImports"
             },
             "preserveWatchOutput": {
               "description": "Disable wiping the console in watch mode",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable wiping the console in watch mode\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveWatchOutput"
             },
             "pretty": {
               "description": "Enable color and formatting in output to make compiler errors easier to read",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable color and formatting in output to make compiler errors easier to read\n\nSee more: https://www.typescriptlang.org/tsconfig#pretty"
             },
             "removeComments": {
               "description": "Disable emitting comments.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#removeComments"
             },
             "rootDir": {
               "description": "Specify the root folder within your source files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root folder within your source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDir"
             },
             "isolatedModules": {
               "description": "Ensure that each file can be safely transpiled without relying on other imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that each file can be safely transpiled without relying on other imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedModules"
             },
             "sourceMap": {
               "description": "Create source map files for emitted JavaScript files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create source map files for emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceMap"
             },
             "sourceRoot": {
               "description": "Specify the root path for debuggers to find the reference source code.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root path for debuggers to find the reference source code.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceRoot"
             },
             "suppressExcessPropertyErrors": {
               "description": "Disable reporting of excess property errors during the creation of object literals.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
               "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
               "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable emitting declarations that have `@internal` in their JSDoc comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#stripInternal"
             },
             "target": {
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "ES3",
               "anyOf": [
@@ -656,7 +656,7 @@
             },
             "useUnknownInCatchVariables": {
               "description": "Default catch clause variables as `unknown` instead of `any`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Default catch clause variables as `unknown` instead of `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables"
@@ -701,85 +701,85 @@
             },
             "experimentalDecorators": {
               "description": "Enable experimental support for TC39 stage 2 draft decorators.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable experimental support for TC39 stage 2 draft decorators.\n\nSee more: https://www.typescriptlang.org/tsconfig#experimentalDecorators"
             },
             "emitDecoratorMetadata": {
               "description": "Emit design-type metadata for decorated declarations in source files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata"
             },
             "allowUnusedLabels": {
               "description": "Disable error reporting for unused labels.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unused labels.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnusedLabels"
             },
             "noImplicitReturns": {
               "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for codepaths that do not explicitly return in a function.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitReturns"
             },
             "noUncheckedIndexedAccess": {
               "description": "Add `undefined` to a type when accessed using an index.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Add `undefined` to a type when accessed using an index.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess"
             },
             "noFallthroughCasesInSwitch": {
               "description": "Enable error reporting for fallthrough cases in switch statements.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for fallthrough cases in switch statements.\n\nSee more: https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch"
             },
             "noImplicitOverride": {
               "description": "Ensure overriding members in derived classes are marked with an override modifier.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure overriding members in derived classes are marked with an override modifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitOverride"
             },
             "allowUnreachableCode": {
               "description": "Disable error reporting for unreachable code.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unreachable code.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnreachableCode"
             },
             "forceConsistentCasingInFileNames": {
               "description": "Ensure that casing is correct in imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
               "description": "Emit a v8 CPU profile of the compiler run for debugging.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "profile.cpuprofile",
               "markdownDescription": "Emit a v8 CPU profile of the compiler run for debugging.\n\nSee more: https://www.typescriptlang.org/tsconfig#generateCpuProfile"
             },
             "baseUrl": {
               "description": "Specify the base directory to resolve non-relative module names.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the base directory to resolve non-relative module names.\n\nSee more: https://www.typescriptlang.org/tsconfig#baseUrl"
             },
             "paths": {
               "description": "Specify a set of entries that re-map imports to additional lookup locations.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["object", "null"],
               "additionalProperties": {
-                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["array", "null"],
                 "uniqueItems": true,
                 "items": {
-                  "$comment": "The value of 'null' is UNDOCUMENTED.",
+                  "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                   "type": ["string", "null"],
                   "description": "Path mapping to be computed relative to baseUrl option."
                 }
@@ -788,10 +788,10 @@
             },
             "plugins": {
               "description": "Specify a list of language service plugins to include.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "items": {
-                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["object", "null"],
                 "properties": {
                   "name": {
@@ -804,7 +804,7 @@
             },
             "rootDirs": {
               "description": "Allow multiple folders to be treated as one when resolving modules.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -814,7 +814,7 @@
             },
             "typeRoots": {
               "description": "Specify multiple folders that act like `./node_modules/@types`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -824,7 +824,7 @@
             },
             "types": {
               "description": "Specify type package names to be included without being referenced in a source file.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -834,58 +834,58 @@
             },
             "traceResolution": {
               "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false
             },
             "allowJs": {
               "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowJs"
             },
             "noErrorTruncation": {
               "description": "Disable truncating types in error messages.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
               "description": "Allow 'import x from y' when a module doesn't have a default export.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow 'import x from y' when a module doesn't have a default export.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports"
             },
             "noImplicitUseStrict": {
               "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable adding 'use strict' directives in emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitUseStrict"
             },
             "listEmittedFiles": {
               "description": "Print the names of emitted files after a compilation.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print the names of emitted files after a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listEmittedFiles"
             },
             "disableSizeLimit": {
               "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSizeLimit"
             },
             "lib": {
               "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["string", "null"],
                 "anyOf": [
                   {
@@ -1003,21 +1003,21 @@
             },
             "strictNullChecks": {
               "description": "When type checking, take into account `null` and `undefined`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
               "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["number", "null"],
               "default": 0,
               "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
               "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow importing helper functions from tslib once per project, instead of including them per-file.\n\nSee more: https://www.typescriptlang.org/tsconfig#importHelpers"
@@ -1029,104 +1029,104 @@
             },
             "alwaysStrict": {
               "description": "Ensure 'use strict' is always emitted.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Ensure 'use strict' is always emitted.\n\nSee more: https://www.typescriptlang.org/tsconfig#alwaysStrict"
             },
             "strict": {
               "description": "Enable all strict type checking options.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable all strict type checking options.\n\nSee more: https://www.typescriptlang.org/tsconfig#strict"
             },
             "strictBindCallApply": {
               "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBindCallApply"
             },
             "downlevelIteration": {
               "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit more compliant, but verbose and less performant JavaScript for iteration.\n\nSee more: https://www.typescriptlang.org/tsconfig#downlevelIteration"
             },
             "checkJs": {
               "description": "Enable error reporting in type-checked JavaScript files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
             },
             "strictFunctionTypes": {
               "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictFunctionTypes"
             },
             "strictPropertyInitialization": {
               "description": "Check for class properties that are declared but not set in the constructor.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
               "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
               "description": "Allow accessing UMD globals from modules.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow accessing UMD globals from modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUmdGlobalAccess"
             },
             "keyofStringsOnly": {
               "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {
               "description": "Emit ECMAScript-standard-compliant class fields.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit ECMAScript-standard-compliant class fields.\n\nSee more: https://www.typescriptlang.org/tsconfig#useDefineForClassFields"
             },
             "declarationMap": {
               "description": "Create sourcemaps for d.ts files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create sourcemaps for d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationMap"
             },
             "resolveJsonModule": {
               "description": "Enable importing .json files",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable importing .json files\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
               "description": "Use the package.json 'exports' field when resolving package imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
               "description": "Use the package.json 'imports' field when resolving imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'imports' field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
@@ -1137,7 +1137,7 @@
             },
             "extendedDiagnostics": {
               "description": "Output more detailed compiler performance information after building.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Output more detailed compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#extendedDiagnostics"
@@ -1148,19 +1148,19 @@
             },
             "disableSourceOfProjectReferenceRedirect": {
               "description": "Disable preferring source files instead of declaration files when referencing composite projects",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable preferring source files instead of declaration files when referencing composite projects\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSourceOfProjectReferenceRedirect"
             },
             "disableSolutionSearching": {
               "description": "Opt a project out of multi-project reference checking when editing.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Opt a project out of multi-project reference checking when editing.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSolutionSearching"
             },
             "verbatimModuleSyntax": {
               "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.\n\nSee more: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax"
             }
@@ -1171,19 +1171,19 @@
     "typeAcquisitionDefinition": {
       "properties": {
         "typeAcquisition": {
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
           "properties": {
             "enable": {
               "description": "Enable auto type acquisition",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false
             },
             "include": {
               "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -1192,7 +1192,7 @@
             },
             "exclude": {
               "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -1206,17 +1206,17 @@
     "referencesDefinition": {
       "properties": {
         "references": {
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "description": "Referenced projects. Requires TypeScript version 3.0 or later.",
           "items": {
-            "$comment": "The value of 'null' is UNDOCUMENTED.",
+            "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
             "type": ["object", "null"],
             "description": "Project reference.",
             "properties": {
               "path": {
-                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["string", "null"],
                 "description": "Path to referenced tsconfig or to folder containing tsconfig."
               }

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -50,7 +50,7 @@
       "properties": {
         "files": {
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -63,7 +63,7 @@
       "properties": {
         "exclude": {
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -76,7 +76,7 @@
       "properties": {
         "include": {
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -119,41 +119,41 @@
           "properties": {
             "dry": {
               "description": "~",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false
             },
             "force": {
               "description": "Build all projects, including those that appear to be up to date",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Build all projects, including those that appear to be up to date\n\nSee more: https://www.typescriptlang.org/tsconfig#force"
             },
             "verbose": {
               "description": "Enable verbose logging",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable verbose logging\n\nSee more: https://www.typescriptlang.org/tsconfig#verbose"
             },
             "incremental": {
               "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "traceResolution": {
               "description": "Log paths used during the `moduleResolution` process.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Log paths used during the `moduleResolution` process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
@@ -165,7 +165,7 @@
     "watchOptionsDefinition": {
       "properties": {
         "watchOptions": {
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Settings for the watch mode in TypeScript.",
           "properties": {
@@ -175,31 +175,31 @@
             },
             "watchFile": {
               "description": "Specify how the TypeScript watch mode works.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify how the TypeScript watch mode works.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchFile"
             },
             "watchDirectory": {
               "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify how directories are watched on systems that lack recursive file-watching functionality.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchDirectory"
             },
             "fallbackPolling": {
               "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify what approach the watcher should use if the system runs out of native file watchers.\n\nSee more: https://www.typescriptlang.org/tsconfig#fallbackPolling"
             },
             "synchronousWatchDirectory": {
               "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.\n\nSee more: https://www.typescriptlang.org/tsconfig#synchronousWatchDirectory"
             },
             "excludeFiles": {
               "description": "Remove a list of files from the watch mode's processing.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -209,7 +209,7 @@
             },
             "excludeDirectories": {
               "description": "Remove a list of directories from the watch process.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -224,38 +224,38 @@
     "compilerOptionsDefinition": {
       "properties": {
         "compilerOptions": {
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "allowArbitraryExtensions": {
               "description": "Enable importing files with any extension, provided a declaration file is present.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable importing files with any extension, provided a declaration file is present.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "allowImportingTsExtensions": {
               "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "charset": {
               "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
               "description": "Enable constraints that allow a TypeScript project to be used with project references.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable constraints that allow a TypeScript project to be used with project references.\n\nSee more: https://www.typescriptlang.org/tsconfig#composite"
             },
             "customConditions": {
               "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -265,52 +265,52 @@
             },
             "declaration": {
               "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Generate .d.ts files from TypeScript and JavaScript files in your project.\n\nSee more: https://www.typescriptlang.org/tsconfig#declaration"
             },
             "declarationDir": {
               "description": "Specify the output directory for generated declaration files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
               "description": "Output compiler performance information after building.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
               "description": "Reduce the number of projects loaded automatically by TypeScript.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Reduce the number of projects loaded automatically by TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad"
             },
             "noPropertyAccessFromIndexSignature": {
               "description": "Enforces using indexed accessors for keys declared using an indexed type",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enforces using indexed accessors for keys declared using an indexed type\n\nSee more: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature"
             },
             "emitBOM": {
               "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitBOM"
             },
             "emitDeclarationOnly": {
               "description": "Only output d.ts files and not JavaScript files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Only output d.ts files and not JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDeclarationOnly"
             },
             "exactOptionalPropertyTypes": {
               "description": "Differentiate between undefined and not present when type checking",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Differentiate between undefined and not present when type checking\n\nSee more: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes"
@@ -320,7 +320,7 @@
               "type": ["boolean", "null"]
             },
             "tsBuildInfoFile": {
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the folder for .tsbuildinfo incremental compilation files.",
               "default": ".tsbuildinfo",
               "type": ["string", "null"],
@@ -328,14 +328,14 @@
             },
             "inlineSourceMap": {
               "description": "Include sourcemap files inside the emitted JavaScript.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include sourcemap files inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSourceMap"
             },
             "inlineSources": {
               "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include source code in the sourcemaps inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSources"
@@ -352,48 +352,48 @@
             },
             "reactNamespace": {
               "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "React",
               "markdownDescription": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.\n\nSee more: https://www.typescriptlang.org/tsconfig#reactNamespace"
             },
             "jsxFactory": {
               "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "React.createElement",
               "markdownDescription": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFactory"
             },
             "jsxFragmentFactory": {
               "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "React.Fragment",
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
               "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "react",
               "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
               "description": "Print all of the files read during the compilation.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print all of the files read during the compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listFiles"
             },
             "mapRoot": {
               "description": "Specify the location where debugger should locate map files instead of generated locations.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the location where debugger should locate map files instead of generated locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#mapRoot"
             },
             "module": {
               "description": "Specify what module code is generated.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -421,7 +421,7 @@
             },
             "moduleResolution": {
               "description": "Specify how TypeScript looks up a file from a given module specifier.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -450,7 +450,7 @@
             },
             "newLine": {
               "description": "Set the newline character for emitting files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -464,188 +464,188 @@
             },
             "noEmit": {
               "description": "Disable emitting file from a compilation.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting file from a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmit"
             },
             "noEmitHelpers": {
               "description": "Disable generating custom helper functions like `__extends` in compiled output.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable generating custom helper functions like `__extends` in compiled output.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitHelpers"
             },
             "noEmitOnError": {
               "description": "Disable emitting files if any type checking errors are reported.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting files if any type checking errors are reported.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitOnError"
             },
             "noImplicitAny": {
               "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
             },
             "noImplicitThis": {
               "description": "Enable error reporting when `this` is given the type `any`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting when `this` is given the type `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitThis"
             },
             "noUnusedLocals": {
               "description": "Enable error reporting when a local variables aren't read.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting when a local variables aren't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
               "description": "Raise an error when a function parameter isn't read",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Raise an error when a function parameter isn't read\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedParameters"
             },
             "noLib": {
               "description": "Disable including any library files, including the default lib.d.ts.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable including any library files, including the default lib.d.ts.\n\nSee more: https://www.typescriptlang.org/tsconfig#noLib"
             },
             "noResolve": {
               "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.\n\nSee more: https://www.typescriptlang.org/tsconfig#noResolve"
             },
             "noStrictGenericChecks": {
               "description": "Disable strict checking of generic signatures in function types.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
             },
             "skipDefaultLibCheck": {
               "description": "Skip type checking .d.ts files that are included with TypeScript.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking .d.ts files that are included with TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck"
             },
             "skipLibCheck": {
               "description": "Skip type checking all .d.ts files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
               "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
               "description": "Specify an output folder for all emitted files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify an output folder for all emitted files.\n\nSee more: https://www.typescriptlang.org/tsconfig#outDir"
             },
             "preserveConstEnums": {
               "description": "Disable erasing `const enum` declarations in generated code.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable erasing `const enum` declarations in generated code.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveConstEnums"
             },
             "preserveSymlinks": {
               "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveSymlinks"
             },
             "preserveValueImports": {
               "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Preserve unused imported values in the JavaScript output that would otherwise be removed\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveValueImports"
             },
             "preserveWatchOutput": {
               "description": "Disable wiping the console in watch mode",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable wiping the console in watch mode\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveWatchOutput"
             },
             "pretty": {
               "description": "Enable color and formatting in output to make compiler errors easier to read",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable color and formatting in output to make compiler errors easier to read\n\nSee more: https://www.typescriptlang.org/tsconfig#pretty"
             },
             "removeComments": {
               "description": "Disable emitting comments.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#removeComments"
             },
             "rootDir": {
               "description": "Specify the root folder within your source files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root folder within your source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDir"
             },
             "isolatedModules": {
               "description": "Ensure that each file can be safely transpiled without relying on other imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that each file can be safely transpiled without relying on other imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedModules"
             },
             "sourceMap": {
               "description": "Create source map files for emitted JavaScript files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create source map files for emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceMap"
             },
             "sourceRoot": {
               "description": "Specify the root path for debuggers to find the reference source code.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root path for debuggers to find the reference source code.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceRoot"
             },
             "suppressExcessPropertyErrors": {
               "description": "Disable reporting of excess property errors during the creation of object literals.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
               "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
               "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable emitting declarations that have `@internal` in their JSDoc comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#stripInternal"
             },
             "target": {
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "ES3",
               "anyOf": [
@@ -674,7 +674,7 @@
             },
             "useUnknownInCatchVariables": {
               "description": "Default catch clause variables as `unknown` instead of `any`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Default catch clause variables as `unknown` instead of `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables"
@@ -719,85 +719,85 @@
             },
             "experimentalDecorators": {
               "description": "Enable experimental support for TC39 stage 2 draft decorators.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable experimental support for TC39 stage 2 draft decorators.\n\nSee more: https://www.typescriptlang.org/tsconfig#experimentalDecorators"
             },
             "emitDecoratorMetadata": {
               "description": "Emit design-type metadata for decorated declarations in source files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata"
             },
             "allowUnusedLabels": {
               "description": "Disable error reporting for unused labels.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unused labels.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnusedLabels"
             },
             "noImplicitReturns": {
               "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for codepaths that do not explicitly return in a function.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitReturns"
             },
             "noUncheckedIndexedAccess": {
               "description": "Add `undefined` to a type when accessed using an index.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Add `undefined` to a type when accessed using an index.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess"
             },
             "noFallthroughCasesInSwitch": {
               "description": "Enable error reporting for fallthrough cases in switch statements.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for fallthrough cases in switch statements.\n\nSee more: https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch"
             },
             "noImplicitOverride": {
               "description": "Ensure overriding members in derived classes are marked with an override modifier.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure overriding members in derived classes are marked with an override modifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitOverride"
             },
             "allowUnreachableCode": {
               "description": "Disable error reporting for unreachable code.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unreachable code.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnreachableCode"
             },
             "forceConsistentCasingInFileNames": {
               "description": "Ensure that casing is correct in imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
               "description": "Emit a v8 CPU profile of the compiler run for debugging.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "default": "profile.cpuprofile",
               "markdownDescription": "Emit a v8 CPU profile of the compiler run for debugging.\n\nSee more: https://www.typescriptlang.org/tsconfig#generateCpuProfile"
             },
             "baseUrl": {
               "description": "Specify the base directory to resolve non-relative module names.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["string", "null"],
               "markdownDescription": "Specify the base directory to resolve non-relative module names.\n\nSee more: https://www.typescriptlang.org/tsconfig#baseUrl"
             },
             "paths": {
               "description": "Specify a set of entries that re-map imports to additional lookup locations.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["object", "null"],
               "additionalProperties": {
-                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["array", "null"],
                 "uniqueItems": true,
                 "items": {
-                  "$comment": "The value of 'null' is UNDOCUMENTED.",
+                  "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                   "type": ["string", "null"],
                   "description": "Path mapping to be computed relative to baseUrl option."
                 }
@@ -806,10 +806,10 @@
             },
             "plugins": {
               "description": "Specify a list of language service plugins to include.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "items": {
-                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["object", "null"],
                 "properties": {
                   "name": {
@@ -822,7 +822,7 @@
             },
             "rootDirs": {
               "description": "Allow multiple folders to be treated as one when resolving modules.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -832,7 +832,7 @@
             },
             "typeRoots": {
               "description": "Specify multiple folders that act like `./node_modules/@types`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -842,7 +842,7 @@
             },
             "types": {
               "description": "Specify type package names to be included without being referenced in a source file.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -852,58 +852,58 @@
             },
             "traceResolution": {
               "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false
             },
             "allowJs": {
               "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowJs"
             },
             "noErrorTruncation": {
               "description": "Disable truncating types in error messages.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
               "description": "Allow 'import x from y' when a module doesn't have a default export.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow 'import x from y' when a module doesn't have a default export.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports"
             },
             "noImplicitUseStrict": {
               "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable adding 'use strict' directives in emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitUseStrict"
             },
             "listEmittedFiles": {
               "description": "Print the names of emitted files after a compilation.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print the names of emitted files after a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listEmittedFiles"
             },
             "disableSizeLimit": {
               "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSizeLimit"
             },
             "lib": {
               "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["string", "null"],
                 "anyOf": [
                   {
@@ -1043,21 +1043,21 @@
             },
             "strictNullChecks": {
               "description": "When type checking, take into account `null` and `undefined`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
               "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["number", "null"],
               "default": 0,
               "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
               "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow importing helper functions from tslib once per project, instead of including them per-file.\n\nSee more: https://www.typescriptlang.org/tsconfig#importHelpers"
@@ -1069,104 +1069,104 @@
             },
             "alwaysStrict": {
               "description": "Ensure 'use strict' is always emitted.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Ensure 'use strict' is always emitted.\n\nSee more: https://www.typescriptlang.org/tsconfig#alwaysStrict"
             },
             "strict": {
               "description": "Enable all strict type checking options.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable all strict type checking options.\n\nSee more: https://www.typescriptlang.org/tsconfig#strict"
             },
             "strictBindCallApply": {
               "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBindCallApply"
             },
             "downlevelIteration": {
               "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit more compliant, but verbose and less performant JavaScript for iteration.\n\nSee more: https://www.typescriptlang.org/tsconfig#downlevelIteration"
             },
             "checkJs": {
               "description": "Enable error reporting in type-checked JavaScript files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
             },
             "strictFunctionTypes": {
               "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictFunctionTypes"
             },
             "strictPropertyInitialization": {
               "description": "Check for class properties that are declared but not set in the constructor.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
               "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
               "description": "Allow accessing UMD globals from modules.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow accessing UMD globals from modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUmdGlobalAccess"
             },
             "keyofStringsOnly": {
               "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {
               "description": "Emit ECMAScript-standard-compliant class fields.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit ECMAScript-standard-compliant class fields.\n\nSee more: https://www.typescriptlang.org/tsconfig#useDefineForClassFields"
             },
             "declarationMap": {
               "description": "Create sourcemaps for d.ts files.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create sourcemaps for d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationMap"
             },
             "resolveJsonModule": {
               "description": "Enable importing .json files",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable importing .json files\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
               "description": "Use the package.json 'exports' field when resolving package imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
               "description": "Use the package.json 'imports' field when resolving imports.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'imports' field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
@@ -1177,7 +1177,7 @@
             },
             "extendedDiagnostics": {
               "description": "Output more detailed compiler performance information after building.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Output more detailed compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#extendedDiagnostics"
@@ -1188,19 +1188,19 @@
             },
             "disableSourceOfProjectReferenceRedirect": {
               "description": "Disable preferring source files instead of declaration files when referencing composite projects",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable preferring source files instead of declaration files when referencing composite projects\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSourceOfProjectReferenceRedirect"
             },
             "disableSolutionSearching": {
               "description": "Opt a project out of multi-project reference checking when editing.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Opt a project out of multi-project reference checking when editing.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSolutionSearching"
             },
             "verbatimModuleSyntax": {
               "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "markdownDescription": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.\n\nSee more: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax"
             }
@@ -1211,19 +1211,19 @@
     "typeAcquisitionDefinition": {
       "properties": {
         "typeAcquisition": {
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
           "properties": {
             "enable": {
               "description": "Enable auto type acquisition",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["boolean", "null"],
               "default": false
             },
             "include": {
               "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -1232,7 +1232,7 @@
             },
             "exclude": {
               "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
-              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -1246,17 +1246,17 @@
     "referencesDefinition": {
       "properties": {
         "references": {
-          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "description": "Referenced projects. Requires TypeScript version 3.0 or later.",
           "items": {
-            "$comment": "The value of 'null' is UNDOCUMENTED.",
+            "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
             "type": ["object", "null"],
             "description": "Project reference.",
             "properties": {
               "path": {
-                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["string", "null"],
                 "description": "Path to referenced tsconfig or to folder containing tsconfig."
               }

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -49,8 +49,8 @@
     "filesDefinition": {
       "properties": {
         "files": {
-          "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+          "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -62,8 +62,8 @@
     "excludeDefinition": {
       "properties": {
         "exclude": {
-          "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+          "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -75,8 +75,8 @@
     "includeDefinition": {
       "properties": {
         "include": {
-          "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+          "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
@@ -118,42 +118,42 @@
         "buildOptions": {
           "properties": {
             "dry": {
-              "description": "~",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "~",
               "type": ["boolean", "null"],
               "default": false
             },
             "force": {
-              "description": "Build all projects, including those that appear to be up to date",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Build all projects, including those that appear to be up to date",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Build all projects, including those that appear to be up to date\n\nSee more: https://www.typescriptlang.org/tsconfig#force"
             },
             "verbose": {
-              "description": "Enable verbose logging",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable verbose logging",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable verbose logging\n\nSee more: https://www.typescriptlang.org/tsconfig#verbose"
             },
             "incremental": {
-              "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
-              "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "traceResolution": {
-              "description": "Log paths used during the `moduleResolution` process.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Log paths used during the `moduleResolution` process.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Log paths used during the `moduleResolution` process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
@@ -174,32 +174,32 @@
               "type": ["string", "null"]
             },
             "watchFile": {
-              "description": "Specify how the TypeScript watch mode works.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify how the TypeScript watch mode works.",
               "type": ["string", "null"],
               "markdownDescription": "Specify how the TypeScript watch mode works.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchFile"
             },
             "watchDirectory": {
-              "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
               "type": ["string", "null"],
               "markdownDescription": "Specify how directories are watched on systems that lack recursive file-watching functionality.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchDirectory"
             },
             "fallbackPolling": {
-              "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
               "type": ["string", "null"],
               "markdownDescription": "Specify what approach the watcher should use if the system runs out of native file watchers.\n\nSee more: https://www.typescriptlang.org/tsconfig#fallbackPolling"
             },
             "synchronousWatchDirectory": {
-              "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
               "type": ["boolean", "null"],
               "markdownDescription": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.\n\nSee more: https://www.typescriptlang.org/tsconfig#synchronousWatchDirectory"
             },
             "excludeFiles": {
-              "description": "Remove a list of files from the watch mode's processing.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Remove a list of files from the watch mode's processing.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -208,8 +208,8 @@
               "markdownDescription": "Remove a list of files from the watch mode's processing.\n\nSee more: https://www.typescriptlang.org/tsconfig#excludeFiles"
             },
             "excludeDirectories": {
-              "description": "Remove a list of directories from the watch process.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Remove a list of directories from the watch process.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -229,33 +229,33 @@
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "allowArbitraryExtensions": {
-              "description": "Enable importing files with any extension, provided a declaration file is present.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable importing files with any extension, provided a declaration file is present.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable importing files with any extension, provided a declaration file is present.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "allowImportingTsExtensions": {
-              "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "charset": {
-              "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
               "type": ["string", "null"],
               "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
-              "description": "Enable constraints that allow a TypeScript project to be used with project references.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable constraints that allow a TypeScript project to be used with project references.",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable constraints that allow a TypeScript project to be used with project references.\n\nSee more: https://www.typescriptlang.org/tsconfig#composite"
             },
             "customConditions": {
-              "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -264,53 +264,53 @@
               "markdownDescription": "Conditions to set in addition to the resolver-specific defaults when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#customConditions"
             },
             "declaration": {
-              "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Generate .d.ts files from TypeScript and JavaScript files in your project.\n\nSee more: https://www.typescriptlang.org/tsconfig#declaration"
             },
             "declarationDir": {
-              "description": "Specify the output directory for generated declaration files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the output directory for generated declaration files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
-              "description": "Output compiler performance information after building.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Output compiler performance information after building.",
               "type": ["boolean", "null"],
               "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
-              "description": "Reduce the number of projects loaded automatically by TypeScript.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Reduce the number of projects loaded automatically by TypeScript.",
               "type": ["boolean", "null"],
               "markdownDescription": "Reduce the number of projects loaded automatically by TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad"
             },
             "noPropertyAccessFromIndexSignature": {
-              "description": "Enforces using indexed accessors for keys declared using an indexed type",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enforces using indexed accessors for keys declared using an indexed type",
               "type": ["boolean", "null"],
               "markdownDescription": "Enforces using indexed accessors for keys declared using an indexed type\n\nSee more: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature"
             },
             "emitBOM": {
-              "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitBOM"
             },
             "emitDeclarationOnly": {
-              "description": "Only output d.ts files and not JavaScript files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Only output d.ts files and not JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Only output d.ts files and not JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDeclarationOnly"
             },
             "exactOptionalPropertyTypes": {
-              "description": "Differentiate between undefined and not present when type checking",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Differentiate between undefined and not present when type checking",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Differentiate between undefined and not present when type checking\n\nSee more: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes"
@@ -327,15 +327,15 @@
               "markdownDescription": "Specify the folder for .tsbuildinfo incremental compilation files.\n\nSee more: https://www.typescriptlang.org/tsconfig#tsBuildInfoFile"
             },
             "inlineSourceMap": {
-              "description": "Include sourcemap files inside the emitted JavaScript.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Include sourcemap files inside the emitted JavaScript.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include sourcemap files inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSourceMap"
             },
             "inlineSources": {
-              "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include source code in the sourcemaps inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSources"
@@ -351,49 +351,49 @@
               ]
             },
             "reactNamespace": {
-              "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
               "type": ["string", "null"],
               "default": "React",
               "markdownDescription": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.\n\nSee more: https://www.typescriptlang.org/tsconfig#reactNamespace"
             },
             "jsxFactory": {
-              "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
               "type": ["string", "null"],
               "default": "React.createElement",
               "markdownDescription": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFactory"
             },
             "jsxFragmentFactory": {
-              "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
               "type": ["string", "null"],
               "default": "React.Fragment",
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
-              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
               "type": ["string", "null"],
               "default": "react",
               "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
-              "description": "Print all of the files read during the compilation.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Print all of the files read during the compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print all of the files read during the compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listFiles"
             },
             "mapRoot": {
-              "description": "Specify the location where debugger should locate map files instead of generated locations.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the location where debugger should locate map files instead of generated locations.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the location where debugger should locate map files instead of generated locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#mapRoot"
             },
             "module": {
-              "description": "Specify what module code is generated.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify what module code is generated.",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -420,8 +420,8 @@
               "markdownDescription": "Specify what module code is generated.\n\nSee more: https://www.typescriptlang.org/tsconfig#module"
             },
             "moduleResolution": {
-              "description": "Specify how TypeScript looks up a file from a given module specifier.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify how TypeScript looks up a file from a given module specifier.",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -449,8 +449,8 @@
               "markdownDescription": "Specify how TypeScript looks up a file from a given module specifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleResolution"
             },
             "newLine": {
-              "description": "Set the newline character for emitting files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Set the newline character for emitting files.",
               "type": ["string", "null"],
               "anyOf": [
                 {
@@ -463,189 +463,189 @@
               "markdownDescription": "Set the newline character for emitting files.\n\nSee more: https://www.typescriptlang.org/tsconfig#newLine"
             },
             "noEmit": {
-              "description": "Disable emitting file from a compilation.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable emitting file from a compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting file from a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmit"
             },
             "noEmitHelpers": {
-              "description": "Disable generating custom helper functions like `__extends` in compiled output.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable generating custom helper functions like `__extends` in compiled output.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable generating custom helper functions like `__extends` in compiled output.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitHelpers"
             },
             "noEmitOnError": {
-              "description": "Disable emitting files if any type checking errors are reported.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable emitting files if any type checking errors are reported.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting files if any type checking errors are reported.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitOnError"
             },
             "noImplicitAny": {
-              "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
             },
             "noImplicitThis": {
-              "description": "Enable error reporting when `this` is given the type `any`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting when `this` is given the type `any`.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting when `this` is given the type `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitThis"
             },
             "noUnusedLocals": {
-              "description": "Enable error reporting when a local variables aren't read.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting when a local variables aren't read.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting when a local variables aren't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
-              "description": "Raise an error when a function parameter isn't read",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Raise an error when a function parameter isn't read",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Raise an error when a function parameter isn't read\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedParameters"
             },
             "noLib": {
-              "description": "Disable including any library files, including the default lib.d.ts.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable including any library files, including the default lib.d.ts.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable including any library files, including the default lib.d.ts.\n\nSee more: https://www.typescriptlang.org/tsconfig#noLib"
             },
             "noResolve": {
-              "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.\n\nSee more: https://www.typescriptlang.org/tsconfig#noResolve"
             },
             "noStrictGenericChecks": {
-              "description": "Disable strict checking of generic signatures in function types.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable strict checking of generic signatures in function types.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
             },
             "skipDefaultLibCheck": {
-              "description": "Skip type checking .d.ts files that are included with TypeScript.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Skip type checking .d.ts files that are included with TypeScript.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking .d.ts files that are included with TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck"
             },
             "skipLibCheck": {
-              "description": "Skip type checking all .d.ts files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Skip type checking all .d.ts files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
-              "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
               "type": ["string", "null"],
               "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
-              "description": "Specify an output folder for all emitted files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify an output folder for all emitted files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify an output folder for all emitted files.\n\nSee more: https://www.typescriptlang.org/tsconfig#outDir"
             },
             "preserveConstEnums": {
-              "description": "Disable erasing `const enum` declarations in generated code.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable erasing `const enum` declarations in generated code.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable erasing `const enum` declarations in generated code.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveConstEnums"
             },
             "preserveSymlinks": {
-              "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveSymlinks"
             },
             "preserveValueImports": {
-              "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Preserve unused imported values in the JavaScript output that would otherwise be removed\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveValueImports"
             },
             "preserveWatchOutput": {
-              "description": "Disable wiping the console in watch mode",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable wiping the console in watch mode",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable wiping the console in watch mode\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveWatchOutput"
             },
             "pretty": {
-              "description": "Enable color and formatting in output to make compiler errors easier to read",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable color and formatting in output to make compiler errors easier to read",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable color and formatting in output to make compiler errors easier to read\n\nSee more: https://www.typescriptlang.org/tsconfig#pretty"
             },
             "removeComments": {
-              "description": "Disable emitting comments.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable emitting comments.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#removeComments"
             },
             "rootDir": {
-              "description": "Specify the root folder within your source files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the root folder within your source files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root folder within your source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDir"
             },
             "isolatedModules": {
-              "description": "Ensure that each file can be safely transpiled without relying on other imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Ensure that each file can be safely transpiled without relying on other imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that each file can be safely transpiled without relying on other imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedModules"
             },
             "sourceMap": {
-              "description": "Create source map files for emitted JavaScript files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Create source map files for emitted JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create source map files for emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceMap"
             },
             "sourceRoot": {
-              "description": "Specify the root path for debuggers to find the reference source code.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the root path for debuggers to find the reference source code.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root path for debuggers to find the reference source code.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceRoot"
             },
             "suppressExcessPropertyErrors": {
-              "description": "Disable reporting of excess property errors during the creation of object literals.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable reporting of excess property errors during the creation of object literals.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
-              "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
-              "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable emitting declarations that have `@internal` in their JSDoc comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#stripInternal"
             },
             "target": {
-              "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": ["string", "null"],
               "default": "ES3",
               "anyOf": [
@@ -673,8 +673,8 @@
               "markdownDescription": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.\n\nSee more: https://www.typescriptlang.org/tsconfig#target"
             },
             "useUnknownInCatchVariables": {
-              "description": "Default catch clause variables as `unknown` instead of `any`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Default catch clause variables as `unknown` instead of `any`.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Default catch clause variables as `unknown` instead of `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables"
@@ -718,79 +718,79 @@
               "default": "useFsEvents"
             },
             "experimentalDecorators": {
-              "description": "Enable experimental support for TC39 stage 2 draft decorators.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable experimental support for TC39 stage 2 draft decorators.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable experimental support for TC39 stage 2 draft decorators.\n\nSee more: https://www.typescriptlang.org/tsconfig#experimentalDecorators"
             },
             "emitDecoratorMetadata": {
-              "description": "Emit design-type metadata for decorated declarations in source files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit design-type metadata for decorated declarations in source files.",
               "type": ["boolean", "null"],
               "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata"
             },
             "allowUnusedLabels": {
-              "description": "Disable error reporting for unused labels.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable error reporting for unused labels.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unused labels.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnusedLabels"
             },
             "noImplicitReturns": {
-              "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for codepaths that do not explicitly return in a function.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitReturns"
             },
             "noUncheckedIndexedAccess": {
-              "description": "Add `undefined` to a type when accessed using an index.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Add `undefined` to a type when accessed using an index.",
               "type": ["boolean", "null"],
               "markdownDescription": "Add `undefined` to a type when accessed using an index.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess"
             },
             "noFallthroughCasesInSwitch": {
-              "description": "Enable error reporting for fallthrough cases in switch statements.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting for fallthrough cases in switch statements.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for fallthrough cases in switch statements.\n\nSee more: https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch"
             },
             "noImplicitOverride": {
-              "description": "Ensure overriding members in derived classes are marked with an override modifier.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Ensure overriding members in derived classes are marked with an override modifier.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure overriding members in derived classes are marked with an override modifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitOverride"
             },
             "allowUnreachableCode": {
-              "description": "Disable error reporting for unreachable code.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable error reporting for unreachable code.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unreachable code.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnreachableCode"
             },
             "forceConsistentCasingInFileNames": {
-              "description": "Ensure that casing is correct in imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Ensure that casing is correct in imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
-              "description": "Emit a v8 CPU profile of the compiler run for debugging.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit a v8 CPU profile of the compiler run for debugging.",
               "type": ["string", "null"],
               "default": "profile.cpuprofile",
               "markdownDescription": "Emit a v8 CPU profile of the compiler run for debugging.\n\nSee more: https://www.typescriptlang.org/tsconfig#generateCpuProfile"
             },
             "baseUrl": {
-              "description": "Specify the base directory to resolve non-relative module names.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the base directory to resolve non-relative module names.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the base directory to resolve non-relative module names.\n\nSee more: https://www.typescriptlang.org/tsconfig#baseUrl"
             },
             "paths": {
-              "description": "Specify a set of entries that re-map imports to additional lookup locations.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify a set of entries that re-map imports to additional lookup locations.",
               "type": ["object", "null"],
               "additionalProperties": {
                 "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -805,8 +805,8 @@
               "markdownDescription": "Specify a set of entries that re-map imports to additional lookup locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#paths"
             },
             "plugins": {
-              "description": "Specify a list of language service plugins to include.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify a list of language service plugins to include.",
               "type": ["array", "null"],
               "items": {
                 "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -821,8 +821,8 @@
               "markdownDescription": "Specify a list of language service plugins to include.\n\nSee more: https://www.typescriptlang.org/tsconfig#plugins"
             },
             "rootDirs": {
-              "description": "Allow multiple folders to be treated as one when resolving modules.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow multiple folders to be treated as one when resolving modules.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -831,8 +831,8 @@
               "markdownDescription": "Allow multiple folders to be treated as one when resolving modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDirs"
             },
             "typeRoots": {
-              "description": "Specify multiple folders that act like `./node_modules/@types`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify multiple folders that act like `./node_modules/@types`.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -841,8 +841,8 @@
               "markdownDescription": "Specify multiple folders that act like `./node_modules/@types`.\n\nSee more: https://www.typescriptlang.org/tsconfig#typeRoots"
             },
             "types": {
-              "description": "Specify type package names to be included without being referenced in a source file.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify type package names to be included without being referenced in a source file.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -851,55 +851,55 @@
               "markdownDescription": "Specify type package names to be included without being referenced in a source file.\n\nSee more: https://www.typescriptlang.org/tsconfig#types"
             },
             "traceResolution": {
-              "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
               "type": ["boolean", "null"],
               "default": false
             },
             "allowJs": {
-              "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowJs"
             },
             "noErrorTruncation": {
-              "description": "Disable truncating types in error messages.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable truncating types in error messages.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
-              "description": "Allow 'import x from y' when a module doesn't have a default export.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow 'import x from y' when a module doesn't have a default export.",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow 'import x from y' when a module doesn't have a default export.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports"
             },
             "noImplicitUseStrict": {
-              "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable adding 'use strict' directives in emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitUseStrict"
             },
             "listEmittedFiles": {
-              "description": "Print the names of emitted files after a compilation.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Print the names of emitted files after a compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print the names of emitted files after a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listEmittedFiles"
             },
             "disableSizeLimit": {
-              "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSizeLimit"
             },
             "lib": {
-              "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -1042,22 +1042,22 @@
               "enum": ["auto", "legacy", "force"]
             },
             "strictNullChecks": {
-              "description": "When type checking, take into account `null` and `undefined`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "When type checking, take into account `null` and `undefined`.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
-              "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
               "type": ["number", "null"],
               "default": 0,
               "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
-              "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow importing helper functions from tslib once per project, instead of including them per-file.\n\nSee more: https://www.typescriptlang.org/tsconfig#importHelpers"
@@ -1068,105 +1068,105 @@
               "enum": ["remove", "preserve", "error"]
             },
             "alwaysStrict": {
-              "description": "Ensure 'use strict' is always emitted.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Ensure 'use strict' is always emitted.",
               "type": ["boolean", "null"],
               "markdownDescription": "Ensure 'use strict' is always emitted.\n\nSee more: https://www.typescriptlang.org/tsconfig#alwaysStrict"
             },
             "strict": {
-              "description": "Enable all strict type checking options.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable all strict type checking options.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable all strict type checking options.\n\nSee more: https://www.typescriptlang.org/tsconfig#strict"
             },
             "strictBindCallApply": {
-              "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBindCallApply"
             },
             "downlevelIteration": {
-              "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit more compliant, but verbose and less performant JavaScript for iteration.\n\nSee more: https://www.typescriptlang.org/tsconfig#downlevelIteration"
             },
             "checkJs": {
-              "description": "Enable error reporting in type-checked JavaScript files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable error reporting in type-checked JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
             },
             "strictFunctionTypes": {
-              "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictFunctionTypes"
             },
             "strictPropertyInitialization": {
-              "description": "Check for class properties that are declared but not set in the constructor.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Check for class properties that are declared but not set in the constructor.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
-              "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
-              "description": "Allow accessing UMD globals from modules.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Allow accessing UMD globals from modules.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow accessing UMD globals from modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUmdGlobalAccess"
             },
             "keyofStringsOnly": {
-              "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {
-              "description": "Emit ECMAScript-standard-compliant class fields.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Emit ECMAScript-standard-compliant class fields.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit ECMAScript-standard-compliant class fields.\n\nSee more: https://www.typescriptlang.org/tsconfig#useDefineForClassFields"
             },
             "declarationMap": {
-              "description": "Create sourcemaps for d.ts files.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Create sourcemaps for d.ts files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create sourcemaps for d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationMap"
             },
             "resolveJsonModule": {
-              "description": "Enable importing .json files",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable importing .json files",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable importing .json files\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
-              "description": "Use the package.json 'exports' field when resolving package imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Use the package.json 'exports' field when resolving package imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
-              "description": "Use the package.json 'imports' field when resolving imports.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Use the package.json 'imports' field when resolving imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'imports' field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
@@ -1176,8 +1176,8 @@
               "type": ["boolean", "null"]
             },
             "extendedDiagnostics": {
-              "description": "Output more detailed compiler performance information after building.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Output more detailed compiler performance information after building.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Output more detailed compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#extendedDiagnostics"
@@ -1187,20 +1187,20 @@
               "type": ["boolean", "null"]
             },
             "disableSourceOfProjectReferenceRedirect": {
-              "description": "Disable preferring source files instead of declaration files when referencing composite projects",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Disable preferring source files instead of declaration files when referencing composite projects",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable preferring source files instead of declaration files when referencing composite projects\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSourceOfProjectReferenceRedirect"
             },
             "disableSolutionSearching": {
-              "description": "Opt a project out of multi-project reference checking when editing.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Opt a project out of multi-project reference checking when editing.",
               "type": ["boolean", "null"],
               "markdownDescription": "Opt a project out of multi-project reference checking when editing.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSolutionSearching"
             },
             "verbatimModuleSyntax": {
-              "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
               "type": ["boolean", "null"],
               "markdownDescription": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.\n\nSee more: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax"
             }
@@ -1216,14 +1216,14 @@
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
           "properties": {
             "enable": {
-              "description": "Enable auto type acquisition",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Enable auto type acquisition",
               "type": ["boolean", "null"],
               "default": false
             },
             "include": {
-              "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
@@ -1231,8 +1231,8 @@
               }
             },
             "exclude": {
-              "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -50,10 +50,11 @@
       "properties": {
         "files": {
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
-          "type": "array",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         }
       }
@@ -62,10 +63,11 @@
       "properties": {
         "exclude": {
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
-          "type": "array",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         }
       }
@@ -74,10 +76,11 @@
       "properties": {
         "include": {
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
-          "type": "array",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["array", "null"],
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         }
       }
@@ -86,7 +89,7 @@
       "properties": {
         "compileOnSave": {
           "description": "Enable Compile-on-Save for this project.",
-          "type": "boolean"
+          "type": ["boolean", "null"]
         }
       }
     },
@@ -116,36 +119,42 @@
           "properties": {
             "dry": {
               "description": "~",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false
             },
             "force": {
               "description": "Build all projects, including those that appear to be up to date",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Build all projects, including those that appear to be up to date\n\nSee more: https://www.typescriptlang.org/tsconfig#force"
             },
             "verbose": {
               "description": "Enable verbose logging",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable verbose logging\n\nSee more: https://www.typescriptlang.org/tsconfig#verbose"
             },
             "incremental": {
               "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "traceResolution": {
               "description": "Log paths used during the `moduleResolution` process.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Log paths used during the `moduleResolution` process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
             }
@@ -156,48 +165,55 @@
     "watchOptionsDefinition": {
       "properties": {
         "watchOptions": {
-          "type": "object",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["object", "null"],
           "description": "Settings for the watch mode in TypeScript.",
           "properties": {
             "force": {
               "description": "~",
-              "type": "string"
+              "type": ["string", "null"]
             },
             "watchFile": {
               "description": "Specify how the TypeScript watch mode works.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify how the TypeScript watch mode works.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchFile"
             },
             "watchDirectory": {
               "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify how directories are watched on systems that lack recursive file-watching functionality.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchDirectory"
             },
             "fallbackPolling": {
               "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify what approach the watcher should use if the system runs out of native file watchers.\n\nSee more: https://www.typescriptlang.org/tsconfig#fallbackPolling"
             },
             "synchronousWatchDirectory": {
               "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.\n\nSee more: https://www.typescriptlang.org/tsconfig#synchronousWatchDirectory"
             },
             "excludeFiles": {
               "description": "Remove a list of files from the watch mode's processing.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Remove a list of files from the watch mode's processing.\n\nSee more: https://www.typescriptlang.org/tsconfig#excludeFiles"
             },
             "excludeDirectories": {
               "description": "Remove a list of directories from the watch process.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Remove a list of directories from the watch process.\n\nSee more: https://www.typescriptlang.org/tsconfig#excludeDirectories"
             }
@@ -208,86 +224,100 @@
     "compilerOptionsDefinition": {
       "properties": {
         "compilerOptions": {
-          "type": "object",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["object", "null"],
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "allowArbitraryExtensions": {
               "description": "Enable importing files with any extension, provided a declaration file is present.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enable importing files with any extension, provided a declaration file is present.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "allowImportingTsExtensions": {
               "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "charset": {
               "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
               "description": "Enable constraints that allow a TypeScript project to be used with project references.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable constraints that allow a TypeScript project to be used with project references.\n\nSee more: https://www.typescriptlang.org/tsconfig#composite"
             },
             "customConditions": {
               "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Conditions to set in addition to the resolver-specific defaults when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#customConditions"
             },
             "declaration": {
               "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Generate .d.ts files from TypeScript and JavaScript files in your project.\n\nSee more: https://www.typescriptlang.org/tsconfig#declaration"
             },
             "declarationDir": {
               "description": "Specify the output directory for generated declaration files.",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
               "description": "Output compiler performance information after building.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
               "description": "Reduce the number of projects loaded automatically by TypeScript.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Reduce the number of projects loaded automatically by TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad"
             },
             "noPropertyAccessFromIndexSignature": {
               "description": "Enforces using indexed accessors for keys declared using an indexed type",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enforces using indexed accessors for keys declared using an indexed type\n\nSee more: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature"
             },
             "emitBOM": {
               "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitBOM"
             },
             "emitDeclarationOnly": {
               "description": "Only output d.ts files and not JavaScript files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Only output d.ts files and not JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDeclarationOnly"
             },
             "exactOptionalPropertyTypes": {
               "description": "Differentiate between undefined and not present when type checking",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Differentiate between undefined and not present when type checking\n\nSee more: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes"
             },
             "incremental": {
               "description": "Enable incremental compilation. Requires TypeScript version 3.4 or later.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "tsBuildInfoFile": {
               "$comment": "The value of 'null' is UNDOCUMENTED.",
@@ -298,13 +328,15 @@
             },
             "inlineSourceMap": {
               "description": "Include sourcemap files inside the emitted JavaScript.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include sourcemap files inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSourceMap"
             },
             "inlineSources": {
               "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include source code in the sourcemaps inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSources"
             },
@@ -320,42 +352,49 @@
             },
             "reactNamespace": {
               "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "React",
               "markdownDescription": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.\n\nSee more: https://www.typescriptlang.org/tsconfig#reactNamespace"
             },
             "jsxFactory": {
               "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "React.createElement",
               "markdownDescription": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFactory"
             },
             "jsxFragmentFactory": {
               "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "React.Fragment",
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
               "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "react",
               "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
               "description": "Print all of the files read during the compilation.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print all of the files read during the compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listFiles"
             },
             "mapRoot": {
               "description": "Specify the location where debugger should locate map files instead of generated locations.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify the location where debugger should locate map files instead of generated locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#mapRoot"
             },
             "module": {
               "description": "Specify what module code is generated.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "anyOf": [
                 {
                   "enum": [
@@ -382,7 +421,8 @@
             },
             "moduleResolution": {
               "description": "Specify how TypeScript looks up a file from a given module specifier.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "anyOf": [
                 {
                   "enum": [
@@ -410,7 +450,8 @@
             },
             "newLine": {
               "description": "Set the newline character for emitting files.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "anyOf": [
                 {
                   "enum": ["crlf", "lf"]
@@ -423,161 +464,189 @@
             },
             "noEmit": {
               "description": "Disable emitting file from a compilation.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting file from a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmit"
             },
             "noEmitHelpers": {
               "description": "Disable generating custom helper functions like `__extends` in compiled output.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable generating custom helper functions like `__extends` in compiled output.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitHelpers"
             },
             "noEmitOnError": {
               "description": "Disable emitting files if any type checking errors are reported.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting files if any type checking errors are reported.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitOnError"
             },
             "noImplicitAny": {
               "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
             },
             "noImplicitThis": {
               "description": "Enable error reporting when `this` is given the type `any`.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting when `this` is given the type `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitThis"
             },
             "noUnusedLocals": {
               "description": "Enable error reporting when a local variables aren't read.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting when a local variables aren't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
               "description": "Raise an error when a function parameter isn't read",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Raise an error when a function parameter isn't read\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedParameters"
             },
             "noLib": {
               "description": "Disable including any library files, including the default lib.d.ts.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable including any library files, including the default lib.d.ts.\n\nSee more: https://www.typescriptlang.org/tsconfig#noLib"
             },
             "noResolve": {
               "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.\n\nSee more: https://www.typescriptlang.org/tsconfig#noResolve"
             },
             "noStrictGenericChecks": {
               "description": "Disable strict checking of generic signatures in function types.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
             },
             "skipDefaultLibCheck": {
               "description": "Skip type checking .d.ts files that are included with TypeScript.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking .d.ts files that are included with TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck"
             },
             "skipLibCheck": {
               "description": "Skip type checking all .d.ts files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
               "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
               "description": "Specify an output folder for all emitted files.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify an output folder for all emitted files.\n\nSee more: https://www.typescriptlang.org/tsconfig#outDir"
             },
             "preserveConstEnums": {
               "description": "Disable erasing `const enum` declarations in generated code.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable erasing `const enum` declarations in generated code.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveConstEnums"
             },
             "preserveSymlinks": {
               "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveSymlinks"
             },
             "preserveValueImports": {
               "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Preserve unused imported values in the JavaScript output that would otherwise be removed\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveValueImports"
             },
             "preserveWatchOutput": {
               "description": "Disable wiping the console in watch mode",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable wiping the console in watch mode\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveWatchOutput"
             },
             "pretty": {
               "description": "Enable color and formatting in output to make compiler errors easier to read",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable color and formatting in output to make compiler errors easier to read\n\nSee more: https://www.typescriptlang.org/tsconfig#pretty"
             },
             "removeComments": {
               "description": "Disable emitting comments.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#removeComments"
             },
             "rootDir": {
               "description": "Specify the root folder within your source files.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify the root folder within your source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDir"
             },
             "isolatedModules": {
               "description": "Ensure that each file can be safely transpiled without relying on other imports.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that each file can be safely transpiled without relying on other imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedModules"
             },
             "sourceMap": {
               "description": "Create source map files for emitted JavaScript files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create source map files for emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceMap"
             },
             "sourceRoot": {
               "description": "Specify the root path for debuggers to find the reference source code.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify the root path for debuggers to find the reference source code.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceRoot"
             },
             "suppressExcessPropertyErrors": {
               "description": "Disable reporting of excess property errors during the creation of object literals.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
               "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
               "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable emitting declarations that have `@internal` in their JSDoc comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#stripInternal"
             },
             "target": {
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "ES3",
               "anyOf": [
                 {
@@ -605,13 +674,14 @@
             },
             "useUnknownInCatchVariables": {
               "description": "Default catch clause variables as `unknown` instead of `any`.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Default catch clause variables as `unknown` instead of `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables"
             },
             "watch": {
               "description": "Watch input files.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "fallbackPolling": {
               "description": "Specify the polling strategy to use when the system runs out of or doesn't support native file watchers. Requires TypeScript version 3.8 or later.",
@@ -649,72 +719,86 @@
             },
             "experimentalDecorators": {
               "description": "Enable experimental support for TC39 stage 2 draft decorators.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Enable experimental support for TC39 stage 2 draft decorators.\n\nSee more: https://www.typescriptlang.org/tsconfig#experimentalDecorators"
             },
             "emitDecoratorMetadata": {
               "description": "Emit design-type metadata for decorated declarations in source files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata"
             },
             "allowUnusedLabels": {
               "description": "Disable error reporting for unused labels.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unused labels.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnusedLabels"
             },
             "noImplicitReturns": {
               "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for codepaths that do not explicitly return in a function.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitReturns"
             },
             "noUncheckedIndexedAccess": {
               "description": "Add `undefined` to a type when accessed using an index.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Add `undefined` to a type when accessed using an index.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess"
             },
             "noFallthroughCasesInSwitch": {
               "description": "Enable error reporting for fallthrough cases in switch statements.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for fallthrough cases in switch statements.\n\nSee more: https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch"
             },
             "noImplicitOverride": {
               "description": "Ensure overriding members in derived classes are marked with an override modifier.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure overriding members in derived classes are marked with an override modifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitOverride"
             },
             "allowUnreachableCode": {
               "description": "Disable error reporting for unreachable code.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unreachable code.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnreachableCode"
             },
             "forceConsistentCasingInFileNames": {
               "description": "Ensure that casing is correct in imports.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
               "description": "Emit a v8 CPU profile of the compiler run for debugging.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "default": "profile.cpuprofile",
               "markdownDescription": "Emit a v8 CPU profile of the compiler run for debugging.\n\nSee more: https://www.typescriptlang.org/tsconfig#generateCpuProfile"
             },
             "baseUrl": {
               "description": "Specify the base directory to resolve non-relative module names.",
-              "type": "string",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["string", "null"],
               "markdownDescription": "Specify the base directory to resolve non-relative module names.\n\nSee more: https://www.typescriptlang.org/tsconfig#baseUrl"
             },
             "paths": {
               "description": "Specify a set of entries that re-map imports to additional lookup locations.",
-              "type": "object",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["object", "null"],
               "additionalProperties": {
-                "type": "array",
+                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "type": ["array", "null"],
                 "uniqueItems": true,
                 "items": {
-                  "type": "string",
+                  "$comment": "The value of 'null' is UNDOCUMENTED.",
+                  "type": ["string", "null"],
                   "description": "Path mapping to be computed relative to baseUrl option."
                 }
               },
@@ -722,13 +806,15 @@
             },
             "plugins": {
               "description": "Specify a list of language service plugins to include.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "items": {
-                "type": "object",
+                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "type": ["object", "null"],
                 "properties": {
                   "name": {
                     "description": "Plugin name.",
-                    "type": "string"
+                    "type": ["string", "null"]
                   }
                 }
               },
@@ -736,77 +822,89 @@
             },
             "rootDirs": {
               "description": "Allow multiple folders to be treated as one when resolving modules.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Allow multiple folders to be treated as one when resolving modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDirs"
             },
             "typeRoots": {
               "description": "Specify multiple folders that act like `./node_modules/@types`.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Specify multiple folders that act like `./node_modules/@types`.\n\nSee more: https://www.typescriptlang.org/tsconfig#typeRoots"
             },
             "types": {
               "description": "Specify type package names to be included without being referenced in a source file.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
               "markdownDescription": "Specify type package names to be included without being referenced in a source file.\n\nSee more: https://www.typescriptlang.org/tsconfig#types"
             },
             "traceResolution": {
               "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false
             },
             "allowJs": {
               "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowJs"
             },
             "noErrorTruncation": {
               "description": "Disable truncating types in error messages.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
               "description": "Allow 'import x from y' when a module doesn't have a default export.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Allow 'import x from y' when a module doesn't have a default export.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports"
             },
             "noImplicitUseStrict": {
               "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable adding 'use strict' directives in emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitUseStrict"
             },
             "listEmittedFiles": {
               "description": "Print the names of emitted files after a compilation.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print the names of emitted files after a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listEmittedFiles"
             },
             "disableSizeLimit": {
               "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSizeLimit"
             },
             "lib": {
               "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string",
+                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "type": ["string", "null"],
                 "anyOf": [
                   {
                     "enum": [
@@ -945,19 +1043,22 @@
             },
             "strictNullChecks": {
               "description": "When type checking, take into account `null` and `undefined`.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
               "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
-              "type": "number",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["number", "null"],
               "default": 0,
               "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
               "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow importing helper functions from tslib once per project, instead of including them per-file.\n\nSee more: https://www.typescriptlang.org/tsconfig#importHelpers"
             },
@@ -968,120 +1069,139 @@
             },
             "alwaysStrict": {
               "description": "Ensure 'use strict' is always emitted.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Ensure 'use strict' is always emitted.\n\nSee more: https://www.typescriptlang.org/tsconfig#alwaysStrict"
             },
             "strict": {
               "description": "Enable all strict type checking options.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable all strict type checking options.\n\nSee more: https://www.typescriptlang.org/tsconfig#strict"
             },
             "strictBindCallApply": {
               "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBindCallApply"
             },
             "downlevelIteration": {
               "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit more compliant, but verbose and less performant JavaScript for iteration.\n\nSee more: https://www.typescriptlang.org/tsconfig#downlevelIteration"
             },
             "checkJs": {
               "description": "Enable error reporting in type-checked JavaScript files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
             },
             "strictFunctionTypes": {
               "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictFunctionTypes"
             },
             "strictPropertyInitialization": {
               "description": "Check for class properties that are declared but not set in the constructor.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
               "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
               "description": "Allow accessing UMD globals from modules.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow accessing UMD globals from modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUmdGlobalAccess"
             },
             "keyofStringsOnly": {
               "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {
               "description": "Emit ECMAScript-standard-compliant class fields.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit ECMAScript-standard-compliant class fields.\n\nSee more: https://www.typescriptlang.org/tsconfig#useDefineForClassFields"
             },
             "declarationMap": {
               "description": "Create sourcemaps for d.ts files.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create sourcemaps for d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationMap"
             },
             "resolveJsonModule": {
               "description": "Enable importing .json files",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable importing .json files\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
               "description": "Use the package.json 'exports' field when resolving package imports.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
               "description": "Use the package.json 'imports' field when resolving imports.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'imports' field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in '--incremental' and '--watch' assume that changes within a file will only affect files directly depending on it. Requires TypeScript version 3.8 or later.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "extendedDiagnostics": {
               "description": "Output more detailed compiler performance information after building.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Output more detailed compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#extendedDiagnostics"
             },
             "listFilesOnly": {
               "description": "Print names of files that are part of the compilation and then stop processing.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "disableSourceOfProjectReferenceRedirect": {
               "description": "Disable preferring source files instead of declaration files when referencing composite projects",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Disable preferring source files instead of declaration files when referencing composite projects\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSourceOfProjectReferenceRedirect"
             },
             "disableSolutionSearching": {
               "description": "Opt a project out of multi-project reference checking when editing.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Opt a project out of multi-project reference checking when editing.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSolutionSearching"
             },
             "verbatimModuleSyntax": {
               "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "markdownDescription": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.\n\nSee more: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax"
             }
           }
@@ -1091,28 +1211,32 @@
     "typeAcquisitionDefinition": {
       "properties": {
         "typeAcquisition": {
-          "type": "object",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["object", "null"],
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
           "properties": {
             "enable": {
               "description": "Enable auto type acquisition",
-              "type": "boolean",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["boolean", "null"],
               "default": false
             },
             "include": {
               "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               }
             },
             "exclude": {
               "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
-              "type": "array",
+              "$comment": "The value of 'null' is UNDOCUMENTED.",
+              "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               }
             }
           }
@@ -1122,15 +1246,18 @@
     "referencesDefinition": {
       "properties": {
         "references": {
-          "type": "array",
+          "$comment": "The value of 'null' is UNDOCUMENTED.",
+          "type": ["array", "null"],
           "uniqueItems": true,
           "description": "Referenced projects. Requires TypeScript version 3.0 or later.",
           "items": {
-            "type": "object",
+            "$comment": "The value of 'null' is UNDOCUMENTED.",
+            "type": ["object", "null"],
             "description": "Project reference.",
             "properties": {
               "path": {
-                "type": "string",
+                "$comment": "The value of 'null' is UNDOCUMENTED.",
+                "type": ["string", "null"],
                 "description": "Path to referenced tsconfig or to folder containing tsconfig."
               }
             }
@@ -1139,7 +1266,7 @@
       }
     },
     "tsNodeModuleTypes": {
-      "type": "object"
+      "type": ["object", "null"]
     },
     "tsNodeDefinition": {
       "properties": {
@@ -1149,12 +1276,12 @@
             "compiler": {
               "default": "typescript",
               "description": "Specify a custom TypeScript compiler.",
-              "type": "string"
+              "type": ["string", "null"]
             },
             "compilerHost": {
               "default": false,
               "description": "Use TypeScript's compiler host API instead of the language service API.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "compilerOptions": {
               "additionalProperties": true,
@@ -1165,54 +1292,54 @@
               ],
               "description": "JSON object to merge with TypeScript `compilerOptions`.",
               "properties": {},
-              "type": "object"
+              "type": ["object", "null"]
             },
             "emit": {
               "default": false,
               "description": "Emit output files into `.ts-node` directory.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "esm": {
               "description": "Enable native ESM support.\n\nFor details, see https://typestrong.org/ts-node/docs/imports#native-ecmascript-modules",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "experimentalReplAwait": {
               "description": "Allows the usage of top level await in REPL.\n\nUses node's implementation which accomplishes this with an AST syntax transformation.\n\nEnabled by default when tsconfig target is es2018 or above. Set to false to disable.\n\n**Note**: setting to `true` when tsconfig target is too low will throw an Error.  Leave as `undefined`\nto get default, automatic behavior.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "experimentalResolver": {
               "description": "Enable experimental features that re-map imports and require calls to support:\n`baseUrl`, `paths`, `rootDirs`, `.js` to `.ts` file extension mappings,\n`outDir` to `rootDir` mappings for composite projects and monorepos.\n\nFor details, see https://github.com/TypeStrong/ts-node/issues/1514",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "experimentalSpecifierResolution": {
               "description": "Like node's `--experimental-specifier-resolution`, , but can also be set in your `tsconfig.json` for convenience.\n\nFor details, see https://nodejs.org/dist/latest-v18.x/docs/api/esm.html#customizing-esm-specifier-resolution-algorithm",
               "enum": ["explicit", "node"],
-              "type": "string"
+              "type": ["string", "null"]
             },
             "files": {
               "default": false,
               "description": "Load \"files\" and \"include\" from `tsconfig.json` on startup.\n\nDefault is to override `tsconfig.json` \"files\" and \"include\" to only include the entrypoint script.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "ignore": {
               "default": ["(?:^|/)node_modules/"],
               "description": "Paths which should not be compiled.\n\nEach string in the array is converted to a regular expression via `new RegExp()` and tested against source paths prior to compilation.\n\nSource paths are normalized to posix-style separators, relative to the directory containing `tsconfig.json` or to cwd if no `tsconfig.json` is loaded.\n\nDefault is to ignore all node_modules subdirectories.",
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
-              "type": "array"
+              "type": ["array", "null"]
             },
             "ignoreDiagnostics": {
               "description": "Ignore TypeScript warnings by diagnostic code.",
               "items": {
                 "type": ["string", "number"]
               },
-              "type": "array"
+              "type": ["array", "null"]
             },
             "logError": {
               "default": false,
               "description": "Logs TypeScript errors to stderr instead of throwing exceptions.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "moduleTypes": {
               "$ref": "#/definitions/tsNodeModuleTypes",
@@ -1221,62 +1348,62 @@
             "preferTsExts": {
               "default": false,
               "description": "Re-order file extensions so that TypeScript imports are preferred.\n\nFor example, when both `index.js` and `index.ts` exist, enabling this option causes `require('./index')` to resolve to `index.ts` instead of `index.js`",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "pretty": {
               "default": false,
               "description": "Use pretty diagnostic formatter.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "require": {
               "description": "Modules to require, like node's `--require` flag.\n\nIf specified in `tsconfig.json`, the modules will be resolved relative to the `tsconfig.json` file.\n\nIf specified programmatically, each input string should be pre-resolved to an absolute path for\nbest results.",
               "items": {
-                "type": "string"
+                "type": ["string", "null"]
               },
-              "type": "array"
+              "type": ["array", "null"]
             },
             "scope": {
               "default": false,
               "description": "Scope compiler to files within `scopeDir`.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "scopeDir": {
               "default": "First of: `tsconfig.json` \"rootDir\" if specified, directory containing `tsconfig.json`, or cwd if no `tsconfig.json` is loaded.",
-              "type": "string"
+              "type": ["string", "null"]
             },
             "skipIgnore": {
               "default": false,
               "description": "Skip ignore check, so that compilation will be attempted for all files with matching extensions.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "swc": {
               "description": "Transpile with swc instead of the TypeScript compiler, and skip typechecking.\n\nEquivalent to setting both `transpileOnly: true` and `transpiler: 'ts-node/transpilers/swc'`\n\nFor complete instructions: https://typestrong.org/ts-node/docs/transpilers",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "transpileOnly": {
               "default": false,
               "description": "Use TypeScript's faster `transpileModule`.",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             },
             "transpiler": {
               "anyOf": [
                 {
                   "items": [
                     {
-                      "type": "string"
+                      "type": ["string", "null"]
                     },
                     {
                       "additionalProperties": true,
                       "properties": {},
-                      "type": "object"
+                      "type": ["object", "null"]
                     }
                   ],
                   "maxItems": 2,
                   "minItems": 2,
-                  "type": "array"
+                  "type": ["array", "null"]
                 },
                 {
-                  "type": "string"
+                  "type": ["string", "null"]
                 }
               ],
               "description": "Specify a custom transpiler for use with transpileOnly"
@@ -1284,10 +1411,10 @@
             "typeCheck": {
               "default": true,
               "description": "**DEPRECATED** Specify type-check is enabled (e.g. `transpileOnly == false`).",
-              "type": "boolean"
+              "type": ["boolean", "null"]
             }
           },
-          "type": "object"
+          "type": ["object", "null"]
         }
       }
     }

--- a/src/test/jsconfig/jsconfig-extends-single.json
+++ b/src/test/jsconfig/jsconfig-extends-single.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "module": null
 }

--- a/src/test/tsconfig/tsconfig-extends-single.json
+++ b/src/test/tsconfig/tsconfig-extends-single.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./tsconfig-test.json"
+  "extends": "./tsconfig-test.json",
+  "module": null
 }


### PR DESCRIPTION
tsconfig.json files allow setting any value to `null`. See https://github.com/microsoft/TypeScript/pull/18058.

Added in 2017, this feature is still in the TypeScript compiler’s source code today (e.g. [1](https://github.com/microsoft/TypeScript/blob/316f1805f3ed740f7f04b359eb86428342a2f378/src/compiler/commandLineParser.ts#L1882-L1885), [2](https://github.com/microsoft/TypeScript/blob/316f1805f3ed740f7f04b359eb86428342a2f378/src/compiler/commandLineParser.ts#L1907)). There are also tests for this behavior ([example](https://github.com/microsoft/TypeScript/blob/316f1805f3ed740f7f04b359eb86428342a2f378/tests/baselines/reference/config/commandLineParsing/parseCommandLine/option%20of%20type%20string%20allows%20setting%20it%20to%20null.js)).

Related to https://github.com/SchemaStore/schemastore/commit/1602f19a7b0e8b649e07c7a8e41eacdbbf49c1e8 (https://github.com/SchemaStore/schemastore/pull/3367).