### PR TITLE
feat(catalog): add EAS config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1925,6 +1925,12 @@
       }
     },
     {
+      "name": "EAS config",
+      "description": "The EAS config (eas.json) validation and documentation.",
+      "fileMatch": ["eas.json"],
+      "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-json/schema/eas.schema.json",
+    },
+    {
       "name": "ezd task runner",
       "description": "ezd task runner. Documentation: https://gitlab.com/sbenv/veroxis/ezd-rs",
       "fileMatch": ["ezd.yaml", "ezd.json", "ezd.yml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1926,7 +1926,7 @@
     },
     {
       "name": "EAS config",
-      "description": "The EAS config (eas.json) validation and documentation.",
+      "description": "The EAS config (eas.json) validation and documentation",
       "fileMatch": ["eas.json"],
       "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-json/schema/eas.schema.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1928,7 +1928,7 @@
       "name": "EAS config",
       "description": "The EAS config (eas.json) validation and documentation.",
       "fileMatch": ["eas.json"],
-      "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-json/schema/eas.schema.json",
+      "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-json/schema/eas.schema.json"
     },
     {
       "name": "ezd task runner",


### PR DESCRIPTION
Add remote schema for `eas.json` config for EAS cli by Expo (https://github.com/expo/eas-cli).

schema file: https://github.com/expo/eas-cli/blob/main/packages/eas-json/schema/eas.schema.json