### PR TITLE
Support fail-fast attribute in zuul-schema

### DIFF
--- a/src/schemas/json/zuul.json
+++ b/src/schemas/json/zuul.json
@@ -309,6 +309,10 @@
     "PipelineModel": {
       "additionalProperties": false,
       "properties": {
+        "fail-fast": {
+          "title": "Fail Fast",
+          "type": "boolean"
+        },
         "jobs": {
           "items": {},
           "title": "Jobs",

--- a/src/test/zuul/jobs.yaml
+++ b/src/test/zuul/jobs.yaml
@@ -129,6 +129,7 @@
       var_for_all_jobs: value
     # common pipeline names (sadly at same level as properties)
     check:
+      fail-fast: true
       jobs:
         - job1
         - job2:


### PR DESCRIPTION
The fail-fast attribute of the pipeline model in the project snippet [1] is currently not recognized by the schema.

[1] https://zuul-ci.org/docs/zuul/latest/config/project.html#attr-project.%3Cpipeline%3E.fail-fast
