### PR TITLE
support '.patch' versions in the 'api-version' field

### DIFF
--- a/src/schemas/json/paper-plugin.json
+++ b/src/schemas/json/paper-plugin.json
@@ -160,7 +160,7 @@
     "api-version": {
       "description": "The API version of the plugin",
       "type": "string",
-      "pattern": "^1\\.\\d{2}$",
+      "pattern": "^1\\.\\d{2}(\\.\\d{1,2})?$",
       "examples": ["1.19", "1.20"]
     },
     "dependencies": {

--- a/src/schemas/json/paper-plugin.json
+++ b/src/schemas/json/paper-plugin.json
@@ -161,7 +161,7 @@
       "description": "The API version of the plugin",
       "type": "string",
       "pattern": "^1\\.\\d{2}(\\.\\d{1,2})?$",
-      "examples": ["1.19", "1.20"]
+      "examples": ["1.19", "1.20", "1.20.6"]
     },
     "dependencies": {
       "description": "Plugin dependencies.",


### PR DESCRIPTION
the `api-version` field now supports an optional 3rd number
