### PR TITLE
Add kaitai struct .ksy to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6104,6 +6104,12 @@
       "description": "Erda Runtime Configuration File",
       "fileMatch": ["dice.yaml", "erda.yml"],
       "url": "https://raw.githubusercontent.com/erda-project/erda/master/.erda/schemas/dice.yaml.json"
+    },
+    {
+      "name": "KSY",
+      "description": "Kaitai Struct format description file",
+      "fileMatch": ["*.ksy"],
+      "url": "https://raw.githubusercontent.com/kaitai-io/ksy_schema/master/ksy_schema.json"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
