### PR TITLE
Add third @typescript-eslint/quotes option

### DIFF
--- a/src/schemas/json/partial-eslint-plugins.json
+++ b/src/schemas/json/partial-eslint-plugins.json
@@ -13767,7 +13767,7 @@
         },
         {
           "minItems": 2,
-          "maxItems": 2,
+          "maxItems": 3,
           "type": "array",
           "items": [
             {
@@ -13781,9 +13781,27 @@
               ]
             },
             {
+              "description": "String option: \"double\" (default) requires the use of double quotes wherever possible; \"single\" requires the use of single quotes wherever possible; \"backtick\" requires the use of backticks wherever possible",
+              "type": "string",
+              "enum": ["double", "single", "backtick"]
+            },
+            {
               "type": "object",
               "additionalProperties": true,
-              "properties": {}
+              "properties": {
+                "avoidEscape": {
+                  "description": "allows strings to use single-quotes or double-quotes so long as the string contains a quote that would have to be escaped otherwise",
+                  "type": "boolean"
+                },
+                "allowTemplateLiterals": {
+                  "description": "allows strings to use backticks",
+                  "type": "boolean"
+                },
+                "avoid-escape": {
+                  "description": "Deprecated: The object property avoid-escape is deprecated; please use the object property avoidEscape instead.",
+                  "type": "boolean"
+                }
+              }
             }
           ]
         }

--- a/src/test/eslintrc/typescript-eslint.json
+++ b/src/test/eslintrc/typescript-eslint.json
@@ -26,8 +26,8 @@
       "error",
       "single",
       {
-        "avoidEscape": true,
-        "allowTemplateLiterals": true
+        "allowTemplateLiterals": true,
+        "avoidEscape": true
       }
     ]
   }

--- a/src/test/eslintrc/typescript-eslint.json
+++ b/src/test/eslintrc/typescript-eslint.json
@@ -21,6 +21,14 @@
         "ignoreRestSiblings": true,
         "varsIgnorePattern": "^_"
       }
+    ],
+    "@typescript-eslint/quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
     ]
   }
 }


### PR DESCRIPTION
The rule described at:
https://typescript-eslint.io/rules/quotes/#options
links to
https://eslint.org/docs/latest/rules/quotes#options

which lists valid configurations including:

`/*eslint quotes: ["error", "double"]*/`
`/*eslint quotes: ["error", "double", { "avoidEscape": true }]*/`
`/*eslint quotes: ["error", "single", { "allowTemplateLiterals": true }]*/`

This adds the object option parameter and a test validating that it accepts the newly valid input.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
