### PR TITLE
Add schema for Cloud Foundry application manifests (manifest.yml)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6164,7 +6164,7 @@
     {
       "name": "Cloud Foundry Application Manifest",
       "description": "A manifest describes a Cloud Foundry application and can be used to deploy it to a Foundation",
-      "fileMatch": ["manifest.yml", "manifest.yaml"],
+      "fileMatch": [],
       "url": "https://json.schemastore.org/cloudfoundry-application-manifest.json"
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6160,6 +6160,12 @@
       "description": "A blogroll interchange format",
       "fileMatch": [],
       "url": "https://www.json-wf.org.uk/json-wf-schema-1.0.json"
+    },
+    {
+      "name": "Cloud Foundry Application Manifest",
+      "description": "A manifest describes a Cloud Foundry application and can be used to deploy it to a Foundation",
+      "fileMatch": ["manifest.yml", "manifest.yaml"],
+      "url": "https://json.schemastore.org/cloudfoundry-application-manifest.json"
     }
   ]
 }

--- a/src/schemas/json/cloudfoundry-application-manifest.json
+++ b/src/schemas/json/cloudfoundry-application-manifest.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/cloudfoundry-application-manifest.json",
+  "$comment": "Descriptions are sourced from https://v3-apidocs.cloudfoundry.org/version/3.163.0/#the-manifest-schema, with some details from https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html and https://v3-apidocs.cloudfoundry.org/version/3.163.0.",
+  "$ref": "#/definitions/Manifest",
+  "definitions": {
+    "Manifest": {
+      "type": "object",
+      "title": "Cloud Foundry Application Manifest",
+      "additionalProperties": false,
+      "description": "A manifest describes a Cloud Foundry application and can be used to deploy it to a Foundation. For authoritative reference, see https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html.",
+      "properties": {
+        "version": {
+          "description": "The version of the manifest schema. Currently, the only valid version is 1.",
+          "type": "integer",
+          "default": 1
+        },
+        "applications": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Application"
+          }
+        }
+      },
+      "required": ["applications"]
+    },
+    "Application": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Name of the app.",
+          "type": "string"
+        },
+        "buildpacks": {
+          "description": "a) An empty array, which will automatically select the appropriate default buildpack according to the coding language; b) An array of one or more URLs pointing to buildpacks; c) An array of one or more installed buildpack names",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "command": {
+          "description": "The command used to start the process; this overrides start commands from Procfiles and buildpacks.",
+          "type": "string"
+        },
+        "disk_quota": {
+          "description": "The disk limit for all instances of the web process; this attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case.",
+          "type": "string"
+        },
+        "docker": {
+          "$ref": "#/definitions/Docker"
+        },
+        "env": {
+          "$ref": "#/definitions/Env"
+        },
+        "health-check-type": {
+          "description": "Type of health check to perform; none is deprecated and an alias to process.",
+          "enum": ["port", "process", "http"],
+          "default": "port"
+        },
+        "health-check-http-endpoint": {
+          "description": "Endpoint called to determine if the app is healthy.",
+          "type": "string",
+          "default": "/"
+        },
+        "health-check-invocation-timeout": {
+          "description": "The timeout in seconds for individual health check requests for http and port health checks.",
+          "type": "integer",
+          "default": 1
+        },
+        "health-check-interval": {
+          "type": "integer",
+          "default": 30
+        },
+        "readiness-health-check-type": {
+          "enum": ["port", "process", "http"],
+          "default": "process"
+        },
+        "readiness-health-check-http-endpoint": {
+          "type": "string",
+          "default": "/"
+        },
+        "readiness-health-check-invocation-timeout": {
+          "type": "integer",
+          "default": 1
+        },
+        "readiness-health-check-interval": {
+          "type": "integer",
+          "default": 30
+        },
+        "instances": {
+          "description": "The number of instances to run.",
+          "type": "integer",
+          "default": 1
+        },
+        "log-rate-limit-per-second": {
+          "type": "string",
+          "description": "The log-rate-limit-per-second attribute specifies the log rate limit for all instances of an app. This attribute requires a unit of measurement: B, K, KB, M, MB, G, or GB, in either uppercase or lowercase.",
+          "default": "16K"
+        },
+        "memory": {
+          "description": "The memory attribute specifies the memory limit for all instances of an app. This attribute requires a unit of measurement: M, MB, G, or GB, in either uppercase or lowercase.",
+          "type": "string",
+          "default": "1G"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata"
+        },
+        "no-route": {
+          "description": "When set to true, any routes specified with the routes attribute will be ignored and any existing routes will be removed.",
+          "type": "boolean",
+          "default": false
+        },
+        "path": {
+          "description": "The path attribute tells Cloud Foundry the directory location in which it can find your app. The directory specified as the path, either as an attribute or as a parameter on the command line, becomes the location where the buildpack Detect script runs.",
+          "type": "string"
+        },
+        "processes": {
+          "type": "array",
+          "description": "List of configurations for individual process types.",
+          "items": {
+            "$ref": "#/definitions/Process"
+          }
+        },
+        "random-route": {
+          "type": "boolean",
+          "description": "Creates a random route for the app if true; if routes is specified, if the app already has routes, or if no-route is specified, this field is ignored regardless of its value.",
+          "default": false
+        },
+        "routes": {
+          "type": "array",
+          "description": "List declaring HTTP and TCP routes to be mapped to the app.",
+          "items": {
+            "$ref": "#/definitions/Route"
+          }
+        },
+        "services": {
+          "type": "array",
+          "description": "Apps can bind to services such as databases, messaging, and key-value stores. The services block consists of a heading and one or more service instance names.",
+          "items": {
+            "$ref": "#/definitions/ServiceElement"
+          }
+        },
+        "sidecars": {
+          "type": "array",
+          "description": "The sidecars attribute specifies additional processes to run in the same container as your app.",
+          "items": {
+            "$ref": "#/definitions/Sidecar"
+          }
+        },
+        "stack": {
+          "description": "The root filesystem to use with the buildpack, for example cflinuxfs4.",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "The duration in seconds that health checks can fail before the process is restarted.",
+          "type": "integer",
+          "default": 60
+        }
+      },
+      "required": ["name"],
+      "title": "Application"
+    },
+    "Docker": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "If your app is contained in a Docker image, the docker attribute specifies it and an Docker user name (optional). This attribute is a combination of push options that include --docker-image and --docker-username.",
+      "properties": {
+        "image": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "required": ["image"],
+      "title": "Docker"
+    },
+    "Env": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "A key-value mapping of environment variables to be used for the app when running.",
+      "title": "Environment Variables"
+    },
+    "Metadata": {
+      "type": "object",
+      "description": "The metadata attribute tags your apps with additional information. You can specify two types of metadata: labels and annotations.",
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/definitions/KVMetadata",
+          "description": "Annotations allow you to add non-identifying metadata to Cloud Foundry resources. You cannot query based on annotations. Also, there are fewer restrictions for key-value pairs of annotations than there are for labels. For example, you can include contact information of persons responsible for the resource, or tool information for debugging purposes.",
+          "title": "Annotations"
+        },
+        "labels": {
+          "$ref": "#/definitions/KVMetadata",
+          "description": "Labels allow you to identify and select Cloud Foundry resources. For example, if you label all apps running in production or all spaces that contain Internet-facing apps, you can then search for them.",
+          "title": "Labels"
+        }
+      },
+      "title": "Metadata"
+    },
+    "KVMetadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "Process": {
+      "type": "object",
+      "description": "This configuration is for the individual process. Each process is created if it does not already exist. For backwards compatibility, the web process configuration may be placed at the top level of the application configuration, rather than listed under processes. However, if there is a process with type: web listed under processes, this configuration will override any at the top level.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The identifier for the processes to be configured."
+        },
+        "command": {
+          "type": "string",
+          "description": "The command used to start the process; this overrides start commands from Procfiles and buildpacks."
+        },
+        "disk_quota": {
+          "description": "The disk limit for all instances of the web process; this attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case",
+          "type": "string"
+        },
+        "health-check-type": {
+          "description": "Type of health check to perform; none is deprecated and an alias to process.",
+          "enum": ["port", "process", "http", "none"],
+          "default": "process"
+        },
+        "health-check-http-endpoint": {
+          "description": "Endpoint called to determine if the app is healthy.",
+          "type": "string",
+          "default": "/"
+        },
+        "health-check-invocation-timeout": {
+          "description": "The timeout in seconds for individual health check requests for http and port health checks.",
+          "type": "integer",
+          "default": 1
+        },
+        "instances": {
+          "description": "The number of instances to run.",
+          "type": "integer",
+          "default": 1
+        },
+        "memory": {
+          "description": "The memory limit for all instances of the web process; this attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case",
+          "type": "string"
+        },
+        "log-rate-limit-per-second": {
+          "description": "The log rate limit for all the instances of the process; this attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case, or -1 or 0",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Time in seconds at which the health-check will report failure",
+          "type": "integer",
+          "default": 60
+        }
+      },
+      "required": ["type"],
+      "title": "Process"
+    },
+    "Route": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "route": {
+          "description": "The route URI. Example: host.domain.com.",
+          "type": "string"
+        },
+        "protocol": {
+          "description": "Protocol to use for this route.",
+          "enum": ["http2", "http1", "tcp"]
+        }
+      },
+      "required": ["route"],
+      "title": "Route"
+    },
+    "ServiceObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The name of the service instance to be bound to.",
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/definitions/ServiceParameters"
+        },
+        "binding_name": {
+          "description": "The name of the service binding to be created",
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "title": "ServiceClass"
+    },
+    "ServiceParameters": {
+      "description": "A map of arbitrary key/value pairs to send to the service broker during binding.",
+      "type": "object",
+      "additionalProperties": true,
+      "title": "Service Parameters"
+    },
+    "Sidecar": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The identifier for the sidecars to be configured",
+          "type": "string"
+        },
+        "process_types": {
+          "description": "List of processes to associate sidecar with",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "command": {
+          "description": "The command used to start the sidecar",
+          "type": "string"
+        },
+        "memory": {
+          "description": "Memory that the sidecar will be allocated",
+          "type": "string"
+        }
+      },
+      "required": ["command", "name", "process_types"],
+      "title": "Sidecar"
+    },
+    "ServiceElement": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ServiceObject"
+        },
+        {
+          "type": "string",
+          "title": "Service Name"
+        }
+      ],
+      "title": "Service"
+    }
+  }
+}

--- a/src/test/cloudfoundry-application-manifest/test-1.yaml
+++ b/src/test/cloudfoundry-application-manifest/test-1.yaml
@@ -1,0 +1,47 @@
+---
+version: 1
+applications:
+  - name: app1
+    buildpacks:
+      - ruby_buildpack
+      - java_buildpack
+    env:
+      VAR1: value1
+      VAR2: value2
+    routes:
+      - route: route.example.com
+      - route: another-route.example.com
+        protocol: http2
+    services:
+      - my-service1
+      - my-service2
+      - name: my-service-with-arbitrary-params
+        binding_name: my-binding
+        parameters:
+          key1: value1
+          key2: value2
+    stack: cflinuxfs4
+    metadata:
+      annotations:
+        contact: 'bob@example.com jane@example.com'
+      labels:
+        sensitive: true
+    processes:
+      - type: web
+        command: start-web.sh
+        disk_quota: 512M
+        health-check-http-endpoint: /healthcheck
+        health-check-type: http
+        health-check-invocation-timeout: 10
+        instances: 3
+        memory: 500M
+        log-rate-limit-per-second: 1KB
+        timeout: 10
+      - type: worker
+        command: start-worker.sh
+        disk_quota: 1G
+        health-check-type: process
+        instances: 2
+        memory: 256M
+        log-rate-limit-per-second: 1KB
+        timeout: 15

--- a/src/test/cloudfoundry-application-manifest/test-2.yaml
+++ b/src/test/cloudfoundry-application-manifest/test-2.yaml
@@ -1,0 +1,65 @@
+---
+version: 1
+applications:
+  - name: app1
+    buildpacks:
+      - ruby_buildpack
+      - java_buildpack
+    env:
+      VAR1: value1
+      VAR2: value2
+    routes:
+      - route: route.example.com
+      - route: another-route.example.com
+        protocol: http2
+    services:
+      - my-service1
+      - my-service2
+      - name: my-service-with-arbitrary-params
+        binding_name: my-binding
+        parameters:
+          key1: value1
+          key2: value2
+    stack: cflinuxfs4
+    metadata:
+      annotations:
+        contact: 'bob@example.com jane@example.com'
+      labels:
+        sensitive: true
+    processes:
+      - type: web
+        command: start-web.sh
+        disk_quota: 512M
+        health-check-http-endpoint: /healthcheck
+        health-check-type: http
+        health-check-invocation-timeout: 10
+        instances: 3
+        memory: 500M
+        log-rate-limit-per-second: 1KB
+        timeout: 10
+      - type: worker
+        command: start-worker.sh
+        disk_quota: 1G
+        health-check-type: process
+        instances: 2
+        memory: 256M
+        log-rate-limit-per-second: 1KB
+        timeout: 15
+  - name: app2
+    env:
+      VAR1: value1
+    processes:
+      - type: web
+        instances: 1
+        memory: 256M
+        log-rate-limit-per-second: 1KB
+    sidecars:
+      - name: authenticator
+        process_types: ['web', 'worker']
+        command: bundle exec run-authenticator
+        memory: 800M
+
+      - name: upcaser
+        process_types: ['worker']
+        command: ./tr-server
+        memory: 2G


### PR DESCRIPTION
This PR adds, registers, and tests a schema for Cloud Foundry application manifests. Cloud Foundry is an open-source platform-as-a-service system in use in many organizations. 

Reference material for the schema includes:

* [Cloud Foundry Documentation: App manifest attribute reference](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html)
* [Cloud Foundry v3 API reference, Manifest Schema](https://v3-apidocs.cloudfoundry.org/version/3.163.0/#the-manifest-schema)

Where the two conflicted, I did my best to include the right information. I may follow up with another PR after testing manifest with my Cloud Foundry instance to see what the API server actually accepts.