### PR TITLE
Added schema for Bazel modules metadata

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3097,6 +3097,12 @@
       "url": "https://raw.githubusercontent.com/meltano/meltano/main/src/meltano/schemas/discovery.schema.json"
     },
     {
+      "name": "Metadata for a Bazel module",
+      "description": "Metadata file for a Bazel module",
+      "fileMatch": ["metadata.json"],
+      "url": "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/metadata.schema.json"
+    },
+    {
       "name": "MetricsHub Configuration",
       "description": "MetricsHub configuration file",
       "fileMatch": ["*metricshub.yaml", "*metricshub.yml"],


### PR DESCRIPTION
Added schema for Bazel modules metadata.
See: https://github.com/bazelbuild/bazel-central-registry/tree/main