### PR TITLE
ESLint: Set `parserOptions.ecmaVersion.default` to 5

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -1385,8 +1385,8 @@
             2024,
             "latest"
           ],
-          "default": 11,
-          "description": "Set to 3, 5, 6, 7, 8, 9, 10, 11 (default), 12, 13, 14, 15 or \"latest\" to specify the version of ECMAScript syntax you want to use. You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12), 2022 (same as 13), 2023 (same as 14) or 2024 (same as 15) to use the year-based naming. \"latest\" always enables the latest supported ECMAScript version."
+          "default": 5,
+          "description": "Set to 3, 5 (default), 6, 7, 8, 9, 10, 11, 12, 13, 14, or 15 to specify the version of ECMAScript syntax you want to use. You can also set it to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12), 2022 (same as 13), 2023 (same as 14), or 2024 (same as 15) to use the year-based naming. You can also set \"latest\" to use the most recently supported version."
         },
         "sourceType": {
           "enum": ["script", "module", "commonjs"],


### PR DESCRIPTION
## Description:
- Sets the default value of `parserOptions.ecmaVersion` to `5`.
- Updates the description text to match the text of the official documentation of ESLint (see [here](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-parser-options))

## Note:
This will revert the following PR:
- https://github.com/SchemaStore/schemastore/pull/1231

I don't know why this was updated to `11`, as both the documentation and the source code itself state that `5` is the default value `ecmaVersion` in the configuration of ESLint:
- Documentation: https://eslint.org/docs/v8.x/use/configure/language-options#specifying-parser-options
  > `ecmaVersion` - set to 3, 5 (default), 6, 7, 8, 9, 10, 11, 12, 13, 14, or 15 to specify the version of ECMAScript syntax you want to use.
- Source code: https://github.com/eslint/espree/blob/main/lib/options.js#L47
  ```JS
  function normalizeEcmaVersion(ecmaVersion = 5) { /*...*/ }
  ```

## ESLint 9
The default value for `ecmaVersion` in ESLint 9 is now `"latest"`, but ESLint 9 does not use the `.eslintrc` JSON config anymore (and instead uses a JS `eslint.config.js` file).

- https://eslint.org/docs/latest/use/configure/language-options#specifying-javascript-options
  > `ecmaVersion` (default: `"latest"`) - Indicates the ECMAScript version of the code being linted, determining both the syntax and the available global variables. Set to `3` or `5` for ECMAScript 3 and 5, respectively. Otherwise, you can use any year between `2015` to present. In most cases, we recommend using the default of `"latest"` to ensure you’re always using the most recent ECMAScript version.
- https://eslint.org/docs/v8.x/use/configure/configuration-files-new#configuration-objects
  > `ecmaVersion` - The version of ECMAScript to support. May be any year (i.e., `2022`) or version (i.e., `5`). Set to `"latest"` for the most recent supported version. (default: `"latest"`)