### PR TITLE
Add language-configuration schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,5 @@ repos:
         args:
           [
             '--ignore-words-list',
-            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn',
+            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn',
           ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6613,9 +6613,9 @@
     },
     {
       "name": "Language configuration",
-       "description": "Configuration file for language features in VS Code and Visual Studio",
-       "fileMatch": ["language-configuration.json"],
-       "url": "https://json.schemastore.org/language-configuration.json"
+      "description": "Configuration file for language features in VS Code and Visual Studio",
+      "fileMatch": ["language-configuration.json"],
+      "url": "https://json.schemastore.org/language-configuration.json"
     },
     {
       "name": "Any",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6612,6 +6612,12 @@
       "url": "https://json.schemastore.org/mprocs-0.6.4.json"
     },
     {
+      "name": "Language configuration",
+       "description": "Configuration file for language features in VS Code and Visual Studio",
+       "fileMatch": ["language-configuration.json"],
+       "url": "https://json.schemastore.org/language-configuration.json"
+    },
+    {
       "name": "Any",
       "description": "Valid for any JSON file",
       "fileMatch": [],

--- a/src/schemas/json/language-configuration.json
+++ b/src/schemas/json/language-configuration.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://json.schemastore.org/language-configuration.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/language-configuration.json",
   "additionalProperties": true,
   "definitions": {
     "regexp": {
@@ -17,10 +17,7 @@
     },
     "charPair": {
       "type": "array",
-      "items": [
-        { "type": "string" },
-        { "type": "string" }
-      ],
+      "items": [{ "type": "string" }, { "type": "string" }],
       "minItems": 2,
       "additionalItems": false
     }
@@ -35,8 +32,8 @@
           "type": "string"
         },
         "blockComment": {
-          "description": "The block comment character pair, like `/* block comment *&#47;`",
-          "$ref": "#/definitions/charPair"
+          "$ref": "#/definitions/charPair",
+          "description": "The block comment character pair, like `/* block comment *&#47;`"
         }
       }
     },

--- a/src/schemas/json/language-configuration.json
+++ b/src/schemas/json/language-configuration.json
@@ -1,0 +1,261 @@
+{
+  "$id": "https://json.schemastore.org/language-configuration.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "definitions": {
+    "regexp": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string"
+        },
+        "flags": {
+          "type": "string"
+        }
+      },
+      "required": ["pattern"]
+    },
+    "charPair": {
+      "type": "array",
+      "items": [
+        { "type": "string" },
+        { "type": "string" }
+      ],
+      "minItems": 2,
+      "additionalItems": false
+    }
+  },
+  "properties": {
+    "comments": {
+      "description": "The language's comment settings.",
+      "type": "object",
+      "properties": {
+        "lineComment": {
+          "description": "The line comment token, like `// this is a comment`.",
+          "type": "string"
+        },
+        "blockComment": {
+          "description": "The block comment character pair, like `/* block comment *&#47;`",
+          "$ref": "#/definitions/charPair"
+        }
+      }
+    },
+    "brackets": {
+      "description": "The language's brackets.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/charPair"
+      }
+    },
+    "autoClosingPairs": {
+      "description": "The language's auto closing pairs. The 'close' character is automatically inserted with the 'open' character is typed.",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/charPair"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "open": {
+                "type": "string"
+              },
+              "close": {
+                "type": "string"
+              },
+              "notIn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["open", "close"]
+          }
+        ]
+      }
+    },
+    "autoCloseBefore": {
+      "description": "What characters must be after the cursor for bracket or quote autoclosing to occur.",
+      "type": "string"
+    },
+    "surroundingPairs": {
+      "description": "The language's surrounding pairs. When the 'open' character is typed on a selection, the selected string is surrounded by the open and close characters.",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/charPair"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "open": {
+                "type": "string"
+              },
+              "close": {
+                "type": "string"
+              }
+            },
+            "required": ["open", "close"]
+          }
+        ]
+      }
+    },
+    "folding": {
+      "description": "The language's folding rules.",
+      "type": "object",
+      "properties": {
+        "markers": {
+          "description": "Region markers used by the language.",
+          "type": "object",
+          "properties": {
+            "start": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/regexp"
+                }
+              ]
+            },
+            "end": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/regexp"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "wordPattern": {
+      "description": "The language's word definition.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/regexp"
+        }
+      ]
+    },
+    "indentationRules": {
+      "description": "The language's indentation settings.",
+      "type": "object",
+      "properties": {
+        "decreaseIndentPattern": {
+          "description": "If a line matches this pattern, then all the lines after it should be unindented once (until another rule matches).",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/regexp"
+            }
+          ]
+        },
+        "increaseIndentPattern": {
+          "description": "If a line matches this pattern, then all the lines after it should be indented once (until another rule matches).",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/regexp"
+            }
+          ]
+        },
+        "indentNextLinePattern": {
+          "description": "If a line matches this pattern, then only the next line after it should be indented once.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/regexp"
+            }
+          ]
+        },
+        "unIndentedLinePattern": {
+          "description": "If a line matches this pattern, then its indentation should not be changed and it should not be evaluated against the other rules.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/regexp"
+            }
+          ]
+        }
+      },
+      "required": ["decreaseIndentPattern", "increaseIndentPattern"]
+    },
+    "onEnterRules": {
+      "description": "The language's rules to be evaluated when pressing Enter.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "beforeText": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/regexp"
+              }
+            ]
+          },
+          "afterText": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/regexp"
+              }
+            ]
+          },
+          "previousLineText": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/regexp"
+              }
+            ]
+          },
+          "action": {
+            "type": "object",
+            "properties": {
+              "indent": {
+                "type": "string",
+                "enum": ["none", "indent", "indentOutdent", "outdent"]
+              },
+              "appendText": {
+                "type": "string"
+              },
+              "removeText": {
+                "type": "integer",
+                "minimum": 1
+              }
+            },
+            "required": ["indent"]
+          }
+        },
+        "required": ["beforeText", "action"]
+      }
+    }
+  },
+  "type": "object",
+  "title": "Language configuration",
+  "description": "Configuration file for language features in VS Code and Visual Studio."
+}

--- a/src/test/language-configuration/language-configuration.json
+++ b/src/test/language-configuration/language-configuration.json
@@ -1,52 +1,61 @@
 {
-	"comments": {
-		"blockComment": [ "<!--", "-->" ]
-	},
-	"brackets": [
-		["<!--", "-->"],
-		["{", "}"],
-		["(", ")"]
-	],
-	"autoClosingPairs": [
-		{ "open": "{", "close": "}"},
-		{ "open": "[", "close": "]"},
-		{ "open": "(", "close": ")" },
-		{ "open": "'", "close": "'" },
-		{ "open": "\"", "close": "\"" },
-		{ "open": "<!--", "close": "-->", "notIn": [ "comment", "string" ]}
-	],
-	"surroundingPairs": [
-		{ "open": "'", "close": "'" },
-		{ "open": "\"", "close": "\"" },
-		{ "open": "{", "close": "}"},
-		{ "open": "[", "close": "]"},
-		{ "open": "(", "close": ")" },
-		{ "open": "<", "close": ">" }
-	],
-	"folding": {
-		"markers": {
-			"start": "^\\s*<!--\\s*#region\\b.*-->",
-			"end": "^\\s*<!--\\s*#endregion\\b.*-->"
-		}
-	},
-	"wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\$\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\s]+)",
-	"onEnterRules": [
-		{
-			"beforeText": { "pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)(?:(?:[^'\"/>]|\"[^\"]*\"|'[^']*')*?(?!\\/)>)[^<]*$", "flags": "i" },
-			"afterText": { "pattern": "^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>", "flags": "i" },
-			"action": {
-				"indent": "indentOutdent"
-			}
-		},
-		{
-			"beforeText": { "pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)(?:(?:[^'\"/>]|\"[^\"]*\"|'[^']*')*?(?!\\/)>)[^<]*$", "flags": "i" },
-			"action": {
-				"indent": "indent"
-			}
-		}
-	],
-	"indentationRules": {
-		"increaseIndentPattern": "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|[^>]*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$",
-		"decreaseIndentPattern": "^\\s*(<\\/(?!html)[-_\\.A-Za-z0-9]+\\b[^>]*>|-->|\\})"
-	}
+  "autoClosingPairs": [
+    { "close": "}", "open": "{" },
+    { "close": "]", "open": "[" },
+    { "close": ")", "open": "(" },
+    { "close": "'", "open": "'" },
+    { "close": "\"", "open": "\"" },
+    { "close": "-->", "notIn": ["comment", "string"], "open": "<!--" }
+  ],
+  "brackets": [
+    ["<!--", "-->"],
+    ["{", "}"],
+    ["(", ")"]
+  ],
+  "comments": {
+    "blockComment": ["<!--", "-->"]
+  },
+  "folding": {
+    "markers": {
+      "end": "^\\s*<!--\\s*#endregion\\b.*-->",
+      "start": "^\\s*<!--\\s*#region\\b.*-->"
+    }
+  },
+  "indentationRules": {
+    "decreaseIndentPattern": "^\\s*(<\\/(?!html)[-_\\.A-Za-z0-9]+\\b[^>]*>|-->|\\})",
+    "increaseIndentPattern": "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|[^>]*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$"
+  },
+  "onEnterRules": [
+    {
+      "action": {
+        "indent": "indentOutdent"
+      },
+      "afterText": {
+        "flags": "i",
+        "pattern": "^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>"
+      },
+      "beforeText": {
+        "flags": "i",
+        "pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)(?:(?:[^'\"/>]|\"[^\"]*\"|'[^']*')*?(?!\\/)>)[^<]*$"
+      }
+    },
+    {
+      "action": {
+        "indent": "indent"
+      },
+      "beforeText": {
+        "flags": "i",
+        "pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)(?:(?:[^'\"/>]|\"[^\"]*\"|'[^']*')*?(?!\\/)>)[^<]*$"
+      }
+    }
+  ],
+  "surroundingPairs": [
+    { "close": "'", "open": "'" },
+    { "close": "\"", "open": "\"" },
+    { "close": "}", "open": "{" },
+    { "close": "]", "open": "[" },
+    { "close": ")", "open": "(" },
+    { "close": ">", "open": "<" }
+  ],
+  "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\$\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\s]+)"
 }

--- a/src/test/language-configuration/language-configuration.json
+++ b/src/test/language-configuration/language-configuration.json
@@ -1,0 +1,52 @@
+{
+	"comments": {
+		"blockComment": [ "<!--", "-->" ]
+	},
+	"brackets": [
+		["<!--", "-->"],
+		["{", "}"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "<!--", "close": "-->", "notIn": [ "comment", "string" ]}
+	],
+	"surroundingPairs": [
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "<", "close": ">" }
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*<!--\\s*#region\\b.*-->",
+			"end": "^\\s*<!--\\s*#endregion\\b.*-->"
+		}
+	},
+	"wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\$\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\s]+)",
+	"onEnterRules": [
+		{
+			"beforeText": { "pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)(?:(?:[^'\"/>]|\"[^\"]*\"|'[^']*')*?(?!\\/)>)[^<]*$", "flags": "i" },
+			"afterText": { "pattern": "^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>", "flags": "i" },
+			"action": {
+				"indent": "indentOutdent"
+			}
+		},
+		{
+			"beforeText": { "pattern": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)(?:(?:[^'\"/>]|\"[^\"]*\"|'[^']*')*?(?!\\/)>)[^<]*$", "flags": "i" },
+			"action": {
+				"indent": "indent"
+			}
+		}
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|[^>]*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$",
+		"decreaseIndentPattern": "^\\s*(<\\/(?!html)[-_\\.A-Za-z0-9]+\\b[^>]*>|-->|\\})"
+	}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->

Adding the JSON schema for `language-configuration.json`, which is used by tools like [VS Code](https://code.visualstudio.com/api/language-extensions/language-configuration-guide) to provide language editing features.
