### PR TITLE
Fixed typo in tsconfig.json

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -497,10 +497,10 @@
             },
             "noUnusedLocals": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
-              "description": "Enable error reporting when a local variables aren't read.",
+              "description": "Enable error reporting when a local variable isn't read.",
               "type": ["boolean", "null"],
               "default": false,
-              "markdownDescription": "Enable error reporting when a local variables aren't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
+              "markdownDescription": "Enable error reporting when a local variable isn't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",


### PR DESCRIPTION
Fixed typo in description of the field `compilerOptions -> noUnusedLocals`