### PR TITLE
Add environmentVariables to tunnelhub.json schema

### DIFF
--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -66,6 +66,12 @@
           "type": "number"
         },
         "lambdaLayers": true,
+        "environmentVariables": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "vpcConfig": {
           "additionalProperties": false,
           "properties": {


### PR DESCRIPTION
An "environmentVariables" field was added to the tunnelhub.json schema. This new property is of type "object" and contains additional string properties. It was integrated to provide configuration flexibility within the VPC environment.
