### PR TITLE
Add new `directories` key to Dependabot 2.0 schema

### DIFF
--- a/src/negative_test/dependabot-2.0/directory-and-directories.json
+++ b/src/negative_test/dependabot-2.0/directory-and-directories.json
@@ -1,17 +1,13 @@
 {
-  "version": 2,
   "updates": [
     {
-      "package-ecosystem": "bundler",
+      "directories": ["/frontend", "/backend", "/admin"],
       "directory": "/",
-      "directories": [
-        "/frontend",
-        "/backend",
-        "/admin"
-      ],
+      "package-ecosystem": "bundler",
       "schedule": {
         "interval": "weekly"
       }
     }
-  ]
+  ],
+  "version": 2
 }

--- a/src/negative_test/dependabot-2.0/directory-and-directories.json
+++ b/src/negative_test/dependabot-2.0/directory-and-directories.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "bundler",
+      "directory": "/",
+      "directories": [
+        "/frontend",
+        "/backend",
+        "/admin"
+      ],
+      "schedule": {
+        "interval": "weekly"
+      }
+    }
+  ]
+}

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -972,13 +972,13 @@
           "required": ["package-ecosystem", "schedule"]
         },
         {
-        "oneOf": [
-          { "required": ["directories"] },
-          { "required": ["directory"] }
-        ]
-      }
-    ]
-  },
+          "oneOf": [
+            { "required": ["directories"] },
+            { "required": ["directory"] }
+          ]
+        }
+      ]
+    },
     "registry": {
       "type": "object",
       "description": "The top-level registries key is optional. It allows you to specify authentication details that Dependabot can use to access private package registries.",

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -746,6 +746,16 @@
           ],
           "additionalProperties": false
         },
+        "directories": {
+          "description": "Locations of package manifests",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
         "directory": {
           "description": "Location of package manifests",
           "type": "string",
@@ -957,8 +967,18 @@
           "description": "How to update manifest version requirements"
         }
       },
-      "required": ["package-ecosystem", "directory", "schedule"]
-    },
+      "allOf": [
+        {
+          "required": ["package-ecosystem", "schedule"]
+        },
+        {
+        "oneOf": [
+          { "required": ["directories"] },
+          { "required": ["directory"] }
+        ]
+      }
+    ]
+  },
     "registry": {
       "type": "object",
       "description": "The top-level registries key is optional. It allows you to specify authentication details that Dependabot can use to access private package registries.",

--- a/src/test/dependabot-2.0/directories.json
+++ b/src/test/dependabot-2.0/directories.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "updates": [
+    {
+      "package-ecosystem": "bundler",
+      "directories": [
+        "/frontend",
+        "/backend",
+        "/admin"
+      ],
+      "schedule": {
+        "interval": "weekly"
+      }
+    }
+  ]
+}

--- a/src/test/dependabot-2.0/directories.json
+++ b/src/test/dependabot-2.0/directories.json
@@ -1,16 +1,12 @@
 {
-  "version": 2,
   "updates": [
     {
+      "directories": ["/frontend", "/backend", "/admin"],
       "package-ecosystem": "bundler",
-      "directories": [
-        "/frontend",
-        "/backend",
-        "/admin"
-      ],
       "schedule": {
         "interval": "weekly"
       }
     }
-  ]
+  ],
+  "version": 2
 }


### PR DESCRIPTION
https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/

This pull request introduces changes to support multiple directories for package manifests in the `dependabot-2.0` schema. The changes include adding a new `directories` field, modifying the required fields, and adding new test cases.

Changes to the schema:

* [`src/schemas/json/dependabot-2.0.json`](diffhunk://#diff-945e6d3f8bbea5d408a0500c8ac1a93ab66ded60be4cc77f397c36dace5a1844R749-R758): Added a new `directories` field to specify multiple locations of package manifests. This field is an array of strings with at least one item and all items must be unique.
* [`src/schemas/json/dependabot-2.0.json`](diffhunk://#diff-945e6d3f8bbea5d408a0500c8ac1a93ab66ded60be4cc77f397c36dace5a1844L960-R980): Modified the required fields. Now, it requires either `directories` or `directory` along with `package-ecosystem` and `schedule`.

Addition of new test cases:

* [`src/negative_test/dependabot-2.0/directory-and-directories.json`](diffhunk://#diff-5177ced611f65dd2cfccdf20f5e3e645dc70dca7312068ac24fd3180332a3390R1-R13): Added a new test case where both `directories` and `directory` fields are present.
* [`src/test/dependabot-2.0/directories.json`](diffhunk://#diff-067ea85c5199446296aaa5f9d380909c1d3270239f7f17887a69db20fe574065R1-R12): Added a new test case that uses the new `directories` field.