### PR TITLE
Update CICS region tagging supported fileMatch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5824,7 +5824,7 @@
     {
       "name": "CICS TS region tagging",
       "description": "CICS region tagging in IBM CICS Transaction Server for z/OS",
-      "fileMatch": ["cicstags.yaml"],
+      "fileMatch": ["cicstags.yaml", "cicstags.yml"],
       "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicstags.json"
     },
     {


### PR DESCRIPTION
CICS TS now supports both the `.yaml` and `.yml` suffixes for region tagging, so this PR updates the `fileMatch` accordingly.