### PR TITLE
Update fly.io "auto_stop_machines" config option

### DIFF
--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -37,9 +37,10 @@
           "default": 8080
         },
         "auto_stop_machines": {
-          "description": "Whether to automatically stop an application’s Machines when there’s excess capacity, per region. If there’s only one Machine in a region, then the Machine is stopped if it has no traffic. The Fly Proxy runs a process to automatically stop Machines every few minutes. The default if not set is false.",
-          "type": "boolean",
-          "default": false
+          "description": "The action, if any, that Fly Proxy should take when the app is idle for several minutes. Options are \"off\", \"stop\", or \"suspend\".",
+          "type": "string",
+          "enum": ["off", "stop", "suspend"],
+          "default": "off"
         },
         "auto_start_machines": {
           "description": "Whether to automatically start an application’s Machines when a new request is made to the application and there’s no excess capacity, per region. If there’s only one Machine in a region, then it’s started whenever a request is made to the application. The default if not set is true.",
@@ -467,8 +468,10 @@
           "description": "A Boolean which determines whether to enforce HTTP to HTTPS redirects."
         },
         "auto_stop_machines": {
-          "type": "boolean",
-          "description": "Whether to automatically stop an application’s Machines when there’s excess capacity, per region."
+          "description": "Whether to automatically stop or suspend an application’s Machines when there’s excess capacity, per region. Options are \"off\", \"stop\", and \"suspend\". If there’s only one Machine in a region, then the Machine is stopped or suspended if it has no traffic. The Fly Proxy runs a process to automatically stop Machines every few minutes. The default if not set is \"off\".",
+          "type": "string",
+          "enum": ["off", "stop", "suspend"],
+          "default": "off"
         },
         "auto_start_machines": {
           "type": "boolean",

--- a/src/test/fly/fly.json
+++ b/src/test/fly/fly.json
@@ -48,7 +48,7 @@
   "host_dedication_id": "06031957",
   "http_service": {
     "auto_start_machines": false,
-    "auto_stop_machines": false,
+    "auto_stop_machines": "off",
     "checks": [
       {
         "grace_period": "2s",
@@ -126,7 +126,7 @@
   "services": [
     {
       "auto_start_machines": false,
-      "auto_stop_machines": false,
+      "auto_stop_machines": "off",
       "concurrency": {
         "hard_limit": 22,
         "soft_limit": 13,


### PR DESCRIPTION
The current schema lists this field as having a boolean value, but the current docs have it as an enum.

Docs for reference:
https://fly.io/docs/reference/configuration/#the-http_service-section

Did my best to follow existing standards -- let me know if anything looks off!

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
