### PR TITLE
Normalize globs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5226,7 +5226,7 @@
     {
       "name": "mirrord config",
       "description": "mirrord",
-      "fileMatch": ["*.mirrord.+(toml|json|y?(a)ml)"],
+      "fileMatch": ["*.mirrord.{toml,json,yaml,yml}"],
       "url": "https://raw.githubusercontent.com/metalbear-co/mirrord/main/mirrord-schema.json"
     },
     {
@@ -5420,7 +5420,7 @@
       "name": "Windows Package Manager Locale Manifest",
       "description": "Windows Package Manager Locale Manifest file, used for detailing locale specific metadata",
       "fileMatch": [
-        "**/manifests/?/*/*/*/*.*.locale@(.en-US|fr-FR|it-IT|ja-JP|ko-KR|pt-BR|ru-RU|zh-CN|zh-TW).yaml"
+        "**/manifests/?/*/*/*/*.*.locale.{en-US,fr-FR,it-IT,ja-JP,ko-KR,pt-BR,ru-RU,zh-CN,zh-TW}.yaml"
       ],
       "url": "https://json.schemastore.org/winget-pkgs-locale-1.0.0.json"
     },


### PR DESCRIPTION
This replaces bracket style globs with equivalent brace syntax. This is simpler and consistent with other similar cases in the catalog.

Brace syntax can also be normalized with a library such as [`braces`](https://github.com/micromatch/braces).