### PR TITLE
chore: add YAML extensions to CRS schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6710,7 +6710,7 @@
     {
       "name": "CRS WAF test file",
       "description": "Definition of a test for verifying WAF behavior",
-      "fileMatch": ["*.waft"],
+      "fileMatch": ["*.waft", ".waft.yaml", ".waft.yml"],
       "url": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/main/spec/v2.1.0/waf-tests-schema-v2.1.0.json",
       "versions": {
         "2.1.0": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/main/spec/v2.1.0/waf-tests-schema-v2.1.0.json"
@@ -6719,7 +6719,7 @@
     {
       "name": "CRS WAF test platform overrides file",
       "description": "Definition of platform specific overrides for WAF tests",
-      "fileMatch": ["*.wafto"],
+      "fileMatch": ["*.wafto", ".wafto.yaml", ".wafto.yml"],
       "url": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/master/spec/v2.1.0/waf-platform-overrides-schema-v2.1.0.json",
       "versions": {
         "2.1.0": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/master/spec/v2.1.0/waf-platform-overrides-schema-v2.1.0.json"


### PR DESCRIPTION
The VS Code extension "vscode-yaml" filters schemas from schemastore.org by file extension in the `fileMatch` property. In order for the extension to pick up a schema, `fileMatch` must contain at least one entry with the substring `.yaml` or `.yml`.
