### PR TITLE
Update Hazelcast schema to version 5.4.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2309,7 +2309,7 @@
         "hz-*.yaml",
         "hz-*.json"
       ],
-      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.3.json"
+      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.4.json"
     },
     {
       "name": "host.json",


### PR DESCRIPTION
Hazelcast 5.4.0 has been released which includes new schema
