### PR TITLE
Update all contributors schema

### DIFF
--- a/src/schemas/json/all-contributors.json
+++ b/src/schemas/json/all-contributors.json
@@ -59,6 +59,11 @@
       ],
       "default": "angular"
     },
+    "commitType": {
+       "description": "UNDOCUMENTED: Sets Conventional Commits commit type to be used by the all contributors bot. See https://www.conventionalcommits.org.",
+       "type": "string",
+       "default": "docs"
+    },
     "contributorsPerLine": {
       "title": "Maximum number of columns for the contributors table",
       "type": "number",

--- a/src/schemas/json/all-contributors.json
+++ b/src/schemas/json/all-contributors.json
@@ -60,9 +60,9 @@
       "default": "angular"
     },
     "commitType": {
-       "description": "UNDOCUMENTED: Sets Conventional Commits commit type to be used by the all contributors bot. See https://www.conventionalcommits.org.",
-       "type": "string",
-       "default": "docs"
+      "description": "UNDOCUMENTED: Sets Conventional Commits commit type to be used by the all contributors bot. See https://www.conventionalcommits.org.",
+      "type": "string",
+      "default": "docs"
     },
     "contributorsPerLine": {
       "title": "Maximum number of columns for the contributors table",

--- a/src/schemas/json/all-contributors.json
+++ b/src/schemas/json/all-contributors.json
@@ -153,8 +153,50 @@
             "type": "array",
             "minItems": 1,
             "items": {
-              "type": "string",
-              "minLength": 0
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "a11y",
+                    "audio",
+                    "blog",
+                    "bug",
+                    "business",
+                    "code",
+                    "content",
+                    "data",
+                    "design",
+                    "doc",
+                    "eventOrganizing",
+                    "example",
+                    "financial",
+                    "fundingFinding",
+                    "ideas",
+                    "infra",
+                    "maintenance",
+                    "mentoring",
+                    "platform",
+                    "plugin",
+                    "projectManagement",
+                    "promotion",
+                    "question",
+                    "research",
+                    "review",
+                    "security",
+                    "talk",
+                    "test",
+                    "tool",
+                    "translation",
+                    "tutorial",
+                    "userTesting",
+                    "video"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "minLength": 0
+                }
+              ]
             }
           }
         },

--- a/src/schemas/json/all-contributors.json
+++ b/src/schemas/json/all-contributors.json
@@ -149,42 +149,7 @@
             "minItems": 1,
             "items": {
               "type": "string",
-              "minLength": 0,
-              "enum": [
-                "a11y",
-                "audio",
-                "blog",
-                "bug",
-                "business",
-                "code",
-                "content",
-                "data",
-                "design",
-                "doc",
-                "eventOrganizing",
-                "example",
-                "financial",
-                "fundingFinding",
-                "ideas",
-                "infra",
-                "maintenance",
-                "mentoring",
-                "platform",
-                "plugin",
-                "projectManagement",
-                "promotion",
-                "question",
-                "research",
-                "review",
-                "security",
-                "talk",
-                "test",
-                "tool",
-                "translation",
-                "tutorial",
-                "userTesting",
-                "video"
-              ]
+              "minLength": 0
             }
           }
         },

--- a/src/test/all-contributors/commit-type.json
+++ b/src/test/all-contributors/commit-type.json
@@ -1,0 +1,32 @@
+{
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/github/all-contributors/<%= projectOwner %>/<%= projectName %>?color=ee8449&style=flat-square)](#contributors)",
+  "commit": false,
+  "commitType": "docs",
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+  "contributors": [
+    {
+      "avatar_url": "https://avatars1.githubusercontent.com/u/26386270?v=4",
+      "contributions": ["code", "doc"],
+      "login": "EndBug",
+      "name": "Federico Grandi",
+      "profile": "https://github.com/EndBug"
+    }
+  ],
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": false,
+  "files": ["README.md", "CONTRIBUTING.md"],
+  "imageSize": 100,
+  "linkToUsage": true,
+  "projectName": "all-contributors",
+  "projectOwner": "all-contributors",
+  "repoHost": "https://github.com",
+  "repoType": "github",
+  "skipCi": true,
+  "types": {
+    "custom": {
+      "description": "A custom contribution type.",
+      "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),",
+      "symbol": "🔭"
+    }
+  }
+}

--- a/src/test/all-contributors/custom-contribution-type.json
+++ b/src/test/all-contributors/custom-contribution-type.json
@@ -5,7 +5,7 @@
   "contributors": [
     {
       "avatar_url": "https://avatars1.githubusercontent.com/u/26386270?v=4",
-      "contributions": ["code", "doc", "jokes"],
+      "contributions": ["code", "doc", "custom"],
       "login": "EndBug",
       "name": "Federico Grandi",
       "profile": "https://github.com/EndBug"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->

This PR

- Adds the undocumented `commitType` property, which is added by the all contributors bot. There is a PR to add documentation to the all contributors project [here](https://github.com/all-contributors/all-contributors/pull/757)
- ~~Remove the enum from `contributions` as it is possible to create custom contribution types.
  Valid files with custom contribution types would fail validation using the existing schema.
  I'm not certain it isn't possible but I couldn't find a way to make a list of valid contribution types, which would be the union of the built in types and any types defined in `types`.
  You cannot know all of the valid values before reading the `allcontributorsrc` file.~~
  Use `anyOf` to so that valid contribution types are either from the list of default contribution types or a string, allowing for custom contributions.
  Perhaps a little redundant as the string option is so permissive.
- Add tests