### PR TITLE
clang-format - allow negative values for Priority/SortPriority

### DIFF
--- a/src/schemas/json/clang-format.json
+++ b/src/schemas/json/clang-format.json
@@ -602,12 +602,10 @@
             "type": "string"
           },
           "Priority": {
-            "type": "integer",
-            "minimum": 0
+            "type": "integer"
           },
           "SortPriority": {
-            "type": "integer",
-            "minimum": 0
+            "type": "integer"
           },
           "CaseSensitive": {
             "type": "boolean"


### PR DESCRIPTION
Minor change to remove the `"minimum": 0` validation rules for `Priority` and `SortPriority` under `IncludeCategories` for clang-format files.

Negative values are permitted in these fields as per [clang-format documentation](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#includecategories):
> The main header for a source file automatically gets category 0 [...] However, you can also assign negative priorities if you have certain headers that always need to be first