### PR TITLE
adjust gitlab-ci globbing patterns to include files in subdirs. 

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2117,9 +2117,9 @@
       "url": "https://json.schemastore.org/github-workflow-template-properties.json"
     },
     {
-      "name": "gitlab-ci",
-      "description": "configuring Gitlab CI",
-      "fileMatch": ["*.gitlab-ci.yml"],
+      "name": "GitLab CI Config .gitlab-ci",
+      "description": "GitLab CI Configuration file",
+      "fileMatch": ["**/.gitlab-ci.yml","**/.gitlab-ci.yaml","**/*.gitlab-ci.yml","**/*.gitlab-ci.yaml"],
       "url": "https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2117,9 +2117,14 @@
       "url": "https://json.schemastore.org/github-workflow-template-properties.json"
     },
     {
-      "name": "GitLab CI Config .gitlab-ci",
+      "name": "gitlab-ci",
       "description": "GitLab CI Configuration file",
-      "fileMatch": ["**/.gitlab-ci.yml","**/.gitlab-ci.yaml","**/*.gitlab-ci.yml","**/*.gitlab-ci.yaml"],
+      "fileMatch": [
+        "**/.gitlab-ci.yml",
+        "**/.gitlab-ci.yaml",
+        "**/*.gitlab-ci.yml",
+        "**/*.gitlab-ci.yaml"
+      ],
       "url": "https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json"
     },
     {


### PR DESCRIPTION
    - Existing pattern expects file not to reside in a subdirectory.
    - Existing pattern expects .yml as a file extension
    - Existing pattern expects a filename prefix
    This change aught help matches properly identify gitlab-ci config tiles.

   -  "**/.gitlab-ci.yml"
   - "**/.gitlab-ci.yaml"
   - "**/*.gitlab-ci.yml"
   - "**/*.gitlab-ci.yaml"

I'm not clear on whether the regex engine under the hood treats `/*.` as 
- zero or more characters, suffixed with a period.
- one or more characters suffixed with a period
- something else entirely.

Since the ci config file is customizable in gitlab, I can see the benefit of leaving the wildcard there..

However for some reason on my system `*.gitlab-ci.yml`... wasn't getting matched against a `_init/.gitlab-ci.yml`.
So adding `**/.gitlab-ci.yml`. 

LMK if there's any further changes desired.


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
