### PR TITLE
Revert Dependabot pip-compile addition

### DIFF
--- a/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-elm-package.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-elm-package.json
@@ -1,0 +1,12 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "elm-package",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-hex.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-hex.json
@@ -1,0 +1,12 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "hex",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-pip-compile.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-pip-compile.json
@@ -1,0 +1,12 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "pip-compile",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-pipenv.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-pipenv.json
@@ -1,0 +1,12 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "pipenv",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-pnpm.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-pnpm.json
@@ -1,0 +1,12 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "pnpm",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-poetry.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-poetry.json
@@ -1,0 +1,12 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "poetry",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-yarn.json
+++ b/src/negative_test/dependabot-2.0/package-ecosystem-tool-name-not-yaml-value-yarn.json
@@ -1,0 +1,12 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "yarn",
+      "schedule": {
+        "interval": "monthly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -663,7 +663,6 @@
         "npm",
         "nuget",
         "pip",
-        "pip-compile",
         "pub",
         "swift",
         "terraform"


### PR DESCRIPTION
This reverts #3580, which added the tool name "pip-compile". "pip-compile" is an invalid YAML value, and the tool must be specified using the value "pip".

> ![image](https://github.com/user-attachments/assets/fbb49229-a299-437c-aa76-adf949d9791a)

The screenshot above shows several [documented tool names that have different YAML values](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem). Only the YAML values listed are valid, so this PR also adds negative tests to help call out that tool names must not be added to the schema.