### PR TITLE
Add shaders field to pubspec

### DIFF
--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -457,6 +457,22 @@
             },
             "required": ["family", "fonts"]
           }
+        },
+        "shaders": {
+          "title": "Fragment Shaders",
+          "description": "Shaders, in the form of GLSL files with the .frag extension. The Flutter command-line tool compiles the shader to its appropriate backend format, and generates its necessary runtime metadata. The compiled shader is then included in the application just like an asset. [Learn more](https://docs.flutter.dev/ui/design/graphics/fragment-shaders#adding-shaders-to-an-application)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Path to a GLSL shader",
+            "pattern": "\\.vert$",
+            "examples": [
+              "shaders/myshader.frag"
+            ]
+          },
+          "examples": [
+            [ "shaders/triangle.frag", "glsl/motion_blur.frag" ]
+          ]
         }
       }
     }

--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -465,7 +465,7 @@
           "items": {
             "type": "string",
             "description": "Path to a GLSL shader",
-            "pattern": "\\.vert$",
+            "pattern": "\\.frag$",
             "examples": ["shaders/myshader.frag"]
           },
           "examples": [["shaders/triangle.frag", "glsl/motion_blur.frag"]]

--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -466,13 +466,9 @@
             "type": "string",
             "description": "Path to a GLSL shader",
             "pattern": "\\.vert$",
-            "examples": [
-              "shaders/myshader.frag"
-            ]
+            "examples": ["shaders/myshader.frag"]
           },
-          "examples": [
-            [ "shaders/triangle.frag", "glsl/motion_blur.frag" ]
-          ]
+          "examples": [["shaders/triangle.frag", "glsl/motion_blur.frag"]]
         }
       }
     }

--- a/src/test/pubspec/shaders.yaml
+++ b/src/test/pubspec/shaders.yaml
@@ -1,0 +1,4 @@
+name: blender_4d
+flutter:
+  shaders:
+    - shaders/myshader.frag


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Sorry, I had forgotten to include [this field for adding custom fragment shaders](https://docs.flutter.dev/ui/design/graphics/fragment-shaders) in my previous PR.