### PR TITLE
Copy latest eslint partial from `jsonschema-extractor`

### DIFF
--- a/src/schemas/json/partial-eslint-plugins.json
+++ b/src/schemas/json/partial-eslint-plugins.json
@@ -13,10 +13,92 @@
       "description": "ESLint rule\n\n\"off\" - turns the rule off\n\"warn\" - turn the rule on as a warning (doesn't affect exit code)\n\"error\" - turn the rule on as an error (exit code is 1 when triggered)\n",
       "type": "string",
       "enum": ["off", "warn", "error"]
+    },
+    "pluginNames": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "enum": [
+              "eslint-plugin-jsx-a11y",
+              "eslint-plugin-jest",
+              "eslint-plugin-react",
+              "eslint-plugin-import",
+              "eslint-plugin-unused-imports",
+              "eslint-plugin-react-hooks",
+              "eslint-plugin-unicorn",
+              "eslint-plugin-security",
+              "eslint-plugin-prettier",
+              "eslint-plugin-ft-flow",
+              "eslint-plugin-cypress",
+              "eslint-plugin-regexp",
+              "eslint-plugin-eslint-plugin",
+              "eslint-plugin-mocha",
+              "eslint-plugin-qunit",
+              "eslint-plugin-ember",
+              "eslint-plugin-no-only-tests",
+              "eslint-plugin-jsdoc",
+              "eslint-plugin-react-native",
+              "@tanstack/eslint-plugin-query",
+              "eslint-plugin-testing-library",
+              "eslint-plugin-canonical",
+              "eslint-plugin-chai-friendly",
+              "eslint-plugin-vue",
+              "eslint-plugin-jest-formatting",
+              "eslint-plugin-promise",
+              "eslint-plugin-html",
+              "eslint-plugin-local-rules",
+              "eslint-plugin-i18next",
+              "eslint-plugin-you-dont-need-lodash-underscore",
+              "eslint-plugin-yml",
+              "eslint-plugin-react-redux",
+              "eslint-plugin-simple-import-sort",
+              "eslint-plugin-react-perf",
+              "eslint-plugin-tsdoc",
+              "@next/eslint-plugin-next",
+              "eslint-plugin-jest-dom",
+              "eslint-plugin-es-x",
+              "eslint-plugin-flowtype",
+              "eslint-plugin-babel",
+              "eslint-plugin-react-native-a11y",
+              "eslint-plugin-n",
+              "eslint-plugin-jasmine",
+              "eslint-plugin-prefer-arrow",
+              "@rushstack/eslint-plugin-security",
+              "eslint-plugin-lit-a11y",
+              "eslint-plugin-deprecation",
+              "eslint-plugin-nuxt",
+              "eslint-plugin-compat",
+              "eslint-plugin-sort-exports",
+              "eslint-plugin-perfectionist",
+              "eslint-plugin-sonarjs",
+              "eslint-plugin-i",
+              "eslint-plugin-check-file",
+              "eslint-plugin-sort-keys-fix",
+              "eslint-plugin-vuejs-accessibility",
+              "eslint-plugin-typescript-sort-keys",
+              "eslint-plugin-tailwindcss",
+              "eslint-plugin-playwright",
+              "eslint-plugin-jsonc",
+              "eslint-plugin-react-refresh",
+              "eslint-plugin-eslint-comments",
+              "eslint-plugin-css-modules",
+              "@angular-eslint/eslint-plugin-template",
+              "eslint-plugin-es",
+              "eslint-plugin-sort-class-members",
+              "eslint-plugin-header"
+            ]
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "uniqueItems": true
     }
   },
   "properties": {
-    "angular-eslint/component-class-suffix": {
+    "@angular-eslint/component-class-suffix": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -56,7 +138,7 @@
       ],
       "description": "Classes decorated with @Component must have suffix \"Component\" (or custom) in their name. See more at https://angular.io/styleguide#style-02-03\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/component-class-suffix.md"
     },
-    "angular-eslint/component-max-inline-declarations": {
+    "@angular-eslint/component-max-inline-declarations": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -102,7 +184,7 @@
       ],
       "description": "Enforces a maximum number of lines in inline template, styles and animations. See more at https://angular.io/guide/styleguide#style-05-04\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/component-max-inline-declarations.md"
     },
-    "angular-eslint/component-selector": {
+    "@angular-eslint/component-selector": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -164,13 +246,13 @@
       ],
       "description": "Component selectors should follow given naming rules. See more at https://angular.io/guide/styleguide#style-02-07, https://angular.io/guide/styleguide#style-05-02\n      and https://angular.io/guide/styleguide#style-05-03.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/component-selector.md"
     },
-    "angular-eslint/contextual-decorator": {
+    "@angular-eslint/contextual-decorator": {
       "description": "Ensures that classes use contextual decorators in its body\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/contextual-decorator.md"
     },
-    "angular-eslint/contextual-lifecycle": {
+    "@angular-eslint/contextual-lifecycle": {
       "description": "Ensures that lifecycle methods are used in a correct context\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/contextual-lifecycle.md"
     },
-    "angular-eslint/directive-class-suffix": {
+    "@angular-eslint/directive-class-suffix": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -210,7 +292,7 @@
       ],
       "description": "Classes decorated with @Directive must have suffix \"Directive\" (or custom) in their name. See more at https://angular.io/styleguide#style-02-03\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/directive-class-suffix.md"
     },
-    "angular-eslint/directive-selector": {
+    "@angular-eslint/directive-selector": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -272,19 +354,19 @@
       ],
       "description": "Directive selectors should follow given naming rules. See more at https://angular.io/guide/styleguide#style-02-06 and https://angular.io/guide/styleguide#style-02-08.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/directive-selector.md"
     },
-    "angular-eslint/no-attribute-decorator": {
+    "@angular-eslint/no-attribute-decorator": {
       "description": "The @Attribute decorator is used to obtain a single value for an attribute. This is a much less common use-case than getting a stream of values (using @Input), so often the @Attribute decorator is mistakenly used when @Input was what was intended. This rule disallows usage of @Attribute decorator altogether in order to prevent these mistakes.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-attribute-decorator.md"
     },
-    "angular-eslint/no-conflicting-lifecycle": {
+    "@angular-eslint/no-conflicting-lifecycle": {
       "description": "Ensures that directives not implement conflicting lifecycle interfaces.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-conflicting-lifecycle.md"
     },
-    "angular-eslint/no-empty-lifecycle-method": {
+    "@angular-eslint/no-empty-lifecycle-method": {
       "description": "Disallows declaring empty lifecycle methods\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-empty-lifecycle-method.md"
     },
-    "angular-eslint/no-forward-ref": {
+    "@angular-eslint/no-forward-ref": {
       "description": "Disallows usage of `forwardRef` references for DI\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-forward-ref.md"
     },
-    "angular-eslint/no-host-metadata-property": {
+    "@angular-eslint/no-host-metadata-property": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -322,7 +404,7 @@
       ],
       "description": "Disallows usage of the `host` metadata property. See more at https://angular.io/styleguide#style-06-03\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-host-metadata-property.md"
     },
-    "angular-eslint/no-input-prefix": {
+    "@angular-eslint/no-input-prefix": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -362,7 +444,7 @@
       ],
       "description": "Ensures that input bindings, including aliases, are not named or prefixed by the configured disallowed prefixes\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-input-prefix.md"
     },
-    "angular-eslint/no-input-rename": {
+    "@angular-eslint/no-input-rename": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -404,31 +486,31 @@
       ],
       "description": "Ensures that input bindings are not aliased\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-input-rename.md"
     },
-    "angular-eslint/no-inputs-metadata-property": {
+    "@angular-eslint/no-inputs-metadata-property": {
       "description": "Disallows usage of the `inputs` metadata property. See more at https://angular.io/styleguide#style-05-12\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-inputs-metadata-property.md"
     },
-    "angular-eslint/no-lifecycle-call": {
+    "@angular-eslint/no-lifecycle-call": {
       "description": "Disallows explicit calls to lifecycle methods\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-lifecycle-call.md"
     },
-    "angular-eslint/no-output-native": {
+    "@angular-eslint/no-output-native": {
       "description": "Ensures that output bindings, including aliases, are not named as standard DOM events\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-output-native.md"
     },
-    "angular-eslint/no-output-on-prefix": {
+    "@angular-eslint/no-output-on-prefix": {
       "description": "Ensures that output bindings, including aliases, are not named \"on\", nor prefixed with it. See more at https://angular.io/guide/styleguide#style-05-16\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-output-on-prefix.md"
     },
-    "angular-eslint/no-output-rename": {
+    "@angular-eslint/no-output-rename": {
       "description": "Ensures that output bindings are not aliased\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-output-rename.md"
     },
-    "angular-eslint/no-outputs-metadata-property": {
+    "@angular-eslint/no-outputs-metadata-property": {
       "description": "Disallows usage of the `outputs` metadata property. See more at https://angular.io/styleguide#style-05-12\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-outputs-metadata-property.md"
     },
-    "angular-eslint/no-pipe-impure": {
+    "@angular-eslint/no-pipe-impure": {
       "description": "Disallows the declaration of impure pipes\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-pipe-impure.md"
     },
-    "angular-eslint/no-queries-metadata-property": {
+    "@angular-eslint/no-queries-metadata-property": {
       "description": "Disallows usage of the `queries` metadata property. See more at https://angular.io/styleguide#style-05-12.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/no-queries-metadata-property.md"
     },
-    "angular-eslint/pipe-prefix": {
+    "@angular-eslint/pipe-prefix": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -469,19 +551,19 @@
       ],
       "description": "Enforce consistent prefix for pipes.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/pipe-prefix.md"
     },
-    "angular-eslint/prefer-on-push-component-change-detection": {
+    "@angular-eslint/prefer-on-push-component-change-detection": {
       "description": "Ensures component's `changeDetection` is set to `ChangeDetectionStrategy.OnPush`\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-on-push-component-change-detection.md"
     },
-    "angular-eslint/prefer-standalone-component": {
+    "@angular-eslint/prefer-standalone-component": {
       "description": "Ensures component `standalone` property is set to `true` in the component decorator\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-standalone-component.md"
     },
-    "angular-eslint/prefer-output-readonly": {
+    "@angular-eslint/prefer-output-readonly": {
       "description": "Prefer to declare `@Output` as `readonly` since they are not supposed to be reassigned\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-output-readonly.md"
     },
-    "angular-eslint/relative-url-prefix": {
+    "@angular-eslint/relative-url-prefix": {
       "description": "The ./ and ../ prefix is standard syntax for relative URLs; don't depend on Angular's current ability to do without that prefix. See more at https://angular.io/styleguide#style-05-04\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/relative-url-prefix.md"
     },
-    "angular-eslint/require-localize-metadata": {
+    "@angular-eslint/require-localize-metadata": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -523,10 +605,10 @@
       ],
       "description": "Ensures that $localize tagged messages contain helpful metadata to aid with translations.\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/require-localize-metadata.md"
     },
-    "angular-eslint/sort-lifecycle-methods": {
+    "@angular-eslint/sort-lifecycle-methods": {
       "description": "Ensures that lifecycle methods are declared in order of execution\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/sort-lifecycle-methods.md"
     },
-    "angular-eslint/sort-ngmodule-metadata-arrays": {
+    "@angular-eslint/sort-ngmodule-metadata-arrays": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -565,13 +647,13 @@
       ],
       "description": "Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual scanning\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md"
     },
-    "angular-eslint/use-component-selector": {
+    "@angular-eslint/use-component-selector": {
       "description": "Component selector must be declared\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-component-selector.md"
     },
-    "angular-eslint/use-component-view-encapsulation": {
+    "@angular-eslint/use-component-view-encapsulation": {
       "description": "Disallows using `ViewEncapsulation.None`\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-component-view-encapsulation.md"
     },
-    "angular-eslint/use-injectable-provided-in": {
+    "@angular-eslint/use-injectable-provided-in": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -608,10 +690,10 @@
       ],
       "description": "Using the `providedIn` property makes `Injectables` tree-shakable\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md"
     },
-    "angular-eslint/use-lifecycle-interface": {
+    "@angular-eslint/use-lifecycle-interface": {
       "description": "Ensures that classes implement lifecycle interfaces corresponding to the declared lifecycle methods. See more at https://angular.io/styleguide#style-09-01\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-lifecycle-interface.md"
     },
-    "angular-eslint/use-pipe-transform-interface": {
+    "@angular-eslint/use-pipe-transform-interface": {
       "description": "Ensures that `Pipes` implement `PipeTransform` interface\nhttps://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-pipe-transform-interface.md"
     },
     "eslint-plugin-import/no-unresolved": {
@@ -9084,10 +9166,10 @@
     "eslint-plugin-vue/valid-v-text": {
       "description": "enforce valid `v-text` directives\nhttps://eslint.vuejs.org/rules/valid-v-text.html"
     },
-    "typescript-eslint/adjacent-overload-signatures": {
+    "@typescript-eslint/adjacent-overload-signatures": {
       "description": "Require that function overload signatures be consecutive\nhttps://typescript-eslint.io/rules/adjacent-overload-signatures"
     },
-    "typescript-eslint/array-type": {
+    "@typescript-eslint/array-type": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9127,10 +9209,10 @@
       ],
       "description": "Require consistently using either `T[]` or `Array<T>` for arrays\nhttps://typescript-eslint.io/rules/array-type"
     },
-    "typescript-eslint/await-thenable": {
+    "@typescript-eslint/await-thenable": {
       "description": "Disallow awaiting a value that is not a Thenable\nhttps://typescript-eslint.io/rules/await-thenable"
     },
-    "typescript-eslint/ban-ts-comment": {
+    "@typescript-eslint/ban-ts-comment": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9172,10 +9254,10 @@
       ],
       "description": "Disallow `@ts-<directive>` comments or require descriptions after directives\nhttps://typescript-eslint.io/rules/ban-ts-comment"
     },
-    "typescript-eslint/ban-tslint-comment": {
+    "@typescript-eslint/ban-tslint-comment": {
       "description": "Disallow `// tslint:<rule-flag>` comments\nhttps://typescript-eslint.io/rules/ban-tslint-comment"
     },
-    "typescript-eslint/ban-types": {
+    "@typescript-eslint/ban-types": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9216,7 +9298,7 @@
       ],
       "description": "Disallow certain types\nhttps://typescript-eslint.io/rules/ban-types"
     },
-    "typescript-eslint/block-spacing": {
+    "@typescript-eslint/block-spacing": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9249,7 +9331,7 @@
       ],
       "description": "Disallow or enforce spaces inside of blocks after opening block and before closing block\nhttps://typescript-eslint.io/rules/block-spacing"
     },
-    "typescript-eslint/brace-style": {
+    "@typescript-eslint/brace-style": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9282,7 +9364,7 @@
       ],
       "description": "Enforce consistent brace style for blocks\nhttps://typescript-eslint.io/rules/brace-style"
     },
-    "typescript-eslint/class-literal-property-style": {
+    "@typescript-eslint/class-literal-property-style": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9315,7 +9397,7 @@
       ],
       "description": "Enforce that literals on classes are exposed in a consistent style\nhttps://typescript-eslint.io/rules/class-literal-property-style"
     },
-    "typescript-eslint/class-methods-use-this": {
+    "@typescript-eslint/class-methods-use-this": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9379,10 +9461,10 @@
       ],
       "description": "Enforce that class methods utilize `this`\nhttps://typescript-eslint.io/rules/class-methods-use-this"
     },
-    "typescript-eslint/comma-dangle": {
+    "@typescript-eslint/comma-dangle": {
       "description": "Require or disallow trailing commas\nhttps://typescript-eslint.io/rules/comma-dangle"
     },
-    "typescript-eslint/comma-spacing": {
+    "@typescript-eslint/comma-spacing": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9424,7 +9506,7 @@
       ],
       "description": "Enforce consistent spacing before and after commas\nhttps://typescript-eslint.io/rules/comma-spacing"
     },
-    "typescript-eslint/consistent-generic-constructors": {
+    "@typescript-eslint/consistent-generic-constructors": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9457,7 +9539,7 @@
       ],
       "description": "Enforce specifying generic type arguments on type annotation or constructor name of a constructor call\nhttps://typescript-eslint.io/rules/consistent-generic-constructors"
     },
-    "typescript-eslint/consistent-indexed-object-style": {
+    "@typescript-eslint/consistent-indexed-object-style": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9490,7 +9572,7 @@
       ],
       "description": "Require or disallow the `Record` type\nhttps://typescript-eslint.io/rules/consistent-indexed-object-style"
     },
-    "typescript-eslint/consistent-type-assertions": {
+    "@typescript-eslint/consistent-type-assertions": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9523,7 +9605,7 @@
       ],
       "description": "Enforce consistent usage of type assertions\nhttps://typescript-eslint.io/rules/consistent-type-assertions"
     },
-    "typescript-eslint/consistent-type-definitions": {
+    "@typescript-eslint/consistent-type-definitions": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9556,7 +9638,7 @@
       ],
       "description": "Enforce type definitions to consistently use either `interface` or `type`\nhttps://typescript-eslint.io/rules/consistent-type-definitions"
     },
-    "typescript-eslint/consistent-type-exports": {
+    "@typescript-eslint/consistent-type-exports": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9593,7 +9675,7 @@
       ],
       "description": "Enforce consistent usage of type exports\nhttps://typescript-eslint.io/rules/consistent-type-exports"
     },
-    "typescript-eslint/consistent-type-imports": {
+    "@typescript-eslint/consistent-type-imports": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9638,10 +9720,10 @@
       ],
       "description": "Enforce consistent usage of type imports\nhttps://typescript-eslint.io/rules/consistent-type-imports"
     },
-    "typescript-eslint/default-param-last": {
+    "@typescript-eslint/default-param-last": {
       "description": "Enforce default parameters to be last\nhttps://typescript-eslint.io/rules/default-param-last"
     },
-    "typescript-eslint/dot-notation": {
+    "@typescript-eslint/dot-notation": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9695,7 +9777,7 @@
       ],
       "description": "Enforce dot notation whenever possible\nhttps://typescript-eslint.io/rules/dot-notation"
     },
-    "typescript-eslint/explicit-function-return-type": {
+    "@typescript-eslint/explicit-function-return-type": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9764,7 +9846,7 @@
       ],
       "description": "Require explicit return types on functions and class methods\nhttps://typescript-eslint.io/rules/explicit-function-return-type"
     },
-    "typescript-eslint/explicit-member-accessibility": {
+    "@typescript-eslint/explicit-member-accessibility": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9816,7 +9898,7 @@
       ],
       "description": "Require explicit accessibility modifiers on class properties and methods\nhttps://typescript-eslint.io/rules/explicit-member-accessibility"
     },
-    "typescript-eslint/explicit-module-boundary-types": {
+    "@typescript-eslint/explicit-module-boundary-types": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9873,10 +9955,10 @@
       ],
       "description": "Require explicit return and argument types on exported functions' and classes' public class methods\nhttps://typescript-eslint.io/rules/explicit-module-boundary-types"
     },
-    "typescript-eslint/func-call-spacing": {
+    "@typescript-eslint/func-call-spacing": {
       "description": "Require or disallow spacing between function identifiers and their invocations\nhttps://typescript-eslint.io/rules/func-call-spacing"
     },
-    "typescript-eslint/indent": {
+    "@typescript-eslint/indent": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9909,10 +9991,10 @@
       ],
       "description": "Enforce consistent indentation\nhttps://typescript-eslint.io/rules/indent"
     },
-    "typescript-eslint/init-declarations": {
+    "@typescript-eslint/init-declarations": {
       "description": "Require or disallow initialization in variable declarations\nhttps://typescript-eslint.io/rules/init-declarations"
     },
-    "typescript-eslint/key-spacing": {
+    "@typescript-eslint/key-spacing": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -9945,7 +10027,7 @@
       ],
       "description": "Enforce consistent spacing between property names and type annotations in types and interfaces\nhttps://typescript-eslint.io/rules/key-spacing"
     },
-    "typescript-eslint/keyword-spacing": {
+    "@typescript-eslint/keyword-spacing": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -10821,7 +10903,7 @@
       ],
       "description": "Enforce consistent spacing before and after keywords\nhttps://typescript-eslint.io/rules/keyword-spacing"
     },
-    "typescript-eslint/lines-around-comment": {
+    "@typescript-eslint/lines-around-comment": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -10927,7 +11009,7 @@
       ],
       "description": "Require empty lines around comments\nhttps://typescript-eslint.io/rules/lines-around-comment"
     },
-    "typescript-eslint/lines-between-class-members": {
+    "@typescript-eslint/lines-between-class-members": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -10960,7 +11042,7 @@
       ],
       "description": "Require or disallow an empty line between class members\nhttps://typescript-eslint.io/rules/lines-between-class-members"
     },
-    "typescript-eslint/max-params": {
+    "@typescript-eslint/max-params": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11005,7 +11087,7 @@
       ],
       "description": "Enforce a maximum number of parameters in function definitions\nhttps://typescript-eslint.io/rules/max-params"
     },
-    "typescript-eslint/member-delimiter-style": {
+    "@typescript-eslint/member-delimiter-style": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11071,7 +11153,7 @@
       ],
       "description": "Require a specific member delimiter style for interfaces and type literals\nhttps://typescript-eslint.io/rules/member-delimiter-style"
     },
-    "typescript-eslint/member-ordering": {
+    "@typescript-eslint/member-ordering": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11110,7 +11192,7 @@
       ],
       "description": "Require a consistent member declaration order\nhttps://typescript-eslint.io/rules/member-ordering"
     },
-    "typescript-eslint/method-signature-style": {
+    "@typescript-eslint/method-signature-style": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11143,13 +11225,13 @@
       ],
       "description": "Enforce using a particular method signature syntax\nhttps://typescript-eslint.io/rules/method-signature-style"
     },
-    "typescript-eslint/naming-convention": {
+    "@typescript-eslint/naming-convention": {
       "description": "Enforce naming conventions for everything across a codebase\nhttps://typescript-eslint.io/rules/naming-convention"
     },
-    "typescript-eslint/no-array-constructor": {
+    "@typescript-eslint/no-array-constructor": {
       "description": "Disallow generic `Array` constructors\nhttps://typescript-eslint.io/rules/no-array-constructor"
     },
-    "typescript-eslint/no-base-to-string": {
+    "@typescript-eslint/no-base-to-string": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11189,10 +11271,10 @@
       ],
       "description": "Require `.toString()` to only be called on objects which provide useful information when stringified\nhttps://typescript-eslint.io/rules/no-base-to-string"
     },
-    "typescript-eslint/no-confusing-non-null-assertion": {
+    "@typescript-eslint/no-confusing-non-null-assertion": {
       "description": "Disallow non-null assertion in locations that may be confusing\nhttps://typescript-eslint.io/rules/no-confusing-non-null-assertion"
     },
-    "typescript-eslint/no-confusing-void-expression": {
+    "@typescript-eslint/no-confusing-void-expression": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11232,13 +11314,13 @@
       ],
       "description": "Require expressions of type void to appear in statement position\nhttps://typescript-eslint.io/rules/no-confusing-void-expression"
     },
-    "typescript-eslint/no-dupe-class-members": {
+    "@typescript-eslint/no-dupe-class-members": {
       "description": "Disallow duplicate class members\nhttps://typescript-eslint.io/rules/no-dupe-class-members"
     },
-    "typescript-eslint/no-duplicate-enum-values": {
+    "@typescript-eslint/no-duplicate-enum-values": {
       "description": "Disallow duplicate enum member values\nhttps://typescript-eslint.io/rules/no-duplicate-enum-values"
     },
-    "typescript-eslint/no-duplicate-type-constituents": {
+    "@typescript-eslint/no-duplicate-type-constituents": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11278,10 +11360,10 @@
       ],
       "description": "Disallow duplicate constituents of union or intersection types\nhttps://typescript-eslint.io/rules/no-duplicate-type-constituents"
     },
-    "typescript-eslint/no-dynamic-delete": {
+    "@typescript-eslint/no-dynamic-delete": {
       "description": "Disallow using the `delete` operator on computed key expressions\nhttps://typescript-eslint.io/rules/no-dynamic-delete"
     },
-    "typescript-eslint/no-empty-function": {
+    "@typescript-eslint/no-empty-function": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11338,7 +11420,7 @@
       ],
       "description": "Disallow empty functions\nhttps://typescript-eslint.io/rules/no-empty-function"
     },
-    "typescript-eslint/no-empty-interface": {
+    "@typescript-eslint/no-empty-interface": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11375,7 +11457,7 @@
       ],
       "description": "Disallow the declaration of empty interfaces\nhttps://typescript-eslint.io/rules/no-empty-interface"
     },
-    "typescript-eslint/no-explicit-any": {
+    "@typescript-eslint/no-explicit-any": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11417,16 +11499,16 @@
       ],
       "description": "Disallow the `any` type\nhttps://typescript-eslint.io/rules/no-explicit-any"
     },
-    "typescript-eslint/no-extra-non-null-assertion": {
+    "@typescript-eslint/no-extra-non-null-assertion": {
       "description": "Disallow extra non-null assertions\nhttps://typescript-eslint.io/rules/no-extra-non-null-assertion"
     },
-    "typescript-eslint/no-extra-parens": {
+    "@typescript-eslint/no-extra-parens": {
       "description": "Disallow unnecessary parentheses\nhttps://typescript-eslint.io/rules/no-extra-parens"
     },
-    "typescript-eslint/no-extra-semi": {
+    "@typescript-eslint/no-extra-semi": {
       "description": "Disallow unnecessary semicolons\nhttps://typescript-eslint.io/rules/no-extra-semi"
     },
-    "typescript-eslint/no-extraneous-class": {
+    "@typescript-eslint/no-extraneous-class": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11476,7 +11558,7 @@
       ],
       "description": "Disallow classes used as namespaces\nhttps://typescript-eslint.io/rules/no-extraneous-class"
     },
-    "typescript-eslint/no-floating-promises": {
+    "@typescript-eslint/no-floating-promises": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11518,16 +11600,16 @@
       ],
       "description": "Require Promise-like statements to be handled appropriately\nhttps://typescript-eslint.io/rules/no-floating-promises"
     },
-    "typescript-eslint/no-for-in-array": {
+    "@typescript-eslint/no-for-in-array": {
       "description": "Disallow iterating over an array with a for-in loop\nhttps://typescript-eslint.io/rules/no-for-in-array"
     },
-    "typescript-eslint/no-implied-eval": {
+    "@typescript-eslint/no-implied-eval": {
       "description": "Disallow the use of `eval()`-like methods\nhttps://typescript-eslint.io/rules/no-implied-eval"
     },
-    "typescript-eslint/no-import-type-side-effects": {
+    "@typescript-eslint/no-import-type-side-effects": {
       "description": "Enforce the use of top-level import type qualifier when an import only has specifiers with inline type qualifiers\nhttps://typescript-eslint.io/rules/no-import-type-side-effects"
     },
-    "typescript-eslint/no-inferrable-types": {
+    "@typescript-eslint/no-inferrable-types": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11567,7 +11649,7 @@
       ],
       "description": "Disallow explicit type declarations for variables or parameters initialized to a number, string, or boolean\nhttps://typescript-eslint.io/rules/no-inferrable-types"
     },
-    "typescript-eslint/no-invalid-this": {
+    "@typescript-eslint/no-invalid-this": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11605,7 +11687,7 @@
       ],
       "description": "Disallow `this` keywords outside of classes or class-like objects\nhttps://typescript-eslint.io/rules/no-invalid-this"
     },
-    "typescript-eslint/no-invalid-void-type": {
+    "@typescript-eslint/no-invalid-void-type": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11656,13 +11738,13 @@
       ],
       "description": "Disallow `void` type outside of generic or return types\nhttps://typescript-eslint.io/rules/no-invalid-void-type"
     },
-    "typescript-eslint/no-loop-func": {
+    "@typescript-eslint/no-loop-func": {
       "description": "Disallow function declarations that contain unsafe references inside loop statements\nhttps://typescript-eslint.io/rules/no-loop-func"
     },
-    "typescript-eslint/no-loss-of-precision": {
+    "@typescript-eslint/no-loss-of-precision": {
       "description": "Disallow literal numbers that lose precision\nhttps://typescript-eslint.io/rules/no-loss-of-precision"
     },
-    "typescript-eslint/no-magic-numbers": {
+    "@typescript-eslint/no-magic-numbers": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11743,7 +11825,7 @@
       ],
       "description": "Disallow magic numbers\nhttps://typescript-eslint.io/rules/no-magic-numbers"
     },
-    "typescript-eslint/no-meaningless-void-operator": {
+    "@typescript-eslint/no-meaningless-void-operator": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11781,10 +11863,10 @@
       ],
       "description": "Disallow the `void` operator except when used to discard a value\nhttps://typescript-eslint.io/rules/no-meaningless-void-operator"
     },
-    "typescript-eslint/no-misused-new": {
+    "@typescript-eslint/no-misused-new": {
       "description": "Enforce valid definition of `new` and `constructor`\nhttps://typescript-eslint.io/rules/no-misused-new"
     },
-    "typescript-eslint/no-misused-promises": {
+    "@typescript-eslint/no-misused-promises": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11852,10 +11934,10 @@
       ],
       "description": "Disallow Promises in places not designed to handle them\nhttps://typescript-eslint.io/rules/no-misused-promises"
     },
-    "typescript-eslint/no-mixed-enums": {
+    "@typescript-eslint/no-mixed-enums": {
       "description": "Disallow enums from having both number and string members\nhttps://typescript-eslint.io/rules/no-mixed-enums"
     },
-    "typescript-eslint/no-namespace": {
+    "@typescript-eslint/no-namespace": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11897,16 +11979,16 @@
       ],
       "description": "Disallow TypeScript namespaces\nhttps://typescript-eslint.io/rules/no-namespace"
     },
-    "typescript-eslint/no-non-null-asserted-nullish-coalescing": {
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": {
       "description": "Disallow non-null assertions in the left operand of a nullish coalescing operator\nhttps://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing"
     },
-    "typescript-eslint/no-non-null-asserted-optional-chain": {
+    "@typescript-eslint/no-non-null-asserted-optional-chain": {
       "description": "Disallow non-null assertions after an optional chain expression\nhttps://typescript-eslint.io/rules/no-non-null-asserted-optional-chain"
     },
-    "typescript-eslint/no-non-null-assertion": {
+    "@typescript-eslint/no-non-null-assertion": {
       "description": "Disallow non-null assertions using the `!` postfix operator\nhttps://typescript-eslint.io/rules/no-non-null-assertion"
     },
-    "typescript-eslint/no-redeclare": {
+    "@typescript-eslint/no-redeclare": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -11946,16 +12028,16 @@
       ],
       "description": "Disallow variable redeclaration\nhttps://typescript-eslint.io/rules/no-redeclare"
     },
-    "typescript-eslint/no-redundant-type-constituents": {
+    "@typescript-eslint/no-redundant-type-constituents": {
       "description": "Disallow members of unions and intersections that do nothing or override type information\nhttps://typescript-eslint.io/rules/no-redundant-type-constituents"
     },
-    "typescript-eslint/no-require-imports": {
+    "@typescript-eslint/no-require-imports": {
       "description": "Disallow invocation of `require()`\nhttps://typescript-eslint.io/rules/no-require-imports"
     },
-    "typescript-eslint/no-restricted-imports": {
+    "@typescript-eslint/no-restricted-imports": {
       "description": "Disallow specified modules when loaded by `import`\nhttps://typescript-eslint.io/rules/no-restricted-imports"
     },
-    "typescript-eslint/no-shadow": {
+    "@typescript-eslint/no-shadow": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12011,7 +12093,7 @@
       ],
       "description": "Disallow variable declarations from shadowing variables declared in the outer scope\nhttps://typescript-eslint.io/rules/no-shadow"
     },
-    "typescript-eslint/no-this-alias": {
+    "@typescript-eslint/no-this-alias": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12056,7 +12138,7 @@
       ],
       "description": "Disallow aliasing `this`\nhttps://typescript-eslint.io/rules/no-this-alias"
     },
-    "typescript-eslint/no-throw-literal": {
+    "@typescript-eslint/no-throw-literal": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12096,7 +12178,7 @@
       ],
       "description": "Disallow throwing literals as exceptions\nhttps://typescript-eslint.io/rules/no-throw-literal"
     },
-    "typescript-eslint/no-type-alias": {
+    "@typescript-eslint/no-type-alias": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12154,7 +12236,7 @@
       ],
       "description": "Disallow type aliases\nhttps://typescript-eslint.io/rules/no-type-alias"
     },
-    "typescript-eslint/no-unnecessary-boolean-literal-compare": {
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12196,7 +12278,7 @@
       ],
       "description": "Disallow unnecessary equality comparisons against boolean literals\nhttps://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare"
     },
-    "typescript-eslint/no-unnecessary-condition": {
+    "@typescript-eslint/no-unnecessary-condition": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12238,13 +12320,13 @@
       ],
       "description": "Disallow conditionals where the type is always truthy or always falsy\nhttps://typescript-eslint.io/rules/no-unnecessary-condition"
     },
-    "typescript-eslint/no-unnecessary-qualifier": {
+    "@typescript-eslint/no-unnecessary-qualifier": {
       "description": "Disallow unnecessary namespace qualifiers\nhttps://typescript-eslint.io/rules/no-unnecessary-qualifier"
     },
-    "typescript-eslint/no-unnecessary-type-arguments": {
+    "@typescript-eslint/no-unnecessary-type-arguments": {
       "description": "Disallow type arguments that are equal to the default\nhttps://typescript-eslint.io/rules/no-unnecessary-type-arguments"
     },
-    "typescript-eslint/no-unnecessary-type-assertion": {
+    "@typescript-eslint/no-unnecessary-type-assertion": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12285,34 +12367,34 @@
       ],
       "description": "Disallow type assertions that do not change the type of an expression\nhttps://typescript-eslint.io/rules/no-unnecessary-type-assertion"
     },
-    "typescript-eslint/no-unnecessary-type-constraint": {
+    "@typescript-eslint/no-unnecessary-type-constraint": {
       "description": "Disallow unnecessary constraints on generic types\nhttps://typescript-eslint.io/rules/no-unnecessary-type-constraint"
     },
-    "typescript-eslint/no-unsafe-argument": {
+    "@typescript-eslint/no-unsafe-argument": {
       "description": "Disallow calling a function with a value with type `any`\nhttps://typescript-eslint.io/rules/no-unsafe-argument"
     },
-    "typescript-eslint/no-unsafe-assignment": {
+    "@typescript-eslint/no-unsafe-assignment": {
       "description": "Disallow assigning a value with type `any` to variables and properties\nhttps://typescript-eslint.io/rules/no-unsafe-assignment"
     },
-    "typescript-eslint/no-unsafe-call": {
+    "@typescript-eslint/no-unsafe-call": {
       "description": "Disallow calling a value with type `any`\nhttps://typescript-eslint.io/rules/no-unsafe-call"
     },
-    "typescript-eslint/no-unsafe-declaration-merging": {
+    "@typescript-eslint/no-unsafe-declaration-merging": {
       "description": "Disallow unsafe declaration merging\nhttps://typescript-eslint.io/rules/no-unsafe-declaration-merging"
     },
-    "typescript-eslint/no-unsafe-enum-comparison": {
+    "@typescript-eslint/no-unsafe-enum-comparison": {
       "description": "Disallow comparing an enum value with a non-enum value\nhttps://typescript-eslint.io/rules/no-unsafe-enum-comparison"
     },
-    "typescript-eslint/no-unsafe-member-access": {
+    "@typescript-eslint/no-unsafe-member-access": {
       "description": "Disallow member access on a value with type `any`\nhttps://typescript-eslint.io/rules/no-unsafe-member-access"
     },
-    "typescript-eslint/no-unsafe-return": {
+    "@typescript-eslint/no-unsafe-return": {
       "description": "Disallow returning a value with type `any` from a function\nhttps://typescript-eslint.io/rules/no-unsafe-return"
     },
-    "typescript-eslint/no-unsafe-unary-minus": {
+    "@typescript-eslint/no-unsafe-unary-minus": {
       "description": "Require unary negation to take a number\nhttps://typescript-eslint.io/rules/no-unsafe-unary-minus"
     },
-    "typescript-eslint/no-unused-expressions": {
+    "@typescript-eslint/no-unused-expressions": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12362,7 +12444,7 @@
       ],
       "description": "Disallow unused expressions\nhttps://typescript-eslint.io/rules/no-unused-expressions"
     },
-    "typescript-eslint/no-unused-vars": {
+    "@typescript-eslint/no-unused-vars": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12395,7 +12477,7 @@
       ],
       "description": "Disallow unused variables\nhttps://typescript-eslint.io/rules/no-unused-vars"
     },
-    "typescript-eslint/no-use-before-define": {
+    "@typescript-eslint/no-use-before-define": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12428,19 +12510,19 @@
       ],
       "description": "Disallow the use of variables before they are defined\nhttps://typescript-eslint.io/rules/no-use-before-define"
     },
-    "typescript-eslint/no-useless-constructor": {
+    "@typescript-eslint/no-useless-constructor": {
       "description": "Disallow unnecessary constructors\nhttps://typescript-eslint.io/rules/no-useless-constructor"
     },
-    "typescript-eslint/no-useless-empty-export": {
+    "@typescript-eslint/no-useless-empty-export": {
       "description": "Disallow empty exports that don't change anything in a module file\nhttps://typescript-eslint.io/rules/no-useless-empty-export"
     },
-    "typescript-eslint/no-var-requires": {
+    "@typescript-eslint/no-var-requires": {
       "description": "Disallow `require` statements except in import statements\nhttps://typescript-eslint.io/rules/no-var-requires"
     },
-    "typescript-eslint/non-nullable-type-assertion-style": {
+    "@typescript-eslint/non-nullable-type-assertion-style": {
       "description": "Enforce non-null assertions over explicit type casts\nhttps://typescript-eslint.io/rules/non-nullable-type-assertion-style"
     },
-    "typescript-eslint/object-curly-spacing": {
+    "@typescript-eslint/object-curly-spacing": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12473,10 +12555,10 @@
       ],
       "description": "Enforce consistent spacing inside braces\nhttps://typescript-eslint.io/rules/object-curly-spacing"
     },
-    "typescript-eslint/padding-line-between-statements": {
+    "@typescript-eslint/padding-line-between-statements": {
       "description": "Require or disallow padding lines between statements\nhttps://typescript-eslint.io/rules/padding-line-between-statements"
     },
-    "typescript-eslint/parameter-properties": {
+    "@typescript-eslint/parameter-properties": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12518,10 +12600,10 @@
       ],
       "description": "Require or disallow parameter properties in class constructors\nhttps://typescript-eslint.io/rules/parameter-properties"
     },
-    "typescript-eslint/prefer-as-const": {
+    "@typescript-eslint/prefer-as-const": {
       "description": "Enforce the use of `as const` over literal type\nhttps://typescript-eslint.io/rules/prefer-as-const"
     },
-    "typescript-eslint/prefer-destructuring": {
+    "@typescript-eslint/prefer-destructuring": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12554,19 +12636,19 @@
       ],
       "description": "Require destructuring from arrays and/or objects\nhttps://typescript-eslint.io/rules/prefer-destructuring"
     },
-    "typescript-eslint/prefer-enum-initializers": {
+    "@typescript-eslint/prefer-enum-initializers": {
       "description": "Require each enum member value to be explicitly initialized\nhttps://typescript-eslint.io/rules/prefer-enum-initializers"
     },
-    "typescript-eslint/prefer-for-of": {
+    "@typescript-eslint/prefer-for-of": {
       "description": "Enforce the use of `for-of` loop over the standard `for` loop where possible\nhttps://typescript-eslint.io/rules/prefer-for-of"
     },
-    "typescript-eslint/prefer-function-type": {
+    "@typescript-eslint/prefer-function-type": {
       "description": "Enforce using function types instead of interfaces with call signatures\nhttps://typescript-eslint.io/rules/prefer-function-type"
     },
-    "typescript-eslint/prefer-includes": {
+    "@typescript-eslint/prefer-includes": {
       "description": "Enforce `includes` method over `indexOf` method\nhttps://typescript-eslint.io/rules/prefer-includes"
     },
-    "typescript-eslint/prefer-literal-enum-member": {
+    "@typescript-eslint/prefer-literal-enum-member": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12603,10 +12685,10 @@
       ],
       "description": "Require all enum members to be literal values\nhttps://typescript-eslint.io/rules/prefer-literal-enum-member"
     },
-    "typescript-eslint/prefer-namespace-keyword": {
+    "@typescript-eslint/prefer-namespace-keyword": {
       "description": "Require using `namespace` keyword over `module` keyword to declare custom TypeScript modules\nhttps://typescript-eslint.io/rules/prefer-namespace-keyword"
     },
-    "typescript-eslint/prefer-nullish-coalescing": {
+    "@typescript-eslint/prefer-nullish-coalescing": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12677,7 +12759,7 @@
       ],
       "description": "Enforce using the nullish coalescing operator instead of logical assignments or chaining\nhttps://typescript-eslint.io/rules/prefer-nullish-coalescing"
     },
-    "typescript-eslint/prefer-optional-chain": {
+    "@typescript-eslint/prefer-optional-chain": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12743,7 +12825,7 @@
       ],
       "description": "Enforce using concise optional chain expressions instead of chained logical ands, negated logical ors, or empty objects\nhttps://typescript-eslint.io/rules/prefer-optional-chain"
     },
-    "typescript-eslint/prefer-readonly": {
+    "@typescript-eslint/prefer-readonly": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12780,7 +12862,7 @@
       ],
       "description": "Require private members to be marked as `readonly` if they're never modified outside of the constructor\nhttps://typescript-eslint.io/rules/prefer-readonly"
     },
-    "typescript-eslint/prefer-readonly-parameter-types": {
+    "@typescript-eslint/prefer-readonly-parameter-types": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12917,22 +12999,22 @@
       ],
       "description": "Require function parameters to be typed as `readonly` to prevent accidental mutation of inputs\nhttps://typescript-eslint.io/rules/prefer-readonly-parameter-types"
     },
-    "typescript-eslint/prefer-reduce-type-parameter": {
+    "@typescript-eslint/prefer-reduce-type-parameter": {
       "description": "Enforce using type parameter when calling `Array#reduce` instead of casting\nhttps://typescript-eslint.io/rules/prefer-reduce-type-parameter"
     },
-    "typescript-eslint/prefer-regexp-exec": {
+    "@typescript-eslint/prefer-regexp-exec": {
       "description": "Enforce `RegExp#exec` over `String#match` if no global flag is provided\nhttps://typescript-eslint.io/rules/prefer-regexp-exec"
     },
-    "typescript-eslint/prefer-return-this-type": {
+    "@typescript-eslint/prefer-return-this-type": {
       "description": "Enforce that `this` is used when only `this` type is returned\nhttps://typescript-eslint.io/rules/prefer-return-this-type"
     },
-    "typescript-eslint/prefer-string-starts-ends-with": {
+    "@typescript-eslint/prefer-string-starts-ends-with": {
       "description": "Enforce using `String#startsWith` and `String#endsWith` over other equivalent methods of checking substrings\nhttps://typescript-eslint.io/rules/prefer-string-starts-ends-with"
     },
-    "typescript-eslint/prefer-ts-expect-error": {
+    "@typescript-eslint/prefer-ts-expect-error": {
       "description": "Enforce using `@ts-expect-error` over `@ts-ignore`\nhttps://typescript-eslint.io/rules/prefer-ts-expect-error"
     },
-    "typescript-eslint/promise-function-async": {
+    "@typescript-eslint/promise-function-async": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -12989,7 +13071,7 @@
       ],
       "description": "Require any function or method that returns a Promise to be marked async\nhttps://typescript-eslint.io/rules/promise-function-async"
     },
-    "typescript-eslint/quotes": {
+    "@typescript-eslint/quotes": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13022,7 +13104,7 @@
       ],
       "description": "Enforce the consistent use of either backticks, double, or single quotes\nhttps://typescript-eslint.io/rules/quotes"
     },
-    "typescript-eslint/require-array-sort-compare": {
+    "@typescript-eslint/require-array-sort-compare": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13060,10 +13142,10 @@
       ],
       "description": "Require `Array#sort` calls to always provide a `compareFunction`\nhttps://typescript-eslint.io/rules/require-array-sort-compare"
     },
-    "typescript-eslint/require-await": {
+    "@typescript-eslint/require-await": {
       "description": "Disallow async functions which have no `await` expression\nhttps://typescript-eslint.io/rules/require-await"
     },
-    "typescript-eslint/restrict-plus-operands": {
+    "@typescript-eslint/restrict-plus-operands": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13121,7 +13203,7 @@
       ],
       "description": "Require both operands of addition to be the same type and be `bigint`, `number`, or `string`\nhttps://typescript-eslint.io/rules/restrict-plus-operands"
     },
-    "typescript-eslint/restrict-template-expressions": {
+    "@typescript-eslint/restrict-template-expressions": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13179,7 +13261,7 @@
       ],
       "description": "Enforce template literal expressions to be of `string` type\nhttps://typescript-eslint.io/rules/restrict-template-expressions"
     },
-    "typescript-eslint/return-await": {
+    "@typescript-eslint/return-await": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13212,10 +13294,10 @@
       ],
       "description": "Enforce consistent returning of awaited values\nhttps://typescript-eslint.io/rules/return-await"
     },
-    "typescript-eslint/semi": {
+    "@typescript-eslint/semi": {
       "description": "Require or disallow semicolons instead of ASI\nhttps://typescript-eslint.io/rules/semi"
     },
-    "typescript-eslint/sort-type-constituents": {
+    "@typescript-eslint/sort-type-constituents": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13278,7 +13360,7 @@
       ],
       "description": "Enforce constituents of a type union/intersection to be sorted alphabetically\nhttps://typescript-eslint.io/rules/sort-type-constituents"
     },
-    "typescript-eslint/space-before-blocks": {
+    "@typescript-eslint/space-before-blocks": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13311,7 +13393,7 @@
       ],
       "description": "Enforce consistent spacing before blocks\nhttps://typescript-eslint.io/rules/space-before-blocks"
     },
-    "typescript-eslint/space-before-function-paren": {
+    "@typescript-eslint/space-before-function-paren": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13344,7 +13426,7 @@
       ],
       "description": "Enforce consistent spacing before function parenthesis\nhttps://typescript-eslint.io/rules/space-before-function-paren"
     },
-    "typescript-eslint/space-infix-ops": {
+    "@typescript-eslint/space-infix-ops": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13382,7 +13464,7 @@
       ],
       "description": "Require spacing around infix operators\nhttps://typescript-eslint.io/rules/space-infix-ops"
     },
-    "typescript-eslint/strict-boolean-expressions": {
+    "@typescript-eslint/strict-boolean-expressions": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13443,7 +13525,7 @@
       ],
       "description": "Disallow certain types in boolean expressions\nhttps://typescript-eslint.io/rules/strict-boolean-expressions"
     },
-    "typescript-eslint/switch-exhaustiveness-check": {
+    "@typescript-eslint/switch-exhaustiveness-check": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13481,7 +13563,7 @@
       ],
       "description": "Require switch-case statements to be exhaustive\nhttps://typescript-eslint.io/rules/switch-exhaustiveness-check"
     },
-    "typescript-eslint/triple-slash-reference": {
+    "@typescript-eslint/triple-slash-reference": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13527,7 +13609,7 @@
       ],
       "description": "Disallow certain triple slash directives in favor of ES6-style import declarations\nhttps://typescript-eslint.io/rules/triple-slash-reference"
     },
-    "typescript-eslint/type-annotation-spacing": {
+    "@typescript-eslint/type-annotation-spacing": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13579,7 +13661,7 @@
       ],
       "description": "Require consistent spacing around type annotations\nhttps://typescript-eslint.io/rules/type-annotation-spacing"
     },
-    "typescript-eslint/typedef": {
+    "@typescript-eslint/typedef": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13637,7 +13719,7 @@
       ],
       "description": "Require type annotations in certain places\nhttps://typescript-eslint.io/rules/typedef"
     },
-    "typescript-eslint/unbound-method": {
+    "@typescript-eslint/unbound-method": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"
@@ -13675,7 +13757,7 @@
       ],
       "description": "Enforce unbound methods are called with their expected scope\nhttps://typescript-eslint.io/rules/unbound-method"
     },
-    "typescript-eslint/unified-signatures": {
+    "@typescript-eslint/unified-signatures": {
       "oneOf": [
         {
           "$ref": "#/definitions/ruleNumber"


### PR DESCRIPTION
Originally fixed by https://github.com/fox-projects/jsonschema-extractor/pull/3, this simply copies those changes to the ESLint partial JSON schema.

Closes #3665