### PR TITLE
schema-catalog: register concord workflow orchestrator schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6645,7 +6645,7 @@
     },
     {
       "name": "Concord",
-      "description": "Concord - https://github.com/walmartlabs/concord,  workflow orcehstrator schema",
+      "description": "Concord - https://github.com/walmartlabs/concord,  workflow orcehstrator",
       "fileMatch": [
         "*.concord.yaml",
         "*.concord.yml",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6646,7 +6646,14 @@
     {
       "name": "Concord",
       "description": "Concord - https://github.com/walmartlabs/concord,  workflow orcehstrator schema",
-      "fileMatch": ["*.concord.yaml", "*.concord.yml", ".concord.yml", ".concord.yaml", "concord.yml", "concord.yaml"],
+      "fileMatch": [
+        "*.concord.yaml",
+        "*.concord.yml",
+        ".concord.yml",
+        ".concord.yaml",
+        "concord.yml",
+        "concord.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/amithkb/concord-json-schema/main/.schema/concord.json"
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6642,6 +6642,12 @@
       "description": "Spice.ai OSS Spicepod Manifest file",
       "fileMatch": ["spicepod.yml", "spicepod.yaml"],
       "url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/.schema/spicepod.schema.json"
+    },
+    {
+      "name": "Concord",
+      "description": "Concord - https://github.com/walmartlabs/concord,  workflow orcehstrator schema",
+      "fileMatch": ["*.concord.yaml", "*.concord.yml", ".concord.yml", ".concord.yaml", "concord.yml", "concord.yaml"],
+      "url": "https://raw.githubusercontent.com/amithkb/concord-json-schema/main/.schema/concord.json"
     }
   ]
 }


### PR DESCRIPTION
concord - https://github.com/walmartlabs/concord

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
