### PR TITLE
Added Landing Zone Accelerator on AWS schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1439,7 +1439,7 @@
     },
     {
       "name": "Landing Zone Accelerator on AWS - Accounts Config",
-      "description": "Used to manage all of the AWS accounts within the AWS Organization.",
+      "description": "Used to manage all of the AWS accounts within the AWS Organization",
       "fileMatch": ["accounts-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json",
       "versions": {
@@ -1448,7 +1448,7 @@
     },
     {
       "name": "Landing Zone Accelerator on AWS - Customizations Config",
-      "description": "Used to manage configuration of custom applications, third-party firewall appliances, and CloudFormation stacks.",
+      "description": "Used to manage configuration of custom applications, third-party firewall appliances, and CloudFormation stacks",
       "fileMatch": ["customizations-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json",
       "versions": {
@@ -1457,7 +1457,7 @@
     },
     {
       "name": "Landing Zone Accelerator on AWS - Global Config",
-      "description": "Used to manage all of the global properties that can be inherited across the AWS Organization.",
+      "description": "Used to manage all of the global properties that can be inherited across the AWS Organization",
       "fileMatch": ["global-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/global-config.json",
       "versions": {
@@ -1466,7 +1466,7 @@
     },
     {
       "name": "Landing Zone Accelerator on AWS - IAM Config",
-      "description": "Used to manage all of the IAM resources across the AWS Organization.",
+      "description": "Used to manage all of the IAM resources across the AWS Organization",
       "fileMatch": ["iam-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json",
       "versions": {
@@ -1475,7 +1475,7 @@
     },
     {
       "name": "Landing Zone Accelerator on AWS - Network Config",
-      "description": "Used to manage and implement network resources to establish a WAN/LAN architecture to support cloud operations and application workloads in AWS.",
+      "description": "Used to manage and implement network resources to establish a WAN/LAN architecture to support cloud operations and application workloads in AWS",
       "fileMatch": ["network-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/network-config.json",
       "versions": {
@@ -1484,7 +1484,7 @@
     },
     {
       "name": "Landing Zone Accelerator on AWS - Organization Config",
-      "description": "Used to manage all of the organization units in the AWS Organization.",
+      "description": "Used to manage all of the organization units in the AWS Organization",
       "fileMatch": ["organization-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/organization-config.json",
       "versions": {
@@ -1493,7 +1493,7 @@
     },
     {
       "name": "Landing Zone Accelerator on AWS - Replacements Config",
-      "description": "Used to manage all of the replacement values across the configuration files.",
+      "description": "Used to manage all of the replacement values across the configuration files",
       "fileMatch": ["replacements-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/replacements-config.json",
       "versions": {
@@ -1502,7 +1502,7 @@
     },
     {
       "name": "Landing Zone Accelerator on AWS - Security Config",
-      "description": "Used to manage configuration of AWS security services.",
+      "description": "Used to manage configuration of AWS security services",
       "fileMatch": ["security-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/security-config.json",
       "versions": {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1438,6 +1438,78 @@
       "url": "https://raw.githubusercontent.com/aws/aws-sam-cli/master/schema/samcli.json"
     },
     {
+      "name": "Landing Zone Accelerator on AWS - Accounts Config",
+      "description": "Used to manage all of the AWS accounts within the AWS Organization.",
+      "fileMatch": ["accounts-config.yaml"],
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json",
+      "versions": {
+        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json"
+      }
+    },
+    {
+      "name": "Landing Zone Accelerator on AWS - Customizations Config",
+      "description": "Used to manage configuration of custom applications, third-party firewall appliances, and CloudFormation stacks.",
+      "fileMatch": ["customizations-config.yaml"],
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json",
+      "versions": {
+        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json"
+      }
+    },
+    {
+      "name": "Landing Zone Accelerator on AWS - Global Config",
+      "description": "Used to manage all of the global properties that can be inherited across the AWS Organization.",
+      "fileMatch": ["global-config.yaml"],
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/global-config.json",
+      "versions": {
+        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/global-config.json"
+      }
+    },
+    {
+      "name": "Landing Zone Accelerator on AWS - IAM Config",
+      "description": "Used to manage all of the IAM resources across the AWS Organization.",
+      "fileMatch": ["iam-config.yaml"],
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json",
+      "versions": {
+        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json"
+      }
+    },
+    {
+      "name": "Landing Zone Accelerator on AWS - Network Config",
+      "description": "Used to manage and implement network resources to establish a WAN/LAN architecture to support cloud operations and application workloads in AWS.",
+      "fileMatch": ["network-config.yaml"],
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/network-config.json",
+      "versions": {
+        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/network-config.json"
+      }
+    },
+    {
+      "name": "Landing Zone Accelerator on AWS - Organization Config",
+      "description": "Used to manage all of the organization units in the AWS Organization.",
+      "fileMatch": ["organization-config.yaml"],
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/organization-config.json",
+      "versions": {
+        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/organization-config.json"
+      }
+    },
+    {
+      "name": "Landing Zone Accelerator on AWS - Replacements Config",
+      "description": "Used to manage all of the replacement values across the configuration files.",
+      "fileMatch": ["replacements-config.yaml"],
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/replacements-config.json",
+      "versions": {
+        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/replacements-config.json"
+      }
+    },
+    {
+      "name": "Landing Zone Accelerator on AWS - Security Config",
+      "description": "Used to manage configuration of AWS security services.",
+      "fileMatch": ["security-config.yaml"],
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/security-config.json",
+      "versions": {
+        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/security-config.json"
+      }
+    },
+    {
       "name": "chisel-slices.json",
       "description": "Canonical Chisel slices definition file",
       "fileMatch": ["**/slices/*.yaml"],


### PR DESCRIPTION
This pull request adds the schema files to support the [Landing Zone Accelerator on AWS](https://aws.amazon.com/solutions/implementations/landing-zone-accelerator-on-aws/) (LZA) solution. The LZA uses [8 different configuration yaml files](https://docs.aws.amazon.com/solutions/latest/landing-zone-accelerator-on-aws/using-configuration-files.html#configuration-file-descriptions), each config file has a schema, which is referenced in this pull request.

Please let me know if you need any additional information or if there are any issues with these remote schema references. Thank you!