### PR TITLE
Update Hazelcast schema for release 5.5.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2585,7 +2585,7 @@
         "hz-*.yaml",
         "hz-*.json"
       ],
-      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.4.json"
+      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.5.json"
     },
     {
       "name": "host.json",


### PR DESCRIPTION
Hazelcast 5.5.0 has been released which includes new schema
