### PR TITLE
Replace use of `code-owner-self-merge` fork with upstream ref

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
       - name: 'Run Codeowners merge check'
-        uses: 'fox-forks/code-owner-self-merge@hyperupcall-feat-ownernopings'
+        uses: 'OSS-Docs-Tools/code-owner-self-merge@a04a7103f8ab9b1abdc60a2a742ac090e1869e52'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:


### PR DESCRIPTION
Since https://github.com/OSS-Docs-Tools/code-owner-self-merge/pull/43, support for `ownerNoPings` has now landed upstream. This make the `fox-forks/code-owner-self-merge` fork obsolete. So, replace use of fork with upstream ref.

No release includes this functionality, so use a Git shasum ref.

Related to #3592
