### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -1731,6 +1731,7 @@
         },
         "ignore-init-module-imports": {
           "description": "Avoid automatically removing unused imports in `__init__.py` files. Such imports will still be flagged, but with a dedicated message suggesting that the import is either added to the module's `__all__` symbol, or re-exported with a redundant alias (e.g., `import os as os`).\n\nThis option is enabled by default, but you can opt-in to removal of imports via an unsafe fix.",
+          "deprecated": true,
           "type": ["boolean", "null"]
         },
         "isort": {
@@ -2094,7 +2095,7 @@
     },
     "PythonVersion": {
       "type": "string",
-      "enum": ["py37", "py38", "py39", "py310", "py311", "py312"]
+      "enum": ["py37", "py38", "py39", "py310", "py311", "py312", "py313"]
     },
     "Quote": {
       "oneOf": [
@@ -2179,6 +2180,8 @@
         "ASYNC100",
         "ASYNC101",
         "ASYNC102",
+        "ASYNC11",
+        "ASYNC116",
         "B",
         "B0",
         "B00",
@@ -2221,6 +2224,7 @@
         "B035",
         "B9",
         "B90",
+        "B901",
         "B904",
         "B905",
         "B909",
@@ -2558,6 +2562,7 @@
         "FURB148",
         "FURB15",
         "FURB152",
+        "FURB154",
         "FURB157",
         "FURB16",
         "FURB161",
@@ -2723,6 +2728,7 @@
         "PLC02",
         "PLC020",
         "PLC0205",
+        "PLC0206",
         "PLC0208",
         "PLC04",
         "PLC041",
@@ -3068,10 +3074,14 @@
         "PYI054",
         "PYI055",
         "PYI056",
+        "PYI057",
         "PYI058",
         "PYI059",
         "PYI06",
         "PYI062",
+        "PYI063",
+        "PYI064",
+        "PYI066",
         "Q",
         "Q0",
         "Q00",
@@ -3435,6 +3445,7 @@
         "github",
         "gitlab",
         "pylint",
+        "rdjson",
         "azure",
         "sarif"
       ]


### PR DESCRIPTION
This updates ruff's JSON schema to [2d6d85e99364ab19082d5735829b6ce9d5b01c07](https://github.com/astral-sh/ruff/commit/2d6d85e99364ab19082d5735829b6ce9d5b01c07)

I had a lot of difficulties with the JSON formatting with prettier directly and resorted to just running `pre-commit` — looks like that may have introduced some additional diff here?
