### PR TITLE
chore: bump scikit-build schema to 0.9

### DIFF
--- a/src/schemas/json/partial-scikit-build.json
+++ b/src/schemas/json/partial-scikit-build.json
@@ -65,6 +65,10 @@
           "description": "A table of environment variables mapped to either string regexs, or booleans. Valid 'truthy' environment variables are case insensitive `true`, `on`, `yes`, `y`, `t`, or a number more than 0."
         }
       }
+    },
+    "inherit": {
+      "enum": ["none", "append", "prepend"],
+      "default": "none"
     }
   },
   "description": "Scikit-build-core's settings.",
@@ -174,7 +178,7 @@
         "make-fallback": {
           "type": "boolean",
           "default": true,
-          "description": "If CMake is not present on the system or is older required, it will be downloaded via PyPI if possible. An empty string will disable this check."
+          "description": "If Ninja is not present on the system or is older than required, it will be downloaded via PyPI if this is false."
         }
       }
     },
@@ -266,7 +270,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A set of patterns to exclude from the wheel. This is additive to the SDist exclude patterns. This applies to the source files, not the final paths. Editable installs may not respect this exclusion."
+          "description": "A set of patterns to exclude from the wheel. This is additive to the SDist exclude patterns. This applies to the final paths in the wheel, and can exclude files from CMake output as well.  Editable installs may not respect this exclusion."
         },
         "build-tag": {
           "type": "string",
@@ -471,6 +475,63 @@
                 "additionalProperties": false
               }
             ]
+          },
+          "inherit": {
+            "type": "object",
+            "properties": {
+              "cmake": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "args": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "define": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "targets": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              },
+              "sdist": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "include": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "exclude": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              },
+              "wheel": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "packages": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "license-files": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "exclude": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              },
+              "install": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "components": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
           },
           "cmake": {
             "$ref": "#/properties/cmake"


### PR DESCRIPTION

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->

Bumping for scikit-build-core 0.9.0.
