### PR TITLE
jetpack-io rename to jetify-com

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1009,13 +1009,13 @@
       "name": "Devbox Config",
       "description": "Configuration for a Devbox shell environment",
       "fileMatch": ["devbox.json"],
-      "url": "https://raw.githubusercontent.com/jetpack-io/devbox/main/.schema/devbox.schema.json"
+      "url": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json"
     },
     {
       "name": "Devbox Plugin",
       "description": "Configuration for a Devbox plugin specification",
       "fileMatch": ["devbox-plugin.json"],
-      "url": "https://raw.githubusercontent.com/jetpack-io/devbox/main/.schema/devbox-plugin.schema.json"
+      "url": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox-plugin.schema.json"
     },
     {
       "name": "Drupal Breakpoints",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

jetpack-io org changed to jetify-com on github. This PR reflects that change.
