### PR TITLE
Allow more env syntaxes for GitHub Actions composite action steps

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -129,10 +129,27 @@
               "env": {
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsenv",
                 "description": "Sets a map of environment variables for only that step.",
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "boolean"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "$ref": "#/definitions/stringContainingExpressionSyntax"
+                  }
+                ]
               },
               "continue-on-error": {
                 "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error",


### PR DESCRIPTION
Match up behavior with other parts of GitHub Actions:
 * https://github.com/SchemaStore/schemastore/blob/dc0b182d3b6821bab840e89e4aec0216bc9216ef/src/schemas/json/github-workflow.json#L208-L232
 * https://github.com/SchemaStore/schemastore/blob/dc0b182d3b6821bab840e89e4aec0216bc9216ef/src/schemas/json/github-action.json#L186-L210

Originally found in https://github.com/TWiStErRob/net.twisterrob.ghlint/issues/221
Tested behaviors in https://github.com/TWiStErRob/github-actions-test/pull/26