### PR TITLE
Add Speakeasy configuration files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4501,6 +4501,24 @@
       "url": "https://json.schemastore.org/sourcery_yaml_schema.json"
     },
     {
+      "name": "Speakeasy Lint Configuration File",
+      "description": "Configuration file for Speakeasy's OpenAPI document linting. Find out more at https://www.speakeasy.com/docs/linting",
+      "fileMatch": ["**/.speakeasy/lint.yaml"],
+      "url": "https://github.com/speakeasy-api/sdk-gen-config/blob/main/schemas/lint.schema.json"
+    },
+    {
+      "name": "Speakeasy Test Generation Configuration File",
+      "description": "Configuration file for Speakeasy's test generation",
+      "fileMatch": ["**/.speakeasy/tests.yaml"],
+      "url": "https://github.com/speakeasy-api/sdk-gen-config/blob/main/schemas/tests.schema.json"
+    },
+    {
+      "name": "Speakeasy Workflow File",
+      "description": "Workflow configuration file. Read more at https://www.speakeasy.com/docs/workflow-file-reference",
+      "fileMatch": ["**/.speakeasy/workflow.yaml"],
+      "url": "https://github.com/speakeasy-api/sdk-gen-config/blob/main/schemas/workflow.schema.json"
+    },
+    {
       "name": "SpecIF",
       "description": "The Specification Integration Facility (SpecIF) integrates partial system models from different methods and tools in a semantic net. Documentation: https://specif.de and https://github.com/GfSE",
       "fileMatch": ["*.specif", "*.specif.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4504,19 +4504,19 @@
       "name": "Speakeasy Lint Configuration File",
       "description": "Configuration file for Speakeasy's OpenAPI document linting. Find out more at https://www.speakeasy.com/docs/linting",
       "fileMatch": ["**/.speakeasy/lint.yaml"],
-      "url": "https://github.com/speakeasy-api/sdk-gen-config/blob/main/schemas/lint.schema.json"
+      "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/lint.schema.json"
     },
     {
       "name": "Speakeasy Test Generation Configuration File",
       "description": "Configuration file for Speakeasy's test generation",
       "fileMatch": ["**/.speakeasy/tests.yaml"],
-      "url": "https://github.com/speakeasy-api/sdk-gen-config/blob/main/schemas/tests.schema.json"
+      "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/tests.schema.json"
     },
     {
       "name": "Speakeasy Workflow File",
       "description": "Workflow configuration file. Read more at https://www.speakeasy.com/docs/workflow-file-reference",
       "fileMatch": ["**/.speakeasy/workflow.yaml"],
-      "url": "https://github.com/speakeasy-api/sdk-gen-config/blob/main/schemas/workflow.schema.json"
+      "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/workflow.schema.json"
     },
     {
       "name": "SpecIF",


### PR DESCRIPTION
Adds support for a variety of [Speakeasy](https://speakeasy.com/) configuration files to the catalog. The JSON schemas for these configuration files are hosted externally on GitHub.
