### PR TITLE
chore: bump scikit-build-core to 0.10

### DIFF
--- a/src/schemas/json/partial-scikit-build.json
+++ b/src/schemas/json/partial-scikit-build.json
@@ -18,6 +18,10 @@
       "minProperties": 1,
       "additionalProperties": false,
       "properties": {
+        "scikit-build-version": {
+          "type": "string",
+          "description": "The version of scikit-build-version. Takes a specifier set."
+        },
         "python-version": {
           "type": "string",
           "description": "The two-digit Python version. Takes a specifier set."
@@ -45,6 +49,26 @@
         "state": {
           "type": "string",
           "description": "The state of the build, one of `sdist`, `wheel`, `editable`, `metadata_wheel`, and `metadata_editable`. Takes a regex."
+        },
+        "from-sdist": {
+          "type": "boolean",
+          "description": "Whether the build is from an sdist."
+        },
+        "failed": {
+          "type": "boolean",
+          "description": "Matches if the build fails. A build will be retried if there is at least one matching override with this set to true."
+        },
+        "system-cmake": {
+          "type": "string",
+          "description": "The version of CMake found on the system. Takes a specifier set."
+        },
+        "cmake-wheel": {
+          "type": "boolean",
+          "description": "Whether a cmake wheel is known to be provided for this system."
+        },
+        "abi-flags": {
+          "type": "string",
+          "description": "A sorted string of the abi flags. Takes a regex."
         },
         "env": {
           "type": "object",
@@ -86,8 +110,7 @@
         },
         "version": {
           "type": "string",
-          "default": ">=3.15",
-          "description": "The versions of CMake to allow. If CMake is not present on the system or does not pass this specifier, it will be downloaded via PyPI if possible. An empty string will disable this check."
+          "description": "The versions of CMake to allow. If CMake is not present on the system or does not pass this specifier, it will be downloaded via PyPI if possible. An empty string will disable this check. The default on 0.10+ is \"CMakeLists.txt\", which will read it from the project's CMakeLists.txt file, or \">=3.15\" if unreadable or <0.10."
         },
         "args": {
           "type": "array",
@@ -139,8 +162,8 @@
         },
         "verbose": {
           "type": "boolean",
-          "default": false,
-          "description": "Verbose printout when building."
+          "description": "DEPRECATED in 0.10, use build.verbose instead.",
+          "deprecated": true
         },
         "build-type": {
           "type": "string",
@@ -157,7 +180,8 @@
           "items": {
             "type": "string"
           },
-          "description": "The build targets to use when building the project. Empty builds the default target."
+          "description": "DEPRECATED in 0.10; use build.targets instead.",
+          "deprecated": true
         }
       }
     },
@@ -228,11 +252,23 @@
       "additionalProperties": false,
       "properties": {
         "packages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "A list of packages to auto-copy into the wheel. If this is not set, it will default to the first of ``src/<package>``, ``python/<package>``, or ``<package>`` if they exist.  The prefix(s) will be stripped from the package name inside the wheel."
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                ".+": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "description": "A list of packages to auto-copy into the wheel. If this is not set, it will default to the first of ``src/<package>``, ``python/<package>``, or ``<package>`` if they exist.  The prefix(s) will be stripped from the package name inside the wheel. If a dict, provides a mapping of package name to source directory."
         },
         "py-api": {
           "type": "string",
@@ -311,6 +347,31 @@
         }
       }
     },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tool-args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Extra args to pass directly to the builder in the build step."
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The build targets to use when building the project. Empty builds the default target."
+        },
+        "verbose": {
+          "type": "boolean",
+          "default": false,
+          "description": "Verbose printout when building."
+        }
+      }
+    },
     "install": {
       "type": "object",
       "additionalProperties": false,
@@ -377,6 +438,22 @@
             }
           }
         ]
+      }
+    },
+    "messages": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "after-failure": {
+          "type": "string",
+          "default": "",
+          "description": "A message to print after a build failure."
+        },
+        "after-success": {
+          "type": "string",
+          "default": "",
+          "description": "A message to print after a successful build."
+        }
       }
     },
     "metadata": {
@@ -450,6 +527,11 @@
       "default": "",
       "description": "The build directory. Defaults to a temporary directory, but can be set."
     },
+    "fail": {
+      "type": "boolean",
+      "default": false,
+      "description": "Immediately fail the build. This is only useful in overrides."
+    },
     "overrides": {
       "type": "array",
       "description": "A list of overrides to apply to the settings, based on the `if` selector.",
@@ -521,6 +603,18 @@
                   }
                 }
               },
+              "build": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "tool-args": {
+                    "$ref": "#/$defs/inherit"
+                  },
+                  "targets": {
+                    "$ref": "#/$defs/inherit"
+                  }
+                }
+              },
               "install": {
                 "type": "object",
                 "additionalProperties": false,
@@ -554,11 +648,17 @@
           "editable": {
             "$ref": "#/properties/editable"
           },
+          "build": {
+            "$ref": "#/properties/build"
+          },
           "install": {
             "$ref": "#/properties/install"
           },
           "generate": {
             "$ref": "#/properties/generate"
+          },
+          "messages": {
+            "$ref": "#/properties/messages"
           },
           "metadata": {
             "$ref": "#/properties/metadata"
@@ -574,6 +674,9 @@
           },
           "build-dir": {
             "$ref": "#/properties/build-dir"
+          },
+          "fail": {
+            "$ref": "#/properties/fail"
           }
         }
       }


### PR DESCRIPTION
Bumping schema to 0.10.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
