### PR TITLE
GitVersion configuration schema is now hosted at gitversion.net

### DIFF
--- a/src/schemas/json/gitversion.json
+++ b/src/schemas/json/gitversion.json
@@ -1,5 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "https://raw.githubusercontent.com/GitTools/GitVersion/main/schemas/6.0/GitVersion.configuration.json",
+  "$ref": "https://gitversion.net/schemas/6.0/GitVersion.configuration.json",
   "title": "GitVersion configuration schema"
 }


### PR DESCRIPTION
The schema for the configuration file is now stored at the [giversion.net](https://gitversion.net/schemas/6.0/GitVersion.configuration.json) and the new versions will also appear there.