### PR TITLE
feat(catalog): add lua language server addons

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2756,6 +2756,18 @@
       "url": "https://json.schemastore.org/kustomization.json"
     },
     {
+      "name": "Lua language server addon config.json",
+      "description": "Lua language server addon config.json",
+      "fileMatch": ["**/module/config.json"],
+      "url": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_config.schema.json"
+    },
+    {
+      "name": "Lua language server addon info.json",
+      "description": "Lua language server addon info.json",
+      "fileMatch": ["**/addons/*/info.json"],
+      "url": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json"
+    },
+    {
       "name": "label-commenter-config.yml",
       "description": "A the configuration of the Label Commenter GitHub Action",
       "fileMatch": ["**/.github/label-commenter-config.yml"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
