### PR TITLE
Add 'lambdaLayers' field to tunnelhub.json schema

### DIFF
--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -65,6 +65,7 @@
         "timeout": {
           "type": "number"
         },
+        "lambdaLayers": true,
         "vpcConfig": {
           "additionalProperties": false,
           "properties": {
@@ -82,7 +83,31 @@
             }
           },
           "required": ["subnetIds", "securityGroupIds"],
-          "type": "object"
+          "type": "object",
+          "if": {
+            "properties": {
+              "runtimeEngine": {
+                "const": "LAMBDA"
+              }
+            },
+            "then": {
+              "properties": {
+                "lambdaLayers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "else": {
+              "not": {
+                "required": [
+                  "lambdaLayers"
+                ]
+              }
+            }
+          }
         }
       },
       "required": ["runtimeEngine", "entrypoint", "runtime", "memorySize"],

--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -89,23 +89,23 @@
               "runtimeEngine": {
                 "const": "LAMBDA"
               }
-            },
-            "then": {
-              "properties": {
-                "lambdaLayers": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
+            }
+          },
+          "then": {
+            "properties": {
+              "lambdaLayers": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               }
-            },
-            "else": {
-              "not": {
-                "required": [
-                  "lambdaLayers"
-                ]
-              }
+            }
+          },
+          "else": {
+            "not": {
+              "required": [
+                "lambdaLayers"
+              ]
             }
           }
         }

--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -103,9 +103,7 @@
           },
           "else": {
             "not": {
-              "required": [
-                "lambdaLayers"
-              ]
+              "required": ["lambdaLayers"]
             }
           }
         }


### PR DESCRIPTION
The schema for 'tunnelhub.json' has been updated to include a new 'lambdaLayers' field. This new field is only required when the 'runtimeEngine' is 'LAMBDA'. For all other instances, it is not a required property.
