### PR TITLE
Add missing `statusAddress` field in Traefik v2 schema

### DIFF
--- a/src/schemas/json/traefik-v2.json
+++ b/src/schemas/json/traefik-v2.json
@@ -898,6 +898,28 @@
             "labelSelector": {
               "type": "string"
             },
+            "statusAddress": {
+              "type": "object",
+              "properties": {
+                "ip": {
+                  "type": "string"
+                },
+                "hostname": {
+                  "type": "string"
+                },
+                "service": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
             "throttleDuration": {
               "type": "string"
             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
Add missing field in Traefik V2 static configuration (`providers.kubernetesGateway.statusAddress` added in this commit https://github.com/traefik/traefik/commit/0017471f0d643ecc53768839c24658183fa07e54)