### PR TITLE
add Kestra flow schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,5 @@ repos:
         args:
           [
             '--ignore-words-list',
-            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn',
+            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn',
           ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2922,6 +2922,15 @@
       "url": "https://raw.githubusercontent.com/graeter-group/kimmdy/main/src/kimmdy/kimmdy-yaml-schema.json"
     },
     {
+      "name": "Kestra flow file",
+      "description": "Kestra Flow definition file, see: kestra.io/docs/workflow-components/flow#flow-sample",
+      "fileMatch": ["**/flows/*.yml"],
+      "url": "https://json.schemastore.org/kestra-0.18.json",
+      "versions": {
+        "0.18": "https://json.schemastore.org/kestra-0.18.json"
+      }
+    },
+    {
       "name": "KrakenD",
       "description": "KrakenD API Gateway configuration file",
       "fileMatch": [

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -112,6 +112,7 @@
     "json-api-1.0.json",
     "json-patch.json",
     "jsone.json",
+    "kestra-0.18.json",
     "kong_json_schema.json",
     "kustomization.json",
     "label-commenter-config.json",
@@ -705,6 +706,14 @@
         "markdownDescription",
         "markdownEnumDescriptions",
         "allowTrailingCommas"
+      ]
+    },
+    "kestra-0.18.json": {
+      "unknownKeywords": [
+        "markdownDescription",
+        "$deprecated",
+        "$dynamic",
+        "$metrics"
       ]
     },
     "launchsettings.json": {

--- a/src/test/kestra-0.18/hello_world.yaml
+++ b/src/test/kestra-0.18/hello_world.yaml
@@ -11,18 +11,18 @@ inputs:
   - id: my-value
     type: STRING
     required: false
-    defaults: "default value"
+    defaults: 'default value'
     description: This is a not required my-value
 
 variables:
-  first: "1"
-  second: "{{vars.first}} > 2"
+  first: '1'
+  second: '{{vars.first}} > 2'
 
 tasks:
   - id: date
     type: io.kestra.plugin.core.debug.Return
-    description: "Some tasks **documentation** in *Markdown*"
-    format: "A log line content with a contextual date variable {{taskrun.startDate}}"
+    description: 'Some tasks **documentation** in *Markdown*'
+    format: 'A log line content with a contextual date variable {{taskrun.startDate}}'
 
 pluginDefaults:
   - type: io.kestra.plugin.core.log.Log

--- a/src/test/kestra-0.18/hello_world.yaml
+++ b/src/test/kestra-0.18/hello_world.yaml
@@ -1,0 +1,30 @@
+id: hello-world
+namespace: company.team
+
+description: flow **documentation** in *Markdown*
+
+labels:
+  env: prod
+  team: engineering
+
+inputs:
+  - id: my-value
+    type: STRING
+    required: false
+    defaults: "default value"
+    description: This is a not required my-value
+
+variables:
+  first: "1"
+  second: "{{vars.first}} > 2"
+
+tasks:
+  - id: date
+    type: io.kestra.plugin.core.debug.Return
+    description: "Some tasks **documentation** in *Markdown*"
+    format: "A log line content with a contextual date variable {{taskrun.startDate}}"
+
+pluginDefaults:
+  - type: io.kestra.plugin.core.log.Log
+    values:
+      level: ERROR


### PR DESCRIPTION
Adds schema for [Kestra flows](https://kestra.io/docs/workflow-components/flow).

[Kestra](https://kestra.io) is an orchestration framework similar to Airflow that defines it's pipelines (flows) in YAML. This schma provides auto-complete and validation of YAML.

When validating the schema I did get the following error `Error: strict more: unknown keyword: "markdownDescription"`. It might be something specific to Kestra but not sure how it should be handled.

Solves #3978 