### PR TITLE
Updated SDF Schema version to 1.2

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3919,10 +3919,11 @@
       "name": "Semantic Data Fabric (SDF) file",
       "description": "SDF blocks",
       "fileMatch": ["*.sdf.yml"],
-      "url": "https://cdn.sdf.com/schemas/sdf-schema-1.1.json",
+      "url": "https://cdn.sdf.com/schemas/sdf-schema-1.2.json",
       "versions": {
         "1.0": "https://cdn.sdf.com/schemas/sdf-schema-1.0.json",
-        "1.1": "https://cdn.sdf.com/schemas/sdf-schema-1.1.json"
+        "1.1": "https://cdn.sdf.com/schemas/sdf-schema-1.1.json",
+        "1.2": "https://cdn.sdf.com/schemas/sdf-schema-1.2.json"
       }
     },
     {


### PR DESCRIPTION
SDF has an update yml schema, now 1.2.

This is a small update to add the new schema as the default url. 
