### PR TITLE
Updated Jekyll schema config props for jekyll-sass-converter 3.x

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -908,17 +908,11 @@
       "description": "Sass options\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
       "type": "object",
       "properties": {
-        "implementation": {
-          "description": "The implementation to use\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
-          "type": "string",
-          "enum": ["sassc", "sass-embedded"],
-          "default": "sassc"
-        },
         "style": {
           "description": "The style of CSS-output\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
           "type": "string",
-          "default": "compact",
-          "enum": ["nested", "compact", "compressed", "expanded"]
+          "default": "expanded",
+          "enum": ["compressed", "expanded"]
         },
         "sass_dir": {
           "description": "The path with Sass partials\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
@@ -935,16 +929,21 @@
           },
           "default": []
         },
-        "line_comments": {
-          "description": "Enable/disable including line number and filename of the source in compiled CSS file\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
-          "type": "boolean",
-          "default": false
-        },
         "sourcemap": {
           "description": "Control when source maps shall be generated\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
           "type": "string",
           "enum": ["never", "always", "development"],
           "default": "always"
+        },
+        "quiet_deps": {
+          "description": "If true, Sass does not print warnings that are caused by dependencies\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "boolean",
+          "default": false
+        },
+        "verbose": {
+          "description": "If true, Sass prints every deprecation warning it encounters\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Updated the Jekyll schema to reflect the most recent configuration options for jekyll-sass-converter.

See [Configuration options](https://github.com/jekyll/jekyll-sass-converter#configuration-options) and [Migrate from 2.x to 3.x](https://github.com/jekyll/jekyll-sass-converter?tab=readme-ov-file#migrate-from-2x-to-3x)
