### PR TITLE
Add support to buf.gen.yaml for protoc_path as an array

### DIFF
--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -92,7 +92,17 @@
             "protoc_path": {
               "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path",
               "description": "Optional. Only applies to the code generators that are built in to protoc. Normally, a plugin is a separate executable with a binary name like protoc-gen-<name>. But for a handful of plugins, the executable used is protoc itself. See https://buf.build/docs/configuration/v1/buf-gen-yaml#protoc_path.",
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             }
           },
           "required": ["out"],
@@ -438,7 +448,17 @@
               "type": "string"
             },
             "protoc_path": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "local": {
               "description": "A string or list of strings that point to the names of plugin binaries on your ${PATH}, or to its relative or absolute location on disk. If you specify a list of strings, the first is the local name, and the subsequent strings are considered arguments passed to the binary.",

--- a/src/test/buf.gen/buf.gen.v1.protoc_path.yaml
+++ b/src/test/buf.gen/buf.gen.v1.protoc_path.yaml
@@ -1,0 +1,5 @@
+version: v1
+plugins:
+  - name: cpp
+    out: cpp/out
+    protoc_path: ['path/to/protoc', '--experimental-editions']

--- a/src/test/buf.gen/buf.gen.v2.protoc_path.yaml
+++ b/src/test/buf.gen/buf.gen.v2.protoc_path.yaml
@@ -1,0 +1,5 @@
+version: v2
+plugins:
+  - local: cpp
+    out: cpp/out
+    protoc_path: ['path/to/protoc', '--experimental-editions']


### PR DESCRIPTION
Support added in [buf v1.34.0].

[buf v1.34.0]: https://github.com/bufbuild/buf/releases/tag/v1.34.0

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
