### PR TITLE
Second @typescript-eslint/consistent-type-definitions option is string enum

### DIFF
--- a/src/schemas/json/partial-eslint-plugins.json
+++ b/src/schemas/json/partial-eslint-plugins.json
@@ -10020,9 +10020,9 @@
               ]
             },
             {
-              "type": "object",
-              "additionalProperties": true,
-              "properties": {}
+              "type": "string",
+              "description": "This rule accepts the following options: \"interface\" (default): enforce using interfaces for object type definitions. \"type\": enforce using types for object type definitions.",
+              "enum": ["interface", "type"]
             }
           ]
         }

--- a/src/test/eslintrc/typescript-eslint.json
+++ b/src/test/eslintrc/typescript-eslint.json
@@ -10,6 +10,7 @@
       "error",
       "index-signature"
     ],
+    "@typescript-eslint/consistent-type-definitions": ["error", "type"],
     "@typescript-eslint/no-unused-vars": [
       "error",
       {


### PR DESCRIPTION
Change the second @typescript-eslint/consistent-type-definitions option to a string enum

As opposed to the undefined object that was declared in the schema, the rule[0] declares that  the second argument is a string, as supported by the playground[1]:

```
This rule accepts the following options:

type Options = ['interface' | 'type'];

const defaultOptions: Options = ['interface'];

"interface" (default): enforce using interfaces for object type definitions.
"type": enforce using types for object type definitions.
```

[0] https://typescript-eslint.io/rules/consistent-type-definitions/#options
[1] https://typescript-eslint.io/play/#ts=5.5.2&fileType=.ts&code=C4TwDgpgBAglC8UDeAoKUCGAuKBnYATgJYB2A5igL4oqnAQEBmGAxtAELJqY77HlUUQA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6MgeyeUuX0Ra0ipWgBNEAM2aV8lLqgwBtSImjQO0SABoowxJAC64MAF8QJoA&tsconfig=&tokens=false

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
