### PR TITLE
Update embrace-config-schema-1.0.0.json

### DIFF
--- a/src/schemas/json/embrace-config-schema-1.0.0.json
+++ b/src/schemas/json/embrace-config-schema-1.0.0.json
@@ -134,7 +134,7 @@
       "minProperties": 1
     }
   },
-  "required": ["app_id", "api_token"],
+  "required": ["api_token"],
   "title": "Embrace Config Schema",
   "type": "object"
 }


### PR DESCRIPTION
Makes one property in the JSON schema non-mandatory as it is no longer always required.