### PR TITLE
Add CodeRabbit JSON schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -507,6 +507,12 @@
       "url": "https://json.schemastore.org/buf.work.json"
     },
     {
+      "name": "CodeRabbit",
+      "description": "Supercharge your entire team with AI-driven contextual feedback & smart chat",
+      "fileMatch": [".coderabbit.yaml"],
+      "url": "https://coderabbit.ai/integrations/schema.v2.json"
+    },
+    {
       "name": "CodeCV",
       "description": "CV format specification",
       "fileMatch": [


### PR DESCRIPTION
CodeRabbit maintains their own schema externally.
