### PR TITLE
Update sdf schema version to 1.3

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4255,11 +4255,12 @@
       "name": "Semantic Data Fabric (SDF) file",
       "description": "SDF blocks",
       "fileMatch": ["*.sdf.yml"],
-      "url": "https://cdn.sdf.com/schemas/sdf-schema-1.2.json",
+      "url": "https://cdn.sdf.com/schemas/sdf-schema-1.3.json",
       "versions": {
         "1.0": "https://cdn.sdf.com/schemas/sdf-schema-1.0.json",
         "1.1": "https://cdn.sdf.com/schemas/sdf-schema-1.1.json",
-        "1.2": "https://cdn.sdf.com/schemas/sdf-schema-1.2.json"
+        "1.2": "https://cdn.sdf.com/schemas/sdf-schema-1.2.json",
+        "1.3": "https://cdn.sdf.com/schemas/sdf-schema-1.3.json"
       }
     },
     {


### PR DESCRIPTION
SDF has an update yml schema, now 1.3.

This is a small update to add the new schema as the default url.