### PR TITLE
Improve Cloud Foundry manifest schema

### DIFF
--- a/src/schemas/json/cloudfoundry-application-manifest.json
+++ b/src/schemas/json/cloudfoundry-application-manifest.json
@@ -33,7 +33,7 @@
           "type": "string"
         },
         "buildpacks": {
-          "description": "a) An empty array, which will automatically select the appropriate default buildpack according to the coding language; b) An array of one or more URLs pointing to buildpacks; c) An array of one or more installed buildpack names",
+          "description": "`buildpacks` may contain: \n\na) An empty array, which will automatically select the appropriate default buildpack according to the coding language;\nb) An array of one or more URLs pointing to buildpacks;\nc) An array of one or more installed buildpack names.",
           "type": "array",
           "items": {
             "type": "string"
@@ -44,7 +44,7 @@
           "type": "string"
         },
         "disk_quota": {
-          "description": "The disk limit for all instances of the web process; this attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case.",
+          "description": "The disk limit for all instances of the web process. This attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case.",
           "type": "string"
         },
         "docker": {
@@ -54,62 +54,55 @@
           "$ref": "#/definitions/Env"
         },
         "health-check-type": {
-          "description": "Type of health check to perform; none is deprecated and an alias to process.",
-          "enum": ["port", "process", "http"],
-          "default": "port"
+          "description": "Type of health check to perform; none is deprecated and an alias to process. Default is port.",
+          "enum": ["port", "process", "http"]
         },
         "health-check-http-endpoint": {
-          "description": "Endpoint called to determine if the app is healthy.",
-          "type": "string",
-          "default": "/"
+          "description": "Endpoint called to determine if the app is healthy. Default is '/'.",
+          "type": "string"
         },
         "health-check-invocation-timeout": {
-          "description": "The timeout in seconds for individual health check requests for http and port health checks.",
-          "type": "integer",
-          "default": 1
+          "description": "The timeout in seconds for individual health check requests for http and port health checks. Default is 1.",
+          "type": "integer"
         },
         "health-check-interval": {
-          "type": "integer",
-          "default": 30
+          "description": "Default is 30 (seconds).",
+          "type": "integer"
         },
         "readiness-health-check-type": {
-          "enum": ["port", "process", "http"],
-          "default": "process"
+          "description": "Default is process.",
+          "enum": ["port", "process", "http"]
         },
         "readiness-health-check-http-endpoint": {
-          "type": "string",
-          "default": "/"
+          "description": "Default is '/'.",
+          "type": "string"
         },
         "readiness-health-check-invocation-timeout": {
-          "type": "integer",
-          "default": 1
+          "description": "Default is 1 (second).",
+          "type": "integer"
         },
         "readiness-health-check-interval": {
-          "type": "integer",
-          "default": 30
+          "description": "Default is 30 (seconds).",
+          "type": "integer"
         },
         "instances": {
-          "description": "The number of instances to run.",
-          "type": "integer",
-          "default": 1
+          "description": "The number of instances to run. Default is 1.",
+          "type": "integer"
         },
         "log-rate-limit-per-second": {
           "type": "string",
-          "description": "The log-rate-limit-per-second attribute specifies the log rate limit for all instances of an app. This attribute requires a unit of measurement: B, K, KB, M, MB, G, or GB, in either uppercase or lowercase.",
-          "default": "16K"
+          "description": "The log-rate-limit-per-second attribute specifies the log rate limit for all instances of an app. This attribute requires a unit of measurement: B, K, KB, M, MB, G, or GB, in either uppercase or lowercase. Default is 16K."
         },
         "memory": {
-          "description": "The memory attribute specifies the memory limit for all instances of an app. This attribute requires a unit of measurement: M, MB, G, or GB, in either uppercase or lowercase.",
-          "type": "string",
-          "default": "1G"
+          "description": "The memory attribute specifies the memory limit for all instances of an app. This attribute requires a unit of measurement: M, MB, G, or GB, in either uppercase or lowercase. Default is 1G.",
+          "type": "string"
         },
         "metadata": {
           "$ref": "#/definitions/Metadata"
         },
         "no-route": {
-          "description": "When set to true, any routes specified with the routes attribute will be ignored and any existing routes will be removed.",
-          "type": "boolean",
-          "default": false
+          "description": "When set to true, any routes specified with the routes attribute will be ignored and any existing routes will be removed. Default is false.",
+          "type": "boolean"
         },
         "path": {
           "description": "The path attribute tells Cloud Foundry the directory location in which it can find your app. The directory specified as the path, either as an attribute or as a parameter on the command line, becomes the location where the buildpack Detect script runs.",
@@ -124,8 +117,7 @@
         },
         "random-route": {
           "type": "boolean",
-          "description": "Creates a random route for the app if true; if routes is specified, if the app already has routes, or if no-route is specified, this field is ignored regardless of its value.",
-          "default": false
+          "description": "Creates a random route for the app if true. If `routes` is specified, if the app already has routes, or if `no-route` is specified, this field is ignored regardless of its value. Default is false."
         },
         "routes": {
           "type": "array",
@@ -153,9 +145,8 @@
           "type": "string"
         },
         "timeout": {
-          "description": "The duration in seconds that health checks can fail before the process is restarted.",
-          "type": "integer",
-          "default": 60
+          "description": "The duration in seconds that health checks can fail before the process is restarted. Default is 60 (seconds).",
+          "type": "integer"
         }
       },
       "required": ["name"],
@@ -218,41 +209,36 @@
           "description": "The command used to start the process; this overrides start commands from Procfiles and buildpacks."
         },
         "disk_quota": {
-          "description": "The disk limit for all instances of the web process; this attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case",
+          "description": "The disk limit for all instances of the web process. This attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case.",
           "type": "string"
         },
         "health-check-type": {
-          "description": "Type of health check to perform; none is deprecated and an alias to process.",
-          "enum": ["port", "process", "http", "none"],
-          "default": "process"
+          "description": "Type of health check to perform; none is deprecated and an alias to process. Default is process.",
+          "enum": ["port", "process", "http", "none"]
         },
         "health-check-http-endpoint": {
-          "description": "Endpoint called to determine if the app is healthy.",
-          "type": "string",
-          "default": "/"
+          "description": "Endpoint called to determine if the app is healthy. Default is '/'.",
+          "type": "string"
         },
         "health-check-invocation-timeout": {
-          "description": "The timeout in seconds for individual health check requests for http and port health checks.",
-          "type": "integer",
-          "default": 1
+          "description": "The timeout in seconds for individual health check requests for http and port health checks. Default is 1 (second).",
+          "type": "integer"
         },
         "instances": {
-          "description": "The number of instances to run.",
-          "type": "integer",
-          "default": 1
+          "description": "The number of instances to run. Default is 1.",
+          "type": "integer"
         },
         "memory": {
-          "description": "The memory limit for all instances of the web process; this attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case",
+          "description": "The memory limit for all instances of the web process. This attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case.",
           "type": "string"
         },
         "log-rate-limit-per-second": {
-          "description": "The log rate limit for all the instances of the process; this attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case, or -1 or 0",
+          "description": "The log rate limit for all the instances of the process. This attribute requires a unit of measurement: B, K, KB, M, MB, G, GB, T, or TB in upper case or lower case, or -1 or 0.",
           "type": "string"
         },
         "timeout": {
-          "description": "Time in seconds at which the health-check will report failure",
-          "type": "integer",
-          "default": 60
+          "description": "Time in seconds at which the health-check will report failure. Default is 60 (seconds).",
+          "type": "integer"
         }
       },
       "required": ["type"],

--- a/src/schemas/json/cloudfoundry-application-manifest.json
+++ b/src/schemas/json/cloudfoundry-application-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/cloudfoundry-application-manifest.json",
-  "$comment": "Descriptions are sourced from https://v3-apidocs.cloudfoundry.org/version/3.163.0/#the-manifest-schema, with some details from https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html and https://v3-apidocs.cloudfoundry.org/version/3.163.0.",
+  "$comment": "Descriptions are sourced from https://v3-apidocs.cloudfoundry.org/version/3.163.0/#the-manifest-schema, with some details from https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html, https://v3-apidocs.cloudfoundry.org/version/3.163.0, and https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html.",
   "$ref": "#/definitions/Manifest",
   "definitions": {
     "Manifest": {
@@ -54,36 +54,28 @@
           "$ref": "#/definitions/Env"
         },
         "health-check-type": {
-          "description": "Type of health check to perform; none is deprecated and an alias to process. Default is port.",
-          "enum": ["port", "process", "http"]
+          "$ref": "#/definitions/HealthCheckType"
         },
         "health-check-http-endpoint": {
-          "description": "Endpoint called to determine if the app is healthy. Default is '/'.",
-          "type": "string"
+          "$ref": "#/definitions/HealthCheckHTTPEndpoint"
         },
         "health-check-invocation-timeout": {
-          "description": "The timeout in seconds for individual health check requests for http and port health checks. Default is 1.",
-          "type": "integer"
+          "$ref": "#/definitions/HealthCheckInvocationTimeout"
         },
         "health-check-interval": {
-          "description": "Default is 30 (seconds).",
-          "type": "integer"
+          "$ref": "#/definitions/HealthCheckInterval"
         },
         "readiness-health-check-type": {
-          "description": "Default is process.",
-          "enum": ["port", "process", "http"]
+          "$ref": "#/definitions/ReadinessHealthCheckType"
         },
         "readiness-health-check-http-endpoint": {
-          "description": "Default is '/'.",
-          "type": "string"
+          "$ref": "#/definitions/ReadinessHealthCheckHTTPEndpoint"
         },
         "readiness-health-check-invocation-timeout": {
-          "description": "Default is 1 (second).",
-          "type": "integer"
+          "$ref": "#/definitions/ReadinessHealthCheckInvocationTimeout"
         },
         "readiness-health-check-interval": {
-          "description": "Default is 30 (seconds).",
-          "type": "integer"
+          "$ref": "#/definitions/ReadinessHealthCheckInterval"
         },
         "instances": {
           "description": "The number of instances to run. Default is 1.",
@@ -101,7 +93,7 @@
           "$ref": "#/definitions/Metadata"
         },
         "no-route": {
-          "description": "When set to true, any routes specified with the routes attribute will be ignored and any existing routes will be removed. Default is false.",
+          "description": "When set to true, any routes specified with the `routes` attribute will be ignored and any existing routes will be removed. Default is false.",
           "type": "boolean"
         },
         "path": {
@@ -173,6 +165,38 @@
       "description": "A key-value mapping of environment variables to be used for the app when running.",
       "title": "Environment Variables"
     },
+    "HealthCheckType": {
+      "description": "Type of liveliness health check to perform; 'none' is deprecated and an alias to process. Default is 'port'.\n\nLiveness health checks are performed to validate that app instances are running. When liveness health checks fail, the app instance is marked as crashed and is restarted.",
+      "enum": ["port", "process", "http"]
+    },
+    "HealthCheckHTTPEndpoint": {
+      "description": "Endpoint called to determine if the app is healthy when readiness-health-check-type='http'. Default is '/'.",
+      "type": "string"
+    },
+    "HealthCheckInvocationTimeout": {
+      "description": "The timeout in seconds for individual health check requests for http and port health checks. Default is 1 (second).",
+      "type": "integer"
+    },
+    "HealthCheckInterval": {
+      "description": "The amount of time in seconds between starting individual health check requests for HTTP and port health checks. Default is 30 (seconds).",
+      "type": "integer"
+    },
+    "ReadinessHealthCheckType": {
+      "description": "Type of readiness health check to perform. Default is 'process'.\n\nReadiness health checks are performed to validate that app instances are ready to serve requests. When readiness health checks fail, the app instance is marked as not ready and removed from the route pool for the app.",
+      "enum": ["port", "process", "http"]
+    },
+    "ReadinessHealthCheckHTTPEndpoint": {
+      "description": "Endpoint called to determine if the app is ready to serve requests when readiness-health-check-type='http'. Default is '/'.",
+      "type": "string"
+    },
+    "ReadinessHealthCheckInvocationTimeout": {
+      "description": "The timeout in seconds for individual readiness health check requests for HTTP and port health checks. Default is 1 (second).",
+      "type": "integer"
+    },
+    "ReadinessHealthCheckInterval": {
+      "description": "The amount of time in seconds between starting individual readiness health check requests for HTTP and port health checks. Default is 30 (seconds).",
+      "type": "integer"
+    },
     "Metadata": {
       "type": "object",
       "description": "The metadata attribute tags your apps with additional information. You can specify two types of metadata: labels and annotations.",
@@ -213,16 +237,28 @@
           "type": "string"
         },
         "health-check-type": {
-          "description": "Type of health check to perform; none is deprecated and an alias to process. Default is process.",
-          "enum": ["port", "process", "http", "none"]
+          "$ref": "#/definitions/HealthCheckType"
         },
         "health-check-http-endpoint": {
-          "description": "Endpoint called to determine if the app is healthy. Default is '/'.",
-          "type": "string"
+          "$ref": "#/definitions/HealthCheckHTTPEndpoint"
         },
         "health-check-invocation-timeout": {
-          "description": "The timeout in seconds for individual health check requests for http and port health checks. Default is 1 (second).",
-          "type": "integer"
+          "$ref": "#/definitions/HealthCheckInvocationTimeout"
+        },
+        "health-check-interval": {
+          "$ref": "#/definitions/HealthCheckInterval"
+        },
+        "readiness-health-check-type": {
+          "$ref": "#/definitions/ReadinessHealthCheckType"
+        },
+        "readiness-health-check-http-endpoint": {
+          "$ref": "#/definitions/ReadinessHealthCheckHTTPEndpoint"
+        },
+        "readiness-health-check-invocation-timeout": {
+          "$ref": "#/definitions/ReadinessHealthCheckInvocationTimeout"
+        },
+        "readiness-health-check-interval": {
+          "$ref": "#/definitions/ReadinessHealthCheckInterval"
         },
         "instances": {
           "description": "The number of instances to run. Default is 1.",

--- a/src/test/cloudfoundry-application-manifest/test-1.yaml
+++ b/src/test/cloudfoundry-application-manifest/test-1.yaml
@@ -33,6 +33,11 @@ applications:
         health-check-http-endpoint: /healthcheck
         health-check-type: http
         health-check-invocation-timeout: 10
+        health-check-interval: 15
+        readiness-health-check-http-endpoint: /healthcheck
+        readiness-health-check-type: http
+        readiness-health-check-invocation-timeout: 10
+        readiness-health-check-interval: 15
         instances: 3
         memory: 500M
         log-rate-limit-per-second: 1KB

--- a/src/test/cloudfoundry-application-manifest/test-3.yaml
+++ b/src/test/cloudfoundry-application-manifest/test-3.yaml
@@ -1,0 +1,42 @@
+---
+version: 1
+applications:
+  - name: app1
+    buildpacks:
+      - ruby_buildpack
+      - java_buildpack
+    command: start-web.sh
+    env:
+      VAR1: value1
+      VAR2: value2
+    disk_quota: 512M
+    log-rate-limit-per-second: 1KB
+    timeout: 10
+    health-check-http-endpoint: /healthcheck
+    health-check-type: http
+    health-check-invocation-timeout: 10
+    health-check-interval: 15
+    readiness-health-check-http-endpoint: /healthcheck
+    readiness-health-check-type: http
+    readiness-health-check-invocation-timeout: 10
+    readiness-health-check-interval: 15
+    instances: 3
+    memory: 500M
+    routes:
+      - route: route.example.com
+      - route: another-route.example.com
+        protocol: http2
+    services:
+      - my-service1
+      - my-service2
+      - name: my-service-with-arbitrary-params
+        binding_name: my-binding
+        parameters:
+          key1: value1
+          key2: value2
+    stack: cflinuxfs4
+    metadata:
+      annotations:
+        contact: 'bob@example.com jane@example.com'
+      labels:
+        sensitive: true


### PR DESCRIPTION
Reduce tab completion verbosity, improve descriptions, and factor out health checks for use in processes.

* `yaml-language-server` automatically creates and fills any property that has a "default" in the schema when using tab completions. This was not the intended behavior when including defaults in e7f7d29bc091a5efe2b0afd4e8126926bb7749fb and results in overly verbose manifests. Removing the "default" properties fixes this behavior. Defaults are now described in each property's `description`. 
* Improve grammar and display of numerous descriptions.
* Health checks (liveliness and readiness) are valid at the top-level and an processes. Factor them out to definitions and reference them in both locations.
* Expand test coverage to cover health checks and more top-level manifest attributes.

In addition to including tests, I experimentally verified that the new properties are valid using a live Cloud Foundry foundation.