### PR TITLE
Increased maximum value in minecraft-pack-mcmeta.json

### DIFF
--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -17,7 +17,7 @@
           "description": "A version for the current pack\nhttps://minecraft.wiki/w/Data_pack#Contents",
           "type": "integer",
           "minimum": 1,
-          "maximum": 34,
+          "maximum": 48,
           "default": 4
         }
       },


### PR DESCRIPTION
Just increased the maximum value to 48 to make it possible to use the schema for Minecraft 1.21 texturepacks.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
