### PR TITLE
ESLint: Add `parserOptions.ecmaVersion` 2024 (15)

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -1381,10 +1381,12 @@
             2022,
             14,
             2023,
+            15,
+            2024,
             "latest"
           ],
           "default": 11,
-          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11 (default), 12, 13, 14 or \"latest\" to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12), 2022 (same as 13) or 2023 (same as 14) to use the year-based naming. \"latest\" always enables the latest supported ECMAScript version."
+          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11 (default), 12, 13, 14, 15 or \"latest\" to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12), 2022 (same as 13), 2023 (same as 14) or 2024 (same as 15) to use the year-based naming. \"latest\" always enables the latest supported ECMAScript version."
         },
         "sourceType": {
           "enum": ["script", "module", "commonjs"],


### PR DESCRIPTION
This PR adds `parserOptions.ecmaVersion` 2024 (15).

Supported versions for Espree (ESLint) are defined here:
https://github.com/eslint/espree/blob/main/lib/options.js#L10-L23

Link to relevant documentation:
https://eslint.org/docs/v8.x/use/configure/language-options#specifying-parser-options