### PR TITLE
Add support for Node.js 20.x to JSON schema

### DIFF
--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -40,6 +40,7 @@
             "nodejs14.x",
             "nodejs16.x",
             "nodejs18.x",
+            "nodejs20.x",
             "nodejs4.3",
             "nodejs4.3-edge",
             "nodejs6.10",


### PR DESCRIPTION
The updated version of the tunnelhub.json file now includes "nodejs20.x" in the list of supported Node.js versions. This update broadens the range of compatible environments with our software.

