### PR TITLE
feat(catalog): add Drupal Recipe

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1130,6 +1130,12 @@
       "url": "https://json.schemastore.org/drupal-permissions.json"
     },
     {
+      "name": "Drupal Recipe",
+      "description": "Drupal configuration for recipe",
+      "fileMatch": ["drupal-recipe.yml", "drupal-recipe.yaml"],
+      "url": "https://json.schemastore.org/drupal-recipe.json"
+    },
+    {
       "name": "Drupal Routing",
       "description": "Drupal configuration for routing",
       "fileMatch": ["*.routing.yml"],

--- a/src/schemas/json/drupal-recipe.json
+++ b/src/schemas/json/drupal-recipe.json
@@ -56,7 +56,7 @@
         },
         "actions": {
           "title": "A list of actions to be performed over configuration.",
-          "description": "The key is the configuration object targeted and the value is the action to be performed. For each action addtional properties can be provided.",
+          "description": "The key is the configuration object targeted and the value is the action to be performed. For each action additional properties can be provided.",
           "type": "object",
           "properties": {},
           "additionalProperties": {

--- a/src/schemas/json/drupal-recipe.json
+++ b/src/schemas/json/drupal-recipe.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/drupal-recipe.json",
+  "additionalProperties": true,
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "type": {
+      "title": "The type of the recipe. Used for administrative purposes.",
+      "type": "string",
+      "examples": ["Content", "Commerce", "Forms"]
+    },
+    "name": {
+      "title": "User interface name for the recipe",
+      "type": "string"
+    },
+    "recipes": {
+      "type": "array",
+      "title": "List of recipes that this recipe depends on. Recipes must be installed relative to the Drupal root directory.",
+      "items": {
+        "type": "string"
+      },
+      "examples": [
+        "core/recipes/remote_video_media_type",
+        "starshot_admin_theme"
+      ]
+    },
+    "install": {
+      "title": "List of modules to be installed.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "import": {
+          "title": "A list of configurations to be installed.",
+          "description": "The key is the configuration provider and the value is the list of configuration names.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "actions": {
+          "title": "A list of actions to be performed over configuration.",
+          "description": "The key is the configuration object targeted and the value is the action to be performed. For each action addtional properties can be provided.",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "content": {
+      "title": "List of content to be created.",
+      "description": "The contents are stored in a directory relative to the recipe file.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["name", "description", "type"],
+  "type": "object"
+}

--- a/src/test/drupal-recipe/drupal-recipe.yml
+++ b/src/test/drupal-recipe/drupal-recipe.yml
@@ -1,0 +1,133 @@
+name: Starshot
+description: Applies all the Starshot recipes.
+type: Site
+recipes:
+  - core/recipes/basic_block_type
+  - core/recipes/content_search
+  - core/recipes/core_recommended_performance
+  - core/recipes/core_recommended_maintenance
+  - core/recipes/core_recommended_front_end_theme
+  - core/recipes/user_picture
+  # Provides a fallback text format which is available to all users.
+  - core/recipes/restricted_html_format
+  # Not in Standard...
+  - core/recipes/remote_video_media_type
+  - starshot_admin_theme
+  - starshot_audio_media_type
+  - starshot_blog
+  - starshot_basic_html_editor
+  - starshot_document_media_type
+  - starshot_event_content_type
+  - starshot_forms
+  - starshot_full_html_editor
+  - starshot_image_media_type
+  - starshot_local_video_media_type
+  - starshot_page_content_type
+install:
+  - metatag
+  - menu_link_content
+  - project_browser
+  - redirect
+  - uli_custom_workflow
+  # The rest of these are in Standard.
+  - help
+  - history
+  - config
+  - contextual
+  - menu_link_content
+  - datetime
+  - menu_ui
+  - options
+  - shortcut
+  - toolbar
+  - field_ui
+  - views_ui
+config:
+  import:
+    help:
+      - search.page.help_search
+    image:
+      - image.style.large
+      - image.style.thumbnail
+    metatag: '*'
+    node:
+      - views.view.archive
+      - views.view.content
+      - views.view.content_recent
+      - views.view.frontpage
+      - views.view.glossary
+    olivero:
+      - block.block.olivero_help
+      - block.block.olivero_search_form_narrow
+      - block.block.olivero_search_form_wide
+      - block.block.olivero_syndicate
+    shortcut:
+      - shortcut.set.default
+    user:
+      - core.entity_view_mode.user.compact
+      - search.page.user_search
+      - views.view.user_admin_people
+      - views.view.who_s_new
+      - views.view.who_s_online
+  actions:
+    node.type.blog:
+      # Don't allow blog posts to have menu links by default, since that's
+      # not normally what blog posts are for.
+      setThirdPartySettings:
+        - module: menu_ui
+          key: available_menus
+          value: []
+        - module: menu_ui
+          key: parent
+          value: ''
+    olivero.settings:
+      simple_config_update:
+        base_primary_color: '#0a205a'
+    project_browser.admin_settings:
+      simple_config_update:
+        enabled_sources:
+          - drupalorg_mockapi
+          - local_recipes
+    system.site:
+      simple_config_update:
+        name: 'Starshot'
+        page.front: '/node'
+    user.role.content_editor:
+      grantPermissionsForEachMediaType:
+        - 'create %bundle media'
+        - 'delete any %bundle media'
+        - 'edit any %bundle media'
+      grantPermissionsForEachNodeType:
+        - 'clone %bundle content'
+        - 'create %bundle content'
+        - 'delete %bundle revisions'
+        - 'delete any %bundle content'
+        - 'edit any %bundle content'
+      grantPermissionsForEachTaxonomyVocabulary:
+        - 'create terms in %bundle'
+        - 'edit terms in %bundle'
+    views.view.files:
+      setStatus: false
+    node.settings:
+      simple_config_update:
+        # @todo Remove `langcode` once https://drupal.org/i/3427564 lands.
+        langcode: en
+        use_admin_theme: true
+    user.role.authenticated:
+      grantPermissions:
+        - 'access help pages'
+        - 'access shortcuts'
+        - 'access user profiles'
+        - 'delete own files'
+        - 'use advanced search'
+        - 'view own unpublished content'
+    user.role.anonymous:
+      grantPermissions:
+        # We assume all published content should be accessible and searchable.
+        - 'access content'
+        - 'use advanced search'
+    user.settings:
+      simple_config_update:
+        verify_mail: true
+        register: admin_only
+        cancel_method: user_cancel_block


### PR DESCRIPTION
Hello there,

This PR is to add [Drupal Recipe schema](https://git.drupalcode.org/project/distributions_recipes/-/blob/1.0.x/docs/recipe.md#an-example-drupal-recipe) to the catalog. Drupal Recipes is a new core API which will be used as a way to compose a Drupal-based solution by adding small blocks configuration and features called recipes. This is supported by Drupal 10.3 onwards.

Contribution check list
- [X] Adding a JSON schema file to the catalog is required.
- [X] Add tests files. (.json, .yml, .yaml or .toml)
- [X] Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
- [X] JSON formatted according to the .editorconfig settings.
