### PR TITLE
Remove Byte Order Mark for several files

### DIFF
--- a/src/_Layout.cshtml
+++ b/src/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head prefix="og: http://ogp.me/ns#">
     <title>@Page.Title</title>

--- a/src/bin/System.Web.Helpers.xml
+++ b/src/bin/System.Web.Helpers.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <doc>
   <assembly>
     <name>System.Web.Helpers</name>

--- a/src/bin/System.Web.Razor.xml
+++ b/src/bin/System.Web.Razor.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <doc>
   <assembly>
     <name>System.Web.Razor</name>

--- a/src/bin/System.Web.WebPages.Deployment.xml
+++ b/src/bin/System.Web.WebPages.Deployment.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <doc>
   <assembly>
     <name>System.Web.WebPages.Deployment</name>

--- a/src/bin/System.Web.WebPages.Razor.xml
+++ b/src/bin/System.Web.WebPages.Razor.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <doc>
   <assembly>
     <name>System.Web.WebPages.Razor</name>

--- a/src/bin/System.Web.WebPages.xml
+++ b/src/bin/System.Web.WebPages.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <doc>
   <assembly>
     <name>System.Web.WebPages</name>

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1,4 +1,4 @@
-﻿@-ms-viewport {
+@-ms-viewport {
   width: device-width;
 }
 

--- a/src/index.cshtml
+++ b/src/index.cshtml
@@ -1,3 +1,3 @@
-﻿@{
+@{
     Response.RedirectPermanent("~/json/");
 }

--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
 	Page.Title = "JSON Schema Store";
 	Page.Description = "JSON Schemas for common JSON file formats";
 	Layout = "~/_layout.cshtml";

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />

--- a/src/vwd.webinfo
+++ b/src/vwd.webinfo
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <!-- 
   Visual Studio global web project settings.
 -->


### PR DESCRIPTION
This removes the BOM of several non-JSON files. This is in a separate PR because changes in these files are more prone to cause breakages of the website.