### PR TITLE
Use versions for cryproj files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5157,11 +5157,11 @@
       "fileMatch": ["*.cryproj"],
       "url": "https://json.schemastore.org/cryproj.json",
       "versions": {
+        "dev": "https://json.schemastore.org/cryproj.dev.schema.json",
         "5.2": "https://json.schemastore.org/cryproj.52.schema.json",
         "5.3": "https://json.schemastore.org/cryproj.53.schema.json",
         "5.4": "https://json.schemastore.org/cryproj.54.schema.json",
-        "5.5": "https://json.schemastore.org/cryproj.55.schema.json",
-        "dev": "https://json.schemastore.org/cryproj.dev.schema.json"
+        "5.5": "https://json.schemastore.org/cryproj.55.schema.json"
       }
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5152,40 +5152,17 @@
       "url": "https://json.schemastore.org/servicehub.config.schema.json"
     },
     {
-      "name": ".cryproj engine-5.2",
-      "description": "A CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
-      "url": "https://json.schemastore.org/cryproj.52.schema.json"
-    },
-    {
-      "name": ".cryproj engine-5.3",
-      "description": "A CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
-      "url": "https://json.schemastore.org/cryproj.53.schema.json"
-    },
-    {
-      "name": ".cryproj engine-5.4",
-      "description": "A CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
-      "url": "https://json.schemastore.org/cryproj.54.schema.json"
-    },
-    {
-      "name": ".cryproj engine-5.5",
-      "description": "A CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
-      "url": "https://json.schemastore.org/cryproj.55.schema.json"
-    },
-    {
-      "name": ".cryproj engine-dev",
-      "description": "A CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
-      "url": "https://json.schemastore.org/cryproj.dev.schema.json"
-    },
-    {
       "name": ".cryproj (generic)",
       "description": "A CRYENGINE projects (.cryproj files)",
       "fileMatch": ["*.cryproj"],
-      "url": "https://json.schemastore.org/cryproj.json"
+      "url": "https://json.schemastore.org/cryproj.json",
+      "versions": {
+        "5.2": "https://json.schemastore.org/cryproj.52.schema.json",
+        "5.3": "https://json.schemastore.org/cryproj.53.schema.json",
+        "5.4": "https://json.schemastore.org/cryproj.54.schema.json",
+        "5.5": "https://json.schemastore.org/cryproj.55.schema.json",
+        "dev": "https://json.schemastore.org/cryproj.dev.schema.json"
+      }
     },
     {
       "name": "typedoc.json",


### PR DESCRIPTION
There are multiple versions of `.cryproj` files. These versions each had their own catalog entry instead of using the `versions` field.

Disclaimer: I have no idea what `.cryproj` files actually mean.