### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -1372,7 +1372,7 @@
           }
         },
         "sections": {
-          "description": "A list of mappings from section names to modules.\n\nBy default, imports are categorized according to their type (e.g., `future`, `third-party`, and so on). This setting allows you to group modules into custom sections, to augment or override the built-in sections.\n\nFor example, to group all testing utilities, you could create a `testing` section: ```toml testing = [\"pytest\", \"hypothesis\"] ```\n\nCustom sections should typically be inserted into the `section-order` list to ensure that they're displayed as a standalone group and in the intended order, as in: ```toml section-order = [ \"future\", \"standard-library\", \"third-party\", \"first-party\", \"local-folder\", \"testing\" ] ```\n\nIf a custom section is omitted from `section-order`, imports in that section will be assigned to the `default-section` (which defaults to `third-party`).",
+          "description": "A list of mappings from section names to modules.\n\nBy default, imports are categorized according to their type (e.g., `future`, `third-party`, and so on). This setting allows you to group modules into custom sections, to augment or override the built-in sections.\n\nFor example, to group all testing utilities, you could create a `testing` section: ```toml testing = [\"pytest\", \"hypothesis\"] ```\n\nThe values in the list are treated as glob patterns. For example, to match all packages in the LangChain ecosystem (`langchain-core`, `langchain-openai`, etc.): ```toml langchain = [\"langchain-*\"] ```\n\nCustom sections should typically be inserted into the `section-order` list to ensure that they're displayed as a standalone group and in the intended order, as in: ```toml section-order = [ \"future\", \"standard-library\", \"third-party\", \"first-party\", \"local-folder\", \"testing\" ] ```\n\nIf a custom section is omitted from `section-order`, imports in that section will be assigned to the `default-section` (which defaults to `third-party`).",
           "type": ["object", "null"],
           "additionalProperties": {
             "type": "array",
@@ -2543,6 +2543,7 @@
         "FURB11",
         "FURB110",
         "FURB113",
+        "FURB116",
         "FURB118",
         "FURB12",
         "FURB129",
@@ -3068,6 +3069,9 @@
         "PYI055",
         "PYI056",
         "PYI058",
+        "PYI059",
+        "PYI06",
+        "PYI062",
         "Q",
         "Q0",
         "Q00",
@@ -3125,6 +3129,7 @@
         "RUF1",
         "RUF10",
         "RUF100",
+        "RUF101",
         "RUF2",
         "RUF20",
         "RUF200",


### PR DESCRIPTION
This updates ruff's JSON schema to [3e8878a1c852399dffedb0236097afcfb4780b81](https://github.com/astral-sh/ruff/commit/3e8878a1c852399dffedb0236097afcfb4780b81)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
