### PR TITLE
Modify Wrangler CLI source

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4615,7 +4615,7 @@
     },
     {
       "name": "Wrangler CLI",
-      "description": "Wrangler is a command-line tool for building with Cloudflare developer products.",
+      "description": "Wrangler is a command-line tool for building with Cloudflare developer products",
       "fileMatch": ["wrangler.json", "wrangler.toml"],
       "url": "https://www.unpkg.com/wrangler/config-schema.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4615,9 +4615,9 @@
     },
     {
       "name": "Wrangler CLI",
-      "description": "Experimental JSON config",
-      "fileMatch": ["wrangler.json"],
-      "url": "https://github.com/cloudflare/workers-sdk/files/12887590/wrangler.schema.json"
+      "description": "Wrangler is a command-line tool for building with Cloudflare developer products.",
+      "fileMatch": ["wrangler.json", "wrangler.toml"],
+      "url": "https://www.unpkg.com/wrangler/config-schema.json"
     },
     {
       "name": "JSON-stat 2.0",


### PR DESCRIPTION
This PR updates the Wrangler JSON schema definition to point to an an up-to-date source that's maintained by the Wrangler team. It depends on https://github.com/cloudflare/workers-sdk/pull/5550, which is why it's currently a draft.