### PR TITLE
Add missing ignore entry for `declaration-empty-line-before` in style…

### DIFF
--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -1384,6 +1384,7 @@
                           "enum": [
                             "after-comment",
                             "after-declaration",
+                            "first-nested",
                             "inside-single-line-block"
                           ]
                         }


### PR DESCRIPTION
…lint

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Add the missing `"first-nested"` in the rule `declaration-empty-line-before` in Stylelint.

Reference:
1. https://stylelint.io/user-guide/rules/declaration-empty-line-before/#ignore-after-comment-after-declaration-first-nested-inside-single-line-block
2. https://github.com/stylelint/stylelint/pull/3103
