### PR TITLE
Feat(zuul): add missing attribute semaphores for job

### DIFF
--- a/src/schemas/json/zuul.json
+++ b/src/schemas/json/zuul.json
@@ -227,6 +227,27 @@
           ],
           "title": "Secrets"
         },
+        "semaphores": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/JobSemaphoreModel"
+            },
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/JobSemaphoreModel"
+                },
+                {
+                  "type": "array"
+                }
+              ]
+            }
+          ],
+          "title": "Semaphore(s)"
+        },
         "success-url": {
           "title": "Success-Url",
           "type": "string"
@@ -304,6 +325,23 @@
       },
       "required": ["name", "secret"],
       "title": "JobSecretModel",
+      "type": "object"
+    },
+    "JobSemaphoreModel": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "resources-first": {
+          "default": false,
+          "title": "Resources-First",
+          "type": "boolean"
+        }
+      },
+      "required": ["name"],
+      "title": "JobSemaphoreModel",
       "type": "object"
     },
     "PipelineModel": {

--- a/src/test/zuul/jobs.yaml
+++ b/src/test/zuul/jobs.yaml
@@ -64,6 +64,9 @@
       - zuul: some_role_name
     final: false
     branches: master
+    semaphores:
+      - name: foo
+        resources-first: true
 
 - job:
     name: c
@@ -100,6 +103,31 @@
     files:
       - foo
       - bar
+
+- job:
+    name: f
+    description: ...
+    semaphores:
+      - foo
+      - bar
+
+- job:
+    name: g
+    description: ...
+    semaphores: foo
+
+- job:
+    name: h
+    description: ...
+    semaphores:
+      name: foo
+      resources-first: false
+
+- job:
+    name: i
+    description: ...
+    semaphores:
+      name: foo
 
 - project-template:
     name: sample-template


### PR DESCRIPTION
The `semaphores` attribute of the job model is currently missing in schema. See https://zuul-ci.org/docs/zuul/latest/config/job.html#attr-job.semaphores for details.
