### PR TITLE
Add new updatecli compose filematch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5843,7 +5843,7 @@
     {
       "name": "Updatecli Compose",
       "description": "Updatecli Compose file, more information on https://www.updatecli.io/docs/core/compose/",
-      "fileMatch": ["update-compose.yaml","updatecli-compose.yaml"],
+      "fileMatch": ["update-compose.yaml", "updatecli-compose.yaml"],
       "url": "https://www.updatecli.io/schema/latest/compose/config.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5842,8 +5842,8 @@
     },
     {
       "name": "Updatecli Compose",
-      "description": "Updatecli Compose file",
-      "fileMatch": ["update-compose.yaml"],
+      "description": "Updatecli Compose file, more information on https://www.updatecli.io/docs/core/compose/",
+      "fileMatch": ["update-compose.yaml","updatecli-compose.yaml"],
       "url": "https://www.updatecli.io/schema/latest/compose/config.json"
     },
     {


### PR DESCRIPTION
The default Updatecli compose file is deprecating "update-compose.yaml" in favor of "updatecli-compose.yaml" which should be less confusing and more specific to Updatecli

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
