### PR TITLE
Schema changes to add the MySql Extension

### DIFF
--- a/src/schemas/json/function.json
+++ b/src/schemas/json/function.json
@@ -46,7 +46,7 @@
               "sql",
               "sqlTrigger",
               "kusto",
-              "mysql",
+              "mysql"
             ]
           }
         },

--- a/src/schemas/json/function.json
+++ b/src/schemas/json/function.json
@@ -45,7 +45,8 @@
               "sendGrid",
               "sql",
               "sqlTrigger",
-              "kusto"
+              "kusto",
+              "mysql",
             ]
           }
         },
@@ -628,6 +629,52 @@
           }
         }
       ]
+    },
+    "mySqlBinding": {
+      "properties": {
+        "connectionStringSetting": {
+          "type": "string",
+          "description": "The name of the app setting that contains the MySql connection string used to connect to the database."
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": ["mysql"]
+            },
+            "direction": {
+              "enum": ["in"]
+            },
+            "commandText": {
+              "type": "string",
+              "description": "Either a query string or the name of a stored procedure to execute."
+            },
+            "commandType": {
+              "enum": ["text", "storedProcedure"],
+              "description": "Whether the commandText is a query or a stored procedure."
+            },
+            "parameters": {
+              "type": "string",
+              "description": "The parameters to the query or stored procedure."
+            }
+          }
+        },
+        {
+          "properties": {
+            "type": {
+              "const": "mysql"
+            },
+            "direction": {
+              "enum": ["out"]
+            },
+            "commandText": {
+              "type": "string",
+              "description": "The name of the table into which rows will be upserted."
+            }
+          }
+        }
+      ]
     }
   },
   "id": "https://json.schemastore.org/function.json",
@@ -757,6 +804,9 @@
               },
               {
                 "$ref": "#/definitions/kustoBinding"
+              },
+              {
+                "$ref": "#/definitions/mySqlBinding"
               }
             ]
           }

--- a/src/test/function/MySql.json
+++ b/src/test/function/MySql.json
@@ -1,28 +1,28 @@
 {
   "bindings": [
     {
-      "type": "mysql",
-      "direction": "in",
+      "commandText": "SELECT * FROM Products",
       "commandType": "text",
       "connectionStringSetting": "MySqlConnectionString",
-      "commandText": "SELECT * FROM Products",
-      "name": "result"
+      "direction": "in",
+      "name": "result",
+      "type": "mysql"
     },
     {
-      "type": "mysql",
-      "direction": "in",
-      "connectionStringSetting": "MySqlConnectionString",
       "commandText": "SelectProductsCost",
       "commandType": "storedProcedure",
+      "connectionStringSetting": "MySqlConnectionString",
+      "direction": "in",
+      "name": "products",
       "parameters": "@Cost={cost}",
-      "name": "products"
+      "type": "mysql"
     },
     {
-      "type": "mysql",
-      "direction": "out",
-      "connectionStringSetting": "MySqlConnectionString",
       "commandText": "Products",
-      "name": "products"
+      "connectionStringSetting": "MySqlConnectionString",
+      "direction": "out",
+      "name": "products",
+      "type": "mysql"
     }
   ],
   "disabled": false

--- a/src/test/function/MySql.json
+++ b/src/test/function/MySql.json
@@ -1,0 +1,29 @@
+{
+  "bindings": [
+    {
+      "type": "mysql",
+      "direction": "in",
+      "commandType": "text",
+      "connectionStringSetting": "MySqlConnectionString",
+      "commandText": "SELECT * FROM Products",
+      "name": "result"
+    },
+    {
+      "type": "mysql",
+      "direction": "in",
+      "connectionStringSetting": "MySqlConnectionString",
+      "commandText": "SelectProductsCost",
+      "commandType": "storedProcedure",
+      "parameters": "@Cost={cost}",
+      "name": "products"
+    },
+    {
+      "type": "mysql",
+      "direction": "out",
+      "connectionStringSetting": "MySqlConnectionString",
+      "commandText": "Products",
+      "name": "products"
+    }
+  ],
+  "disabled": false
+}


### PR DESCRIPTION
1. Added mysql input and output bindings in function.json file.
2. Created the test file for mysql input and output bindings.
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
