### PR TITLE
Add missing `markdownDescription` properties for `partial-pyright.json`

### DIFF
--- a/src/schemas/json/partial-pyright.json
+++ b/src/schemas/json/partial-pyright.json
@@ -29,6 +29,7 @@
       "type": "string",
       "title": "Python version to assume during type analysis",
       "description": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. `3.0` or `3.6`). If a version is provided, pyright will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version. If no version is specified, pyright will use the version of the current python interpreter, if one is present.",
+      "markdownDescription": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format `M.m` where `M` is the major version and `m` is the minor (e.g. `3.0` or `3.6`). If a version is provided, pyright will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version. If no version is specified, pyright will use the version of the current python interpreter, if one is present.",
       "x-intellij-html-description": "Specifies the version of Python that will be used to execute the source code. The version should be specified as a string in the format <code>M.m</code> where <code>M</code> is the major version and <code>m</code> is the minor (e.g. <code>3.0</code> or <code>3.6</code>). If a version is provided, pyright will generate errors if the source code makes use of language features that are not supported in that version. It will also tailor its use of type stub files, which conditionalizes type definitions based on the version. If no version is specified, pyright will use the version of the current python interpreter, if one is present.",
       "default": "",
       "examples": ["3.7"],
@@ -38,6 +39,7 @@
       "type": "string",
       "title": "Python platform to assume during type analysis",
       "description": "Specifies the target platform that will be used to execute the source code. Should be one of `Windows`, `Darwin`, `Linux`, or `All`. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
+      "markdownDescription": "Specifies the target platform that will be used to execute the source code. Should be one of `Windows`, `Darwin`, `Linux`, or `All`. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
       "x-intellij-html-description": "Specifies the target platform that will be used to execute the source code. Should be one of <code>Windows</code>, <code>Darwin</code>, <code>Linux</code>, or <code>All</code>. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
       "default": "",
       "examples": ["Linux"],
@@ -55,6 +57,7 @@
       "type": "boolean",
       "title": "Infer strict types for list expressions",
       "description": "When inferring the type of a list, use strict type assumptions. For example, the expression `[1, 'a', 3.4]` could be inferred to be of type `list[Any]` or `list[int | str | float]`. If this setting is `true`, it will use the latter (stricter) type.",
+      "markdownDescription": "When inferring the type of a list, use strict type assumptions. For example, the expression `[1, 'a', 3.4]` could be inferred to be of type `list[Any]` or `list[int | str | float]`. If this setting is `true`, it will use the latter (stricter) type.",
       "x-intellij-html-description": "When inferring the type of a list, use strict type assumptions. For example, the expression <code>[1, &#39;a&#39;, 3.4]</code> could be inferred to be of type <code>list[Any]</code> or <code>list[int | str | float]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type.",
       "default": false
     },
@@ -62,6 +65,7 @@
       "type": "boolean",
       "title": "Infer strict types for set expressions",
       "description": "When inferring the type of a set, use strict type assumptions. For example, the expression `{1, 'a', 3.4}` could be inferred to be of type `set[Any]` or `set[int | str | float]`. If this setting is `true`, it will use the latter (stricter) type.",
+      "markdownDescription": "When inferring the type of a set, use strict type assumptions. For example, the expression `{1, 'a', 3.4}` could be inferred to be of type `set[Any]` or `set[int | str | float]`. If this setting is `true`, it will use the latter (stricter) type.",
       "x-intellij-html-description": "When inferring the type of a set, use strict type assumptions. For example, the expression <code>{1, &#39;a&#39;, 3.4}</code> could be inferred to be of type <code>set[Any]</code> or <code>set[int | str | float]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type.",
       "default": false
     },
@@ -69,6 +73,7 @@
       "type": "boolean",
       "title": "Infer strict types for dictionary expressions",
       "description": "When inferring the type of a dictionary's keys and values, use strict type assumptions. For example, the expression `{'a': 1, 'b': 'a'}` could be inferred to be of type `dict[str, Any]` or `dict[str, int | str]`. If this setting is `true`, it will use the latter (stricter) type.",
+      "markdownDescription": "When inferring the type of a dictionary's keys and values, use strict type assumptions. For example, the expression `{'a': 1, 'b': 'a'}` could be inferred to be of type `dict[str, Any]` or `dict[str, int | str]`. If this setting is `true`, it will use the latter (stricter) type.",
       "x-intellij-html-description": "When inferring the type of a dictionary&#39;s keys and values, use strict type assumptions. For example, the expression <code>{&#39;a&#39;: 1, &#39;b&#39;: &#39;a&#39;}</code> could be inferred to be of type <code>dict[str, Any]</code> or <code>dict[str, int | str]</code>. If this setting is <code>true</code>, it will use the latter (stricter) type.",
       "default": false
     },
@@ -208,6 +213,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of type mismatch detected by `typing.assert_type` call",
       "description": "Generate or suppress diagnostics for a type mismatch detected by the `typing.assert_type` call.",
+      "markdownDescription": "Generate or suppress diagnostics for a type mismatch detected by the `typing.assert_type` call.",
       "x-intellij-html-description": "Generate or suppress diagnostics for a type mismatch detected by the <code>typing.assert_type</code> call.",
       "default": "error"
     },
@@ -257,6 +263,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of diagnostics related to unary and binary operators",
       "description": "Generate or suppress diagnostics related to the use of unary or binary operators (like `*` or `not`).",
+      "markdownDescription": "Generate or suppress diagnostics related to the use of unary or binary operators (like `*` or `not`).",
       "x-intellij-html-description": "Generate or suppress diagnostics related to the use of unary or binary operators (like <code>*</code> or <code>not</code>).",
       "default": "error"
     },
@@ -264,6 +271,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to subscript (index) a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to subscript (index) a variable with an `Optional` type.",
+      "markdownDescription": "Generate or suppress diagnostics for an attempt to subscript (index) a variable with an `Optional` type.",
       "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to subscript (index) a variable with an <code>Optional</code> type.",
       "default": "error"
     },
@@ -271,6 +279,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to access a member of a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to access a member of a variable with an `Optional` type.",
+      "markdownDescription": "Generate or suppress diagnostics for an attempt to access a member of a variable with an `Optional` type.",
       "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to access a member of a variable with an <code>Optional</code> type.",
       "default": "error"
     },
@@ -278,6 +287,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to call a variable with `Optional` type",
       "description": "Generate or suppress diagnostics for an attempt to call a variable with an `Optional` type.",
+      "markdownDescription": "Generate or suppress diagnostics for an attempt to call a variable with an `Optional` type.",
       "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to call a variable with an <code>Optional</code> type.",
       "default": "error"
     },
@@ -285,6 +295,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as an iterable value",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as an iterable value (e.g. within a `for` statement).",
+      "markdownDescription": "Generate or suppress diagnostics for an attempt to use an `Optional` type as an iterable value (e.g. within a `for` statement).",
       "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as an iterable value (e.g. within a <code>for</code> statement).",
       "default": "error"
     },
@@ -292,6 +303,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as a parameter to a `with` statement",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as a context manager (as a parameter to a `with` statement).",
+      "markdownDescription": "Generate or suppress diagnostics for an attempt to use an `Optional` type as a context manager (as a parameter to a `with` statement).",
       "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as a context manager (as a parameter to a <code>with</code> statement).",
       "default": "error"
     },
@@ -299,6 +311,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to use an `Optional` type as an operand for a binary or unary operator",
       "description": "Generate or suppress diagnostics for an attempt to use an `Optional` type as an operand to a unary operator (like `~` or `not`) or the left-hand operator of a binary operator (like `*`, `==`, `or`).",
+      "markdownDescription": "Generate or suppress diagnostics for an attempt to use an `Optional` type as an operand to a unary operator (like `~` or `not`) or the left-hand operator of a binary operator (like `*`, `==`, `or`).",
       "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to use an <code>Optional</code> type as an operand to a unary operator (like <code>~</code> or <code>not</code>) or the left-hand operator of a binary operator (like <code>*</code>, <code>==</code>, <code>or</code>).",
       "default": "error"
     },
@@ -318,6 +331,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of attempts to access a non-required key in a `TypedDict` without a check for its presence",
       "description": "Generate or suppress diagnostics for an attempt to access a non-required field within a `TypedDict` without first checking whether it is present.",
+      "markdownDescription": "Generate or suppress diagnostics for an attempt to access a non-required field within a `TypedDict` without first checking whether it is present.",
       "x-intellij-html-description": "Generate or suppress diagnostics for an attempt to access a non-required field within a <code>TypedDict</code> without first checking whether it is present.",
       "default": "error"
     },
@@ -343,6 +357,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of a named tuple definition that does not contain type information",
       "description": "Generate or suppress diagnostics when `namedtuple` is used rather than `NamedTuple`. The former contains no type information, whereas the latter does.",
+      "markdownDescription": "Generate or suppress diagnostics when `namedtuple` is used rather than `NamedTuple`. The former contains no type information, whereas the latter does.",
       "x-intellij-html-description": "Generate or suppress diagnostics when <code>namedtuple</code> is used rather than <code>NamedTuple</code>. The former contains no type information, whereas the latter does.",
       "default": "none"
     },
@@ -350,6 +365,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of private variables and functions used outside of the owning class or module and usage of protected members outside of subclasses",
       "description": "Generate or suppress diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore (`_`) and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
+      "markdownDescription": "Generate or suppress diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore (`_`) and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
       "x-intellij-html-description": "Generate or suppress diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore (<code>_</code>) and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module.",
       "default": "none"
     },
@@ -363,6 +379,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of improper usage of symbol imported from a `py.typed` module that is not re-exported from that module",
       "description": "Generate or suppress diagnostics for use of a symbol from a `py.typed` module that is not meant to be exported from that module.",
+      "markdownDescription": "Generate or suppress diagnostics for use of a symbol from a `py.typed` module that is not meant to be exported from that module.",
       "x-intellij-html-description": "Generate or suppress diagnostics for use of a symbol from a <code>py.typed</code> module that is not meant to be exported from that module.",
       "default": "error"
     },
@@ -394,6 +411,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `__init__` and `__new__` methods whose signatures are inconsistent",
       "description": "Generate or suppress diagnostics when an `__init__` method signature is inconsistent with a `__new__` signature.",
+      "markdownDescription": "Generate or suppress diagnostics when an `__init__` method signature is inconsistent with a `__new__` signature.",
       "x-intellij-html-description": "Generate or suppress diagnostics when an <code>__init__</code> method signature is inconsistent with a <code>__new__</code> signature.",
       "default": "none"
     },
@@ -413,6 +431,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of missing call to parent class for inherited `__init__` methods",
       "description": "Generate or suppress diagnostics for `__init__`, `__init_subclass__`, `__enter__` and `__exit__` methods in a subclass that fail to call through to the same-named method on a base class.",
+      "markdownDescription": "Generate or suppress diagnostics for `__init__`, `__init_subclass__`, `__enter__` and `__exit__` methods in a subclass that fail to call through to the same-named method on a base class.",
       "x-intellij-html-description": "Generate or suppress diagnostics for <code>__init__</code>, <code>__init_subclass__</code>, <code>__enter__</code> and <code>__exit__</code> methods in a subclass that fail to call through to the same-named method on a base class.",
       "default": "none"
     },
@@ -420,6 +439,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of instance variables that are not initialized in the constructor",
       "description": "Generate or suppress diagnostics for instance variables within a class that are not initialized or declared within the class body or the `__init__` method.",
+      "markdownDescription": "Generate or suppress diagnostics for instance variables within a class that are not initialized or declared within the class body or the `__init__` method.",
       "x-intellij-html-description": "Generate or suppress diagnostics for instance variables within a class that are not initialized or declared within the class body or the <code>__init__</code> method.",
       "default": "none"
     },
@@ -463,6 +483,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting input parameters that are missing a type annotation",
       "description": "Generate or suppress diagnostics for input parameters for functions or methods that are missing a type annotation. The `self` and `cls` parameters used within methods are exempt from this check.",
+      "markdownDescription": "Generate or suppress diagnostics for input parameters for functions or methods that are missing a type annotation. The `self` and `cls` parameters used within methods are exempt from this check.",
       "x-intellij-html-description": "Generate or suppress diagnostics for input parameters for functions or methods that are missing a type annotation. The <code>self</code> and <code>cls</code> parameters used within methods are exempt from this check.",
       "default": "none"
     },
@@ -476,6 +497,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting improper use of type variables within function signatures",
       "description": "Generate or suppress diagnostics when a `TypeVar` is used inappropriately (e.g. if a `TypeVar` appears only once) within a generic function signature.",
+      "markdownDescription": "Generate or suppress diagnostics when a `TypeVar` is used inappropriately (e.g. if a `TypeVar` appears only once) within a generic function signature.",
       "x-intellij-html-description": "Generate or suppress diagnostics when a <code>TypeVar</code> is used inappropriately (e.g. if a <code>TypeVar</code> appears only once) within a generic function signature.",
       "default": "warning"
     },
@@ -489,6 +511,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting calls to `isinstance` or `issubclass` where the result is statically determined to be always true",
       "description": "Generate or suppress diagnostics for `isinstance` or `issubclass` calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
+      "markdownDescription": "Generate or suppress diagnostics for `isinstance` or `issubclass` calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
       "x-intellij-html-description": "Generate or suppress diagnostics for <code>isinstance</code> or <code>issubclass</code> calls where the result is statically determined to be always true. Such calls are often indicative of a programming error.",
       "default": "none"
     },
@@ -496,6 +519,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting calls to `cast` that are unnecessary",
       "description": "Generate or suppress diagnostics for `cast` calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
+      "markdownDescription": "Generate or suppress diagnostics for `cast` calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
       "x-intellij-html-description": "Generate or suppress diagnostics for <code>cast</code> calls that are statically determined to be unnecessary. Such calls are sometimes indicative of a programming error.",
       "default": "none"
     },
@@ -503,6 +527,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting the use of `==` or `!=` comparisons that are unnecessary",
       "description": "Generate or suppress diagnostics for `==` or `!=` comparisons or other conditional expressions that are statically determined to always evaluate to `False` or `True`. Such comparisons are sometimes indicative of a programming error.",
+      "markdownDescription": "Generate or suppress diagnostics for `==` or `!=` comparisons or other conditional expressions that are statically determined to always evaluate to `False` or `True`. Such comparisons are sometimes indicative of a programming error.",
       "x-intellij-html-description": "Generate or suppress diagnostics for <code>==</code> or <code>!=</code> comparisons or other conditional expressions that are statically determined to always evaluate to <code>False</code> or <code>True</code>. Such comparisons are sometimes indicative of a programming error.",
       "default": "none"
     },
@@ -510,6 +535,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting the use of `in` operations that are unnecessary",
       "description": "Generate or suppress diagnostics for `in` operations that are statically determined to always evaluate to `False` or `True`. Such operations are sometimes indicative of a programming error.",
+      "markdownDescription": "Generate or suppress diagnostics for `in` operations that are statically determined to always evaluate to `False` or `True`. Such operations are sometimes indicative of a programming error.",
       "x-intellij-html-description": "Generate or suppress diagnostics for <code>in</code> operations that are statically determined to always evaluate to <code>False</code> or <code>True</code>. Such operations are sometimes indicative of a programming error.",
       "default": "none"
     },
@@ -517,6 +543,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting `assert` expressions that will always evaluate to `True`",
       "description": "Generate or suppress diagnostics for `assert` statement that will provably always assert. This can be indicative of a programming error.",
+      "markdownDescription": "Generate or suppress diagnostics for `assert` statement that will provably always assert. This can be indicative of a programming error.",
       "x-intellij-html-description": "Generate or suppress diagnostics for <code>assert</code> statement that will provably always assert. This can be indicative of a programming error.",
       "default": "warning"
     },
@@ -524,6 +551,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting missing or misnamed `self` parameters",
       "description": "Generate or suppress diagnostics for a missing or misnamed `self` parameter in instance methods and `cls` parameter in class methods. Instance methods in metaclasses (classes that derive from `type`) are allowed to use `cls` for instance methods.",
+      "markdownDescription": "Generate or suppress diagnostics for a missing or misnamed `self` parameter in instance methods and `cls` parameter in class methods. Instance methods in metaclasses (classes that derive from `type`) are allowed to use `cls` for instance methods.",
       "x-intellij-html-description": "Generate or suppress diagnostics for a missing or misnamed <code>self</code> parameter in instance methods and <code>cls</code> parameter in class methods. Instance methods in metaclasses (classes that derive from <code>type</code>) are allowed to use <code>cls</code> for instance methods.",
       "default": "warning"
     },
@@ -561,6 +589,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of incomplete type stubs that declare a module-level `__getattr__` function",
       "description": "Generate or suppress diagnostics for a module-level `__getattr__` call in a type stub file, indicating that it is incomplete.",
+      "markdownDescription": "Generate or suppress diagnostics for a module-level `__getattr__` call in a type stub file, indicating that it is incomplete.",
       "x-intellij-html-description": "Generate or suppress diagnostics for a module-level <code>__getattr__</code> call in a type stub file, indicating that it is incomplete.",
       "default": "none"
     },
@@ -568,6 +597,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of unsupported operations performed on `__all__`",
       "description": "Generate or suppress diagnostics for statements that define or manipulate `__all__` in a way that is not allowed by a static type checker, thus rendering the contents of `__all__` to be unknown or incorrect. Also reports names within the `__all__` list that are not present in the module namespace.",
+      "markdownDescription": "Generate or suppress diagnostics for statements that define or manipulate `__all__` in a way that is not allowed by a static type checker, thus rendering the contents of `__all__` to be unknown or incorrect. Also reports names within the `__all__` list that are not present in the module namespace.",
       "x-intellij-html-description": "Generate or suppress diagnostics for statements that define or manipulate <code>__all__</code> in a way that is not allowed by a static type checker, thus rendering the contents of <code>__all__</code> to be unknown or incorrect. Also reports names within the <code>__all__</code> list that are not present in the module namespace.",
       "default": "warning"
     },
@@ -575,6 +605,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of call expressions whose results are not consumed",
       "description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is not `None`.",
+      "markdownDescription": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is not `None`.",
       "x-intellij-html-description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is not <code>None</code>.",
       "default": "none"
     },
@@ -582,6 +613,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of call expressions that returns `Coroutine` whose results are not consumed",
       "description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is a `Coroutine`. This identifies a common error where an `await` keyword is mistakenly omitted.",
+      "markdownDescription": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is a `Coroutine`. This identifies a common error where an `await` keyword is mistakenly omitted.",
       "x-intellij-html-description": "Generate or suppress diagnostics for call statements whose return value is not used in any way and is a <code>Coroutine</code>. This identifies a common error where an <code>await</code> keyword is mistakenly omitted.",
       "default": "error"
     },
@@ -589,6 +621,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of unreachable except clauses",
       "description": "Generate or suppress diagnostics for an `except` clause that will never be reached.",
+      "markdownDescription": "Generate or suppress diagnostics for an `except` clause that will never be reached.",
       "x-intellij-html-description": "Generate or suppress diagnostics for an <code>except</code> clause that will never be reached.",
       "default": "error"
     },
@@ -602,6 +635,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `# type: ignore` comments that have no effect",
       "description": "Generate or suppress diagnostics for a `# type: ignore` or `# pyright: ignore` comment that would have no effect if removed.",
+      "markdownDescription": "Generate or suppress diagnostics for a `# type: ignore` or `# pyright: ignore` comment that would have no effect if removed.",
       "x-intellij-html-description": "Generate or suppress diagnostics for a <code># type: ignore</code> or <code># pyright: ignore</code> comment that would have no effect if removed.",
       "default": "none"
     },
@@ -609,6 +643,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of `match` statements that do not exhaustively match all possible values",
       "description": "Generate or suppress diagnostics for a `match` statement that does not provide cases that exhaustively match against all potential types of the target expression.",
+      "markdownDescription": "Generate or suppress diagnostics for a `match` statement that does not provide cases that exhaustively match against all potential types of the target expression.",
       "x-intellij-html-description": "Generate or suppress diagnostics for a <code>match</code> statement that does not provide cases that exhaustively match against all potential types of the target expression.",
       "default": "none"
     },
@@ -622,6 +657,7 @@
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting overridden methods that are missing an `@override` decorator",
       "description": "Generate or suppress diagnostics for overridden methods in a class that are missing an explicit `@override` decorator.",
+      "markdownDescription": "Generate or suppress diagnostics for overridden methods in a class that are missing an explicit `@override` decorator.",
       "x-intellij-html-description": "Generate or suppress diagnostics for overridden methods in a class that are missing an explicit <code>@override</code> decorator.",
       "default": "none"
     }
@@ -631,6 +667,7 @@
       "type": "string",
       "title": "Path to configuration file that this configuration extends",
       "description": "Path to another `.json` or `.toml` file that is used as a \"base configuration\", allowing this configuration to inherit configuration settings. Top-level keys within this configuration overwrite top-level keys in the base configuration. Multiple levels of inheritance are supported. Relative paths specified in a configuration file are resolved relative to the location of that configuration file.",
+      "markdownDescription": "Path to another `.json` or `.toml` file that is used as a \"base configuration\", allowing this configuration to inherit configuration settings. Top-level keys within this configuration overwrite top-level keys in the base configuration. Multiple levels of inheritance are supported. Relative paths specified in a configuration file are resolved relative to the location of that configuration file.",
       "x-intellij-html-description": "Path to another <code>.json</code> or <code>.toml</code> file that is used as a &quot;base configuration&quot;, allowing this configuration to inherit configuration settings. Top-level keys within this configuration overwrite top-level keys in the base configuration. Multiple levels of inheritance are supported. Relative paths specified in a configuration file are resolved relative to the location of that configuration file.",
       "pattern": "^(.*)$"
     },
@@ -638,6 +675,7 @@
       "type": "array",
       "title": "Files and directories included in type analysis",
       "description": "Paths of directories or files that should be considered part of the project. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character). If no include paths are specified, the root path for the workspace is assumed.",
+      "markdownDescription": "Paths of directories or files that should be considered part of the project. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character). If no include paths are specified, the root path for the workspace is assumed.",
       "x-intellij-html-description": "Paths of directories or files that should be considered part of the project. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no include paths are specified, the root path for the workspace is assumed.",
       "items": {
         "type": "string",
@@ -649,6 +687,7 @@
       "type": "array",
       "title": "Files and directories excluded from type analysis",
       "description": "Paths of directories or files that should not be considered part of the project. These override the includes directories and files, allowing specific subdirectories to be excluded. Note that files in the exclude paths may still be included in the analysis if they are referenced (imported) by source files that are not excluded. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character). If no exclude paths are specified, Pyright automatically excludes the following: `**/node_modules`, `**/__pycache__`, `**/.*` and any virtual environment directories.",
+      "markdownDescription": "Paths of directories or files that should not be considered part of the project. These override the includes directories and files, allowing specific subdirectories to be excluded. Note that files in the exclude paths may still be included in the analysis if they are referenced (imported) by source files that are not excluded. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character). If no exclude paths are specified, Pyright automatically excludes the following: `**/node_modules`, `**/__pycache__`, `**/.*` and any virtual environment directories.",
       "x-intellij-html-description": "Paths of directories or files that should not be considered part of the project. These override the includes directories and files, allowing specific subdirectories to be excluded. Note that files in the exclude paths may still be included in the analysis if they are referenced (imported) by source files that are not excluded. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no exclude paths are specified, Pyright automatically excludes the following: <code>**/node_modules</code>, <code>**/__pycache__</code>, <code>**/.*</code> and any virtual environment directories.",
       "items": {
         "type": "string",
@@ -660,6 +699,7 @@
       "type": "array",
       "title": "Files and directories whose diagnostics are suppressed",
       "description": "Paths of directories or files whose diagnostic output (errors and warnings) should be suppressed even if they are an included file or within the transitive closure of an included file. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character).",
+      "markdownDescription": "Paths of directories or files whose diagnostic output (errors and warnings) should be suppressed even if they are an included file or within the transitive closure of an included file. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character).",
       "x-intellij-html-description": "Paths of directories or files whose diagnostic output (errors and warnings) should be suppressed even if they are an included file or within the transitive closure of an included file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character).",
       "items": {
         "type": "string",
@@ -671,6 +711,7 @@
       "type": "array",
       "title": "Files and directories that should use \"strict\" type checking rules",
       "description": "Paths of directories or files that should use \"strict\" analysis if they are included. This is the same as manually adding a `# pyright: strict` comment. In strict mode, most type-checking rules are enabled. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character).",
+      "markdownDescription": "Paths of directories or files that should use \"strict\" analysis if they are included. This is the same as manually adding a `# pyright: strict` comment. In strict mode, most type-checking rules are enabled. Paths may contain wildcard characters: `**` (a directory or multiple levels of directories), `*` (a sequence of zero or more characters), or `?` (a single character).",
       "x-intellij-html-description": "Paths of directories or files that should use &quot;strict&quot; analysis if they are included. This is the same as manually adding a <code># pyright: strict</code> comment. In strict mode, most type-checking rules are enabled. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character).",
       "items": {
         "type": "string",
@@ -682,6 +723,7 @@
       "type": "object",
       "title": "Identifiers that should be treated as constants",
       "description": "Set of identifiers that should be assumed to contain a constant value wherever used within this program. For example, `{ \"DEBUG\": true }` indicates that pyright should assume that the identifier `DEBUG` will always be equal to `True`. If this identifier is used within a conditional expression (such as `if not DEBUG:`) pyright will use the indicated value to determine whether the guarded block is reachable or not. Member expressions that reference one of these constants (e.g. `my_module.DEBUG`) are also supported.",
+      "markdownDescription": "Set of identifiers that should be assumed to contain a constant value wherever used within this program. For example, `{ \"DEBUG\": true }` indicates that pyright should assume that the identifier `DEBUG` will always be equal to `True`. If this identifier is used within a conditional expression (such as `if not DEBUG:`) pyright will use the indicated value to determine whether the guarded block is reachable or not. Member expressions that reference one of these constants (e.g. `my_module.DEBUG`) are also supported.",
       "x-intellij-html-description": "Set of identifiers that should be assumed to contain a constant value wherever used within this program. For example, <code>{ &quot;DEBUG&quot;: true }</code> indicates that pyright should assume that the identifier <code>DEBUG</code> will always be equal to <code>True</code>. If this identifier is used within a conditional expression (such as <code>if not DEBUG:</code>) pyright will use the indicated value to determine whether the guarded block is reachable or not. Member expressions that reference one of these constants (e.g. <code>my_module.DEBUG</code>) are also supported.",
       "properties": {},
       "additionalProperties": {
@@ -694,6 +736,7 @@
       "enum": ["off", "basic", "standard", "strict"],
       "title": "Specifies the default rule set to use for type checking",
       "description": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to `off`, all type-checking rules are disabled, but Python syntax and semantic errors are still reported.",
+      "markdownDescription": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to `off`, all type-checking rules are disabled, but Python syntax and semantic errors are still reported.",
       "x-intellij-html-description": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to <code>off</code>, all type-checking rules are disabled, but Python syntax and semantic errors are still reported.",
       "default": "standard"
     },
@@ -1004,6 +1047,7 @@
       "type": "string",
       "title": "Path to directory containing a folder of virtual environments",
       "description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a `venv` setting, pyright will search for imports in the virtual environment's site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
+      "markdownDescription": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a `venv` setting, pyright will search for imports in the virtual environment's site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
       "x-intellij-html-description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a <code>venv</code> setting, pyright will search for imports in the virtual environment&#39;s site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
       "default": "",
       "pattern": "^(.*)$"
@@ -1012,6 +1056,7 @@
       "type": "string",
       "title": "Name of virtual environment subdirectory within `venvPath`",
       "description": "Used in conjunction with the `venvPath`, specifies the virtual environment to use.",
+      "markdownDescription": "Used in conjunction with the `venvPath`, specifies the virtual environment to use.",
       "x-intellij-html-description": "Used in conjunction with the <code>venvPath</code>, specifies the virtual environment to use.",
       "default": "",
       "examples": ["python37"],


### PR DESCRIPTION
Previous:

![Description rendered as-is](https://github.com/SchemaStore/schemastore/assets/122007197/486ca4c2-b495-4dda-bab7-9901caa1e5b7)

After:

![Description rendered as Markdown](https://github.com/SchemaStore/schemastore/assets/122007197/777e825b-487d-44b4-8c3e-17ef706b171d)