### PR TITLE
Remove restrictive patterns for `workerPool` and `serviceAccount` from `cloudbuild.json`

### DIFF
--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -141,8 +141,7 @@
             "name": {
               "description": "Required. The full resource name of the private pool of the form 'projects/$PRIVATEPOOL_PROJECT_ID/locations/$REGION/workerPools/$PRIVATEPOOL_ID'.",
               "markdownDescription": "Required. The full resource name of the private pool of the form `projects/$PRIVATEPOOL_PROJECT_ID/locations/$REGION/workerPools/$PRIVATEPOOL_ID`.",
-              "type": "string",
-              "pattern": "^projects/\\w+/locations/\\w+/workerPools/\\w+$"
+              "type": "string"
             }
           },
           "additionalProperties": false,
@@ -459,8 +458,7 @@
     },
     "serviceAccount": {
       "description": "Use this field to specify the IAM service account to use at build time.",
-      "type": "string",
-      "pattern": "^projects/[\\w\\-]+/serviceAccounts/[\\w\\-.]+@[\\w\\-.]+$"
+      "type": "string"
     },
     "queueTtl": {
       "description": "Specifies the amount of time a build can be queued. If a build is in the queue for longer than the value set in queueTtl, the build expires and the build status is set to EXPIRED.",

--- a/src/test/cloudbuild/test-1.json
+++ b/src/test/cloudbuild/test-1.json
@@ -1,10 +1,12 @@
 {
+  "logsBucket": "gs://build-logs-bucket-9999991",
+  "serviceAccount": "projects/gcloud-project-id-0192853/serviceAccounts/gcloud-service-account@gcloud-project-id-0192853.iam.gserviceaccount.com",
   "steps": [
     {
       "args": [
         "build",
         "-t",
-        "us-central1-docker.pkg.dev/${PROJECT_ID}/my-docker-repo/myimage",
+        "us-central1-docker.pkg.dev/${_PROJECT_ID}/my-docker-repo/myimage",
         "."
       ],
       "name": "gcr.io/cloud-builders/docker"
@@ -12,7 +14,7 @@
     {
       "args": [
         "push",
-        "us-central1-docker.pkg.dev/${PROJECT_ID}/my-docker-repo/myimage"
+        "us-central1-docker.pkg.dev/${_PROJECT_ID}/my-docker-repo/myimage"
       ],
       "name": "gcr.io/cloud-builders/docker"
     },
@@ -23,7 +25,7 @@
         "create-with-container",
         "my-vm-name",
         "--container-image",
-        "us-central1-docker.pkg.dev/${PROJECT_ID}/my-docker-repo/myimage"
+        "us-central1-docker.pkg.dev/${_PROJECT_ID}/my-docker-repo/myimage"
       ],
       "entrypoint": "gcloud",
       "env": [

--- a/src/test/cloudbuild/test-1.yaml
+++ b/src/test/cloudbuild/test-1.yaml
@@ -1,6 +1,9 @@
 options:
   machineType: UNSPECIFIED
 
+serviceAccount: projects/$PROJECT_ID/serviceAccounts/${_SERVICE_ACCOUNT}
+logsBucket: ${_LOGS_BUCKET}
+
 steps:
   - id: terraform-version
     name: hashicorp/terraform

--- a/src/test/cloudbuild/test-2.json
+++ b/src/test/cloudbuild/test-2.json
@@ -1,4 +1,6 @@
 {
+  "logsBucket": "${_LOGS_BUCKET}",
+  "serviceAccount": "${_SERVICE_ACCOUNT}",
   "steps": [
     {
       "args": [


### PR DESCRIPTION
Fixes #3682.

- Removes `pattern` for `workerPool` and `serviceAccount`, which was overly restrictive and did not allow passing the values as substitution variables
- Updates positive tests to prevent regressions for `serviceAccount`  
- Adds `logsBucket` to tests as this is often specified in conjunction with `serviceAccount`