### PR TITLE
Add uv configuration to SchemaStore

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4322,6 +4322,12 @@
       "url": "https://raw.githubusercontent.com/evg4b/uncors/main/schema.json"
     },
     {
+      "name": "uv",
+      "description": "uv, a fast Python package installer",
+      "fileMatch": ["uv.toml"],
+      "url": "https://json.schemastore.org/uv.json"
+    },
+    {
       "name": "vega.json",
       "description": "Vega visualization specification file",
       "fileMatch": ["*.vg", "*.vg.json"],

--- a/src/negative_test/pyproject/uv-bad-index-url.toml
+++ b/src/negative_test/pyproject/uv-bad-index-url.toml
@@ -1,0 +1,2 @@
+[tool.uv.pip]
+index-url = 1

--- a/src/schema-validation.json
+++ b/src/schema-validation.json
@@ -790,6 +790,7 @@
         "partial-setuptools.json",
         "poetry.json",
         "ruff.json",
+        "uv.json",
         "base.json"
       ],
       "unknownFormat": [
@@ -934,6 +935,9 @@
     },
     "uproject.json": {
       "unknownKeywords": ["markdownDescription"]
+    },
+    "uv.json": {
+      "unknownFormat": ["uint16", "uint8", "uint", "int"]
     },
     "vega.json": {
       "unknownKeywords": ["defs", "refs", "numItems"]

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -128,6 +128,9 @@
         },
         "pyright": {
           "$ref": "https://json.schemastore.org/partial-pyright.json"
+        },
+        "uv": {
+          "$ref": "https://json.schemastore.org/uv.json"
         }
       },
       "examples": [

--- a/src/schemas/json/uv.json
+++ b/src/schemas/json/uv.json
@@ -1,0 +1,680 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/uv.json",
+  "title": "ToolUv",
+  "description": "Metadata and configuration for uv.",
+  "type": "object",
+  "properties": {
+    "cache-dir": {
+      "type": ["string", "null"]
+    },
+    "native-tls": {
+      "type": ["boolean", "null"]
+    },
+    "no-cache": {
+      "type": ["boolean", "null"]
+    },
+    "pip": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PipOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "preview": {
+      "type": ["boolean", "null"]
+    },
+    "sources": {
+      "type": ["object", "null"],
+      "additionalProperties": {
+        "$ref": "#/definitions/Source"
+      }
+    },
+    "workspace": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ToolUvWorkspace"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "AnnotationStyle": {
+      "description": "Indicate the style of annotation comments, used to indicate the dependencies that requested each package.",
+      "oneOf": [
+        {
+          "description": "Render the annotations on a single, comma-separated line.",
+          "type": "string",
+          "enum": ["line"]
+        },
+        {
+          "description": "Render each annotation on its own line.",
+          "type": "string",
+          "enum": ["split"]
+        }
+      ]
+    },
+    "ConfigSettingValue": {
+      "oneOf": [
+        {
+          "description": "The value consists of a single string.",
+          "type": "object",
+          "required": ["String"],
+          "properties": {
+            "String": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "The value consists of a list of strings.",
+          "type": "object",
+          "required": ["List"],
+          "properties": {
+            "List": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ConfigSettings": {
+      "description": "Settings to pass to a PEP 517 build backend, structured as a map from (string) key to string or list of strings.\n\nSee: <https://peps.python.org/pep-0517/#config-settings>",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ConfigSettingValue"
+      }
+    },
+    "ExcludeNewer": {
+      "description": "Exclude distributions uploaded after the given timestamp.\n\nAccepts both RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(Z|[+-]\\d{2}:\\d{2}))?$"
+    },
+    "ExtraName": {
+      "description": "The normalized name of an extra dependency group.\n\nConverts the name to lowercase and collapses runs of `-`, `_`, and `.` down to a single `-`. For example, `---`, `.`, and `__` are all converted to a single `-`.\n\nSee: - <https://peps.python.org/pep-0685/#specification/> - <https://packaging.python.org/en/latest/specifications/name-normalization/>",
+      "type": "string"
+    },
+    "FlatIndexLocation": {
+      "description": "The path to a directory of distributions, or a URL to an HTML file with a flat listing of distributions.",
+      "type": "string",
+      "format": "uri"
+    },
+    "IndexStrategy": {
+      "oneOf": [
+        {
+          "description": "Only use results from the first index that returns a match for a given package name.\n\nWhile this differs from pip's behavior, it's the default index strategy as it's the most secure.",
+          "type": "string",
+          "enum": ["first-index"]
+        },
+        {
+          "description": "Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next.\n\nIn this strategy, we look for every package across all indexes. When resolving, we attempt to use versions from the indexes in order, such that we exhaust all available versions from the first index before moving on to the next. Further, if a version is found to be incompatible in the first index, we do not reconsider that version in subsequent indexes, even if the secondary index might contain compatible versions (e.g., variants of the same versions with different ABI tags or Python version constraints).\n\nSee: <https://peps.python.org/pep-0708/>",
+          "type": "string",
+          "enum": ["unsafe-first-match"]
+        },
+        {
+          "description": "Search for every package name across all indexes, preferring the \"best\" version found. If a package version is in multiple indexes, only look at the entry for the first index.\n\nIn this strategy, we look for every package across all indexes. When resolving, we consider all versions from all indexes, choosing the \"best\" version found (typically, the highest compatible version).\n\nThis most closely matches pip's behavior, but exposes the resolver to \"dependency confusion\" attacks whereby malicious actors can publish packages to public indexes with the same name as internal packages, causing the resolver to install the malicious package in lieu of the intended internal package.\n\nSee: <https://peps.python.org/pep-0708/>",
+          "type": "string",
+          "enum": ["unsafe-best-match"]
+        }
+      ]
+    },
+    "IndexUrl": {
+      "description": "The URL of an index to use for fetching packages (e.g., `https://pypi.org/simple`).",
+      "type": "string",
+      "format": "uri"
+    },
+    "KeyringProviderType": {
+      "description": "Keyring provider type to use for credential lookup.",
+      "oneOf": [
+        {
+          "description": "Do not use keyring for credential lookup.",
+          "type": "string",
+          "enum": ["disabled"]
+        },
+        {
+          "description": "Use the `keyring` command for credential lookup.",
+          "type": "string",
+          "enum": ["subprocess"]
+        }
+      ]
+    },
+    "LinkMode": {
+      "oneOf": [
+        {
+          "description": "Clone (i.e., copy-on-write) packages from the wheel into the site packages.",
+          "type": "string",
+          "enum": ["clone"]
+        },
+        {
+          "description": "Copy packages from the wheel into the site packages.",
+          "type": "string",
+          "enum": ["copy"]
+        },
+        {
+          "description": "Hard link packages from the wheel into the site packages.",
+          "type": "string",
+          "enum": ["hardlink"]
+        }
+      ]
+    },
+    "PackageName": {
+      "description": "The normalized name of a package.\n\nConverts the name to lowercase and collapses runs of `-`, `_`, and `.` down to a single `-`. For example, `---`, `.`, and `__` are all converted to a single `-`.\n\nSee: <https://packaging.python.org/en/latest/specifications/name-normalization/>",
+      "type": "string"
+    },
+    "PackageNameSpecifier": {
+      "description": "The name of a package, or `:all:` or `:none:` to select or omit all packages, respectively.",
+      "type": "string",
+      "pattern": "^(:none:|:all:|([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]))$"
+    },
+    "PipOptions": {
+      "description": "A `[tool.uv.pip]` section.",
+      "type": "object",
+      "properties": {
+        "all-extras": {
+          "type": ["boolean", "null"]
+        },
+        "annotation-style": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnnotationStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "break-system-packages": {
+          "type": ["boolean", "null"]
+        },
+        "compile-bytecode": {
+          "type": ["boolean", "null"]
+        },
+        "config-settings": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConfigSettings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "custom-compile-command": {
+          "type": ["string", "null"]
+        },
+        "emit-find-links": {
+          "type": ["boolean", "null"]
+        },
+        "emit-index-annotation": {
+          "type": ["boolean", "null"]
+        },
+        "emit-index-url": {
+          "type": ["boolean", "null"]
+        },
+        "emit-marker-expression": {
+          "type": ["boolean", "null"]
+        },
+        "exclude-newer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExcludeNewer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "extra": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/ExtraName"
+          }
+        },
+        "extra-index-url": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/IndexUrl"
+          }
+        },
+        "find-links": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/FlatIndexLocation"
+          }
+        },
+        "generate-hashes": {
+          "type": ["boolean", "null"]
+        },
+        "index-strategy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IndexStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "index-url": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IndexUrl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "keyring-provider": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/KeyringProviderType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "legacy-setup-py": {
+          "type": ["boolean", "null"]
+        },
+        "link-mode": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LinkMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "no-annotate": {
+          "type": ["boolean", "null"]
+        },
+        "no-binary": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/PackageNameSpecifier"
+          }
+        },
+        "no-build": {
+          "type": ["boolean", "null"]
+        },
+        "no-build-isolation": {
+          "type": ["boolean", "null"]
+        },
+        "no-deps": {
+          "type": ["boolean", "null"]
+        },
+        "no-emit-package": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/PackageName"
+          }
+        },
+        "no-header": {
+          "type": ["boolean", "null"]
+        },
+        "no-index": {
+          "type": ["boolean", "null"]
+        },
+        "no-strip-extras": {
+          "type": ["boolean", "null"]
+        },
+        "offline": {
+          "type": ["boolean", "null"]
+        },
+        "only-binary": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/PackageNameSpecifier"
+          }
+        },
+        "output-file": {
+          "type": ["string", "null"]
+        },
+        "prerelease": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PreReleaseMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "python": {
+          "type": ["string", "null"]
+        },
+        "python-platform": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TargetTriple"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "python-version": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PythonVersion"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "require-hashes": {
+          "type": ["boolean", "null"]
+        },
+        "resolution": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResolutionMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strict": {
+          "type": ["boolean", "null"]
+        },
+        "system": {
+          "type": ["boolean", "null"]
+        },
+        "target": {
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "PreReleaseMode": {
+      "oneOf": [
+        {
+          "description": "Disallow all pre-release versions.",
+          "type": "string",
+          "enum": ["disallow"]
+        },
+        {
+          "description": "Allow all pre-release versions.",
+          "type": "string",
+          "enum": ["allow"]
+        },
+        {
+          "description": "Allow pre-release versions if all versions of a package are pre-release.",
+          "type": "string",
+          "enum": ["if-necessary"]
+        },
+        {
+          "description": "Allow pre-release versions for first-party packages with explicit pre-release markers in their version requirements.",
+          "type": "string",
+          "enum": ["explicit"]
+        },
+        {
+          "description": "Allow pre-release versions if all versions of a package are pre-release, or if the package has an explicit pre-release marker in its version requirements.",
+          "type": "string",
+          "enum": ["if-necessary-or-explicit"]
+        }
+      ]
+    },
+    "PythonVersion": {
+      "description": "A Python version specifier, e.g. `3.7` or `3.8.0`.",
+      "type": "string",
+      "pattern": "^3\\.\\d+(\\.\\d+)?$"
+    },
+    "ResolutionMode": {
+      "oneOf": [
+        {
+          "description": "Resolve the highest compatible version of each package.",
+          "type": "string",
+          "enum": ["highest"]
+        },
+        {
+          "description": "Resolve the lowest compatible version of each package.",
+          "type": "string",
+          "enum": ["lowest"]
+        },
+        {
+          "description": "Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies.",
+          "type": "string",
+          "enum": ["lowest-direct"]
+        }
+      ]
+    },
+    "Source": {
+      "description": "A `tool.uv.sources` value.",
+      "anyOf": [
+        {
+          "description": "A remote Git repository, available over HTTPS or SSH.\n\nExample: ```toml flask = { git = \"https://github.com/pallets/flask\", tag = \"3.0.0\" } ```",
+          "type": "object",
+          "required": ["git"],
+          "properties": {
+            "branch": {
+              "type": ["string", "null"]
+            },
+            "git": {
+              "description": "The repository URL (without the `git+` prefix).",
+              "type": "string",
+              "format": "uri"
+            },
+            "rev": {
+              "type": ["string", "null"]
+            },
+            "subdirectory": {
+              "description": "The path to the directory with the `pyproject.toml`, if it's not in the archive root.",
+              "type": ["string", "null"]
+            },
+            "tag": {
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "A remote `http://` or `https://` URL, either a wheel (`.whl`) or a source distribution (`.zip`, `.tar.gz`).\n\nExample: ```toml flask = { url = \"https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl\" } ```",
+          "type": "object",
+          "required": ["url"],
+          "properties": {
+            "subdirectory": {
+              "description": "For source distributions, the path to the directory with the `pyproject.toml`, if it's not in the archive root.",
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "The path to a dependency, either a wheel (a `.whl` file), source distribution (a `.zip` or `.tag.gz` file), or source tree (i.e., a directory containing a `pyproject.toml` or `setup.py` file in the root).",
+          "type": "object",
+          "required": ["path"],
+          "properties": {
+            "editable": {
+              "description": "`false` by default.",
+              "type": ["boolean", "null"]
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "A dependency pinned to a specific index, e.g., `torch` after setting `torch` to `https://download.pytorch.org/whl/cu118`.",
+          "type": "object",
+          "required": ["index"],
+          "properties": {
+            "index": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "A dependency on another package in the workspace.",
+          "type": "object",
+          "required": ["workspace"],
+          "properties": {
+            "editable": {
+              "description": "`true` by default.",
+              "type": ["boolean", "null"]
+            },
+            "workspace": {
+              "description": "When set to `false`, the package will be fetched from the remote index, rather than included as a workspace package.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "A catch-all variant used to emit precise error messages when deserializing.",
+          "type": "object",
+          "required": ["git", "index", "patch", "url", "workspace"],
+          "properties": {
+            "branch": {
+              "type": ["string", "null"]
+            },
+            "git": {
+              "type": "string"
+            },
+            "index": {
+              "type": "string"
+            },
+            "patch": {
+              "type": "string"
+            },
+            "rev": {
+              "type": ["string", "null"]
+            },
+            "subdirectory": {
+              "type": ["string", "null"]
+            },
+            "tag": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": "string"
+            },
+            "workspace": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "String": {
+      "type": "string"
+    },
+    "TargetTriple": {
+      "description": "The supported target triples. Each triple consists of an architecture, vendor, and operating system.\n\nSee: <https://doc.rust-lang.org/nightly/rustc/platform-support.html>",
+      "oneOf": [
+        {
+          "description": "An alias for `x86_64-pc-windows-msvc`, the default target for Windows.",
+          "type": "string",
+          "enum": ["windows"]
+        },
+        {
+          "description": "An alias for `x86_64-unknown-linux-gnu`, the default target for Linux.",
+          "type": "string",
+          "enum": ["linux"]
+        },
+        {
+          "description": "An alias for `aarch64-apple-darwin`, the default target for macOS.",
+          "type": "string",
+          "enum": ["macos"]
+        },
+        {
+          "description": "An x86 Windows target.",
+          "type": "string",
+          "enum": ["x86_64-pc-windows-msvc"]
+        },
+        {
+          "description": "An x86 Linux target. Equivalent to `x86_64-manylinux_2_17`.",
+          "type": "string",
+          "enum": ["x86_64-unknown-linux-gnu"]
+        },
+        {
+          "description": "An ARM-based macOS target, as seen on Apple Silicon devices.",
+          "type": "string",
+          "enum": ["aarch64-apple-darwin"]
+        },
+        {
+          "description": "An x86 macOS target.",
+          "type": "string",
+          "enum": ["x86_64-apple-darwin"]
+        },
+        {
+          "description": "An ARM64 Linux target. Equivalent to `aarch64-manylinux_2_17`.",
+          "type": "string",
+          "enum": ["aarch64-unknown-linux-gnu"]
+        },
+        {
+          "description": "An ARM64 Linux target.",
+          "type": "string",
+          "enum": ["aarch64-unknown-linux-musl"]
+        },
+        {
+          "description": "An `x86_64` Linux target.",
+          "type": "string",
+          "enum": ["x86_64-unknown-linux-musl"]
+        },
+        {
+          "description": "An `x86_64` target for the `manylinux_2_17` platform.",
+          "type": "string",
+          "enum": ["x86_64-manylinux_2_17"]
+        },
+        {
+          "description": "An `x86_64` target for the `manylinux_2_28` platform.",
+          "type": "string",
+          "enum": ["x86_64-manylinux_2_28"]
+        },
+        {
+          "description": "An ARM64 target for the `manylinux_2_17` platform.",
+          "type": "string",
+          "enum": ["aarch64-manylinux_2_17"]
+        },
+        {
+          "description": "An ARM64 target for the `manylinux_2_28` platform.",
+          "type": "string",
+          "enum": ["aarch64-manylinux_2_28"]
+        }
+      ]
+    },
+    "ToolUvWorkspace": {
+      "type": "object",
+      "properties": {
+        "exclude": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/String"
+          }
+        },
+        "members": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/String"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/test/pyproject/uv-sample-project.toml
+++ b/src/test/pyproject/uv-sample-project.toml
@@ -1,0 +1,4 @@
+[tool.uv]
+
+[tool.uv.pip]
+index-url = "https://test.pypi.org/simple"


### PR DESCRIPTION
## Summary

This PR adds the JSON Schema for uv, our Python package installer and resolver (https://github.com/astral-sh/uv). The setup follows the approach used for Ruff (https://github.com/astral-sh/ruff), whereby we support both `uv.toml` and `pyproject.toml`.