### PR TITLE
remove reference to deprecated Apple Silicon image

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -1387,7 +1387,6 @@
       "description": "Amount of CPU and RAM allocated for each job. View [available resource classes](https://circleci.com/docs/configuration-reference/#macos-execution-environment).",
       "type": "string",
       "enum": [
-        "macos.x86.medium.gen2",
         "macos.m1.medium.gen1",
         "macos.m1.large.gen1"
       ]

--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -1386,15 +1386,13 @@
     "macOSResourceClass": {
       "description": "Amount of CPU and RAM allocated for each job. View [available resource classes](https://circleci.com/docs/configuration-reference/#macos-execution-environment).",
       "type": "string",
-      "enum": [
-        "macos.m1.medium.gen1",
-        "macos.m1.large.gen1"
-      ]
+      "enum": ["macos.m1.medium.gen1", "macos.m1.large.gen1"]
     },
     "xcodeVersion": {
       "description": "The version of Xcode to use. View [available versions](https://circleci.com/developer/machine/image/xcode)",
       "type": "string",
       "enum": [
+        "16.0.0",
         "15.4.0",
         "15.3.0",
         "15.2.0",


### PR DESCRIPTION
CircleCI has deprecated Apple Silicon (details [here](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718)) - I've removed this reference, and also added an additional version of XCode that was missing.
