### PR TITLE
Add remote_write.queue_config.sample_age_limit definition to prometheus configuration

### DIFF
--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -982,6 +982,11 @@
                 "description": "Retry upon receiving a 429 status code from the remote-write storage.",
                 "type": ["boolean", "null"],
                 "default": false
+              },
+              "sample_age_limit": {
+                "$ref": "#/definitions/duration",
+                "description": "If set, any sample that is older than sample_age_limit will not be sent to the remote storage.",
+                "default": "0s"
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
Adds recently added configuration for Prometheus `remote_write`
https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write

```
# Configures the queue used to write to remote storage.
queue_config:
  ...
  # If set, any sample that is older than sample_age_limit
  # will not be sent to the remote storage. The default value is 0s,
  # which means that all samples are sent.
  [ sample_age_limit: <duration> | default = 0s ]
```