### PR TITLE
Update Landing Zone Accelerator on AWS schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1483,73 +1483,49 @@
       "name": "Landing Zone Accelerator on AWS - Accounts Config",
       "description": "Used to manage all of the AWS accounts within the AWS Organization",
       "fileMatch": ["accounts-config.yaml"],
-      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json",
-      "versions": {
-        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json"
-      }
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Customizations Config",
       "description": "Used to manage configuration of custom applications, third-party firewall appliances, and CloudFormation stacks",
       "fileMatch": ["customizations-config.yaml"],
-      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json",
-      "versions": {
-        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json"
-      }
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Global Config",
       "description": "Used to manage all of the global properties that can be inherited across the AWS Organization",
       "fileMatch": ["global-config.yaml"],
-      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/global-config.json",
-      "versions": {
-        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/global-config.json"
-      }
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/global-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - IAM Config",
       "description": "Used to manage all of the IAM resources across the AWS Organization",
       "fileMatch": ["iam-config.yaml"],
-      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json",
-      "versions": {
-        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json"
-      }
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Network Config",
       "description": "Used to manage and implement network resources to establish a WAN/LAN architecture to support cloud operations and application workloads in AWS",
       "fileMatch": ["network-config.yaml"],
-      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/network-config.json",
-      "versions": {
-        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/network-config.json"
-      }
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/network-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Organization Config",
       "description": "Used to manage all of the organization units in the AWS Organization",
       "fileMatch": ["organization-config.yaml"],
-      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/organization-config.json",
-      "versions": {
-        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/organization-config.json"
-      }
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/organization-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Replacements Config",
       "description": "Used to manage all of the replacement values across the configuration files",
       "fileMatch": ["replacements-config.yaml"],
-      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/replacements-config.json",
-      "versions": {
-        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/replacements-config.json"
-      }
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/replacements-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Security Config",
       "description": "Used to manage configuration of AWS security services",
       "fileMatch": ["security-config.yaml"],
-      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/security-config.json",
-      "versions": {
-        "v1.7.0": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/v1.7.0/source/packages/@aws-accelerator/config/lib/schemas/security-config.json"
-      }
+      "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/security-config.json"
     },
     {
       "name": "Changesets",


### PR DESCRIPTION
This pull request updates the Landing Zone Accelerator on AWS schemas to point directly to our `main` branch instead of maintaining tagged versions. We have made the decision internally to always reference the schemas from `main`, as it makes the most sense for our solution.

Please let me know if there are any issues with this update. Thank you!
