### PR TITLE
ci: Use `code-owner-self-merge` fork with some fixes

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
       - name: 'Run Codeowners merge check'
-        uses: 'OSS-Docs-Tools/code-owner-self-merge@7c66472de8c7189f4ab4110e9fcc3e7944cad5f6'
+        uses: 'fox-forks/code-owner-self-merge@hyperupcall-bug-fixes'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->

Came across two bugs in `code-owner-self-merge`:

- Inaccurate error message, when user tries to merge PR with "LGTM", but the mergability check has not been completed. This code path was seen in #3795
- When "LGTM" is in quotation marks, it should not merge since that is not the intent. This bug was seen activated in #3824

Update ref to my fork which fixes these errors. Eventually, it will be upstreamed and this ref will be updated yet again.