### PR TITLE
Update traefik-v2 logs properties

### DIFF
--- a/src/schemas/json/traefik-v2.json
+++ b/src/schemas/json/traefik-v2.json
@@ -6,11 +6,18 @@
     "accessLog": {
       "type": "object",
       "properties": {
+        "addInternals": {
+          "type": "boolean",
+          "default": false
+        },
         "filePath": {
           "type": "string"
         },
         "format": {
           "type": "string"
+        },
+        "bufferingSize": {
+          "type": "integer"
         },
         "filters": {
           "type": "object",
@@ -60,9 +67,6 @@
               }
             }
           }
-        },
-        "bufferingSize": {
-          "type": "integer"
         }
       },
       "additionalProperties": false
@@ -414,14 +418,29 @@
     "log": {
       "type": "object",
       "properties": {
-        "level": {
-          "type": "string"
-        },
         "filePath": {
           "type": "string"
         },
         "format": {
           "type": "string"
+        },
+        "level": {
+          "type": "string"
+        },
+        "noColor": {
+          "type": "boolean"
+        },
+        "maxSize": {
+          "type": "integer"
+        },
+        "maxBackups": {
+          "type": "integer"
+        },
+        "maxAge": {
+          "type": "integer"
+        },
+        "compress": {
+          "type": "integer"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Update "logs"
- add missing `noColor`, `maxSize`, `maxBackups`, `maxAge` and `compress`
 
Update "accessLog"
- add missing `addInternals`

https://doc.traefik.io/traefik/observability/logs/
https://doc.traefik.io/traefik/observability/access-logs/