### PR TITLE
Prevent mis-configuration of workflow_dispatch in GitHub Actions

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1615,7 +1615,8 @@
                   },
                   "additionalProperties": false
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "workflow_run": {
               "$comment": "https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run",


### PR DESCRIPTION
Before:

<img src=https://github.com/SchemaStore/schemastore/assets/2906988/2b29c2e7-d820-4b9a-952b-af30c9f25459 width=50% />

\+ a big confusion as to why the inputs are not showing up:
![image](https://github.com/SchemaStore/schemastore/assets/2906988/569c0906-941e-499c-af95-936fece524af)


After:

<img src=https://github.com/SchemaStore/schemastore/assets/2906988/e7036420-0706-4bc8-9292-c86411c18bf1 width=50% />

The problem was the missing `workflow_dispatch: inputs: ...` nesting.