### PR TITLE
fix: Modify the report type of coverage-py

### DIFF
--- a/src/schemas/json/pantsbuild-2.14.0.json
+++ b/src/schemas/json/pantsbuild-2.14.0.json
@@ -924,7 +924,10 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.14/docs/reference-coverage-py#report",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          }
         },
         "version": {
           "default": "coverage[toml]>=5.5,<5.6",

--- a/src/schemas/json/pantsbuild-2.14.0.json
+++ b/src/schemas/json/pantsbuild-2.14.0.json
@@ -924,7 +924,7 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.14/docs/reference-coverage-py#report",
-          "enum": ["console", "xml", "html", "raw", "json"]
+          "type": "array"
         },
         "version": {
           "default": "coverage[toml]>=5.5,<5.6",

--- a/src/schemas/json/pantsbuild-2.15.0.json
+++ b/src/schemas/json/pantsbuild-2.15.0.json
@@ -935,7 +935,7 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.15/docs/reference-coverage-py#report",
-          "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          "type": "array"
         },
         "version": {
           "default": "coverage[toml]>=6.5,<6.6",

--- a/src/schemas/json/pantsbuild-2.15.0.json
+++ b/src/schemas/json/pantsbuild-2.15.0.json
@@ -935,7 +935,10 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.15/docs/reference-coverage-py#report",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          }
         },
         "version": {
           "default": "coverage[toml]>=6.5,<6.6",

--- a/src/schemas/json/pantsbuild-2.16.0.json
+++ b/src/schemas/json/pantsbuild-2.16.0.json
@@ -745,7 +745,7 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.16/docs/reference-coverage-py#report",
-          "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          "type": "array"
         },
         "requirements": {
           "default": [],

--- a/src/schemas/json/pantsbuild-2.16.0.json
+++ b/src/schemas/json/pantsbuild-2.16.0.json
@@ -745,7 +745,10 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.16/docs/reference-coverage-py#report",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          }
         },
         "requirements": {
           "default": [],

--- a/src/schemas/json/pantsbuild-2.17.0.json
+++ b/src/schemas/json/pantsbuild-2.17.0.json
@@ -745,7 +745,7 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.17/docs/reference-coverage-py#report",
-          "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          "type": "array"
         },
         "requirements": {
           "default": [],

--- a/src/schemas/json/pantsbuild-2.17.0.json
+++ b/src/schemas/json/pantsbuild-2.17.0.json
@@ -745,7 +745,10 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.17/docs/reference-coverage-py#report",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          }
         },
         "requirements": {
           "default": [],

--- a/src/schemas/json/pantsbuild-2.18.0.json
+++ b/src/schemas/json/pantsbuild-2.18.0.json
@@ -924,7 +924,10 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.14/docs/reference-coverage-py#report",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          }
         },
         "version": {
           "default": "coverage[toml]>=5.5,<5.6",

--- a/src/schemas/json/pantsbuild-2.18.0.json
+++ b/src/schemas/json/pantsbuild-2.18.0.json
@@ -924,7 +924,7 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.14/docs/reference-coverage-py#report",
-          "enum": ["console", "xml", "html", "raw", "json"]
+          "type": "array"
         },
         "version": {
           "default": "coverage[toml]>=5.5,<5.6",

--- a/src/schemas/json/pantsbuild-2.19.0.json
+++ b/src/schemas/json/pantsbuild-2.19.0.json
@@ -759,7 +759,7 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.19/docs/reference-coverage-py#report",
-          "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          "type": "array"
         },
         "requirements": {
           "default": [],

--- a/src/schemas/json/pantsbuild-2.19.0.json
+++ b/src/schemas/json/pantsbuild-2.19.0.json
@@ -759,7 +759,10 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.19/docs/reference-coverage-py#report",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          }
         },
         "requirements": {
           "default": [],

--- a/src/schemas/json/pantsbuild-2.20.0.json
+++ b/src/schemas/json/pantsbuild-2.20.0.json
@@ -779,7 +779,7 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.20/docs/reference-coverage-py#report",
-          "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          "type": "array"
         },
         "requirements": {
           "default": [],

--- a/src/schemas/json/pantsbuild-2.20.0.json
+++ b/src/schemas/json/pantsbuild-2.20.0.json
@@ -779,7 +779,10 @@
         "report": {
           "default": ["console"],
           "description": "Which coverage report type(s) to emit\nhttps://www.pantsbuild.org/v2.20/docs/reference-coverage-py#report",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "enum": ["console", "xml", "html", "raw", "json", "lcov"]
+          }
         },
         "requirements": {
           "default": [],

--- a/src/test/pantsbuild-2.14.0/pants.toml
+++ b/src/test/pantsbuild-2.14.0/pants.toml
@@ -61,6 +61,9 @@ extra_type_stubs = [
 version = "black==22.6.0"
 lockfile = "requirements/black.lock"
 
+[coverage-py]
+report = ["xml", "console"]
+
 [docformatter]
 version = "docformatter>=1.4,<1.5"
 lockfile = "requirements/docformatter.lock"


### PR DESCRIPTION

<img width="1234" alt="CleanShot 2024-05-08 at 00 42 00@2x" src="https://github.com/SchemaStore/schemastore/assets/31057849/b39e864b-f792-4b59-b569-3418b4ea0c95">
https://www.pantsbuild.org/2.19/reference/subsystems/coverage-py#report

The report option of [coverage-py] is entered in array format.

In fact, the default value is also ["console"].

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
