### PR TITLE
Remove JavaScript files from the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1912,10 +1912,7 @@
       "description": "Configuration files for the esm module/package in Node.js",
       "fileMatch": [
         ".esmrc",
-        ".esmrc.json",
-        ".esmrc.js",
-        ".esmrc.cjs",
-        ".esmrc.mjs"
+        ".esmrc.json"
       ],
       "url": "https://json.schemastore.org/esmrc.json"
     },
@@ -2510,7 +2507,6 @@
         ".meshrc.yml",
         ".meshrc.yaml",
         ".meshrc.json",
-        ".meshrc.js",
         ".graphql-mesh.yaml",
         ".graphql-mesh.yml"
       ],
@@ -2521,14 +2517,12 @@
       "description": "GraphQL Config config file",
       "fileMatch": [
         "graphql.config.json",
-        "graphql.config.js",
         "graphql.config.yaml",
         "graphql.config.yml",
         ".graphqlrc",
         ".graphqlrc.json",
         ".graphqlrc.yaml",
-        ".graphqlrc.yml",
-        ".graphqlrc.js"
+        ".graphqlrc.yml"
       ],
       "url": "https://unpkg.com/graphql-config/config-schema.json"
     },
@@ -2539,11 +2533,9 @@
         "codegen.yml",
         "codegen.yaml",
         "codegen.json",
-        "codegen.js",
         ".codegen.yml",
         ".codegen.yaml",
-        ".codegen.json",
-        ".codegen.js"
+        ".codegen.json"
       ],
       "url": "https://www.graphql-code-generator.com/config.schema.json"
     },
@@ -4973,7 +4965,7 @@
     {
       "name": ".versionrc.json",
       "description": "Conventional Changelog Configuration file",
-      "fileMatch": [".versionrc", ".versionrc.json", ".versionrc.js"],
+      "fileMatch": [".versionrc", ".versionrc.json"],
       "url": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.2.0/schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/1.0.0/schema.json",
@@ -5350,7 +5342,7 @@
     {
       "name": "jsdoc",
       "description": "JSDoc configuration file",
-      "fileMatch": ["conf.js*", "jsdoc.js*"],
+      "fileMatch": ["conf.json", "jsdoc.json"],
       "url": "https://json.schemastore.org/jsdoc-1.0.0.json"
     },
     {
@@ -5968,9 +5960,7 @@
       "fileMatch": [
         ".gherking.json",
         ".gherkingrc",
-        ".gherking.js",
-        "gherking.json",
-        "gherking.js"
+        "gherking.json"
       ],
       "url": "https://raw.githubusercontent.com/gherking/gherking/master/schema/gherking.schema.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1910,10 +1910,7 @@
     {
       "name": ".esmrc.json",
       "description": "Configuration files for the esm module/package in Node.js",
-      "fileMatch": [
-        ".esmrc",
-        ".esmrc.json"
-      ],
+      "fileMatch": [".esmrc", ".esmrc.json"],
       "url": "https://json.schemastore.org/esmrc.json"
     },
     {
@@ -5957,11 +5954,7 @@
     {
       "name": "GherKing",
       "description": "GherKing configuration",
-      "fileMatch": [
-        ".gherking.json",
-        ".gherkingrc",
-        "gherking.json"
-      ],
+      "fileMatch": [".gherking.json", ".gherkingrc", "gherking.json"],
       "url": "https://raw.githubusercontent.com/gherking/gherking/master/schema/gherking.schema.json"
     },
     {


### PR DESCRIPTION
JavaScript is a dynamic language that can’t be statically analyzed with JSON schema. There’s no reason to keep them in the catalog.