### PR TITLE
Add edition 2024 to the schema for Cargo.toml

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -212,7 +212,7 @@
       "title": "Edition",
       "description": "The `edition` key affects which edition your package is compiled with. Cargo\nwill always generate packages via [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html) with the `edition` key set to the\nlatest edition. Setting the `edition` key in `[package]` will affect all\ntargets/crates in the package, including test suites, benchmarks, binaries,\nexamples, etc.",
       "type": "string",
-      "enum": ["2015", "2018", "2021"],
+      "enum": ["2015", "2018", "2021", "2024"],
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/stable/edition-guide/introduction.html"


### PR DESCRIPTION
This is a very small change that adds `"2024"` to the list of valid values for the `edition` field.

---

This year, approximately in October, Rust will add the 2024 edition to the stable channel. It is already available to those using the nightly channel.

Instructions on how to use the 2024 edition now: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024

Guide to the 2024 edition: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
