### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -1372,7 +1372,7 @@
           }
         },
         "sections": {
-          "description": "A list of mappings from section names to modules. By default custom sections are output last, but this can be overridden with `section-order`.",
+          "description": "A list of mappings from section names to modules.\n\nBy default, imports are categorized according to their type (e.g., `future`, `third-party`, and so on). This setting allows you to group modules into custom sections, to augment or override the built-in sections.\n\nFor example, to group all testing utilities, you could create a `testing` section: ```toml testing = [\"pytest\", \"hypothesis\"] ```\n\nCustom sections should typically be inserted into the `section-order` list to ensure that they're displayed as a standalone group and in the intended order, as in: ```toml section-order = [ \"future\", \"standard-library\", \"third-party\", \"first-party\", \"local-folder\", \"testing\" ] ```\n\nIf a custom section is omitted from `section-order`, imports in that section will be assigned to the `default-section` (which defaults to `third-party`).",
           "type": ["object", "null"],
           "additionalProperties": {
             "type": "array",
@@ -2573,6 +2573,8 @@
         "FURB180",
         "FURB181",
         "FURB187",
+        "FURB19",
+        "FURB192",
         "G",
         "G0",
         "G00",
@@ -2765,8 +2767,10 @@
         "PLE0302",
         "PLE0303",
         "PLE0304",
+        "PLE0305",
         "PLE0307",
         "PLE0308",
+        "PLE0309",
         "PLE06",
         "PLE060",
         "PLE0604",


### PR DESCRIPTION
This updates ruff's JSON schema to [77c93fd63c1c072501d297082aa59c741b2d5466](https://github.com/astral-sh/ruff/commit/77c93fd63c1c072501d297082aa59c741b2d5466)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
