### PR TITLE
Fix traefik-v2 log.compress type

### DIFF
--- a/src/schemas/json/traefik-v2.json
+++ b/src/schemas/json/traefik-v2.json
@@ -440,7 +440,7 @@
           "type": "integer"
         },
         "compress": {
-          "type": "integer"
+          "type": "boolean"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Turns out there were a bug in the docs

https://github.com/traefik/traefik/pull/10716