### PR TITLE
Add schema for runny

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4160,6 +4160,12 @@
       "url": "https://raw.githubusercontent.com/canonical/rockcraft/main/schema/rockcraft.json"
     },
     {
+      "name": "runny",
+      "description": "runny, a rool for running things",
+      "fileMatch": [".runny.yaml", ".runny.yml"],
+      "url": "https://raw.githubusercontent.com/simonwhitaker/runny/main/schema/runny.schema.json"
+    },
+    {
       "name": "rustfmt",
       "description": "rustfmt, a tool to format Rust code",
       "fileMatch": ["rustfmt.toml"],


### PR DESCRIPTION
Adds a schema for validating config files for [runny](https://github.com/simonwhitaker/runny/).

An example of a file that adheres to this schema is [the .runny.yaml file for runny itself](https://github.com/simonwhitaker/runny/blob/main/.runny.yaml).

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
