### PR TITLE
Align bundleDependencies in package.json with npm docs

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -616,7 +616,7 @@
         }
       }
     },
-    "bundledDependencies": {
+    "bundleDependencies": {
       "description": "Array of package names that will be bundled when publishing the package.",
       "oneOf": [
         {
@@ -630,8 +630,8 @@
         }
       ]
     },
-    "bundleDependencies": {
-      "description": "DEPRECATED: This field is honored, but \"bundledDependencies\" is the correct field name.",
+    "bundledDependencies": {
+      "description": "DEPRECATED: This field is honored, but \"bundleDependencies\" is the correct field name.",
       "oneOf": [
         {
           "type": "array",


### PR DESCRIPTION
`arborist` normalizes `bundledDependencies` to `bundleDependencies`. The same is documented by [npm](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bundledependencies). 

This change corrects the description of the preferred value to match that reality. 

Ref https://github.com/npm/cli/pull/5171

