### PR TITLE
add 'strictBuiltinIteratorReturn' to the tsconfig.json schema

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -1217,6 +1217,13 @@
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check side effect imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedSideEffectImports"
+            },
+            "strictBuiltinIteratorReturn": {
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'.",
+              "type": ["boolean", "null"],
+              "default": false,
+              "markdownDescription": "Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBuiltinIteratorReturn"
             }
           }
         }

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1226,6 +1226,13 @@
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check side effect imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedSideEffectImports"
+            },
+            "strictBuiltinIteratorReturn": {
+              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
+              "description": "Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'.",
+              "type": ["boolean", "null"],
+              "default": false,
+              "markdownDescription": "Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBuiltinIteratorReturn"
             }
           }
         }

--- a/src/test/jsconfig/jsconfig-strictBuiltinIteratorReturn.json
+++ b/src/test/jsconfig/jsconfig-strictBuiltinIteratorReturn.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strictBuiltinIteratorReturn": true
+  }
+}

--- a/src/test/tsconfig/tsconfig-strictBuiltinIteratorReturn.json
+++ b/src/test/tsconfig/tsconfig-strictBuiltinIteratorReturn.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strictBuiltinIteratorReturn": true
+  }
+}


### PR DESCRIPTION
This adds the `strictBuiltinIteratorReturn` compiler option introduced in the TypeScript 5.6 beta to the `tsconfig.json` schema.