### PR TITLE
Add `*dbt*` to fileMatch paths for dbt files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -989,10 +989,34 @@
       "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/job.schema.json"
     },
     {
+      "name": "dbt Dependencies",
+      "description": "dbt's dependencies.yml file for external packages and cross-project refs",
+      "fileMatch": ["**/*dbt*/dependencies.{yaml,yml}"],
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dependencies-latest.json"
+    },
+    {
       "name": "dbt Project",
-      "description": "dbt project configurations",
-      "fileMatch": ["dbt_project.yml"],
+      "description": "dbt's project configuration file",
+      "fileMatch": ["dbt_project.{yaml,yml}"],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dbt_project-latest.json"
+    },
+    {
+      "name": "dbt Packages",
+      "description": "dbt's packages.yml file for external packages",
+      "fileMatch": ["**/*dbt*/packages.{yaml,yml}"],
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/packages-latest.json"
+    },
+    {
+      "name": "dbt Selectors",
+      "description": "dbt's selectors.yml file for configuring YAML selectors",
+      "fileMatch": ["**/*dbt*/selectors.{yaml,yml}"],
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/selectors-latest.json"
+    },
+    {
+      "name": "dbt YAML files",
+      "description": "dbt YAML files configurations",
+      "fileMatch": ["**/*dbt*/{macros,models,seeds,snapshots}/**/*.{yaml,yml}"],
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dbt_yml_files-latest.json"
     },
     {
       "name": "Dein Config",


### PR DESCRIPTION
Replaces https://github.com/SchemaStore/schemastore/pull/3948 based on [discussion here](https://github.com/SchemaStore/schemastore/pull/3948#issuecomment-2261779446) and [here](https://github.com/SchemaStore/schemastore/pull/3948#issuecomment-2263963084). 

Adds more schemas for yaml files in dbt projects, with a check for `*dbt*` in the directory path. dbt itself doesn't require that naming scheme, but it's a useful convention to avoid false positives from what would otherwise be an overenthusiastic pattern. 