### PR TITLE
Add $schema field to .omletrc

### DIFF
--- a/src/schemas/json/omletrc.json
+++ b/src/schemas/json/omletrc.json
@@ -3,6 +3,11 @@
   "$id": "https://json.schemastore.org/omletrc.json",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "The schema that the configuration file uses.",
+      "const": "https://json.schemastore.org/omletrc.json"
+    },
     "include": {
       "type": "array",
       "description": "Filenames or glob patterns that will be included in the scan.",


### PR DESCRIPTION
Thank you for the swift release of the .omletrc schema. Post-release, it has come to our attention that users might find it beneficial to have a $schema field included in the configuration. This addition would provide users with a clear reference to the schema that the configuration adheres to, enhancing usability and understanding.

We apologize for any inconvenience this additional request may cause and appreciate your understanding and assistance in this matter.