### PR TITLE
add Erda Pipeline & Runtime schemas to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6079,6 +6079,28 @@
       "description": "Shards configuration file",
       "fileMatch": ["shard.yml"],
       "url": "https://raw.githubusercontent.com/crystal-lang/shards/master/docs/shard.yml.schema.json"
+    },
+    {
+      "name": "Erda Pipeline",
+      "description": "Erda Pipeline Configuration File",
+      "fileMatch": [
+        "pipeline.yaml",
+        "pipeline.yml",
+        ".erda/pipelines/*.yaml",
+        ".erda/pipelines/*.yml",
+        ".dice/pipelines/*.yaml",
+        ".dice/pipelines/*.yml",
+      ],
+      "url": "https://raw.githubusercontent.com/erda-project/erda/master/.erda/schemas/pipeline.yaml.json"
+    },
+    {
+      "name": "Erda Runtime",
+      "description": "Erda Runtime Configuration File",
+      "fileMatch": [
+        "dice.yaml",
+        "erda.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/erda-project/erda/master/.erda/schemas/dice.yaml.json"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Analogously to https://github.com/SchemaStore/schemastore/pull/1211, this PR adds references to the version mapping schemas on master of [https://erda-project/erda pipeline & runtime](https://github.com/erda-project/erda/tree/master/.erda/schemas).

Note that these mapper schemas are stable versions for some years.
