### PR TITLE
Update github organization name for kimmdy in catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2805,9 +2805,9 @@
     },
     {
       "name": "KIMMDY config file",
-      "description": "KIMMDY config file, see: hits-mbm-dev.github.io/kimmdy",
+      "description": "KIMMDY config file, see: graeter-group.github.io/kimmdy",
       "fileMatch": ["kimmdy.yml", "kimmdy.yaml"],
-      "url": "https://raw.githubusercontent.com/hits-mbm-dev/kimmdy/main/src/kimmdy/kimmdy-yaml-schema.json"
+      "url": "https://raw.githubusercontent.com/graeter-group/kimmdy/main/src/kimmdy/kimmdy-yaml-schema.json"
     },
     {
       "name": "KrakenD",


### PR DESCRIPTION
Our research group is moving, so we updated our GitHub organization name to be future proof. This affects links to our KIMMDY (https://graeter-group.github.io/kimmdy/) software and documentation.