### PR TITLE
Add CVE Record Format to catalogue

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1010,6 +1010,12 @@
       "url": "https://raw.githubusercontent.com/clawject/clawject/main/packages/clawject/src/compile-time/config/schema.json"
     },
     {
+      "name": "CVE Record Format",
+      "description": "CVE record format to describe security vulnerabilities",
+      "fileMatch": ["CVE-*.json"],
+      "url": "https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/docs/CVE_Record_Format_bundled.json"
+    },
+    {
       "name": "Cycle Stack File",
       "description": "A Cycle.io stack file for environments as code",
       "fileMatch": ["cycle.json", "cycle.yml", "cycle.yaml"],


### PR DESCRIPTION
Add the CVE Record Format, as maintained by cve.org, to catalog.json.
