### PR TITLE
Add support for `buf` v2 configuration files

### DIFF
--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -1,325 +1,337 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/buf.gen.json",
-  "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml",
+  "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml",
   "title": "buf.gen.yaml",
   "description": "buf.gen.yaml is a configuration file used by the buf generate command to generate integration code for the languages of your choice.",
   "type": "object",
   "properties": {
     "version": {
-      "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#version",
-      "description": "Required. Defines the current configuration version. Accepted values are v1beta1 and v1.",
+      "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#version",
+      "description": "Required. Defines the current configuration version. Accepted values are `v2`, `v1`, or `v1beta1`.",
       "type": "string",
-      "enum": ["v1beta1", "v1"]
-    },
-    "plugins": {
-      "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugins",
-      "description": "Required. Each entry in the plugins key is a protoc plugin configuration. Plugins are invoked in parallel and their outputs are written in the order you specify here.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "plugin": {
-            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin",
-            "type": "string",
-            "description": "Required. The name of the plugin to use—can be local or remote. See https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin."
-          },
-          "name": {
-            "type": "string"
-          },
-          "remote": {
-            "type": "string",
-            "deprecated": true
-          },
-          "out": {
-            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#out",
-            "type": "string",
-            "description": "Required. Controls where the generated files are deposited for a given plugin. Although absolute paths are supported, this configuration is typically a relative output directory to where buf generate is run."
-          },
-          "opt": {
-            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#opt",
-            "description": "Optional. Specifies one or more plugin options for each plugin independently. You can provide options as either a single string or a list of strings.",
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            ]
-          },
-          "path": {
-            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#path",
-            "description": "Optional. Only works with local plugins. Overrides the default location and explicitly specifies where to locate the plugin.",
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            ]
-          },
-          "revision": {
-            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#revision",
-            "description": "Optional. May be used along with the plugin field to pin an exact version of a remote plugin. In most cases, we recommend omitting revision, in which case the latest revision of that version of the plugin will be used (automatically pulling in the latest bug fixes).",
-            "type": "integer",
-            "minimum": 0
-          },
-          "strategy": {
-            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy",
-            "description": "Optional. Specifies the invocation strategy to use. See https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy.",
-            "type": "string",
-            "enum": ["directory", "all"]
-          },
-          "protoc_path": {
-            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path",
-            "description": "Optional. Only applies to the code generators that are built in to protoc. Normally, a plugin is a separate executable with a binary name like protoc-gen-<name>. But for a handful of plugins, the executable used is protoc itself. See https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path.",
-            "type": "string"
-          }
-        },
-        "required": ["out"],
-        "additionalProperties": false
+      "enum": ["v2", "v1", "v1beta1"]
+    }
+  },
+  "if": {
+    "properties": {
+      "version": {
+        "const": "v1"
       }
-    },
-    "managed": {
-      "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#managed",
-      "description": "The managed key is used to configure managed mode, an advanced feature for Protobuf options. See https://buf.build/docs/generate/managed-mode.",
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#enabled",
-          "description": "Required if any other managed keys are set. Setting enabled equal to true with no other keys set enables managed mode according to default behavior. See https://buf.build/docs/generate/managed-mode#default-behavior.",
-          "type": "boolean"
-        },
-        "cc_enable_arenas": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#cc_enable_arenas",
-          "description": "Optional. If unset, this option is left as specified in your .proto files. As of Protocol Buffers release v3.14.0, changing this value no longer has any effect.",
-          "type": "boolean"
-        },
-        "csharp_namespace": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#csharp_namespace",
-          "description": "Optional. Controls the default C# namespace for classes generated from all of the .proto files contained within the input. Managed mode generates C# files with a top-level namespace based on each .proto file’s package, with each part transformed to PascalCase.",
+    }
+  },
+  "then": {
+    "required": ["version", "plugins"],
+    "properties": {
+      "plugins": {
+        "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugins",
+        "description": "Required. Each entry in the plugins key is a protoc plugin configuration. Plugins are invoked in parallel and their outputs are written in the order you specify here.",
+        "type": "array",
+        "items": {
           "type": "object",
           "properties": {
-            "except": {
-              "description": "Optional. Removes the specified modules from the default csharp_namespace option behavior. The except keys must be valid module names.",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "plugin": {
+              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin",
+              "type": "string",
+              "description": "Required. The name of the plugin to use—can be local or remote. See https://buf.build/docs/configuration/v1/buf-gen-yaml#plugin."
             },
-            "override": {
-              "description": "Optional. Overrides the csharp_namespace value used for specific modules. The override keys must be valid module names.",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        "go_package_prefix": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#go_package_prefix",
-          "description": "Optional. Controls what the go_package value is set to for all of the .proto files contained within the input. If unset, this option is left as specified in your .proto files.",
-          "type": "object",
-          "properties": {
-            "default": {
-              "description": "Required if the go_package_prefix key is set. The default value is used as a prefix for the go_package value set in each of the files. It must be a relative file path that must not jump context from the current directory—that is, it must be subdirectories relative to the current working directory.",
+            "name": {
               "type": "string"
             },
-            "except": {
-              "description": "Optional. Removes certain modules from the go_package option behavior. The except values must be valid module names. There are situations where you may want to enable managed mode for the go_package option in most of your Protobuf files, but not necessarily for all of your Protobuf files. This is particularly relevant for the buf.build/googleapis/googleapis module, which points its go_package value to an external repository. Popular libraries such as grpc-go depend on these go_package values, so it's important that managed mode does not overwrite them.",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "remote": {
+              "type": "string",
+              "deprecated": true
             },
-            "override": {
-              "description": "Optional. Overrides the go_package file option value used for specific modules. The override keys must be valid module names. Additionally, the corresponding override values must be a valid Go import path and must not jump context from the current directory. As an example, ../external is invalid. This setting is used for workspace environments, where you have a module that imports from another module in the same workspace, and you need to generate the Go code for each module in different directories. This is particularly relevant for repositories that decouple their private API definitions from their public API definitions.",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          },
-          "required": ["default"],
-          "additionalProperties": false
-        },
-        "java_multiple_files": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_multiple_files",
-          "description": "Optional. Controls what the java_multiple_files value is set to for all of the .proto files contained within the input. The only accepted values are false and true. Managed mode defaults to true (Protobuf's default is false). See https://buf.build/docs/configuration/v1/buf-gen-yaml#java_multiple_files.",
-          "type": "boolean"
-        },
-        "java_package_prefix": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_package_prefix",
-          "description": "Optional. Controls what is prepended to the java_package value is set to for all of the .proto files contained within the input. If this is unset, managed mode's default value is `com`.",
-          "oneOf": [
-            {
-              "type": "string"
+            "out": {
+              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#out",
+              "type": "string",
+              "description": "Required. Controls where the generated files are deposited for a given plugin. Although absolute paths are supported, this configuration is typically a relative output directory to where buf generate is run."
             },
-            {
-              "type": "object",
-              "properties": {
-                "default": {
-                  "description": "Required if the java_package_prefix key is set. The default value is used as a prefix for the java_package value set in each of the files.",
+            "opt": {
+              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#opt",
+              "description": "Optional. Specifies one or more plugin options for each plugin independently. You can provide options as either a single string or a list of strings.",
+              "oneOf": [
+                {
                   "type": "string"
                 },
-                "except": {
-                  "description": "Optional. Removes the specified modules from the java_package option behavior. The except keys must be valid module names.",
+                {
                   "type": "array",
                   "items": {
                     "type": "string"
                   }
+                }
+              ]
+            },
+            "path": {
+              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#path",
+              "description": "Optional. Only works with local plugins. Overrides the default location and explicitly specifies where to locate the plugin.",
+              "oneOf": [
+                {
+                  "type": "string"
                 },
-                "override": {
-                  "description": "Optional. Overrides the java_package option value used for specific modules. The override keys must be valid module names.",
-                  "type": "object",
-                  "additionalProperties": {
+                {
+                  "type": "array",
+                  "items": {
                     "type": "string"
                   }
                 }
-              },
-              "required": ["default"],
-              "additionalProperties": false
-            }
-          ]
-        },
-        "java_string_check_utf8": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_string_check_utf8",
-          "description": "Optional. Controls what the java_string_check_utf8 value is set to for all of the .proto files contained within the input. The only accepted values are false and true. If unset, this option is left as specified in your .proto files. Protobuf's default is false.",
-          "type": "boolean"
-        },
-        "objc_class_prefix": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#objc_class_prefix",
-          "description": "Optional. When managed mode is enabled, this defaults to an abbreviation of the package name as described in the default behavior section. The value is prepended to all generated classes. See https://buf.build/docs/generate/managed-mode#default-behavior.",
-          "type": "object",
-          "properties": {
-            "default": {
-              "description": "Optional. Overrides managed mode's default value for the class prefix.",
+              ]
+            },
+            "revision": {
+              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#revision",
+              "description": "Optional. May be used along with the plugin field to pin an exact version of a remote plugin. In most cases, we recommend omitting revision, in which case the latest revision of that version of the plugin will be used (automatically pulling in the latest bug fixes).",
+              "type": "integer",
+              "minimum": 0
+            },
+            "strategy": {
+              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy",
+              "description": "Optional. Specifies the invocation strategy to use. See https://buf.build/docs/configuration/v1/buf-gen-yaml#strategy.",
+              "type": "string",
+              "enum": ["directory", "all"]
+            },
+            "protoc_path": {
+              "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path",
+              "description": "Optional. Only applies to the code generators that are built in to protoc. Normally, a plugin is a separate executable with a binary name like protoc-gen-<name>. But for a handful of plugins, the executable used is protoc itself. See https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path.",
               "type": "string"
-            },
-            "except": {
-              "description": "Optional. Removes the specified modules from the objc_class_prefix option behavior. The except keys must be valid module names.",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "override": {
-              "description": "Optional. Overrides any default objc_class_prefix option value for specific modules. The override keys must be valid module names.",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
+            }
+          },
+          "required": ["out"],
+          "additionalProperties": false
+        }
+      },
+      "managed": {
+        "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#managed",
+        "description": "The managed key is used to configure managed mode, an advanced feature for Protobuf options. See https://buf.build/docs/generate/managed-mode.",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#enabled",
+            "description": "Required if any other managed keys are set. Setting enabled equal to true with no other keys set enables managed mode according to default behavior. See https://buf.build/docs/generate/managed-mode#default-behavior.",
+            "type": "boolean"
+          },
+          "cc_enable_arenas": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#cc_enable_arenas",
+            "description": "Optional. If unset, this option is left as specified in your .proto files. As of Protocol Buffers release v3.14.0, changing this value no longer has any effect.",
+            "type": "boolean"
+          },
+          "csharp_namespace": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#csharp_namespace",
+            "description": "Optional. Controls the default C# namespace for classes generated from all of the .proto files contained within the input. Managed mode generates C# files with a top-level namespace based on each .proto file’s package, with each part transformed to PascalCase.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "except": {
+                "description": "Optional. Removes the specified modules from the default csharp_namespace option behavior. The except keys must be valid module names.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "override": {
+                "description": "Optional. Overrides the csharp_namespace value used for specific modules. The override keys must be valid module names.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             }
           },
-          "required": ["default"],
-          "additionalProperties": false
-        },
-        "optimize_for": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#optimize_for",
-          "description": "Optional. Controls what the optimize_for value is set to for all of the .proto files contained within the input. The only accepted values are SPEED, CODE_SIZE and LITE_RUNTIME. Managed mode will not modify this option if unset.",
-          "type": "string",
-          "enum": ["SPEED", "CODE_SIZE", "LITE_RUNTIME"]
-        },
-        "ruby_package": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#ruby_package",
-          "description": "Optional. Controls what the ruby_package value is set to for all of the .proto files contained within the input. Managed mode's default value is the package name with each package sub-name capitalized, with :: substituted for .",
-          "type": "object",
-          "properties": {
-            "except": {
-              "description": "Optional. Removes the specified modules from the ruby_package file option override behavior. The except keys must be valid module names.",
-              "type": "array",
-              "items": {
+          "go_package_prefix": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#go_package_prefix",
+            "description": "Optional. Controls what the go_package value is set to for all of the .proto files contained within the input. If unset, this option is left as specified in your .proto files.",
+            "type": "object",
+            "required": ["default"],
+            "additionalProperties": false,
+            "properties": {
+              "default": {
+                "description": "Required if the go_package_prefix key is set. The default value is used as a prefix for the go_package value set in each of the files. It must be a relative file path that must not jump context from the current directory—that is, it must be subdirectories relative to the current working directory.",
                 "type": "string"
-              }
-            },
-            "override": {
-              "description": "Optional. Overrides the ruby_package file option value used for specific modules. The override keys must be valid module names.",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
+              },
+              "except": {
+                "description": "Optional. Removes certain modules from the go_package option behavior. The except values must be valid module names. There are situations where you may want to enable managed mode for the go_package option in most of your Protobuf files, but not necessarily for all of your Protobuf files. This is particularly relevant for the buf.build/googleapis/googleapis module, which points its go_package value to an external repository. Popular libraries such as grpc-go depend on these go_package values, so it's important that managed mode does not overwrite them.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "override": {
+                "description": "Optional. Overrides the go_package file option value used for specific modules. The override keys must be valid module names. Additionally, the corresponding override values must be a valid Go import path and must not jump context from the current directory. As an example, ../external is invalid. This setting is used for workspace environments, where you have a module that imports from another module in the same workspace, and you need to generate the Go code for each module in different directories. This is particularly relevant for repositories that decouple their private API definitions from their public API definitions.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             }
           },
-          "additionalProperties": false
-        },
-        "override": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#per-file-override",
-          "description": "Optional. This is a list of per-file overrides for each modifier. See https://buf.build/docs/configuration/v1/buf-gen-yaml#per-file-override.",
-          "type": "object",
-          "properties": {
-            "CSHARP_NAMESPACE": {
-              "type": "object",
-              "additionalProperties": {
+          "java_multiple_files": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_multiple_files",
+            "description": "Optional. Controls what the java_multiple_files value is set to for all of the .proto files contained within the input. The only accepted values are false and true. Managed mode defaults to true (Protobuf's default is false). See https://buf.build/docs/configuration/v1/buf-gen-yaml#java_multiple_files.",
+            "type": "boolean"
+          },
+          "java_package_prefix": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_package_prefix",
+            "description": "Optional. Controls what is prepended to the java_package value is set to for all of the .proto files contained within the input. If this is unset, managed mode's default value is `com`.",
+            "oneOf": [
+              {
                 "type": "string"
+              },
+              {
+                "type": "object",
+                "required": ["default"],
+                "additionalProperties": false,
+                "properties": {
+                  "default": {
+                    "description": "Required if the java_package_prefix key is set. The default value is used as a prefix for the java_package value set in each of the files.",
+                    "type": "string"
+                  },
+                  "except": {
+                    "description": "Optional. Removes the specified modules from the java_package option behavior. The except keys must be valid module names.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "override": {
+                    "description": "Optional. Overrides the java_package option value used for specific modules. The override keys must be valid module names.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                }
               }
-            },
-            "GO_PACKAGE": {
-              "type": "object",
-              "additionalProperties": {
+            ]
+          },
+          "java_string_check_utf8": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#java_string_check_utf8",
+            "description": "Optional. Controls what the java_string_check_utf8 value is set to for all of the .proto files contained within the input. The only accepted values are false and true. If unset, this option is left as specified in your .proto files. Protobuf's default is false.",
+            "type": "boolean"
+          },
+          "objc_class_prefix": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#objc_class_prefix",
+            "description": "Optional. When managed mode is enabled, this defaults to an abbreviation of the package name as described in the default behavior section. The value is prepended to all generated classes. See https://buf.build/docs/generate/managed-mode#default-behavior.",
+            "type": "object",
+            "required": ["default"],
+            "additionalProperties": false,
+            "properties": {
+              "default": {
+                "description": "Optional. Overrides managed mode's default value for the class prefix.",
                 "type": "string"
+              },
+              "except": {
+                "description": "Optional. Removes the specified modules from the objc_class_prefix option behavior. The except keys must be valid module names.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "override": {
+                "description": "Optional. Overrides any default objc_class_prefix option value for specific modules. The override keys must be valid module names.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
-            },
-            "JAVA_MULTIPLE_FILES": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
+            }
+          },
+          "optimize_for": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#optimize_for",
+            "description": "Optional. Controls what the optimize_for value is set to for all of the .proto files contained within the input. The only accepted values are SPEED, CODE_SIZE and LITE_RUNTIME. Managed mode will not modify this option if unset.",
+            "type": "string",
+            "enum": ["SPEED", "CODE_SIZE", "LITE_RUNTIME"]
+          },
+          "ruby_package": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#ruby_package",
+            "description": "Optional. Controls what the ruby_package value is set to for all of the .proto files contained within the input. Managed mode's default value is the package name with each package sub-name capitalized, with :: substituted for .",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "except": {
+                "description": "Optional. Removes the specified modules from the ruby_package file option override behavior. The except keys must be valid module names.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "override": {
+                "description": "Optional. Overrides the ruby_package file option value used for specific modules. The override keys must be valid module names.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
-            },
-            "JAVA_OUTER_CLASSNAME": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "JAVA_PACKAGE": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "JAVA_STRING_CHECK_UTF8": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "OBJC_CLASS_PREFIX": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "OPTIMIZE_FOR": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "PHP_METADATA_NAMESPACE": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "PHP_NAMESPACE": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "RUBY_PACKAGE": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
+            }
+          },
+          "override": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#per-file-override",
+            "description": "Optional. This is a list of per-file overrides for each modifier. See https://buf.build/docs/configuration/v1/buf-gen-yaml#per-file-override.",
+            "type": "object",
+            "properties": {
+              "CSHARP_NAMESPACE": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "GO_PACKAGE": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "JAVA_MULTIPLE_FILES": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "JAVA_OUTER_CLASSNAME": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "JAVA_PACKAGE": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "JAVA_STRING_CHECK_UTF8": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "OBJC_CLASS_PREFIX": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "OPTIMIZE_FOR": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "PHP_METADATA_NAMESPACE": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "PHP_NAMESPACE": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "RUBY_PACKAGE": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -327,5 +339,249 @@
       }
     }
   },
-  "required": ["version", "plugins"]
+  "else": {
+    "$comment": "v2 properties",
+    "properties": {
+      "managed": {
+        "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#managed",
+        "description": "The managed key is used to enable managed mode, an advanced feature that allows you to specify Protobuf file and field options without defining them in the Protobuf files. See Managed mode for details about default behavior and accepted values for each available option key.",
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#enabled",
+            "description": "Required if any other managed keys are set. Default is false. If a file or field option has no default, then managed mode doesn't modify that option and will only modify it if an override rule is specified.",
+            "type": "boolean",
+            "default": false
+          },
+          "disable": {
+            "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#disable",
+            "description": "Optional. Allows you to granularly disable managed mode for either file options or field options by specifying a list of rules. There are two types of rules: file option or field option. For both types of disable rules, you can set any combination of keys and the union is used to determine the combination of file and field options that managed mode doesn't modify. A disable rule must have at least one key set.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "minProperties": 1,
+              "properties": {
+                "module": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "file_option": {
+                  "type": "string"
+                },
+                "field_option": {
+                  "type": "string"
+                },
+                "field": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "override": {
+            "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#override",
+            "description": "Optional. Allows you to granularly override the file and field options that managed mode handles. Similar to disable rules, there are two types of override rules: field option or file option. For each override rule, you must provide an option and a valid value based on the option. You can then choose to set a path and/or module to filter the files that the override rule applies to. The rules will be applied instead of managed mode's default behavior, unless an option or file has an applicable disable rule.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "minProperties": 1,
+              "properties": {
+                "file_option": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "module": {
+                  "type": "string"
+                },
+                "field_option": {
+                  "type": "string"
+                },
+                "field": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "plugins": {
+        "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#plugins",
+        "description": "Required. Each entry in the plugins key is a protoc plugin configuration. Plugins are invoked in parallel and their outputs are written in the order you specify here.",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "required": ["out"],
+          "properties": {
+            "remote": {
+              "description": "Indicates a remote plugin hosted on either the public BSR or a private BSR. Its value must be in the form of <REMOTE>/<ORGANIZATION>/<PLUGIN>.",
+              "type": "string"
+            },
+            "revision": {
+              "description": "The revision of the remote plugin. Only valid when specified with the `remote` key.",
+              "type": "integer",
+              "minimum": 1
+            },
+            "protoc_builtin": {
+              "description": "Only applies to the code generators that are built into protoc. The following values for this field result in invoking protoc instead of a dedicated plugin binary. If you specify this type of plugin, you must also provide the protoc_path value as a string.",
+              "type": "string"
+            },
+            "protoc_path": {
+              "type": "string"
+            },
+            "local": {
+              "description": "A string or list of strings that point to the names of plugin binaries on your ${PATH}, or to its relative or absolute location on disk. If you specify a list of strings, the first is the local name, and the subsequent strings are considered arguments passed to the binary.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "out": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#out",
+              "description": "Required. Controls where the generated files are deposited for a given plugin. Although absolute paths are supported, this configuration is typically a relative output directory to where buf generate is run.",
+              "type": "string"
+            },
+            "opt": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#opt",
+              "description": "Optional. Specifies one or more plugin options for a plugin. You can provide options as either a single string or a list of strings.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "strategy": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#strategy",
+              "description": "Optional. Specifies the invocation strategy to use.",
+              "type": "string",
+              "enum": ["directory", "all"]
+            },
+            "include_imports": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#include_imports",
+              "description": "Optional. Generates all imports except for Well-Known Types. This setting works the same as the --include-imports flag on buf generate—if they conflict with each other, the flag gets precedence.",
+              "type": "boolean"
+            },
+            "include_wkt": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#include_wkt",
+              "description": "Optional. Generates Well-Known Types. Can't be set without --include-imports. This setting works the same as the --include-wkt flag on buf generate—if they conflict with each other, the flag gets precedence.",
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "inputs": {
+        "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#inputs",
+        "description": "Required. A list of inputs to generate code for.",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "git_repo": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "subdir": {
+              "type": "string"
+            },
+            "depth": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "module": {
+              "type": "string"
+            },
+            "directory": {
+              "type": "string"
+            },
+            "tarball": {
+              "type": "string"
+            },
+            "compression": {
+              "type": "string"
+            },
+            "strip_components": {
+              "type": "integer"
+            },
+            "zip_archive": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "proto_file": {
+              "type": "string"
+            },
+            "include_package_files": {
+              "type": "boolean",
+              "default": false
+            },
+            "binary_image": {
+              "type": "string"
+            },
+            "json_image": {
+              "type": "string"
+            },
+            "txt_image": {
+              "type": "string"
+            },
+            "yaml_image": {
+              "type": "string"
+            },
+            "types": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "include": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclude": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/schemas/json/buf.json
+++ b/src/schemas/json/buf.json
@@ -122,6 +122,699 @@
         "FILE_SAME_RUBY_PACKAGE",
         "FILE_SAME_SWIFT_PREFIX"
       ]
+    },
+    "lint-ignore-only": {
+      "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#ignore_only - All of the #/$defs/lint-rule values can be keys",
+      "description": "Optional. Allows directories or files to be excluded from specific lint categories or rules. As with ignore, the paths must be relative to buf.yaml.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "DEFAULT": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BASIC": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "MINIMAL": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENTS": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "UNARY_RPC": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "DIRECTORY_SAME_PACKAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_DEFINED": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_DIRECTORY_MATCH": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_DIRECTORY": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_PASCAL_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_VALUE_UPPER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "FIELD_LOWER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "MESSAGE_PASCAL_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ONEOF_LOWER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_LOWER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_PASCAL_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SERVICE_PASCAL_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_CSHARP_NAMESPACE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_GO_PACKAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_JAVA_MULTIPLE_FILES": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_JAVA_PACKAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_PHP_NAMESPACE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_RUBY_PACKAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_SWIFT_PREFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_FIRST_VALUE_ZERO": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_NO_ALLOW_ALIAS": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IMPORT_NO_WEAK": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IMPORT_NO_PUBLIC": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IMPORT_USED": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_VALUE_PREFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_ZERO_VALUE_SUFFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "FILE_LOWER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_REQUEST_RESPONSE_UNIQUE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_REQUEST_STANDARD_NAME": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_RESPONSE_STANDARD_NAME": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_VERSION_SUFFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PROTOVALIDATE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SERVICE_SUFFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_ENUM": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_ENUM_VALUE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_FIELD": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_MESSAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_ONEOF": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_RPC": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_SERVICE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_NO_CLIENT_STREAMING": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_NO_SERVER_STREAMING": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_NO_IMPORT_CYCLE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "breaking-ignore-only": {
+      "$comment": "All of the #/$defs/breaking-rule values can be keys.",
+      "description": "The ignore_only key is optional, and allows directories or files to be excluded from specific breaking rules when running buf breaking by taking a map from breaking rule ID or category to path. As with ignore, the paths must be relative to the buf.yaml. We do not recommend this option in general.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "DEFAULT": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BASIC": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "MINIMAL": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENTS": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "UNARY_RPC": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "DIRECTORY_SAME_PACKAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_DEFINED": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_DIRECTORY_MATCH": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_DIRECTORY": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_PASCAL_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_VALUE_UPPER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "FIELD_LOWER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "MESSAGE_PASCAL_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ONEOF_LOWER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_LOWER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_PASCAL_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SERVICE_PASCAL_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_CSHARP_NAMESPACE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_GO_PACKAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_JAVA_MULTIPLE_FILES": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_JAVA_PACKAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_PHP_NAMESPACE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_RUBY_PACKAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SAME_SWIFT_PREFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_FIRST_VALUE_ZERO": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_NO_ALLOW_ALIAS": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IMPORT_NO_WEAK": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IMPORT_NO_PUBLIC": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_VALUE_PREFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ENUM_ZERO_VALUE_SUFFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "FILE_LOWER_SNAKE_CASE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_REQUEST_RESPONSE_UNIQUE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_REQUEST_STANDARD_NAME": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_RESPONSE_STANDARD_NAME": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_VERSION_SUFFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PROTOVALIDATE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SERVICE_SUFFIX": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_ENUM": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_ENUM_VALUE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_FIELD": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_MESSAGE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_ONEOF": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_RPC": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "COMMENT_SERVICE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_NO_CLIENT_STREAMING": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_NO_SERVER_STREAMING": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_NO_IMPORT_CYCLE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v2-lint": {
+      "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#lint",
+      "description": "Optional. The lint settings you specify in this section are the default for all modules in the workspace, but can be replaced for individual modules by specifying different settings at the module level. Module-level settings have all of the same fields and behavior as workspace-level settings. If no lint settings are specified for the workspace, it uses the default settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "use": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#use",
+          "description": "Optional. Lists the categories and/or specific rules to use. The DEFAULT category is used if lint is unset.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/lint-rule"
+          }
+        },
+        "except": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#except",
+          "description": "Optional. Removes rules or categories from the use list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/lint-rule"
+          }
+        },
+        "ignore": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#ignore",
+          "description": "Optional. Excludes specific directories or files from all lint rules. If a directory is ignored, then all files and subfolders of the directory are also ignored. The specified paths must be relative to the buf.yaml file.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignore_only": {
+          "$ref": "#/$defs/lint-ignore-only"
+        },
+        "disallow_comment_ignores": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#disallow_comment_ignores",
+          "description": "Optional. Default is false if unset. If this option is set to true, you can't add leading comments within Protobuf files to ignore lint errors for certain components within the files. If the option is unset, for any line in a leading comment that starts with buf:lint:ignore <rule_id>, the linter ignores errors for that rule.",
+          "type": "boolean"
+        },
+        "enum_zero_value_suffix": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#enum_zero_value_suffix",
+          "description": "Optional. Controls the behavior of the ENUM_ZERO_VALUE_SUFFIX lint rule. By default, this rule verifies that the zero value of all enums ends in _UNSPECIFIED, as recommended by the Google Protobuf Style Guide.",
+          "type": "string",
+          "default": "_UNSPECIFIED"
+        },
+        "rpc_allow_same_request_response": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#rpc_allow_same_request_response",
+          "description": "Optional. Allows the same message type to be used for a single RPC's request and response type. We don't recommend using this option.",
+          "type": "boolean"
+        },
+        "rpc_allow_google_protobuf_empty_requests": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#rpc_allow_google_protobuf_empty_requests",
+          "description": "Optional. Allows RPC requests to be google.protobuf.Empty messages. You can set this if you want to allow messages to be void forever and never take any parameters. We don't recommend using this option.",
+          "type": "boolean"
+        },
+        "rpc_allow_google_protobuf_empty_responses": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#rpc_allow_google_protobuf_empty_responses",
+          "description": "Optional. Allows RPC responses to be google.protobuf.Empty messages. You can set this if you want to allow messages to never return any parameters. We don't recommend using this option.",
+          "type": "boolean"
+        },
+        "service_suffix": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#service_suffix",
+          "description": "Optional. Controls the behavior of the SERVICE_SUFFIX lint rule. By default, this rule verifies that all service names are suffixed with Service.",
+          "type": "string",
+          "default": "Service"
+        }
+      }
+    },
+    "v2-breaking": {
+      "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#breaking",
+      "description": "Optional. Specifies the breaking change detection rules enforced on the Protobuf files in the directory.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "use": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#use-1",
+          "description": "Optional. Lists the rules or categories to use for breaking change detection. The FILE category is used if breaking is unset, which is conservative and appropriate for most teams.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/breaking-rule"
+          }
+        },
+        "except": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#except-1",
+          "description": "Optional. Removes rules or categories from the use list. We don't recommend using this option.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/breaking-rule"
+          }
+        },
+        "ignore": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#ignore-1",
+          "description": "Optional. Excludes specific directories or files from all breaking change detection rules. If a directory is ignored, then all files and subfolders of the directory are also ignored. The specified paths must be relative to the buf.yaml file. This option can be useful for ignoring packages that are in active development but not deployed in production, especially alpha or beta packages. If you want to ignore all alpha,beta, or test packages, we recommend using the ignore_unstable_packages setting instead.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignore_only": {
+          "$ref": "#/$defs/breaking-ignore-only"
+        },
+        "ignore_unstable_packages": {
+          "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#ignore_unstable_packages",
+          "description": "Optional. Ignores packages with a last component that's one of the unstable forms recognized by the Buf linter's PACKAGE_VERSION_SUFFIX rule.",
+          "type": "boolean"
+        }
+      }
     }
   },
   "title": "buf.yaml",
@@ -130,798 +823,205 @@
   "required": ["version"],
   "properties": {
     "version": {
-      "description": "The version key is required, and defines the current configuration version. The only accepted values are v1beta1 and v1.",
+      "description": "The version key is required, and defines the current configuration version. The accepted values are `v2`, `v1`, and `v1beta1`.",
       "type": "string",
-      "enum": ["v1", "v1beta1"]
-    },
-    "name": {
-      "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#name",
-      "description": "The name is optional, and uniquely identifies your module. The name must be a valid module name and is directly associated with the repository that owns it.",
-      "type": "string"
-    },
-    "deps": {
-      "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#deps",
-      "description": "The deps key is optional, and declares one or more modules that your module depends on. Each deps entry must be a module reference, and, is directly associated with a repository, as well as a reference, which is either a tag or commit.",
-      "type": "array",
-      "items": {
+      "enum": ["v2", "v1", "v1beta1"]
+    }
+  },
+  "if": {
+    "properties": {
+      "version": {
+        "const": "v1"
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "name": {
+        "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#name",
+        "description": "The name is optional, and uniquely identifies your module. The name must be a valid module name and is directly associated with the repository that owns it.",
         "type": "string"
-      }
-    },
-    "build": {
-      "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#build",
-      "description": "The build key is optional, and is used to control how buf builds modules.",
-      "type": "object",
-      "properties": {
-        "excludes": {
-          "description": "The excludes key is optional, and lists directories to ignore from .proto file discovery. Any directories added to this list are completely skipped and excluded in the module. We do not recommend using this option in general, however in some situations it is unavoidable.",
-          "type": "array",
-          "items": {
-            "type": "string"
+      },
+      "deps": {
+        "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#deps",
+        "description": "The deps key is optional, and declares one or more modules that your module depends on. Each deps entry must be a module reference, and, is directly associated with a repository, as well as a reference, which is either a tag or commit.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "build": {
+        "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#build",
+        "description": "The build key is optional, and is used to control how buf builds modules.",
+        "type": "object",
+        "properties": {
+          "excludes": {
+            "description": "The excludes key is optional, and lists directories to ignore from .proto file discovery. Any directories added to this list are completely skipped and excluded in the module. We do not recommend using this option in general, however in some situations it is unavoidable.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
-      }
-    },
-    "lint": {
-      "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#lint",
-      "description": "The lint key is optional, and specifies the lint rules enforced on the files in the module. See https://buf.build/docs/lint/rules.",
-      "type": "object",
-      "properties": {
-        "use": {
-          "description": "The use key is optional, and lists the IDs or categories to use for linting.",
-          "type": "array",
-          "default": ["DEFAULT"],
-          "items": {
-            "$ref": "#/$defs/lint-rule"
-          }
-        },
-        "except": {
-          "description": "The except key is optional, and removes IDs or categories from the use list.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/lint-rule"
-          }
-        },
-        "ignore": {
-          "description": "The ignore key is optional, and allows directories or files to be excluded from all lint rules when running buf lint. If a directory is ignored, then all files and subfolders of the directory will also be ignored. The specified directory or file paths must be relative to the buf.yaml.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "ignore_only": {
-          "$comment": "All of the #/$defs/lint-rule values can be keys",
-          "description": "The ignore_only key is optional, and allows directories or files to be excluded from specific lint rules when running buf lint by taking a map from lint rule ID or category to path. As with ignore, the paths must be relative to the buf.yaml.",
-          "type": "object",
-          "properties": {
-            "DEFAULT": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "BASIC": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "MINIMAL": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "COMMENTS": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "UNARY_RPC": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "DIRECTORY_SAME_PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_DEFINED": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_DIRECTORY_MATCH": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SAME_DIRECTORY": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_PASCAL_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_VALUE_UPPER_SNAKE_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_LOWER_SNAKE_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "MESSAGE_PASCAL_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ONEOF_LOWER_SNAKE_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_LOWER_SNAKE_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_PASCAL_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "SERVICE_PASCAL_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SAME_CSHARP_NAMESPACE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SAME_GO_PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SAME_JAVA_MULTIPLE_FILES": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SAME_JAVA_PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SAME_PHP_NAMESPACE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SAME_RUBY_PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SAME_SWIFT_PREFIX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_FIRST_VALUE_ZERO": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_NO_ALLOW_ALIAS": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "IMPORT_NO_WEAK": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "IMPORT_NO_PUBLIC": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "IMPORT_USED": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_VALUE_PREFIX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_ZERO_VALUE_SUFFIX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_LOWER_SNAKE_CASE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_REQUEST_RESPONSE_UNIQUE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_REQUEST_STANDARD_NAME": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_RESPONSE_STANDARD_NAME": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_VERSION_SUFFIX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PROTOVALIDATE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "SERVICE_SUFFIX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "COMMENT_ENUM": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "COMMENT_ENUM_VALUE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "COMMENT_FIELD": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "COMMENT_MESSAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "COMMENT_ONEOF": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "COMMENT_RPC": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "COMMENT_SERVICE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_NO_CLIENT_STREAMING": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_NO_SERVER_STREAMING": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_NO_IMPORT_CYCLE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+      },
+      "lint": {
+        "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#lint",
+        "description": "The lint key is optional, and specifies the lint rules enforced on the files in the module. See https://buf.build/docs/lint/rules.",
+        "type": "object",
+        "properties": {
+          "use": {
+            "description": "The use key is optional, and lists the IDs or categories to use for linting.",
+            "type": "array",
+            "default": ["DEFAULT"],
+            "items": {
+              "$ref": "#/$defs/lint-rule"
             }
           },
-          "additionalProperties": false
-        },
-        "allow_comment_ignores": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#allow_comment_ignores",
-          "description": "The allow_comment_ignores key is optional, and turns on comment-driven ignores. We do not recommend using this option in general, however in some situations it is unavoidable. See https://buf.build/docs/configuration/v1/buf-yaml#allow_comment_ignores.",
-          "type": "boolean",
-          "default": false
-        },
-        "enum_zero_value_suffix": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#enum_zero_value_suffix",
-          "description": "The enum_zero_value_suffix key is optional, and controls the behavior of the ENUM_ZERO_VALUE_SUFFIX lint rule. See https://buf.build/docs/configuration/v1/buf-yaml#enum_zero_value_suffix.",
-          "type": "string",
-          "default": "_UNSPECIFIED"
-        },
-        "rpc_allow_same_request_response": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_same_request_response",
-          "description": "The rpc_allow_same_request_response key is optional, and allows the same message type to be used for a single RPC's request and response type. We do not recommend using this option in general.",
-          "type": "boolean",
-          "default": false
-        },
-        "rpc_allow_google_protobuf_empty_requests": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_google_protobuf_empty_requests",
-          "description": "The rpc_allow_google_protobuf_empty_requests key is optional, and allows RPC requests to be google.protobuf.Empty messages. This can be set if you want to allow messages to be void forever, that is, to never take any parameters. We do not recommend using this option in general.",
-          "type": "boolean",
-          "default": false
-        },
-        "rpc_allow_google_protobuf_empty_responses": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_google_protobuf_empty_responses",
-          "description": "The rpc_allow_google_protobuf_empty_responses key is optional, and allows RPC responses to be google.protobuf.Empty messages. This can be set if you want to allow messages to never return any parameters. We do not recommend using this option in general.",
-          "type": "boolean",
-          "default": false
-        },
-        "service_suffix": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#service_suffix",
-          "description": "The service_suffix key is optional, and controls the behavior of the SERVICE_SUFFIX lint rule. See https://buf.build/docs/configuration/v1/buf-yaml#service_suffix.",
-          "type": "string",
-          "default": "Service"
-        }
-      }
-    },
-    "breaking": {
-      "description": "The breaking key is optional, and specifies the breaking change detection rules enforced on the files contained within the module.",
-      "type": "object",
-      "properties": {
-        "use": {
-          "description": "The use key is optional, and lists the IDs or categories to use for breaking change detection. The default value is the single item FILE, which is what we recommend.",
-          "type": "array",
-          "default": ["FILE"],
-          "items": {
-            "$ref": "#/$defs/breaking-rule"
-          }
-        },
-        "except": {
-          "description": "The except key is optional, and removes IDs or categories from the use list. We do not recommend using this option in general.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/breaking-rule"
-          }
-        },
-        "ignore": {
-          "description": "The ignore key is optional, and allows directories or files to be excluded from all breaking rules when running buf breaking. If a directory is ignored, then all files and subfolders of the directory will also be ignored. The specified directory or file paths must be relative to the buf.yaml. This option can be useful for ignoring packages that are in active development but not deployed in production, especially alpha or beta packages, and we expect ignore to be commonly used for this case.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "ignore_only": {
-          "$comment": "All of the #/$defs/breaking-rule values can be keys.",
-          "description": "The ignore_only key is optional, and allows directories or files to be excluded from specific breaking rules when running buf breaking by taking a map from breaking rule ID or category to path. As with ignore, the paths must be relative to the buf.yaml. We do not recommend this option in general.",
-          "type": "object",
-          "properties": {
-            "FILE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "WIRE_JSON": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "WIRE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "MESSAGE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "SERVICE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_ENUM_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_MESSAGE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_SERVICE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "PACKAGE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_VALUE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_VALUE_NO_DELETE_UNLESS_NUMBER_RESERVED": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_VALUE_NO_DELETE_UNLESS_NAME_RESERVED": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_NO_DELETE_UNLESS_NAME_RESERVED": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ONEOF_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "MESSAGE_NO_REMOVE_STANDARD_DESCRIPTOR_ACCESSOR": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_SYNTAX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ENUM_VALUE_SAME_NAME": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_SAME_CTYPE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_SAME_JSTYPE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_SAME_TYPE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_WIRE_COMPATIBLE_TYPE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_WIRE_JSON_COMPATIBLE_TYPE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_SAME_LABEL": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_SAME_ONEOF": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_SAME_NAME": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FIELD_SAME_JSON_NAME": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RESERVED_ENUM_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RESERVED_MESSAGE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "EXTENSION_MESSAGE_NO_DELETE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "MESSAGE_SAME_MESSAGE_SET_WIRE_FORMAT": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_SAME_REQUEST_TYPE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_SAME_RESPONSE_TYPE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_SAME_CLIENT_STREAMING": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_SAME_SERVER_STREAMING": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "RPC_SAME_IDEMPOTENCY_LEVEL": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_CC_ENABLE_ARENAS": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_CC_GENERIC_SERVICES": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_CSHARP_NAMESPACE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_GO_PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_JAVA_GENERIC_SERVICES": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_JAVA_MULTIPLE_FILES": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_JAVA_OUTER_CLASSNAME": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_JAVA_PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_JAVA_STRING_CHECK_UTF8": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_OBJC_CLASS_PREFIX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_OPTIMIZE_FOR": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_PHP_CLASS_PREFIX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_PHP_GENERIC_SERVICES": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_PHP_METADATA_NAMESPACE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_PHP_NAMESPACE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_PY_GENERIC_SERVICES": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_RUBY_PACKAGE": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "FILE_SAME_SWIFT_PREFIX": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+          "except": {
+            "description": "The except key is optional, and removes IDs or categories from the use list.",
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/lint-rule"
             }
           },
-          "additionalProperties": false
-        },
-        "ignore_unstable_packages": {
-          "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#ignore_unstable_packages",
-          "description": "The ignore_unstable_packages key is optional, and ignores packages with a last component that is one of the unstable forms recognized by PACKAGE_VERSION_SUFFIX.",
-          "type": "boolean",
-          "default": false
+          "ignore": {
+            "description": "The ignore key is optional, and allows directories or files to be excluded from all lint rules when running buf lint. If a directory is ignored, then all files and subfolders of the directory will also be ignored. The specified directory or file paths must be relative to the buf.yaml.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ignore_only": {
+            "$ref": "#/$defs/lint-ignore-only"
+          },
+          "allow_comment_ignores": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#allow_comment_ignores",
+            "description": "The allow_comment_ignores key is optional, and turns on comment-driven ignores. We do not recommend using this option in general, however in some situations it is unavoidable. See https://buf.build/docs/configuration/v1/buf-yaml#allow_comment_ignores.",
+            "type": "boolean",
+            "default": false
+          },
+          "enum_zero_value_suffix": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#enum_zero_value_suffix",
+            "description": "The enum_zero_value_suffix key is optional, and controls the behavior of the ENUM_ZERO_VALUE_SUFFIX lint rule. See https://buf.build/docs/configuration/v1/buf-yaml#enum_zero_value_suffix.",
+            "type": "string",
+            "default": "_UNSPECIFIED"
+          },
+          "rpc_allow_same_request_response": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_same_request_response",
+            "description": "The rpc_allow_same_request_response key is optional, and allows the same message type to be used for a single RPC's request and response type. We do not recommend using this option in general.",
+            "type": "boolean",
+            "default": false
+          },
+          "rpc_allow_google_protobuf_empty_requests": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_google_protobuf_empty_requests",
+            "description": "The rpc_allow_google_protobuf_empty_requests key is optional, and allows RPC requests to be google.protobuf.Empty messages. This can be set if you want to allow messages to be void forever, that is, to never take any parameters. We do not recommend using this option in general.",
+            "type": "boolean",
+            "default": false
+          },
+          "rpc_allow_google_protobuf_empty_responses": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#rpc_allow_google_protobuf_empty_responses",
+            "description": "The rpc_allow_google_protobuf_empty_responses key is optional, and allows RPC responses to be google.protobuf.Empty messages. This can be set if you want to allow messages to never return any parameters. We do not recommend using this option in general.",
+            "type": "boolean",
+            "default": false
+          },
+          "service_suffix": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#service_suffix",
+            "description": "The service_suffix key is optional, and controls the behavior of the SERVICE_SUFFIX lint rule. See https://buf.build/docs/configuration/v1/buf-yaml#service_suffix.",
+            "type": "string",
+            "default": "Service"
+          }
         }
+      },
+      "breaking": {
+        "description": "The breaking key is optional, and specifies the breaking change detection rules enforced on the files contained within the module.",
+        "type": "object",
+        "properties": {
+          "use": {
+            "description": "The use key is optional, and lists the IDs or categories to use for breaking change detection. The default value is the single item FILE, which is what we recommend.",
+            "type": "array",
+            "default": ["FILE"],
+            "items": {
+              "$ref": "#/$defs/breaking-rule"
+            }
+          },
+          "except": {
+            "description": "The except key is optional, and removes IDs or categories from the use list. We do not recommend using this option in general.",
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/breaking-rule"
+            }
+          },
+          "ignore": {
+            "description": "The ignore key is optional, and allows directories or files to be excluded from all breaking rules when running buf breaking. If a directory is ignored, then all files and subfolders of the directory will also be ignored. The specified directory or file paths must be relative to the buf.yaml. This option can be useful for ignoring packages that are in active development but not deployed in production, especially alpha or beta packages, and we expect ignore to be commonly used for this case.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ignore_only": {
+            "$ref": "#/$defs/breaking-ignore-only"
+          },
+          "ignore_unstable_packages": {
+            "$comment": "https://buf.build/docs/configuration/v1/buf-yaml#ignore_unstable_packages",
+            "description": "The ignore_unstable_packages key is optional, and ignores packages with a last component that is one of the unstable forms recognized by PACKAGE_VERSION_SUFFIX.",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    }
+  },
+  "else": {
+    "$comment": "v2 properties",
+    "properties": {
+      "modules": {
+        "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#modules",
+        "description": "Required. Defines the list of modules that will be built together in this workspace. Any dependencies that the files have on each other are automatically taken into account when building and shouldn't be declared in the deps section.",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#path",
+              "description": "Required. The path to a directory containing Protobuf files, which must be defined relative to the workspace root (the directory that contains the buf.yaml file). All path values must point to directories within the workspace.",
+              "type": "string"
+            },
+            "name": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#name",
+              "description": "Optional. A Buf Schema Registry (BSR) path that uniquely identifies this directory. The name must be a valid module name and it defines the BSR repository that contains the commit and label history and generated artifacts for the Protobuf files in the directory.",
+              "type": "string"
+            },
+            "excludes": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#excludes",
+              "description": "Optional. Lists directories within this directory to exclude from Protobuf file discovery. Any directories added to this list are completely skipped and excluded from Buf operations. We don't recommend using this option, but in some situations it's unavoidable.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "lint": {
+              "$ref": "#/$defs/v2-lint"
+            },
+            "breaking": {
+              "$ref": "#/$defs/v2-breaking"
+            }
+          }
+        }
+      },
+      "deps": {
+        "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#deps",
+        "description": "Optional. Declares one or more modules that your workspace depends on. Each deps entry must be a module name, which is directly associated with a BSR repository, and can also include a specific reference, which is either a commit ID or a label. Dependencies are shared between all modules in the set. Buf tooling already accounts for dependencies between the modules that are part of the set, so they shouldn't be declared here.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "lint": {
+        "$ref": "#/$defs/v2-lint"
+      },
+      "breaking": {
+        "$ref": "#/$defs/v2-breaking"
       }
     }
   }

--- a/src/schemas/json/buf.json
+++ b/src/schemas/json/buf.json
@@ -38,6 +38,7 @@
         "IMPORT_USED",
         "ENUM_VALUE_PREFIX",
         "ENUM_ZERO_VALUE_SUFFIX",
+        "FIELD_NOT_REQUIRED",
         "FILE_LOWER_SNAKE_CASE",
         "RPC_REQUEST_RESPONSE_UNIQUE",
         "RPC_REQUEST_STANDARD_NAME",
@@ -66,43 +67,24 @@
         "WIRE_JSON",
         "WIRE",
         "ENUM_NO_DELETE",
-        "MESSAGE_NO_DELETE",
-        "SERVICE_NO_DELETE",
-        "PACKAGE_ENUM_NO_DELETE",
-        "PACKAGE_MESSAGE_NO_DELETE",
-        "PACKAGE_SERVICE_NO_DELETE",
-        "FILE_NO_DELETE",
-        "PACKAGE_NO_DELETE",
         "ENUM_VALUE_NO_DELETE",
-        "FIELD_NO_DELETE",
-        "ENUM_VALUE_NO_DELETE_UNLESS_NUMBER_RESERVED",
-        "FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED",
         "ENUM_VALUE_NO_DELETE_UNLESS_NAME_RESERVED",
-        "FIELD_NO_DELETE_UNLESS_NAME_RESERVED",
-        "RPC_NO_DELETE",
-        "ONEOF_NO_DELETE",
-        "MESSAGE_NO_REMOVE_STANDARD_DESCRIPTOR_ACCESSOR",
-        "FILE_SAME_PACKAGE",
-        "FILE_SAME_SYNTAX",
+        "ENUM_VALUE_NO_DELETE_UNLESS_NUMBER_RESERVED",
         "ENUM_VALUE_SAME_NAME",
+        "EXTENSION_MESSAGE_NO_DELETE",
+        "FIELD_NO_DELETE",
+        "FIELD_NO_DELETE_UNLESS_NAME_RESERVED",
+        "FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED",
         "FIELD_SAME_CTYPE",
+        "FIELD_SAME_JSON_NAME",
         "FIELD_SAME_JSTYPE",
+        "FIELD_SAME_LABEL",
+        "FIELD_SAME_NAME",
+        "FIELD_SAME_ONEOF",
         "FIELD_SAME_TYPE",
         "FIELD_WIRE_COMPATIBLE_TYPE",
         "FIELD_WIRE_JSON_COMPATIBLE_TYPE",
-        "FIELD_SAME_LABEL",
-        "FIELD_SAME_ONEOF",
-        "FIELD_SAME_NAME",
-        "FIELD_SAME_JSON_NAME",
-        "RESERVED_ENUM_NO_DELETE",
-        "RESERVED_MESSAGE_NO_DELETE",
-        "EXTENSION_MESSAGE_NO_DELETE",
-        "MESSAGE_SAME_MESSAGE_SET_WIRE_FORMAT",
-        "RPC_SAME_REQUEST_TYPE",
-        "RPC_SAME_RESPONSE_TYPE",
-        "RPC_SAME_CLIENT_STREAMING",
-        "RPC_SAME_SERVER_STREAMING",
-        "RPC_SAME_IDEMPOTENCY_LEVEL",
+        "FILE_NO_DELETE",
         "FILE_SAME_CC_ENABLE_ARENAS",
         "FILE_SAME_CC_GENERIC_SERVICES",
         "FILE_SAME_CSHARP_NAMESPACE",
@@ -114,13 +96,32 @@
         "FILE_SAME_JAVA_STRING_CHECK_UTF8",
         "FILE_SAME_OBJC_CLASS_PREFIX",
         "FILE_SAME_OPTIMIZE_FOR",
+        "FILE_SAME_PACKAGE",
         "FILE_SAME_PHP_CLASS_PREFIX",
         "FILE_SAME_PHP_GENERIC_SERVICES",
         "FILE_SAME_PHP_METADATA_NAMESPACE",
         "FILE_SAME_PHP_NAMESPACE",
         "FILE_SAME_PY_GENERIC_SERVICES",
         "FILE_SAME_RUBY_PACKAGE",
-        "FILE_SAME_SWIFT_PREFIX"
+        "FILE_SAME_SWIFT_PREFIX",
+        "FILE_SAME_SYNTAX",
+        "MESSAGE_NO_DELETE",
+        "MESSAGE_NO_REMOVE_STANDARD_DESCRIPTOR_ACCESSOR",
+        "MESSAGE_SAME_MESSAGE_SET_WIRE_FORMAT",
+        "ONEOF_NO_DELETE",
+        "PACKAGE_ENUM_NO_DELETE",
+        "PACKAGE_MESSAGE_NO_DELETE",
+        "PACKAGE_NO_DELETE",
+        "PACKAGE_SERVICE_NO_DELETE",
+        "RESERVED_ENUM_NO_DELETE",
+        "RESERVED_MESSAGE_NO_DELETE",
+        "RPC_NO_DELETE",
+        "RPC_SAME_CLIENT_STREAMING",
+        "RPC_SAME_IDEMPOTENCY_LEVEL",
+        "RPC_SAME_REQUEST_TYPE",
+        "RPC_SAME_RESPONSE_TYPE",
+        "RPC_SAME_SERVER_STREAMING",
+        "SERVICE_NO_DELETE"
       ]
     },
     "lint-ignore-only": {
@@ -315,6 +316,12 @@
             "type": "string"
           }
         },
+        "FIELD_NOT_REQUIRED": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "FILE_LOWER_SNAKE_CASE": {
           "type": "array",
           "items": {
@@ -425,283 +432,361 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "DEFAULT": {
+        "FILE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "BASIC": {
+        "PACKAGE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "MINIMAL": {
+        "WIRE_JSON": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "COMMENTS": {
+        "WIRE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "UNARY_RPC": {
+        "ENUM_NO_DELETE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "DIRECTORY_SAME_PACKAGE": {
+        "ENUM_VALUE_NO_DELETE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_DEFINED": {
+        "ENUM_VALUE_NO_DELETE_UNLESS_NAME_RESERVED": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_DIRECTORY_MATCH": {
+        "ENUM_VALUE_NO_DELETE_UNLESS_NUMBER_RESERVED": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_SAME_DIRECTORY": {
+        "ENUM_VALUE_SAME_NAME": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "ENUM_PASCAL_CASE": {
+        "EXTENSION_MESSAGE_NO_DELETE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "ENUM_VALUE_UPPER_SNAKE_CASE": {
+        "FIELD_NO_DELETE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "FIELD_LOWER_SNAKE_CASE": {
+        "FIELD_NO_DELETE_UNLESS_NAME_RESERVED": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "MESSAGE_PASCAL_CASE": {
+        "FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "ONEOF_LOWER_SNAKE_CASE": {
+        "FIELD_SAME_CTYPE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_LOWER_SNAKE_CASE": {
+        "FIELD_SAME_JSON_NAME": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "RPC_PASCAL_CASE": {
+        "FIELD_SAME_JSTYPE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "SERVICE_PASCAL_CASE": {
+        "FIELD_SAME_LABEL": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_SAME_CSHARP_NAMESPACE": {
+        "FIELD_SAME_NAME": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_SAME_GO_PACKAGE": {
+        "FIELD_SAME_ONEOF": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_SAME_JAVA_MULTIPLE_FILES": {
+        "FIELD_SAME_TYPE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_SAME_JAVA_PACKAGE": {
+        "FIELD_WIRE_COMPATIBLE_TYPE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_SAME_PHP_NAMESPACE": {
+        "FIELD_WIRE_JSON_COMPATIBLE_TYPE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_SAME_RUBY_PACKAGE": {
+        "FILE_NO_DELETE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_SAME_SWIFT_PREFIX": {
+        "FILE_SAME_CC_ENABLE_ARENAS": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "ENUM_FIRST_VALUE_ZERO": {
+        "FILE_SAME_CC_GENERIC_SERVICES": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "ENUM_NO_ALLOW_ALIAS": {
+        "FILE_SAME_CSHARP_NAMESPACE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "IMPORT_NO_WEAK": {
+        "FILE_SAME_GO_PACKAGE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "IMPORT_NO_PUBLIC": {
+        "FILE_SAME_JAVA_GENERIC_SERVICES": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "ENUM_VALUE_PREFIX": {
+        "FILE_SAME_JAVA_MULTIPLE_FILES": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "ENUM_ZERO_VALUE_SUFFIX": {
+        "FILE_SAME_JAVA_OUTER_CLASSNAME": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "FILE_LOWER_SNAKE_CASE": {
+        "FILE_SAME_JAVA_PACKAGE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "RPC_REQUEST_RESPONSE_UNIQUE": {
+        "FILE_SAME_JAVA_STRING_CHECK_UTF8": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "RPC_REQUEST_STANDARD_NAME": {
+        "FILE_SAME_OBJC_CLASS_PREFIX": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "RPC_RESPONSE_STANDARD_NAME": {
+        "FILE_SAME_OPTIMIZE_FOR": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_VERSION_SUFFIX": {
+        "FILE_SAME_PACKAGE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PROTOVALIDATE": {
+        "FILE_SAME_PHP_CLASS_PREFIX": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "SERVICE_SUFFIX": {
+        "FILE_SAME_PHP_GENERIC_SERVICES": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "COMMENT_ENUM": {
+        "FILE_SAME_PHP_METADATA_NAMESPACE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "COMMENT_ENUM_VALUE": {
+        "FILE_SAME_PHP_NAMESPACE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "COMMENT_FIELD": {
+        "FILE_SAME_PY_GENERIC_SERVICES": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "COMMENT_MESSAGE": {
+        "FILE_SAME_RUBY_PACKAGE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "COMMENT_ONEOF": {
+        "FILE_SAME_SWIFT_PREFIX": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "COMMENT_RPC": {
+        "FILE_SAME_SYNTAX": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "COMMENT_SERVICE": {
+        "MESSAGE_NO_DELETE": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "RPC_NO_CLIENT_STREAMING": {
+        "MESSAGE_NO_REMOVE_STANDARD_DESCRIPTOR_ACCESSOR": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "RPC_NO_SERVER_STREAMING": {
+        "MESSAGE_SAME_MESSAGE_SET_WIRE_FORMAT": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "PACKAGE_NO_IMPORT_CYCLE": {
+        "ONEOF_NO_DELETE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_ENUM_NO_DELETE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_MESSAGE_NO_DELETE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_NO_DELETE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PACKAGE_SERVICE_NO_DELETE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RESERVED_ENUM_NO_DELETE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RESERVED_MESSAGE_NO_DELETE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_NO_DELETE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_SAME_CLIENT_STREAMING": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_SAME_IDEMPOTENCY_LEVEL": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_SAME_REQUEST_TYPE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_SAME_RESPONSE_TYPE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "RPC_SAME_SERVER_STREAMING": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SERVICE_NO_DELETE": {
           "type": "array",
           "items": {
             "type": "string"

--- a/src/test/buf.gen/v2.buf.gen.yaml
+++ b/src/test/buf.gen/v2.buf.gen.yaml
@@ -1,0 +1,162 @@
+# Stitched together from examples at
+# https://buf.build/docs/configuration/v2/buf-gen-yaml
+
+version: v2
+managed:
+  enabled: true
+  disable:
+    # Don't modify any files in buf.build/googleapis/googleapis
+    - module: buf.build/googleapis/googleapis
+    # Don't modify any files in the foo/v1 directory. This can be a path to a directory
+    # or a .proto file. If it's a directory path, all .proto files in the directory are
+    # ignored.
+    - path: foo/v1
+    # Ignore the csharp_namespace file option for all modules and files in the input.
+    - file_option: csharp_namespace
+    # Ignore the js_type field option for any file.
+    - field_option: js_type
+    # Ignore the foo.bar.Baz.field_name field.
+    - field: foo.bar.Baz.field_name
+    # Setting all 3 for file options: don't modify java_package for files in foo/v1 in
+    # buf.build/acme/weather
+    - module: buf.build/acme/weather
+      path: foo/v1
+      file_option: java_package
+    # Setting all 4 for field options: disable js_type for all files that match the
+    # module, path, and field name.
+    - module: buf.build/acme/petapis
+      field: foo.bar.Baz.field_name
+      path: foo/v1
+      field_option: js_type
+
+  override:
+    # When `file_option` and `value` are set, managed mode uses the value set in
+    # this rule instead of the default value or sets it to this value if the default
+    # value is none.
+    #
+    # Example: Modify the java_package options to <net>.<proto_package> for all files.
+    - file_option: java_package_prefix
+      value: net
+    # When `file_option`, `value`, and `module` are set, managed mode uses the value
+    # set in this rule instead of the default value for all files in the specified module.
+    # It sets it to this value if the default value is none.
+    #
+    # Example: Modify the java_package options to <com>.<proto_package>.<com> for all files
+    # in `buf.build/acme/petapis`. These rules take precedence over the rule above.
+    - file_option: java_package_prefix
+      module: buf.build/acme/petapis
+      value: com
+    - file_option: java_package_suffix
+      module: buf.build/acme/petapis
+      value: com
+    # When `file_option`, `value`, and `path`are set, managed mode uses the value set
+    # in this rule instead of the default value for the specific file path. If the path
+    # is a directory, the rule affects all .proto files in the directory. Otherwise, it
+    # only affects the specified .proto file.
+    #
+    # Example: For the file foo/bar/baz.proto, set java_package specifically to
+    # "com.x.y.z". This takes precedence over the previous rules above.
+    - file_option: java_package
+      path: foo/bar/baz.proto
+      value: com.x.y.z
+    # When `field_option`, `value`, and `module` are set, managed mode uses the value
+    # set in this rule instead of the default value for all files in the specified module.
+    # It sets it to this value if the default value is none.
+    #
+    # Example: For all fields in the buf.build/acme/paymentapis module where the field is
+    # one of the compatible types, set the js_type to JS_NORMAL.
+    - field_option: js_type
+      module: buf.build/acme/paymentapis
+      value: JS_NORMAL
+    # When `field_option`, `value`, and `field` are set, managed mode uses the value set
+    # in this ule instead of the default value of the specified field. It sets it to
+    # this value if the default value is none.
+    #
+    # Example: Set the package1.Message2.field3 field js_type value to JS_STRING. You can additionally
+    # specify the module and path, but the field name is sufficient.
+    - field_option: js_type
+      value: JS_STRING
+      field: package1.Message2.field3
+
+plugins:
+  # BSR remote plugin with revision #
+  - remote: buf.build/protocolbuffers/go
+    revision: 1
+    out: gen/proto
+  # Built-in protoc plugin for C++
+  - protoc_builtin: cpp
+    protoc_path: /path/to/protoc
+    out: gen/proto
+  # Local binary plugin, search in ${PATH} by default
+  - local: protoc-gen-validate
+    out: gen/proto
+  # Relative paths automatically work
+  - local: path/to/protoc-gen-validate
+    out: gen/proto
+  # Absolute paths automatically work
+  - local: /usr/bin/path/to/protoc-gen-validate
+    out: gen/proto2
+  # Binary plugin with arguments
+  - local: ['go', 'run', 'google.golang.org/protobuf/cmd/protoc-gen-go']
+    out: gen/proto
+    opt:
+      - paths=source_relative
+      - foo=bar
+      - baz
+    strategy: all
+    include_imports: true
+    include_wkt: true
+
+inputs:
+  # Git repository
+  - git_repo: github.com/acme/weather
+    branch: dev
+    subdir: proto
+    depth: 30
+  # BSR module with types, include, and exclude keys specified
+  - module: buf.build/acme/weather
+    types:
+      - 'foo.v1.User'
+      - 'foo.v1.UserService'
+    # If empty, include all paths.
+    include:
+      - a/b/c
+      - a/b/d
+    exclude:
+      - a/b/c/x.proto
+      - a/b/d/y.proto
+  # Local module at provided directory path
+  - directory: x/y/z
+  # Tarball at provided directory path. Automatically derives compression algorithm from
+  # the file extension:
+  # - `.tgz` and `.tar.gz` extensions automatically use Gzip
+  # - `.tar.zst` automatically uses Zstandard.
+  - tarball: a/b/x.tar.gz
+  # Tarball with `compression`, `strip_components`, and `subdir` keys set explicitly.
+  # - `strip_components=<int>`, reads at the relative path and strips some number of
+  #    components—in this example, 2.
+  # - `subdir=<string>` reads at the relative path and uses the subdirectory specified
+  #    within the archive as the base directory—in this case, `proto`.
+  - tarball: c/d/x.tar.zst
+    compression: zstd
+    strip_components: 2
+    subdir: proto
+  # The same applies `zip` inputs. A `zip` input is read at the relative path or http
+  # location, and can set `format`, `strip_components`, and `subdir` optionally.
+  - zip_archive: https://github.com/googleapis/googleapis/archive/master.zip
+    strip_components: 1
+    format: zip
+  # A proto_file is a path to a specific proto file. Optionally, you can include package
+  # files as part of the files to be generated (the default is false).
+  - proto_file: foo/bar/baz.proto
+    include_package_files: true
+  # We also support Buf images as inputs. Images can be any of the following formats:
+  #  - `binary_image`
+  #  - `json_image`
+  #  - `txt_image`
+  #  - `yaml_image`
+  # Each image format also supports compression optionally.
+  #
+  # The example below is a binary Buf image with compression set for Gzip.
+  - binary_image: image.binpb.gz
+    compression: gz

--- a/src/test/buf/buf.v2.yaml
+++ b/src/test/buf/buf.v2.yaml
@@ -1,58 +1,70 @@
 # via https://buf.build/docs/configuration/v2/buf-yaml
+
 version: v2
+# The v2 buf.yaml file specifies a local workspace, which consists of at least one module.
+# The buf.yaml file should be placed at the root directory of the workspace, which
+# should generally be the root of your source control repository.
 modules:
-  # Basic configuration: local directory with corresponding BSR repository.
+  # Each module entry defines a path, which must be relative to the directory where the
+  # buf.yaml is located. You can also specify files or directories to exclude from a module.
+  # Directories across modules cannot overlap. For example, "a" and "a/b" cannot be two paths
+  # to modules in a given workspace.
   - path: proto/foo
+    # Modules can also optionally specify their Buf Schema Repository name if it exists.
     name: buf.build/acme/foo
-  # Local directory & repository, but excluding a directory and a specific .proto file.
-  # Note that the paths for exclusion are relative to the buf.yaml file.
+  # Excluding a subdirectory and a specific .proto file. Note that the paths for exclusion
+  # are relative to the buf.yaml file.
   - path: proto/bar
     name: buf.build/acme/bar
     excludes:
       - proto/bar/a
-      - proto/bar/b/c.proto
-    # Lint configuration for this module only. This rule set completely replaces the workspace defaults.
+      - proto/bar/b/e.proto
+    # A module can have its own lint and breaking configuration, which overrides the default
+    # lint and breaking configuration in its entirety for that module. All values from the
+    # default configuration are overridden and no rules are merged.
     lint:
       use:
         - DEFAULT
       except:
         - IMPORT_USED
       ignore:
-        - proto/bar/b/c.proto
+        - proto/bar/c
       ignore_only:
         ENUM_ZERO_VALUE_SUFFIX:
-          - proto/bar/d
-          - proto/bar/e/f.proto
-      disallow_comment_ignores: false # The default behavior of this key has changed from v1
+          - proto/bar/a
+          - proto/bar/b/f.proto
+      # v1 configurations had an allow_comment_ignores option to opt-in to comment ignores.
+      #
+      # In v2, we allow comment ignores by default, and allow opt-out from comment ignores
+      # with the disallow_comment_ignores option.
+      disallow_comment_ignores: false
       enum_zero_value_suffix: _UNSPECIFIED
       rpc_allow_same_request_response: false
       rpc_allow_google_protobuf_empty_requests: false
       rpc_allow_google_protobuf_empty_responses: false
       service_suffix: Service
-    # Breaking changes configuration for this module only. This rule set completely replaces the workspace defaults.
+    # Breaking configuration for this module only. Behaves the same as a module-level
+    # lint configuration.
     breaking:
       use:
         - FILE
       except:
         - EXTENSION_MESSAGE_NO_DELETE
-      ignore:
-        - proto/bar/a
-        - proto/bar/b/c.proto
-      ignore_only:
-        ENUM_ZERO_VALUE_SUFFIX:
-          - proto/bar/d
-          - proto/bar/e/f.proto
       ignore_unstable_packages: true
-# Module dependencies available to all modules in the workspace. Modules within the workspace
-# shouldn't be listed here. The resolution of these dependencies is stored in the buf.lock file.
+# Dependencies shared by all modules in the workspace. Must be modules hosted in the Buf Schema Registry.
+# The resolution of these dependencies is stored in the buf.lock file.
 deps:
-  - buf.build/google/googleapis
-  - buf.build/grpc/grpc
-# Default lint configuration for all modules in the workspace.
+  - buf.build/acme/paymentapis # The latest accepted commit.
+  - buf.build/acme/pkg:47b927cbb41c4fdea1292bafadb8976f # The '47b927cbb41c4fdea1292bafadb8976f' commit.
+  - buf.build/googleapis/googleapis:v1beta1.1.0 # The 'v1beta1.1.0' label.
+# The default lint configuration for any modules that don't have a specific lint configuration.
+#
+# If this section isn't present, AND a module does not have a specific lint configuration, the default
+# lint configuration is used for the module.
 lint:
   use:
     - DEFAULT
-# Default breaking changes configuration for all modules in the workspace.
+# Default breaking configuration. It behaves the same as the default lint configuration.
 breaking:
   use:
     - FILE

--- a/src/test/buf/buf.v2.yaml
+++ b/src/test/buf/buf.v2.yaml
@@ -1,0 +1,58 @@
+# via https://buf.build/docs/configuration/v2/buf-yaml
+version: v2
+modules:
+  # Basic configuration: local directory with corresponding BSR repository.
+  - path: proto/foo
+    name: buf.build/acme/foo
+  # Local directory & repository, but excluding a directory and a specific .proto file.
+  # Note that the paths for exclusion are relative to the buf.yaml file.
+  - path: proto/bar
+    name: buf.build/acme/bar
+    excludes:
+      - proto/bar/a
+      - proto/bar/b/c.proto
+    # Lint configuration for this module only. This rule set completely replaces the workspace defaults.
+    lint:
+      use:
+        - DEFAULT
+      except:
+        - IMPORT_USED
+      ignore:
+        - proto/bar/b/c.proto
+      ignore_only:
+        ENUM_ZERO_VALUE_SUFFIX:
+          - proto/bar/d
+          - proto/bar/e/f.proto
+      disallow_comment_ignores: false # The default behavior of this key has changed from v1
+      enum_zero_value_suffix: _UNSPECIFIED
+      rpc_allow_same_request_response: false
+      rpc_allow_google_protobuf_empty_requests: false
+      rpc_allow_google_protobuf_empty_responses: false
+      service_suffix: Service
+    # Breaking changes configuration for this module only. This rule set completely replaces the workspace defaults.
+    breaking:
+      use:
+        - FILE
+      except:
+        - EXTENSION_MESSAGE_NO_DELETE
+      ignore:
+        - proto/bar/a
+        - proto/bar/b/c.proto
+      ignore_only:
+        ENUM_ZERO_VALUE_SUFFIX:
+          - proto/bar/d
+          - proto/bar/e/f.proto
+      ignore_unstable_packages: true
+# Module dependencies available to all modules in the workspace. Modules within the workspace
+# shouldn't be listed here. The resolution of these dependencies is stored in the buf.lock file.
+deps:
+  - buf.build/google/googleapis
+  - buf.build/grpc/grpc
+# Default lint configuration for all modules in the workspace.
+lint:
+  use:
+    - DEFAULT
+# Default breaking changes configuration for all modules in the workspace.
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
Includes support for `version: v2` of `buf.yaml` and `buf.gen.yaml`.

See:

* https://buf.build/blog/buf-cli-next-generation
* https://buf.build/docs/migration-guides/migrate-v2-config-files