### PR TITLE
Fix Micro editor matching settings they are too greedy an incorrect

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2745,7 +2745,7 @@
     {
       "name": "A micro editor config",
       "description": "A micro editor config",
-      "fileMatch": ["*.settings.json"],
+      "fileMatch": ["settings.json"],
       "url": "https://json.schemastore.org/micro.json"
     },
     {


### PR DESCRIPTION
Micro editor schema matching is too greedy. There is another bug in SchemaStore.nvim that is exacerbating this issue:
https://github.com/b0o/SchemaStore.nvim/pull/30

Here is proof showing that Micro does not look at/use `*.settings.nvim` but only uses `settings.nvim`:
https://github.com/search?q=repo%3Azyedidia%2Fmicro%20settings.json&type=code

