### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -457,7 +457,7 @@
       "description": "The style in which violation messages should be formatted: `\"full\"` (shows source),`\"concise\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
       "anyOf": [
         {
-          "$ref": "#/definitions/SerializationFormat"
+          "$ref": "#/definitions/OutputFormat"
         },
         {
           "type": "null"
@@ -576,11 +576,6 @@
     },
     "show-fixes": {
       "description": "Whether to show an enumeration of all fixed lint violations (overridden by the `--show-fixes` command-line flag).",
-      "type": ["boolean", "null"]
-    },
-    "show-source": {
-      "description": "Whether to show source code snippets when reporting lint violations (overridden by the `--show-source` command-line flag).",
-      "deprecated": true,
       "type": ["boolean", "null"]
     },
     "src": {
@@ -1886,6 +1881,32 @@
       },
       "additionalProperties": false
     },
+    "OutputFormat": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "concise",
+            "full",
+            "json",
+            "json-lines",
+            "junit",
+            "grouped",
+            "github",
+            "gitlab",
+            "pylint",
+            "rdjson",
+            "azure",
+            "sarif"
+          ]
+        },
+        {
+          "deprecated": true,
+          "type": "string",
+          "enum": ["text"]
+        }
+      ]
+    },
     "ParametrizeNameType": {
       "type": "string",
       "enum": ["csv", "tuple", "list"]
@@ -2178,10 +2199,23 @@
         "ASYNC1",
         "ASYNC10",
         "ASYNC100",
-        "ASYNC101",
-        "ASYNC102",
+        "ASYNC105",
+        "ASYNC109",
         "ASYNC11",
+        "ASYNC110",
+        "ASYNC115",
         "ASYNC116",
+        "ASYNC2",
+        "ASYNC21",
+        "ASYNC210",
+        "ASYNC22",
+        "ASYNC220",
+        "ASYNC221",
+        "ASYNC222",
+        "ASYNC23",
+        "ASYNC230",
+        "ASYNC25",
+        "ASYNC251",
         "B",
         "B0",
         "B00",
@@ -2857,7 +2891,6 @@
         "PLR1",
         "PLR17",
         "PLR170",
-        "PLR1701",
         "PLR1702",
         "PLR1704",
         "PLR171",
@@ -3136,6 +3169,8 @@
         "RUF027",
         "RUF028",
         "RUF029",
+        "RUF03",
+        "RUF030",
         "RUF1",
         "RUF10",
         "RUF100",
@@ -3321,15 +3356,6 @@
         "TID251",
         "TID252",
         "TID253",
-        "TRIO",
-        "TRIO1",
-        "TRIO10",
-        "TRIO100",
-        "TRIO105",
-        "TRIO109",
-        "TRIO11",
-        "TRIO110",
-        "TRIO115",
         "TRY",
         "TRY0",
         "TRY00",
@@ -3430,24 +3456,6 @@
         "YTT301",
         "YTT302",
         "YTT303"
-      ]
-    },
-    "SerializationFormat": {
-      "type": "string",
-      "enum": [
-        "text",
-        "concise",
-        "full",
-        "json",
-        "json-lines",
-        "junit",
-        "grouped",
-        "github",
-        "gitlab",
-        "pylint",
-        "rdjson",
-        "azure",
-        "sarif"
       ]
     },
     "Strictness": {


### PR DESCRIPTION
This updates ruff's JSON schema to [244b923f615c2c162278fc0e06051853614760f3](https://github.com/astral-sh/ruff/commit/244b923f615c2c162278fc0e06051853614760f3)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
