### PR TITLE
Stricten pattern of micro settings.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2751,7 +2751,7 @@
     {
       "name": "A micro editor config",
       "description": "A micro editor config",
-      "fileMatch": ["settings.json"],
+      "fileMatch": ["**/micro/settings.json"],
       "url": "https://json.schemastore.org/micro.json"
     },
     {


### PR DESCRIPTION
In #3717 the pattern of the Micro editor config file was changed from `*.settings.json` to `settings.json`. The name `settings.json` is too generic and is used by multiple tools, including Visual Studio Code.

Based on the links in the referenced pull request, this changes the pattern to the more specific `**/micro/settings.json`.