### PR TITLE
Add resticprofile schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6760,6 +6760,15 @@
       "description": "Tycho.yaml file",
       "fileMatch": ["**/tycho.yml", "**/tycho.yaml"],
       "url": "https://deployments.allegrogroup.com/tycho/schema"
+    },
+    {
+      "name": "resticprofile",
+      "description": "Configuration profiles manager for restic backup",
+      "fileMatch": [
+        "profiles.json",
+        "profiles.yaml"
+      ],
+      "url": "https://creativeprojects.github.io/resticprofile/jsonschema/config-1.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6764,10 +6764,7 @@
     {
       "name": "resticprofile",
       "description": "Configuration profiles manager for restic backup",
-      "fileMatch": [
-        "profiles.json",
-        "profiles.yaml"
-      ],
+      "fileMatch": ["profiles.json", "profiles.yaml"],
       "url": "https://creativeprojects.github.io/resticprofile/jsonschema/config-1.json"
     }
   ]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.
-->
[resticprofile](https://creativeprojects.github.io) is a configuration profiles manager for [restic backup](https://restic.net)