### PR TITLE
Add cache-warmup config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -893,6 +893,16 @@
       "url": "https://raw.githubusercontent.com/Kitware/CMake/master/Help/manual/presets/schema.json"
     },
     {
+      "name": "Cache Warmup config",
+      "description": "Cache Warmup config",
+      "fileMatch": [
+        "cache-warmup.json",
+        "cache-warmup.yaml",
+        "cache-warmup.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/eliashaeussler/cache-warmup/main/res/cache-warmup-config.schema.json"
+    },
+    {
       "name": "Calqulus pipeline",
       "description": "Qualisys Calqulus pipeline",
       "fileMatch": ["*.calqulus.yaml", "*.calqulus.yml"],


### PR DESCRIPTION
This PR adds the [JSON schema](https://github.com/eliashaeussler/cache-warmup/blob/main/res/cache-warmup-config.schema.json) for the [`eliashaeussler/cache-warmup`](https://github.com/eliashaeussler/cache-warmup) library to the `catalog.json`.