### PR TITLE
Add job name validation for CircleCI config 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ test.json
 *.user
 *.sln.docstates
 *.publishproj
-*.pubxml
 node_modules/
 
 # Build results
@@ -49,7 +48,6 @@ packages/
 *.vssscc
 .builds
 *.pidb
-*.log
 *.scc
 *.sln.ide
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test.json
 *.user
 *.sln.docstates
 *.publishproj
+*.pubxml
 node_modules/
 
 # Build results
@@ -48,6 +49,7 @@ packages/
 *.vssscc
 .builds
 *.pidb
+*.log
 *.scc
 *.sln.ide
 

--- a/src/negative_test/circleciconfig/invalid-job-name-format.yml
+++ b/src/negative_test/circleciconfig/invalid-job-name-format.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../schemas/json/circleciconfig.json
+version: 2.1
+
+jobs:
+  this_name_is valid until . or , then bye_bye:
+    docker:
+      - image: image
+    steps:
+      - add_ssh_keys

--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -1430,7 +1430,10 @@
       "$ref": "#/definitions/executors"
     },
     "jobs": {
-      "$ref": "#/definitions/jobs"
+      "$ref": "#/definitions/jobs",
+      "propertyNames": {
+        "pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
+      }
     },
     "workflows": {
       "description": "Used for orchestrating all jobs. Each workflow consists of the workflow name as a key and a map as a value",


### PR DESCRIPTION
Fixes #3832 

I ran the tests for this schema `npm run grunt -- --SchemaName=circleciconfig.json`, all the existing positive cases passed and the negative case that was added looks to be moaning where the config moaned at me:

```
pass negative test   | src/negative_test/circleciconfig/invalid-job-name-format.yml (Schema: #/properties/jobs/propertyNames/pattern) (Test: /jobs) (Message): must match pattern "^[A-Za-z][A-Za-z\s\d_-]*$")
```

I am not an expert at writing json schema so please let me know if this is right way to write this, since it is possible that this also applies to the naming of jobs when inlining orbs, e.g. see `src/schemas/json/circleciconfig.json:115`, but since I have never written or used these, I have no idea. A @CircleCI-Public/developer-experience wizard(s) can provide some insight. 

And I did read the section about `Overconstraint`, but I do not suspect that this falls into this category, but feel free to disagree.

(and I snuck in removing duplicated gitignores since my editor told me about this)