### PR TITLE
Add in Open Data Contract Standard (ODCS) JSON schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3349,6 +3349,15 @@
       "url": "https://raw.githubusercontent.com/openrewrite/rewrite/main/rewrite-core/openrewrite.json"
     },
     {
+      "name": "Open Data Contract Standard (ODCS))",
+      "description": "Open Data Contract Standard contract file",
+      "fileMatch": ["*.odcs.yaml", "*.odcs.yml"],
+      "url": "https://raw.githubusercontent.com/bitol-io/open-data-contract-standard/main/schema/odcs-json-schema-latest.json",
+      "versions": {
+        "v2.2.2": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v2.2.2.json"
+      }
+    },
+    {
       "name": "Outblocks project configuration",
       "description": "Outblocks project configuration files",
       "fileMatch": ["project.outblocks.yaml", "project.outblocks.yml"],


### PR DESCRIPTION
Add Open Data Contract Standard (ODCS) JSON schema.

Referencing from the following repository:
https://github.com/bitol-io/open-data-contract-standard
