### PR TITLE
Including CloudEvents specification

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -974,6 +974,12 @@
       "url": "https://raw.githubusercontent.com/cityjson/specs/master/schemas/cityjson.min.schema.json"
     },
     {
+      "name": "CloudEvents specification",
+      "description": "A specification for describing event data in a common way. Documentation: https://cloudevents.io",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/cloudevents/spec/master/cloudevents/formats/cloudevents.json"
+    },
+    {
       "name": "conda-forge",
       "description": "Conda-forge configuration file",
       "fileMatch": ["conda-forge.yml"],


### PR DESCRIPTION
CloudEvents is a specification for describing event data in a common way. I'm including a reference to it in the API catalog.