### PR TITLE
include "serial" in ava schema

### DIFF
--- a/src/schemas/json/ava.json
+++ b/src/schemas/json/ava.json
@@ -66,6 +66,11 @@
         "type": "string"
       }
     },
+    "serial": {
+      "type": "boolean",
+      "default": false,
+      "description": "if `true`, prevents parallel execution of tests within a file"
+    },
     "tap": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
[The docs](https://github.com/avajs/ava/blob/main/docs/06-configuration.md) say,
> All of the CLI options can be configured in the ava section of either your package.json file, or an ava.config.* file

That it's not included in the table I think is simply an oversight,
- https://github.com/avajs/ava/pull/3321

`serial` is a CLI option: https://github.com/avajs/ava/blob/01ec2804ab9db0ab3ef11e3b5b0c5697d68f8bc5/lib/cli.js#L58-L63

and this code merges the config,
[ava/lib/cli.js](https://github.com/avajs/ava/blob/01ec2804ab9db0ab3ef11e3b5b0c5697d68f8bc5/lib/cli.js#L438)


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
