### PR TITLE
Update the rudder-techniques schema:

### DIFF
--- a/src/schemas/json/rudder-techniques.json
+++ b/src/schemas/json/rudder-techniques.json
@@ -170,7 +170,7 @@
     },
     "policyMode": {
       "type": "string",
-      "enum": ["audit", "enforce", "default"]
+      "enum": ["audit", "enforce", "none"]
     },
     "methodReportingMode": {
       "type": "object",
@@ -266,7 +266,7 @@
           "$ref": "#/$defs/tags",
           "title": "method call tags"
         },
-        "policy_mode": {
+        "policy_mode_override": {
           "$ref": "#/$defs/policyMode",
           "title": "method call policy mode override"
         },
@@ -327,7 +327,7 @@
           "$ref": "#/$defs/tags",
           "title": "block call tags"
         },
-        "policy_mode": {
+        "policy_mode_override": {
           "$ref": "#/$defs/policyMode",
           "title": "block call policy mode"
         },
@@ -375,10 +375,10 @@
     "id": {
       "type": "string",
       "title": "id",
-      "description": "Technique id, must match the '^[a-zA-Z][a-zA-Z0-9_]+$' pattern",
-      "markdownDescription": "```Mandatory```\n\nTechnique id, must respect the ```^[a-zA-Z][a-zA-Z0-9_]+$``` pattern.\n\nUsed implicitly in technique parameters and resource folder variable definitions:\n\n* ```${<technique_id>.<parameter_name>}```\n* ```${<technique_id>.resources_dir}```",
-      "pattern": "^[a-zA-Z][a-zA-Z0-9_]+$",
-      "default": "my_new_technique",
+      "description": "Technique, must match the '^[a-zA-Z0-9_]+$' pattern",
+      "markdownDescription": "```Mandatory```\n\nTechnique id, must respect the ```^[a-zA-Z0-9_]+$``` pattern.\n\nUsed implicitly in technique parameters and resource folder variable definitions:\n\n* ```${<technique_id>.<parameter_name>}```\n* ```${<technique_id>.resources_dir}```",
+      "pattern": "^[a-zA-Z0-9_]+$",
+      "default": "my_technique",
       "examples": ["my_new_technique"]
     },
     "name": {

--- a/src/test/rudder-techniques/13.yml
+++ b/src/test/rudder-techniques/13.yml
@@ -12,7 +12,7 @@ items:
     id: 46b8025a-0b06-485c-9127-50e4258ee7e6
     reporting:
       mode: enabled
-    policy_mode: audit
+    policy_mode_override: audit
   - name: In omit mode
     params:
       lines: foobar
@@ -31,7 +31,7 @@ items:
     id: dbd5ba50-8dfc-11ee-a57e-84a938c470d4
     reporting:
       mode: enabled
-    policy_mode: enforce
+    policy_mode_override: enforce
   - name: In default mode
     params:
       lines: foobar

--- a/src/test/rudder-techniques/14.yml
+++ b/src/test/rudder-techniques/14.yml
@@ -10,7 +10,7 @@ items:
       path: /tmp/1
       lines: 'foobar'
       enforce: 'true'
-    policy_mode: audit
+    policy_mode_override: audit
   - id: 1eedce7b-3441-4251-bdd6-706fda3ec7a8
     name: 'In omit mode'
     method: file_content
@@ -25,18 +25,18 @@ items:
       path: /tmp/1
       lines: 'foobar'
       enforce: 'true'
-    policy_mode: enforce
+    policy_mode_override: enforce
   - id: 1d809592-808e-4177-8351-8b7b7769af69
-    name: 'In default mode'
+    name: 'In none mode'
     method: file_content
     params:
       path: /tmp/1
       lines: 'foobar'
       enforce: 'true'
-    policy_mode: default
+    policy_mode_override: none
   - id: 57f54359-2b2e-49f9-ab61-a77705615302
     name: 'A block in audit mode'
-    policy_mode: audit
+    policy_mode_override: audit
     items:
       - id: ea274579-40fc-4545-b384-8d5576a7c69b
         name: 'Resolve to audit'
@@ -45,7 +45,7 @@ items:
           path: /tmp/1
           lines: 'foobar'
           enforce: 'true'
-        policy_mode: audit
+        policy_mode_override: audit
       - id: 85659b7e-968c-458c-b566-c90108c50833
         name: 'Resolve to enforce'
         method: file_content
@@ -53,7 +53,7 @@ items:
           path: /tmp/1
           lines: 'foobar'
           enforce: 'true'
-        policy_mode: enforce
+        policy_mode_override: enforce
       - id: d8def455-cd43-441f-8dba-1ebae3a29389
         name: 'Resolve to audit'
         method: file_content
@@ -61,10 +61,10 @@ items:
           path: /tmp/1
           lines: 'foobar'
           enforce: 'true'
-        policy_mode: default
+        policy_mode_override: none
   - id: 1ff82fc2-38fc-4324-92ab-3de5fafcdc14
     name: 'A block in enforce mode'
-    policy_mode: enforce
+    policy_mode_override: enforce
     items:
       - id: f9417d97-3a18-4db6-85c3-72e28618bff1
         name: 'Resolve to audit'
@@ -73,7 +73,7 @@ items:
           path: /tmp/1
           lines: 'foobar'
           enforce: 'true'
-        policy_mode: audit
+        policy_mode_override: audit
       - id: c4b4faa1-85e5-4922-b713-c198bf99226e
         name: 'Resolve to enforce'
         method: file_content
@@ -81,7 +81,7 @@ items:
           path: /tmp/1
           lines: 'foobar'
           enforce: 'true'
-        policy_mode: enforce
+        policy_mode_override: enforce
       - id: cce62a59-bd17-4858-ba06-6ae41f39b15a
         name: 'Resolve to enforce'
         method: file_content
@@ -89,14 +89,14 @@ items:
           path: /tmp/1
           lines: 'foobar'
           enforce: 'true'
-        policy_mode: default
+        policy_mode_override: none
   - id: 7def389a-78d2-4104-b6fc-19c74f14fe93
     name: 'An audit block'
-    policy_mode: enforce
+    policy_mode_override: enforce
     items:
       - id: 9fca6ca8-ccaa-4688-a5fc-e2a0d9d60165
         name: 'A nested block in audit'
-        policy_mode: audit
+        policy_mode_override: audit
         items:
           - id: 0a4299dd-0902-48b2-85ee-13dfe6fc3af6
             name: 'Resolve to audit'
@@ -105,7 +105,7 @@ items:
               path: /tmp/1
               lines: 'foobar'
               enforce: 'true'
-            policy_mode: default
+            policy_mode_override: none
       - id: 3b8352df-1329-4956-a019-bb9c072bc830
         name: 'Resolve to enforce'
         method: file_content
@@ -113,4 +113,4 @@ items:
           path: /tmp/1
           lines: 'foobar'
           enforce: 'true'
-        policy_mode: default
+        policy_mode_override: none


### PR DESCRIPTION
Update the rudder-techniques schema:

* To rename the 'policy_mode' option to 'policy_mode_override'
* To make the technique name less restrictive

Previous policy mode option was not officially released so backward-compatibiliity should not be an issue here.