### PR TITLE
Update Traefik JSON Schema

### DIFF
--- a/src/schemas/json/traefik-v2.json
+++ b/src/schemas/json/traefik-v2.json
@@ -1,58 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/traefik-v2.json",
-  "title": "Traefik v2 Static Configuration",
-  "properties": {
-    "accessLog": {
-      "$ref": "#/$defs/typesAccessLog"
-    },
-    "api": {
-      "$ref": "#/$defs/staticAPI"
-    },
-    "certificatesResolvers": {
-      "additionalProperties": {
-        "$ref": "#/$defs/staticCertificateResolver"
-      },
-      "type": "object"
-    },
-    "entryPoints": {
-      "additionalProperties": {
-        "$ref": "#/$defs/staticEntryPoint"
-      },
-      "type": "object"
-    },
-    "experimental": {
-      "$ref": "#/$defs/staticExperimental"
-    },
-    "global": {
-      "$ref": "#/$defs/staticGlobal"
-    },
-    "hostResolver": {
-      "$ref": "#/$defs/typesHostResolverConfig"
-    },
-    "log": {
-      "$ref": "#/$defs/typesTraefikLog"
-    },
-    "metrics": {
-      "$ref": "#/$defs/typesMetrics"
-    },
-    "pilot": {
-      "$ref": "#/$defs/staticPilot"
-    },
-    "ping": {
-      "$ref": "#/$defs/pingHandler"
-    },
-    "providers": {
-      "$ref": "#/$defs/staticProviders"
-    },
-    "serversTransport": {
-      "$ref": "#/$defs/staticServersTransport"
-    },
-    "tracing": {
-      "$ref": "#/$defs/staticTracing"
-    }
-  },
-  "type": "object",
   "$defs": {
     "acmeConfiguration": {
       "additionalProperties": false,
@@ -106,10 +54,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -146,10 +91,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "namespace": {
           "type": "string"
@@ -158,10 +100,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "rootKey": {
           "type": "string"
@@ -245,10 +184,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "prefix": {
           "type": "string"
@@ -299,10 +235,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "throttleDuration": {
           "type": "string"
@@ -407,10 +340,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "constraints": {
           "type": "string"
@@ -458,10 +388,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "password": {
           "type": "string"
@@ -512,10 +439,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "throttleDuration": {
           "type": "string"
@@ -569,9 +493,7 @@
           "$ref": "#/$defs/typesClientTLS"
         }
       },
-      "required": [
-        "endpoint"
-      ],
+      "required": ["endpoint"],
       "type": "object"
     },
     "ingressEndpointIngress": {
@@ -617,10 +539,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "throttleDuration": {
           "type": "string"
@@ -803,10 +722,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "prefix": {
           "type": "string"
@@ -896,10 +812,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "password": {
           "type": "string"
@@ -1064,10 +977,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1127,10 +1037,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "redirections": {
           "$ref": "#/$defs/staticRedirections"
@@ -1239,10 +1146,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1305,10 +1209,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1323,10 +1224,7 @@
           "items": {
             "$ref": "#/$defs/typesDomain"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "options": {
           "type": "string"
@@ -1425,10 +1323,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1488,10 +1383,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1641,10 +1533,7 @@
           "items": {
             "type": "number"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "entryPoint": {
           "type": "string"
@@ -1725,10 +1614,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "password": {
           "type": "string"
@@ -1742,5 +1628,57 @@
       },
       "type": "object"
     }
-  }
+  },
+  "title": "Traefik v2 Static Configuration",
+  "properties": {
+    "accessLog": {
+      "$ref": "#/$defs/typesAccessLog"
+    },
+    "api": {
+      "$ref": "#/$defs/staticAPI"
+    },
+    "certificatesResolvers": {
+      "additionalProperties": {
+        "$ref": "#/$defs/staticCertificateResolver"
+      },
+      "type": "object"
+    },
+    "entryPoints": {
+      "additionalProperties": {
+        "$ref": "#/$defs/staticEntryPoint"
+      },
+      "type": "object"
+    },
+    "experimental": {
+      "$ref": "#/$defs/staticExperimental"
+    },
+    "global": {
+      "$ref": "#/$defs/staticGlobal"
+    },
+    "hostResolver": {
+      "$ref": "#/$defs/typesHostResolverConfig"
+    },
+    "log": {
+      "$ref": "#/$defs/typesTraefikLog"
+    },
+    "metrics": {
+      "$ref": "#/$defs/typesMetrics"
+    },
+    "pilot": {
+      "$ref": "#/$defs/staticPilot"
+    },
+    "ping": {
+      "$ref": "#/$defs/pingHandler"
+    },
+    "providers": {
+      "$ref": "#/$defs/staticProviders"
+    },
+    "serversTransport": {
+      "$ref": "#/$defs/staticServersTransport"
+    },
+    "tracing": {
+      "$ref": "#/$defs/staticTracing"
+    }
+  },
+  "type": "object"
 }

--- a/src/schemas/json/traefik-v2.json
+++ b/src/schemas/json/traefik-v2.json
@@ -1,617 +1,827 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "additionalProperties": false,
-  "id": "https://json.schemastore.org/traefik-v2.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/traefik-v2.json",
+  "title": "Traefik v2 Static Configuration",
   "properties": {
     "accessLog": {
-      "type": "object",
-      "properties": {
-        "addInternals": {
-          "type": "boolean",
-          "default": false
-        },
-        "filePath": {
-          "type": "string"
-        },
-        "format": {
-          "type": "string"
-        },
-        "bufferingSize": {
-          "type": "integer"
-        },
-        "filters": {
-          "type": "object",
-          "properties": {
-            "statusCodes": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "retryAttempts": {
-              "type": "boolean"
-            },
-            "minDuration": {
-              "type": "string"
-            }
-          }
-        },
-        "fields": {
-          "type": "object",
-          "properties": {
-            "defaultMode": {
-              "type": "string"
-            },
-            "names": {
-              "type": "object",
-              "patternProperties": {
-                "[a-zA-Z0-9-_]+": {
-                  "type": "string"
-                }
-              }
-            },
-            "headers": {
-              "type": "object",
-              "properties": {
-                "defaultMode": {
-                  "type": "string"
-                },
-                "names": {
-                  "type": "object",
-                  "patternProperties": {
-                    "[a-zA-Z0-9-_]+": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "additionalProperties": false
+      "$ref": "#/$defs/typesAccessLog"
     },
     "api": {
-      "type": "object",
+      "$ref": "#/$defs/staticAPI"
+    },
+    "certificatesResolvers": {
+      "additionalProperties": {
+        "$ref": "#/$defs/staticCertificateResolver"
+      },
+      "type": "object"
+    },
+    "entryPoints": {
+      "additionalProperties": {
+        "$ref": "#/$defs/staticEntryPoint"
+      },
+      "type": "object"
+    },
+    "experimental": {
+      "$ref": "#/$defs/staticExperimental"
+    },
+    "global": {
+      "$ref": "#/$defs/staticGlobal"
+    },
+    "hostResolver": {
+      "$ref": "#/$defs/typesHostResolverConfig"
+    },
+    "log": {
+      "$ref": "#/$defs/typesTraefikLog"
+    },
+    "metrics": {
+      "$ref": "#/$defs/typesMetrics"
+    },
+    "pilot": {
+      "$ref": "#/$defs/staticPilot"
+    },
+    "ping": {
+      "$ref": "#/$defs/pingHandler"
+    },
+    "providers": {
+      "$ref": "#/$defs/staticProviders"
+    },
+    "serversTransport": {
+      "$ref": "#/$defs/staticServersTransport"
+    },
+    "tracing": {
+      "$ref": "#/$defs/staticTracing"
+    }
+  },
+  "type": "object",
+  "$defs": {
+    "acmeConfiguration": {
+      "additionalProperties": false,
       "properties": {
-        "insecure": {
+        "caServer": {
+          "type": "string"
+        },
+        "certificatesDuration": {
+          "type": "integer"
+        },
+        "dnsChallenge": {
+          "$ref": "#/$defs/acmeDNSChallenge"
+        },
+        "eab": {
+          "$ref": "#/$defs/acmeEAB"
+        },
+        "email": {
+          "type": "string"
+        },
+        "httpChallenge": {
+          "$ref": "#/$defs/acmeHTTPChallenge"
+        },
+        "keyType": {
+          "type": "string"
+        },
+        "preferredChain": {
+          "type": "string"
+        },
+        "storage": {
+          "type": "string"
+        },
+        "tlsChallenge": {
+          "$ref": "#/$defs/acmeTLSChallenge"
+        }
+      },
+      "type": "object"
+    },
+    "acmeDNSChallenge": {
+      "additionalProperties": false,
+      "properties": {
+        "delayBeforeCheck": {
+          "type": "string"
+        },
+        "disablePropagationCheck": {
           "type": "boolean"
         },
-        "dashboard": {
+        "provider": {
+          "type": "string"
+        },
+        "resolvers": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "acmeEAB": {
+      "additionalProperties": false,
+      "properties": {
+        "hmacEncoded": {
+          "type": "string"
+        },
+        "kid": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "acmeHTTPChallenge": {
+      "additionalProperties": false,
+      "properties": {
+        "entryPoint": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "acmeTLSChallenge": {
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "consulProviderBuilder": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "rootKey": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "consulcatalogEndpointConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "datacenter": {
+          "type": "string"
+        },
+        "endpointWaitTime": {
+          "type": "string"
+        },
+        "httpAuth": {
+          "$ref": "#/$defs/consulcatalogEndpointHTTPAuthConfig"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "consulcatalogEndpointHTTPAuthConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "consulcatalogProviderBuilder": {
+      "additionalProperties": false,
+      "properties": {
+        "cache": {
           "type": "boolean"
+        },
+        "connectAware": {
+          "type": "boolean"
+        },
+        "connectByDefault": {
+          "type": "boolean"
+        },
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "endpoint": {
+          "$ref": "#/$defs/consulcatalogEndpointConfig"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "requireConsistent": {
+          "type": "boolean"
+        },
+        "serviceName": {
+          "type": "string"
+        },
+        "stale": {
+          "type": "boolean"
+        },
+        "watch": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "crdProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "allowCrossNamespace": {
+          "type": "boolean"
+        },
+        "allowEmptyServices": {
+          "type": "boolean"
+        },
+        "allowExternalNameServices": {
+          "type": "boolean"
+        },
+        "certAuthFilePath": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "ingressClass": {
+          "type": "string"
+        },
+        "labelSelector": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "throttleDuration": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "datadogConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "bagagePrefixHeaderName": {
+          "type": "string"
         },
         "debug": {
           "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "certificatesResolvers": {
-      "type": "object",
-      "patternProperties": {
-        "[a-zA-Z0-9-_]+": {
-          "type": "object",
-          "properties": {
-            "acme": {
-              "type": "object",
-              "properties": {
-                "email": {
-                  "type": "string"
-                },
-                "caServer": {
-                  "type": "string"
-                },
-                "certificatesDuration": {
-                  "type": "integer"
-                },
-                "preferredChain": {
-                  "type": "string"
-                },
-                "storage": {
-                  "type": "string"
-                },
-                "keyType": {
-                  "type": "string"
-                },
-                "eab": {
-                  "type": "object",
-                  "properties": {
-                    "kid": {
-                      "type": "string"
-                    },
-                    "hmacEncoded": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "dnsChallenge": {
-                  "type": "object",
-                  "properties": {
-                    "provider": {
-                      "type": "string"
-                    },
-                    "delayBeforeCheck": {
-                      "type": "string"
-                    },
-                    "resolvers": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "disablePropagationCheck": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "httpChallenge": {
-                  "type": "object",
-                  "properties": {
-                    "entryPoint": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "tlsChallenge": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      }
-    },
-    "entryPoints": {
-      "type": "object",
-      "patternProperties": {
-        "[a-zA-Z0-9-_]+": {
-          "type": "object",
-          "properties": {
-            "address": {
-              "type": "string"
-            },
-            "transport": {
-              "type": "object",
-              "properties": {
-                "lifeCycle": {
-                  "type": "object",
-                  "properties": {
-                    "requestAcceptGraceTimeout": {
-                      "type": "string"
-                    },
-                    "graceTimeOut": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "respondingTimeouts": {
-                  "type": "object",
-                  "properties": {
-                    "readTimeout": {
-                      "type": "string"
-                    },
-                    "writeTimeout": {
-                      "type": "string"
-                    },
-                    "idleTimeout": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            },
-            "proxyProtocol": {
-              "type": "object",
-              "properties": {
-                "insecure": {
-                  "type": "boolean"
-                },
-                "trustedIPs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "forwardedHeaders": {
-              "type": "object",
-              "properties": {
-                "insecure": {
-                  "type": "boolean"
-                },
-                "trustedIPs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "http": {
-              "type": "object",
-              "properties": {
-                "redirections": {
-                  "type": "object",
-                  "properties": {
-                    "entryPoint": {
-                      "type": "object",
-                      "properties": {
-                        "to": {
-                          "type": "string"
-                        },
-                        "scheme": {
-                          "type": "string"
-                        },
-                        "permanent": {
-                          "type": "boolean"
-                        },
-                        "priority": {
-                          "type": "integer"
-                        }
-                      }
-                    }
-                  }
-                },
-                "middlewares": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "tls": {
-                  "type": "object",
-                  "properties": {
-                    "options": {
-                      "type": "string"
-                    },
-                    "certResolver": {
-                      "type": "string"
-                    },
-                    "domains": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "main": {
-                            "type": "string"
-                          },
-                          "sans": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "http2": {
-              "type": "object",
-              "properties": {
-                "maxConcurrentStreams": {
-                  "type": "integer"
-                }
-              }
-            },
-            "http3": {
-              "type": "object",
-              "properties": {
-                "advertisedPort": {
-                  "type": "integer"
-                }
-              }
-            },
-            "udp": {
-              "type": "object",
-              "properties": {
-                "timeout": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      }
-    },
-    "experimental": {
-      "type": "object",
-      "properties": {
-        "kubernetesGateway": {
-          "type": "boolean"
         },
-        "http3": {
-          "type": "boolean"
-        },
-        "hub": {
-          "type": "boolean"
-        },
-        "plugins": {
-          "type": "object",
-          "patternProperties": {
-            "[a-zA-Z0-9-_]+": {
-              "type": "object",
-              "properties": {
-                "moduleName": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        },
-        "localPlugins": {
-          "type": "object",
-          "patternProperties": {
-            "[a-zA-Z0-9-_]+": {
-              "type": "object",
-              "properties": {
-                "moduleName": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "global": {
-      "type": "object",
-      "properties": {
-        "checkNewVersion": {
-          "type": "boolean"
-        },
-        "sendAnonymousUsage": {
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "hostResolver": {
-      "type": "object",
-      "properties": {
-        "cnameFlattening": {
-          "type": "boolean"
-        },
-        "resolvConfig": {
+        "globalTag": {
           "type": "string"
         },
-        "resolvDepth": {
-          "type": "integer"
+        "globalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "localAgentHostPort": {
+          "type": "string"
+        },
+        "localAgentSocket": {
+          "type": "string"
+        },
+        "parentIDHeaderName": {
+          "type": "string"
+        },
+        "prioritySampling": {
+          "type": "boolean"
+        },
+        "samplingPriorityHeaderName": {
+          "type": "string"
+        },
+        "traceIDHeaderName": {
+          "type": "string"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
-    "hub": {
-      "type": "object",
+    "dockerProvider": {
+      "additionalProperties": false,
       "properties": {
+        "allowEmptyServices": {
+          "type": "boolean"
+        },
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "httpClientTimeout": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string"
+        },
+        "swarmMode": {
+          "type": "boolean"
+        },
+        "swarmModeRefreshSeconds": {
+          "type": "string"
+        },
         "tls": {
-          "type": "object",
-          "properties": {
-            "insecure": {
-              "type": "boolean"
-            },
-            "ca": {
-              "type": "string"
-            },
-            "cert": {
-              "type": "string"
-            },
-            "key": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "additionalProperties": false
-    },
-    "log": {
-      "type": "object",
-      "properties": {
-        "filePath": {
-          "type": "string"
+          "$ref": "#/$defs/typesClientTLS"
         },
-        "format": {
-          "type": "string"
-        },
-        "level": {
-          "type": "string"
-        },
-        "noColor": {
+        "useBindPortIP": {
           "type": "boolean"
         },
-        "maxSize": {
-          "type": "integer"
-        },
-        "maxBackups": {
-          "type": "integer"
-        },
-        "maxAge": {
-          "type": "integer"
-        },
-        "compress": {
+        "watch": {
           "type": "boolean"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
-    "metrics": {
-      "type": "object",
+    "ecsProvider": {
+      "additionalProperties": false,
       "properties": {
-        "prometheus": {
-          "type": "object",
-          "properties": {
-            "buckets": {
-              "type": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            "addEntryPointsLabels": {
-              "type": "boolean"
-            },
-            "addRoutersLabels": {
-              "type": "boolean"
-            },
-            "addServicesLabels": {
-              "type": "boolean"
-            },
-            "entryPoint": {
-              "type": "string"
-            },
-            "manualRouting": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
+        "accessKeyID": {
+          "type": "string"
         },
-        "datadog": {
-          "type": "object",
-          "properties": {
-            "address": {
-              "type": "string"
-            },
-            "pushInterval": {
-              "type": "string"
-            },
-            "addEntryPointsLabels": {
-              "type": "boolean"
-            },
-            "addRoutersLabels": {
-              "type": "boolean"
-            },
-            "addServicesLabels": {
-              "type": "boolean"
-            },
-            "prefix": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+        "autoDiscoverClusters": {
+          "type": "boolean"
         },
-        "statsD": {
-          "type": "object",
-          "properties": {
-            "address": {
-              "type": "string"
-            },
-            "pushInterval": {
-              "type": "string"
-            },
-            "addEntryPointsLabels": {
-              "type": "boolean"
-            },
-            "addRoutersLabels": {
-              "type": "boolean"
-            },
-            "addServicesLabels": {
-              "type": "boolean"
-            },
-            "prefix": {
-              "type": "string"
-            }
+        "clusters": {
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false
+          "type": [
+            "array",
+            "null"
+          ]
         },
-        "influxDB": {
-          "type": "object",
-          "properties": {
-            "address": {
-              "type": "string"
-            },
-            "protocol": {
-              "type": "string"
-            },
-            "pushInterval": {
-              "type": "string"
-            },
-            "database": {
-              "type": "string"
-            },
-            "retentionPolicy": {
-              "type": "string"
-            },
-            "username": {
-              "type": "string"
-            },
-            "password": {
-              "type": "string"
-            },
-            "addEntryPointsLabels": {
-              "type": "boolean"
-            },
-            "addRoutersLabels": {
-              "type": "boolean"
-            },
-            "addServicesLabels": {
-              "type": "boolean"
-            },
-            "additionalLabels": {
-              "type": "object"
-            }
-          },
-          "additionalProperties": false
+        "constraints": {
+          "type": "string"
         },
-        "influxDB2": {
-          "type": "object",
-          "properties": {
-            "address": {
-              "type": "string"
-            },
-            "token": {
-              "type": "string"
-            },
-            "pushInterval": {
-              "type": "string"
-            },
-            "org": {
-              "type": "string"
-            },
-            "bucket": {
-              "type": "string"
-            },
-            "addEntryPointsLabels": {
-              "type": "boolean"
-            },
-            "addRoutersLabels": {
-              "type": "boolean"
-            },
-            "addServicesLabels": {
-              "type": "boolean"
-            },
-            "additionalLabels": {
-              "type": "object"
-            }
-          },
-          "additionalProperties": false
+        "defaultRule": {
+          "type": "string"
+        },
+        "ecsAnywhere": {
+          "type": "boolean"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "refreshSeconds": {
+          "type": "integer"
+        },
+        "region": {
+          "type": "string"
+        },
+        "secretAccessKey": {
+          "type": "string"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
-    "pilot": {
-      "type": "object",
+    "elasticConfig": {
+      "additionalProperties": false,
       "properties": {
+        "secretToken": {
+          "type": "string"
+        },
+        "serverURL": {
+          "type": "string"
+        },
+        "serviceEnvironment": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "etcdProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "password": {
+          "type": "string"
+        },
+        "rootKey": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "fileProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "debugLogGeneratedTemplate": {
+          "type": "boolean"
+        },
+        "directory": {
+          "type": "string"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "watch": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "gatewayProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "certAuthFilePath": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "labelSelector": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "throttleDuration": {
+          "type": "string"
+        },
         "token": {
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "haystackConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "baggagePrefixHeaderName": {
+          "type": "string"
         },
-        "dashboard": {
+        "globalTag": {
+          "type": "string"
+        },
+        "localAgentHost": {
+          "type": "string"
+        },
+        "localAgentPort": {
+          "type": "integer"
+        },
+        "parentIDHeaderName": {
+          "type": "string"
+        },
+        "spanIDHeaderName": {
+          "type": "string"
+        },
+        "traceIDHeaderName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "httpProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "pollInterval": {
+          "type": "string"
+        },
+        "pollTimeout": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "type": "object"
+    },
+    "ingressEndpointIngress": {
+      "additionalProperties": false,
+      "properties": {
+        "hostname": {
+          "type": "string"
+        },
+        "ip": {
+          "type": "string"
+        },
+        "publishedService": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ingressProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "allowEmptyServices": {
+          "type": "boolean"
+        },
+        "allowExternalNameServices": {
+          "type": "boolean"
+        },
+        "certAuthFilePath": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "ingressClass": {
+          "type": "string"
+        },
+        "ingressEndpoint": {
+          "$ref": "#/$defs/ingressEndpointIngress"
+        },
+        "labelSelector": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "throttleDuration": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "instanaConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "enableAutoProfile": {
+          "type": "boolean"
+        },
+        "localAgentHost": {
+          "type": "string"
+        },
+        "localAgentPort": {
+          "type": "integer"
+        },
+        "logLevel": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "jaegerCollector": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "jaegerConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "collector": {
+          "$ref": "#/$defs/jaegerCollector"
+        },
+        "disableAttemptReconnecting": {
+          "type": "boolean"
+        },
+        "gen128Bit": {
+          "type": "boolean"
+        },
+        "localAgentHostPort": {
+          "type": "string"
+        },
+        "propagation": {
+          "type": "string"
+        },
+        "samplingParam": {
+          "type": "number"
+        },
+        "samplingServerURL": {
+          "type": "string"
+        },
+        "samplingType": {
+          "type": "string"
+        },
+        "traceContextHeaderName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "marathonBasic": {
+      "additionalProperties": false,
+      "properties": {
+        "httpBasicAuthUser": {
+          "type": "string"
+        },
+        "httpBasicPassword": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "marathonProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "basic": {
+          "$ref": "#/$defs/marathonBasic"
+        },
+        "constraints": {
+          "type": "string"
+        },
+        "dcosToken": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "dialerTimeout": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "forceTaskHostname": {
+          "type": "boolean"
+        },
+        "keepAlive": {
+          "type": "string"
+        },
+        "respectReadinessChecks": {
+          "type": "boolean"
+        },
+        "responseHeaderTimeout": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "tlsHandshakeTimeout": {
+          "type": "string"
+        },
+        "trace": {
+          "type": "boolean"
+        },
+        "watch": {
           "type": "boolean"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
-    "ping": {
-      "type": "object",
+    "nomadEndpointConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "endpointWaitTime": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "nomadProviderBuilder": {
+      "additionalProperties": false,
+      "properties": {
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "endpoint": {
+          "$ref": "#/$defs/nomadEndpointConfig"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "stale": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "pingHandler": {
+      "additionalProperties": false,
       "properties": {
         "entryPoint": {
           "type": "string"
@@ -623,966 +833,914 @@
           "type": "integer"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
-    "providers": {
-      "type": "object",
+    "pluginsDescriptor": {
+      "additionalProperties": false,
       "properties": {
+        "moduleName": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "pluginsLocalDescriptor": {
+      "additionalProperties": false,
+      "properties": {
+        "moduleName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "rancherProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "enableServiceHealthFilter": {
+          "type": "boolean"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "intervalPoll": {
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "refreshSeconds": {
+          "type": "integer"
+        },
+        "watch": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "redisProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "db": {
+          "type": "integer"
+        },
+        "endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "password": {
+          "type": "string"
+        },
+        "rootKey": {
+          "type": "string"
+        },
+        "sentinel": {
+          "$ref": "#/$defs/redisSentinel"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "redisSentinel": {
+      "additionalProperties": false,
+      "properties": {
+        "latencyStrategy": {
+          "type": "boolean"
+        },
+        "masterName": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "randomStrategy": {
+          "type": "boolean"
+        },
+        "replicaStrategy": {
+          "type": "boolean"
+        },
+        "useDisconnectedReplicas": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "restProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "insecure": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "staticAPI": {
+      "additionalProperties": false,
+      "properties": {
+        "dashboard": {
+          "type": "boolean"
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "disableDashboardAd": {
+          "type": "boolean"
+        },
+        "insecure": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "staticCertificateResolver": {
+      "additionalProperties": false,
+      "properties": {
+        "acme": {
+          "$ref": "#/$defs/acmeConfiguration"
+        }
+      },
+      "type": "object"
+    },
+    "staticEntryPoint": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "forwardedHeaders": {
+          "$ref": "#/$defs/staticForwardedHeaders"
+        },
+        "http": {
+          "$ref": "#/$defs/staticHTTPConfig"
+        },
+        "http2": {
+          "$ref": "#/$defs/staticHTTP2Config"
+        },
+        "http3": {
+          "$ref": "#/$defs/staticHTTP3Config"
+        },
+        "proxyProtocol": {
+          "$ref": "#/$defs/staticProxyProtocol"
+        },
+        "transport": {
+          "$ref": "#/$defs/staticEntryPointsTransport"
+        },
+        "udp": {
+          "$ref": "#/$defs/staticUDPConfig"
+        }
+      },
+      "type": "object"
+    },
+    "staticEntryPointsTransport": {
+      "additionalProperties": false,
+      "properties": {
+        "keepAliveMaxRequests": {
+          "type": "integer"
+        },
+        "keepAliveMaxTime": {
+          "type": "string"
+        },
+        "lifeCycle": {
+          "$ref": "#/$defs/staticLifeCycle"
+        },
+        "respondingTimeouts": {
+          "$ref": "#/$defs/staticRespondingTimeouts"
+        }
+      },
+      "type": "object"
+    },
+    "staticExperimental": {
+      "additionalProperties": false,
+      "properties": {
+        "http3": {
+          "type": "boolean"
+        },
+        "kubernetesGateway": {
+          "type": "boolean"
+        },
+        "localPlugins": {
+          "additionalProperties": {
+            "$ref": "#/$defs/pluginsLocalDescriptor"
+          },
+          "type": "object"
+        },
+        "plugins": {
+          "additionalProperties": {
+            "$ref": "#/$defs/pluginsDescriptor"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "staticForwardedHeaders": {
+      "additionalProperties": false,
+      "properties": {
+        "insecure": {
+          "type": "boolean"
+        },
+        "trustedIPs": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "staticForwardingTimeouts": {
+      "additionalProperties": false,
+      "properties": {
+        "dialTimeout": {
+          "type": "string"
+        },
+        "idleConnTimeout": {
+          "type": "string"
+        },
+        "responseHeaderTimeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticGlobal": {
+      "additionalProperties": false,
+      "properties": {
+        "checkNewVersion": {
+          "type": "boolean"
+        },
+        "sendAnonymousUsage": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "staticHTTP2Config": {
+      "additionalProperties": false,
+      "properties": {
+        "maxConcurrentStreams": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "staticHTTP3Config": {
+      "additionalProperties": false,
+      "properties": {
+        "advertisedPort": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "staticHTTPConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "encodeQuerySemicolons": {
+          "type": "boolean"
+        },
+        "middlewares": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "redirections": {
+          "$ref": "#/$defs/staticRedirections"
+        },
+        "tls": {
+          "$ref": "#/$defs/staticTLSConfig"
+        }
+      },
+      "type": "object"
+    },
+    "staticLifeCycle": {
+      "additionalProperties": false,
+      "properties": {
+        "graceTimeOut": {
+          "type": "string"
+        },
+        "requestAcceptGraceTimeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticPilot": {
+      "additionalProperties": false,
+      "properties": {
+        "dashboard": {
+          "type": "boolean"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticProviders": {
+      "additionalProperties": false,
+      "properties": {
+        "consul": {
+          "$ref": "#/$defs/consulProviderBuilder"
+        },
+        "consulCatalog": {
+          "$ref": "#/$defs/consulcatalogProviderBuilder"
+        },
+        "docker": {
+          "$ref": "#/$defs/dockerProvider"
+        },
+        "ecs": {
+          "$ref": "#/$defs/ecsProvider"
+        },
+        "etcd": {
+          "$ref": "#/$defs/etcdProvider"
+        },
+        "file": {
+          "$ref": "#/$defs/fileProvider"
+        },
+        "http": {
+          "$ref": "#/$defs/httpProvider"
+        },
+        "kubernetesCRD": {
+          "$ref": "#/$defs/crdProvider"
+        },
+        "kubernetesGateway": {
+          "$ref": "#/$defs/gatewayProvider"
+        },
+        "kubernetesIngress": {
+          "$ref": "#/$defs/ingressProvider"
+        },
+        "marathon": {
+          "$ref": "#/$defs/marathonProvider"
+        },
+        "nomad": {
+          "$ref": "#/$defs/nomadProviderBuilder"
+        },
+        "plugin": {
+          "additionalProperties": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "type": "object"
+        },
         "providersThrottleDuration": {
           "type": "string"
         },
-        "docker": {
-          "type": "object",
-          "properties": {
-            "allowEmptyServices": {
-              "type": "boolean"
-            },
-            "constraints": {
-              "type": "string"
-            },
-            "defaultRule": {
-              "type": "string"
-            },
-            "endpoint": {
-              "type": "string"
-            },
-            "exposedByDefault": {
-              "type": "boolean"
-            },
-            "httpClientTimeout": {
-              "type": "integer"
-            },
-            "network": {
-              "type": "string"
-            },
-            "swarmMode": {
-              "type": "boolean"
-            },
-            "swarmModeRefreshSeconds": {
-              "type": "string"
-            },
-            "tls": {
-              "type": "object",
-              "properties": {
-                "ca": {
-                  "type": "string"
-                },
-                "caOptional": {
-                  "type": "boolean"
-                },
-                "cert": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "string"
-                },
-                "insecureSkipVerify": {
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
-            },
-            "useBindPortIP": {
-              "type": "boolean"
-            },
-            "watch": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "file": {
-          "type": "object",
-          "properties": {
-            "directory": {
-              "type": "string"
-            },
-            "watch": {
-              "type": "boolean"
-            },
-            "filename": {
-              "type": "string"
-            },
-            "debugLogGeneratedTemplate": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "marathon": {
-          "type": "object",
-          "properties": {
-            "constraints": {
-              "type": "string"
-            },
-            "trace": {
-              "type": "boolean"
-            },
-            "watch": {
-              "type": "boolean"
-            },
-            "endpoint": {
-              "type": "string"
-            },
-            "defaultRule": {
-              "type": "string"
-            },
-            "exposedByDefault": {
-              "type": "boolean"
-            },
-            "dcosToken": {
-              "type": "string"
-            },
-            "tls": {
-              "type": "object",
-              "properties": {
-                "ca": {
-                  "type": "string"
-                },
-                "caOptional": {
-                  "type": "boolean"
-                },
-                "cert": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "string"
-                },
-                "insecureSkipVerify": {
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
-            },
-            "dialerTimeout": {
-              "type": "string"
-            },
-            "responseHeaderTimeout": {
-              "type": "string"
-            },
-            "tlsHandshakeTimeout": {
-              "type": "string"
-            },
-            "keepAlive": {
-              "type": "string"
-            },
-            "forceTaskHostname": {
-              "type": "boolean"
-            },
-            "basic": {
-              "type": "object",
-              "properties": {
-                "httpBasicAuthUser": {
-                  "type": "string"
-                },
-                "httpBasicPassword": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            },
-            "respectReadinessChecks": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "kubernetesIngress": {
-          "type": "object",
-          "properties": {
-            "endpoint": {
-              "type": "string"
-            },
-            "token": {
-              "type": "string"
-            },
-            "certAuthFilePath": {
-              "type": "string"
-            },
-            "namespaces": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "labelSelector": {
-              "type": "string"
-            },
-            "ingressClass": {
-              "type": "string"
-            },
-            "throttleDuration": {
-              "type": "string"
-            },
-            "allowEmptyServices": {
-              "type": "boolean"
-            },
-            "allowExternalNameServices": {
-              "type": "boolean"
-            },
-            "ingressEndpoint": {
-              "type": "object",
-              "properties": {
-                "ip": {
-                  "type": "string"
-                },
-                "hostname": {
-                  "type": "string"
-                },
-                "publishedService": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        "kubernetesCRD": {
-          "type": "object",
-          "properties": {
-            "endpoint": {
-              "type": "string"
-            },
-            "token": {
-              "type": "string"
-            },
-            "certAuthFilePath": {
-              "type": "string"
-            },
-            "namespaces": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "allowCrossNamespace": {
-              "type": "boolean"
-            },
-            "allowExternalNameServices": {
-              "type": "boolean"
-            },
-            "labelSelector": {
-              "type": "string"
-            },
-            "ingressClass": {
-              "type": "string"
-            },
-            "throttleDuration": {
-              "type": "string"
-            },
-            "allowEmptyServices": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "kubernetesGateway": {
-          "type": "object",
-          "properties": {
-            "endpoint": {
-              "type": "string"
-            },
-            "token": {
-              "type": "string"
-            },
-            "certAuthFilePath": {
-              "type": "string"
-            },
-            "namespaces": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "labelSelector": {
-              "type": "string"
-            },
-            "statusAddress": {
-              "type": "object",
-              "properties": {
-                "ip": {
-                  "type": "string"
-                },
-                "hostname": {
-                  "type": "string"
-                },
-                "service": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "namespace": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            },
-            "throttleDuration": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        "rest": {
-          "type": "object",
-          "properties": {
-            "insecure": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
         "rancher": {
-          "type": "object",
-          "properties": {
-            "constraints": {
-              "type": "string"
-            },
-            "watch": {
-              "type": "boolean"
-            },
-            "defaultRule": {
-              "type": "string"
-            },
-            "exposedByDefault": {
-              "type": "boolean"
-            },
-            "enableServiceHealthFilter": {
-              "type": "boolean"
-            },
-            "refreshSeconds": {
-              "type": "integer"
-            },
-            "intervalPoll": {
-              "type": "boolean"
-            },
-            "prefix": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        "consulCatalog": {
-          "type": "object",
-          "properties": {
-            "constraints": {
-              "type": "string"
-            },
-            "prefix": {
-              "type": "string"
-            },
-            "refreshInterval": {
-              "type": "string"
-            },
-            "requireConsistent": {
-              "type": "boolean"
-            },
-            "stale": {
-              "type": "boolean"
-            },
-            "cache": {
-              "type": "boolean"
-            },
-            "exposedByDefault": {
-              "type": "boolean"
-            },
-            "defaultRule": {
-              "type": "string"
-            },
-            "connectAware": {
-              "type": "boolean"
-            },
-            "connectByDefault": {
-              "type": "boolean"
-            },
-            "serviceName": {
-              "type": "string"
-            },
-            "namespace": {
-              "type": "string"
-            },
-            "namespaces": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "watch": {
-              "type": "boolean"
-            },
-            "endpoint": {
-              "type": "object",
-              "properties": {
-                "address": {
-                  "type": "string"
-                },
-                "scheme": {
-                  "type": "string"
-                },
-                "datacenter": {
-                  "type": "string"
-                },
-                "token": {
-                  "type": "string"
-                },
-                "endpointWaitTime": {
-                  "type": "string"
-                },
-                "tls": {
-                  "type": "object",
-                  "properties": {
-                    "ca": {
-                      "type": "string"
-                    },
-                    "caOptional": {
-                      "type": "boolean"
-                    },
-                    "cert": {
-                      "type": "string"
-                    },
-                    "key": {
-                      "type": "string"
-                    },
-                    "insecureSkipVerify": {
-                      "type": "boolean"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "httpAuth": {
-                  "type": "object",
-                  "properties": {
-                    "username": {
-                      "type": "string"
-                    },
-                    "password": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        },
-        "nomad": {
-          "type": "object",
-          "properties": {
-            "constraints": {
-              "type": "string"
-            },
-            "prefix": {
-              "type": "string"
-            },
-            "refreshInterval": {
-              "type": "string"
-            },
-            "stale": {
-              "type": "boolean"
-            },
-            "exposedByDefault": {
-              "type": "boolean"
-            },
-            "defaultRule": {
-              "type": "string"
-            },
-            "namespace": {
-              "type": "string"
-            },
-            "endpoint": {
-              "type": "object",
-              "properties": {
-                "address": {
-                  "type": "string"
-                },
-                "region": {
-                  "type": "string"
-                },
-                "token": {
-                  "type": "string"
-                },
-                "endpointWaitTime": {
-                  "type": "string"
-                },
-                "tls": {
-                  "type": "object",
-                  "properties": {
-                    "ca": {
-                      "type": "string"
-                    },
-                    "caOptional": {
-                      "type": "boolean"
-                    },
-                    "cert": {
-                      "type": "string"
-                    },
-                    "key": {
-                      "type": "string"
-                    },
-                    "insecureSkipVerify": {
-                      "type": "boolean"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        "ecs": {
-          "type": "object",
-          "properties": {
-            "constraints": {
-              "type": "string"
-            },
-            "exposedByDefault": {
-              "type": "boolean"
-            },
-            "ecsAnywhere": {
-              "type": "boolean"
-            },
-            "refreshSeconds": {
-              "type": "integer"
-            },
-            "defaultRule": {
-              "type": "string"
-            },
-            "clusters": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "autoDiscoverClusters": {
-              "type": "boolean"
-            },
-            "region": {
-              "type": "string"
-            },
-            "accessKeyID": {
-              "type": "string"
-            },
-            "secretAccessKey": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        "consul": {
-          "type": "object",
-          "properties": {
-            "rootKey": {
-              "type": "string"
-            },
-            "endpoints": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "token": {
-              "type": "string"
-            },
-            "namespace": {
-              "type": "string"
-            },
-            "namespaces": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "tls": {
-              "type": "object",
-              "properties": {
-                "ca": {
-                  "type": "string"
-                },
-                "caOptional": {
-                  "type": "boolean"
-                },
-                "cert": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "string"
-                },
-                "insecureSkipVerify": {
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        "etcd": {
-          "type": "object",
-          "properties": {
-            "rootKey": {
-              "type": "string"
-            },
-            "endpoints": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "username": {
-              "type": "string"
-            },
-            "password": {
-              "type": "string"
-            },
-            "tls": {
-              "type": "object",
-              "properties": {
-                "ca": {
-                  "type": "string"
-                },
-                "caOptional": {
-                  "type": "boolean"
-                },
-                "cert": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "string"
-                },
-                "insecureSkipVerify": {
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        "zooKeeper": {
-          "type": "object",
-          "properties": {
-            "rootKey": {
-              "type": "string"
-            },
-            "endpoints": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "username": {
-              "type": "string"
-            },
-            "password": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/rancherProvider"
         },
         "redis": {
-          "type": "object",
-          "properties": {
-            "rootKey": {
-              "type": "string"
-            },
-            "endpoints": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "username": {
-              "type": "string"
-            },
-            "password": {
-              "type": "string"
-            },
-            "db": {
-              "type": "integer"
-            },
-            "tls": {
-              "type": "object",
-              "properties": {
-                "ca": {
-                  "type": "string"
-                },
-                "caOptional": {
-                  "type": "boolean"
-                },
-                "cert": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "string"
-                },
-                "insecureSkipVerify": {
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/redisProvider"
         },
-        "http": {
-          "type": "object",
-          "properties": {
-            "endpoint": {
-              "type": "string"
-            },
-            "pollInterval": {
-              "type": "string"
-            },
-            "pollTimeout": {
-              "type": "string"
-            },
-            "tls": {
-              "type": "object",
-              "properties": {
-                "ca": {
-                  "type": "string"
-                },
-                "caOptional": {
-                  "type": "boolean"
-                },
-                "cert": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "string"
-                },
-                "insecureSkipVerify": {
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
+        "rest": {
+          "$ref": "#/$defs/restProvider"
         },
-        "plugin": {
-          "type": "object",
-          "patternProperties": {
-            "[a-zA-Z0-9-_]+": {
-              "type": "object"
-            }
-          }
+        "zooKeeper": {
+          "$ref": "#/$defs/zkProvider"
         }
-      }
+      },
+      "type": "object"
     },
-    "serversTransport": {
-      "type": "object",
+    "staticProxyProtocol": {
+      "additionalProperties": false,
       "properties": {
-        "insecureSkipVerify": {
+        "insecure": {
           "type": "boolean"
         },
-        "rootCAs": {
-          "type": "array",
+        "trustedIPs": {
           "items": {
             "type": "string"
-          }
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "staticRedirectEntryPoint": {
+      "additionalProperties": false,
+      "properties": {
+        "permanent": {
+          "type": "boolean"
+        },
+        "priority": {
+          "type": "integer"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticRedirections": {
+      "additionalProperties": false,
+      "properties": {
+        "entryPoint": {
+          "$ref": "#/$defs/staticRedirectEntryPoint"
+        }
+      },
+      "type": "object"
+    },
+    "staticRespondingTimeouts": {
+      "additionalProperties": false,
+      "properties": {
+        "idleTimeout": {
+          "type": "string"
+        },
+        "readTimeout": {
+          "type": "string"
+        },
+        "writeTimeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticServersTransport": {
+      "additionalProperties": false,
+      "properties": {
+        "forwardingTimeouts": {
+          "$ref": "#/$defs/staticForwardingTimeouts"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
         },
         "maxIdleConnsPerHost": {
           "type": "integer"
         },
-        "forwardingTimeouts": {
-          "type": "object",
-          "properties": {
-            "dialTimeout": {
-              "type": "string"
-            },
-            "responseHeaderTimeout": {
-              "type": "string"
-            },
-            "idleConnTimeout": {
-              "type": "string"
-            }
+        "rootCAs": {
+          "items": {
+            "type": "string"
           },
-          "additionalProperties": false
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
-    "tracing": {
-      "type": "object",
+    "staticTLSConfig": {
+      "additionalProperties": false,
       "properties": {
+        "certResolver": {
+          "type": "string"
+        },
+        "domains": {
+          "items": {
+            "$ref": "#/$defs/typesDomain"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticTracing": {
+      "additionalProperties": false,
+      "properties": {
+        "datadog": {
+          "$ref": "#/$defs/datadogConfig"
+        },
+        "elastic": {
+          "$ref": "#/$defs/elasticConfig"
+        },
+        "haystack": {
+          "$ref": "#/$defs/haystackConfig"
+        },
+        "instana": {
+          "$ref": "#/$defs/instanaConfig"
+        },
+        "jaeger": {
+          "$ref": "#/$defs/jaegerConfig"
+        },
         "serviceName": {
           "type": "string"
         },
         "spanNameLimit": {
           "type": "integer"
         },
-        "jaeger": {
-          "type": "object",
-          "properties": {
-            "samplingServerURL": {
-              "type": "string"
-            },
-            "samplingType": {
-              "type": "string"
-            },
-            "samplingParam": {
-              "type": "integer"
-            },
-            "localAgentHostPort": {
-              "type": "string"
-            },
-            "gen128Bit": {
-              "type": "boolean"
-            },
-            "propagation": {
-              "type": "string"
-            },
-            "traceContextHeaderName": {
-              "type": "string"
-            },
-            "disableAttemptReconnecting": {
-              "type": "boolean"
-            },
-            "collector": {
-              "type": "object",
-              "properties": {
-                "endpoint": {
-                  "type": "string"
-                },
-                "user": {
-                  "type": "string"
-                },
-                "password": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
         "zipkin": {
-          "type": "object",
-          "properties": {
-            "httpEndpoint": {
-              "type": "string"
-            },
-            "sameSpan": {
-              "type": "boolean"
-            },
-            "id128Bit": {
-              "type": "boolean"
-            },
-            "sampleRate": {
-              "type": "integer"
-            }
-          },
-          "additionalProperties": false
-        },
-        "datadog": {
-          "type": "object",
-          "properties": {
-            "localAgentHostPort": {
-              "type": "string"
-            },
-            "globalTag": {
-              "type": "string"
-            },
-            "globalTags": {
-              "type": "object",
-              "description": "Sets a list of key:value tags on all spans.",
-              "patternProperties": {
-                "[a-zA-Z0-9-_]+": {
-                  "type": "string"
-                }
-              }
-            },
-            "debug": {
-              "type": "boolean"
-            },
-            "prioritySampling": {
-              "type": "boolean"
-            },
-            "traceIDHeaderName": {
-              "type": "string"
-            },
-            "parentIDHeaderName": {
-              "type": "string"
-            },
-            "samplingPriorityHeaderName": {
-              "type": "string"
-            },
-            "bagagePrefixHeaderName": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        "instana": {
-          "type": "object",
-          "properties": {
-            "localAgentHost": {
-              "type": "string"
-            },
-            "localAgentPort": {
-              "type": "integer"
-            },
-            "logLevel": {
-              "type": "string"
-            },
-            "enableAutoProfile": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "haystack": {
-          "type": "object",
-          "properties": {
-            "localAgentHost": {
-              "type": "string"
-            },
-            "localAgentPort": {
-              "type": "integer"
-            },
-            "globalTag": {
-              "type": "string"
-            },
-            "traceIDHeaderName": {
-              "type": "string"
-            },
-            "parentIDHeaderName": {
-              "type": "string"
-            },
-            "spanIDHeaderName": {
-              "type": "string"
-            },
-            "baggagePrefixHeaderName": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        "elastic": {
-          "type": "object",
-          "properties": {
-            "serverURL": {
-              "type": "string"
-            },
-            "secretToken": {
-              "type": "string"
-            },
-            "serviceEnvironment": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/zipkinConfig"
         }
       },
-      "additionalProperties": false
+      "type": "object"
+    },
+    "staticUDPConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "timeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesAccessLog": {
+      "additionalProperties": false,
+      "properties": {
+        "bufferingSize": {
+          "type": "integer"
+        },
+        "fields": {
+          "$ref": "#/$defs/typesAccessLogFields"
+        },
+        "filePath": {
+          "type": "string"
+        },
+        "filters": {
+          "$ref": "#/$defs/typesAccessLogFilters"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesAccessLogFields": {
+      "additionalProperties": false,
+      "properties": {
+        "defaultMode": {
+          "type": "string"
+        },
+        "headers": {
+          "$ref": "#/$defs/typesFieldHeaders"
+        },
+        "names": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "typesAccessLogFilters": {
+      "additionalProperties": false,
+      "properties": {
+        "minDuration": {
+          "type": "string"
+        },
+        "retryAttempts": {
+          "type": "boolean"
+        },
+        "statusCodes": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "typesClientTLS": {
+      "additionalProperties": false,
+      "properties": {
+        "ca": {
+          "type": "string"
+        },
+        "caOptional": {
+          "type": "boolean"
+        },
+        "cert": {
+          "type": "string"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesDatadog": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "address": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "pushInterval": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesDomain": {
+      "additionalProperties": false,
+      "properties": {
+        "main": {
+          "type": "string"
+        },
+        "sans": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "typesFieldHeaders": {
+      "additionalProperties": false,
+      "properties": {
+        "defaultMode": {
+          "type": "string"
+        },
+        "names": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "typesHostResolverConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "cnameFlattening": {
+          "type": "boolean"
+        },
+        "resolvConfig": {
+          "type": "string"
+        },
+        "resolvDepth": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "typesInfluxDB": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "additionalLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "address": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "pushInterval": {
+          "type": "string"
+        },
+        "retentionPolicy": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesInfluxDB2": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "additionalLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "address": {
+          "type": "string"
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "org": {
+          "type": "string"
+        },
+        "pushInterval": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesMetrics": {
+      "additionalProperties": false,
+      "properties": {
+        "datadog": {
+          "$ref": "#/$defs/typesDatadog"
+        },
+        "influxDB": {
+          "$ref": "#/$defs/typesInfluxDB"
+        },
+        "influxDB2": {
+          "$ref": "#/$defs/typesInfluxDB2"
+        },
+        "prometheus": {
+          "$ref": "#/$defs/typesPrometheus"
+        },
+        "statsD": {
+          "$ref": "#/$defs/typesStatsd"
+        }
+      },
+      "type": "object"
+    },
+    "typesPrometheus": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "buckets": {
+          "items": {
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "entryPoint": {
+          "type": "string"
+        },
+        "headerLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "manualRouting": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "typesStatsd": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "address": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "pushInterval": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesTraefikLog": {
+      "additionalProperties": false,
+      "properties": {
+        "filePath": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "level": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "zipkinConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "httpEndpoint": {
+          "type": "string"
+        },
+        "id128Bit": {
+          "type": "boolean"
+        },
+        "sameSpan": {
+          "type": "boolean"
+        },
+        "sampleRate": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "zkProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "password": {
+          "type": "string"
+        },
+        "rootKey": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
-  },
-  "type": "object"
+  }
 }

--- a/src/schemas/json/traefik-v3.json
+++ b/src/schemas/json/traefik-v3.json
@@ -1,0 +1,1771 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/traefik-v3.json",
+  "title": "Traefik v3 Static Configuration",
+  "properties": {
+    "accessLog": {
+      "$ref": "#/$defs/typesAccessLog"
+    },
+    "api": {
+      "$ref": "#/$defs/staticAPI"
+    },
+    "certificatesResolvers": {
+      "additionalProperties": {
+        "$ref": "#/$defs/staticCertificateResolver"
+      },
+      "type": "object"
+    },
+    "core": {
+      "$ref": "#/$defs/staticCore"
+    },
+    "entryPoints": {
+      "additionalProperties": {
+        "$ref": "#/$defs/staticEntryPoint"
+      },
+      "type": "object"
+    },
+    "experimental": {
+      "$ref": "#/$defs/staticExperimental"
+    },
+    "global": {
+      "$ref": "#/$defs/staticGlobal"
+    },
+    "hostResolver": {
+      "$ref": "#/$defs/typesHostResolverConfig"
+    },
+    "log": {
+      "$ref": "#/$defs/typesTraefikLog"
+    },
+    "metrics": {
+      "$ref": "#/$defs/typesMetrics"
+    },
+    "ping": {
+      "$ref": "#/$defs/pingHandler"
+    },
+    "providers": {
+      "$ref": "#/$defs/staticProviders"
+    },
+    "serversTransport": {
+      "$ref": "#/$defs/staticServersTransport"
+    },
+    "spiffe": {
+      "$ref": "#/$defs/staticSpiffeClientConfig"
+    },
+    "tcpServersTransport": {
+      "$ref": "#/$defs/staticTCPServersTransport"
+    },
+    "tracing": {
+      "$ref": "#/$defs/staticTracing"
+    }
+  },
+  "type": "object",
+  "$defs": {
+    "CertificateResolverTailscaleStruct": {
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "acmeConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "caServer": {
+          "type": "string"
+        },
+        "certificatesDuration": {
+          "type": "integer"
+        },
+        "dnsChallenge": {
+          "$ref": "#/$defs/acmeDNSChallenge"
+        },
+        "eab": {
+          "$ref": "#/$defs/acmeEAB"
+        },
+        "email": {
+          "type": "string"
+        },
+        "httpChallenge": {
+          "$ref": "#/$defs/acmeHTTPChallenge"
+        },
+        "keyType": {
+          "type": "string"
+        },
+        "preferredChain": {
+          "type": "string"
+        },
+        "storage": {
+          "type": "string"
+        },
+        "tlsChallenge": {
+          "$ref": "#/$defs/acmeTLSChallenge"
+        }
+      },
+      "type": "object"
+    },
+    "acmeDNSChallenge": {
+      "additionalProperties": false,
+      "properties": {
+        "delayBeforeCheck": {
+          "type": "string"
+        },
+        "disablePropagationCheck": {
+          "type": "boolean"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "resolvers": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "acmeEAB": {
+      "additionalProperties": false,
+      "properties": {
+        "hmacEncoded": {
+          "type": "string"
+        },
+        "kid": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "acmeHTTPChallenge": {
+      "additionalProperties": false,
+      "properties": {
+        "entryPoint": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "acmeTLSChallenge": {
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "consulProviderBuilder": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "rootKey": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "consulcatalogEndpointConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "datacenter": {
+          "type": "string"
+        },
+        "endpointWaitTime": {
+          "type": "string"
+        },
+        "httpAuth": {
+          "$ref": "#/$defs/consulcatalogEndpointHTTPAuthConfig"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "consulcatalogEndpointHTTPAuthConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "consulcatalogProviderBuilder": {
+      "additionalProperties": false,
+      "properties": {
+        "cache": {
+          "type": "boolean"
+        },
+        "connectAware": {
+          "type": "boolean"
+        },
+        "connectByDefault": {
+          "type": "boolean"
+        },
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "endpoint": {
+          "$ref": "#/$defs/consulcatalogEndpointConfig"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "requireConsistent": {
+          "type": "boolean"
+        },
+        "serviceName": {
+          "type": "string"
+        },
+        "stale": {
+          "type": "boolean"
+        },
+        "strictChecks": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "watch": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "crdProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "allowCrossNamespace": {
+          "type": "boolean"
+        },
+        "allowEmptyServices": {
+          "type": "boolean"
+        },
+        "allowExternalNameServices": {
+          "type": "boolean"
+        },
+        "certAuthFilePath": {
+          "type": "string"
+        },
+        "disableClusterScopeResources": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "ingressClass": {
+          "type": "string"
+        },
+        "labelSelector": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "nativeLBByDefault": {
+          "type": "boolean"
+        },
+        "throttleDuration": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "dockerProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "allowEmptyServices": {
+          "type": "boolean"
+        },
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "httpClientTimeout": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "useBindPortIP": {
+          "type": "boolean"
+        },
+        "watch": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "dockerSwarmProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "allowEmptyServices": {
+          "type": "boolean"
+        },
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "httpClientTimeout": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string"
+        },
+        "refreshSeconds": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "useBindPortIP": {
+          "type": "boolean"
+        },
+        "watch": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ecsProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "accessKeyID": {
+          "type": "string"
+        },
+        "autoDiscoverClusters": {
+          "type": "boolean"
+        },
+        "clusters": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "ecsAnywhere": {
+          "type": "boolean"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "healthyTasksOnly": {
+          "type": "boolean"
+        },
+        "refreshSeconds": {
+          "type": "integer"
+        },
+        "region": {
+          "type": "string"
+        },
+        "secretAccessKey": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "etcdProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "password": {
+          "type": "string"
+        },
+        "rootKey": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "fileProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "debugLogGeneratedTemplate": {
+          "type": "boolean"
+        },
+        "directory": {
+          "type": "string"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "watch": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "gatewayProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "certAuthFilePath": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "experimentalChannel": {
+          "type": "boolean"
+        },
+        "labelSelector": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "statusAddress": {
+          "$ref": "#/$defs/gatewayStatusAddress"
+        },
+        "throttleDuration": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "gatewayServiceRef": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "gatewayStatusAddress": {
+      "additionalProperties": false,
+      "properties": {
+        "hostname": {
+          "type": "string"
+        },
+        "ip": {
+          "type": "string"
+        },
+        "service": {
+          "$ref": "#/$defs/gatewayServiceRef"
+        }
+      },
+      "type": "object"
+    },
+    "httpProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "pollInterval": {
+          "type": "string"
+        },
+        "pollTimeout": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "type": "object"
+    },
+    "ingressEndpointIngress": {
+      "additionalProperties": false,
+      "properties": {
+        "hostname": {
+          "type": "string"
+        },
+        "ip": {
+          "type": "string"
+        },
+        "publishedService": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ingressProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "allowEmptyServices": {
+          "type": "boolean"
+        },
+        "allowExternalNameServices": {
+          "type": "boolean"
+        },
+        "certAuthFilePath": {
+          "type": "string"
+        },
+        "disableClusterScopeResources": {
+          "type": "boolean"
+        },
+        "disableIngressClassLookup": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "ingressClass": {
+          "type": "string"
+        },
+        "ingressEndpoint": {
+          "$ref": "#/$defs/ingressEndpointIngress"
+        },
+        "labelSelector": {
+          "type": "string"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "nativeLBByDefault": {
+          "type": "boolean"
+        },
+        "throttleDuration": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "nomadEndpointConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "endpointWaitTime": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "nomadProviderBuilder": {
+      "additionalProperties": false,
+      "properties": {
+        "allowEmptyServices": {
+          "type": "boolean"
+        },
+        "constraints": {
+          "type": "string"
+        },
+        "defaultRule": {
+          "type": "string"
+        },
+        "endpoint": {
+          "$ref": "#/$defs/nomadEndpointConfig"
+        },
+        "exposedByDefault": {
+          "type": "boolean"
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "stale": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "opentelemetryConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "grpc": {
+          "$ref": "#/$defs/typesOtelGRPC"
+        },
+        "http": {
+          "$ref": "#/$defs/typesOtelHTTP"
+        }
+      },
+      "type": "object"
+    },
+    "pingHandler": {
+      "additionalProperties": false,
+      "properties": {
+        "entryPoint": {
+          "type": "string"
+        },
+        "manualRouting": {
+          "type": "boolean"
+        },
+        "terminatingStatusCode": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "pluginsDescriptor": {
+      "additionalProperties": false,
+      "properties": {
+        "moduleName": {
+          "type": "string"
+        },
+        "settings": {
+          "$ref": "#/$defs/pluginsSettings"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "pluginsLocalDescriptor": {
+      "additionalProperties": false,
+      "properties": {
+        "moduleName": {
+          "type": "string"
+        },
+        "settings": {
+          "$ref": "#/$defs/pluginsSettings"
+        }
+      },
+      "type": "object"
+    },
+    "pluginsSettings": {
+      "additionalProperties": false,
+      "properties": {
+        "envs": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "mounts": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "redisProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "db": {
+          "type": "integer"
+        },
+        "endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "password": {
+          "type": "string"
+        },
+        "rootKey": {
+          "type": "string"
+        },
+        "sentinel": {
+          "$ref": "#/$defs/redisSentinel"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "redisSentinel": {
+      "additionalProperties": false,
+      "properties": {
+        "latencyStrategy": {
+          "type": "boolean"
+        },
+        "masterName": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "randomStrategy": {
+          "type": "boolean"
+        },
+        "replicaStrategy": {
+          "type": "boolean"
+        },
+        "useDisconnectedReplicas": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "restProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "insecure": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "staticAPI": {
+      "additionalProperties": false,
+      "properties": {
+        "dashboard": {
+          "type": "boolean"
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "disableDashboardAd": {
+          "type": "boolean"
+        },
+        "insecure": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "staticCertificateResolver": {
+      "additionalProperties": false,
+      "properties": {
+        "acme": {
+          "$ref": "#/$defs/acmeConfiguration"
+        },
+        "tailscale": {
+          "$ref": "#/$defs/CertificateResolverTailscaleStruct"
+        }
+      },
+      "type": "object"
+    },
+    "staticCore": {
+      "additionalProperties": false,
+      "properties": {
+        "defaultRuleSyntax": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticEntryPoint": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "asDefault": {
+          "type": "boolean"
+        },
+        "forwardedHeaders": {
+          "$ref": "#/$defs/staticForwardedHeaders"
+        },
+        "http": {
+          "$ref": "#/$defs/staticHTTPConfig"
+        },
+        "http2": {
+          "$ref": "#/$defs/staticHTTP2Config"
+        },
+        "http3": {
+          "$ref": "#/$defs/staticHTTP3Config"
+        },
+        "proxyProtocol": {
+          "$ref": "#/$defs/staticProxyProtocol"
+        },
+        "reusePort": {
+          "type": "boolean"
+        },
+        "transport": {
+          "$ref": "#/$defs/staticEntryPointsTransport"
+        },
+        "udp": {
+          "$ref": "#/$defs/staticUDPConfig"
+        }
+      },
+      "type": "object"
+    },
+    "staticEntryPointsTransport": {
+      "additionalProperties": false,
+      "properties": {
+        "keepAliveMaxRequests": {
+          "type": "integer"
+        },
+        "keepAliveMaxTime": {
+          "type": "string"
+        },
+        "lifeCycle": {
+          "$ref": "#/$defs/staticLifeCycle"
+        },
+        "respondingTimeouts": {
+          "$ref": "#/$defs/staticRespondingTimeouts"
+        }
+      },
+      "type": "object"
+    },
+    "staticExperimental": {
+      "additionalProperties": false,
+      "properties": {
+        "kubernetesGateway": {
+          "type": "boolean"
+        },
+        "localPlugins": {
+          "additionalProperties": {
+            "$ref": "#/$defs/pluginsLocalDescriptor"
+          },
+          "type": "object"
+        },
+        "plugins": {
+          "additionalProperties": {
+            "$ref": "#/$defs/pluginsDescriptor"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "staticForwardedHeaders": {
+      "additionalProperties": false,
+      "properties": {
+        "insecure": {
+          "type": "boolean"
+        },
+        "trustedIPs": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "staticForwardingTimeouts": {
+      "additionalProperties": false,
+      "properties": {
+        "dialTimeout": {
+          "type": "string"
+        },
+        "idleConnTimeout": {
+          "type": "string"
+        },
+        "responseHeaderTimeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticGlobal": {
+      "additionalProperties": false,
+      "properties": {
+        "checkNewVersion": {
+          "type": "boolean"
+        },
+        "sendAnonymousUsage": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "staticHTTP2Config": {
+      "additionalProperties": false,
+      "properties": {
+        "maxConcurrentStreams": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "staticHTTP3Config": {
+      "additionalProperties": false,
+      "properties": {
+        "advertisedPort": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "staticHTTPConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "encodeQuerySemicolons": {
+          "type": "boolean"
+        },
+        "middlewares": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "redirections": {
+          "$ref": "#/$defs/staticRedirections"
+        },
+        "tls": {
+          "$ref": "#/$defs/staticTLSConfig"
+        }
+      },
+      "type": "object"
+    },
+    "staticLifeCycle": {
+      "additionalProperties": false,
+      "properties": {
+        "graceTimeOut": {
+          "type": "string"
+        },
+        "requestAcceptGraceTimeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticProviders": {
+      "additionalProperties": false,
+      "properties": {
+        "consul": {
+          "$ref": "#/$defs/consulProviderBuilder"
+        },
+        "consulCatalog": {
+          "$ref": "#/$defs/consulcatalogProviderBuilder"
+        },
+        "docker": {
+          "$ref": "#/$defs/dockerProvider"
+        },
+        "ecs": {
+          "$ref": "#/$defs/ecsProvider"
+        },
+        "etcd": {
+          "$ref": "#/$defs/etcdProvider"
+        },
+        "file": {
+          "$ref": "#/$defs/fileProvider"
+        },
+        "http": {
+          "$ref": "#/$defs/httpProvider"
+        },
+        "kubernetesCRD": {
+          "$ref": "#/$defs/crdProvider"
+        },
+        "kubernetesGateway": {
+          "$ref": "#/$defs/gatewayProvider"
+        },
+        "kubernetesIngress": {
+          "$ref": "#/$defs/ingressProvider"
+        },
+        "nomad": {
+          "$ref": "#/$defs/nomadProviderBuilder"
+        },
+        "plugin": {
+          "additionalProperties": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "providersThrottleDuration": {
+          "type": "string"
+        },
+        "redis": {
+          "$ref": "#/$defs/redisProvider"
+        },
+        "rest": {
+          "$ref": "#/$defs/restProvider"
+        },
+        "swarm": {
+          "$ref": "#/$defs/dockerSwarmProvider"
+        },
+        "zooKeeper": {
+          "$ref": "#/$defs/zkProvider"
+        }
+      },
+      "type": "object"
+    },
+    "staticProxyProtocol": {
+      "additionalProperties": false,
+      "properties": {
+        "insecure": {
+          "type": "boolean"
+        },
+        "trustedIPs": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "staticRedirectEntryPoint": {
+      "additionalProperties": false,
+      "properties": {
+        "permanent": {
+          "type": "boolean"
+        },
+        "priority": {
+          "type": "integer"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticRedirections": {
+      "additionalProperties": false,
+      "properties": {
+        "entryPoint": {
+          "$ref": "#/$defs/staticRedirectEntryPoint"
+        }
+      },
+      "type": "object"
+    },
+    "staticRespondingTimeouts": {
+      "additionalProperties": false,
+      "properties": {
+        "idleTimeout": {
+          "type": "string"
+        },
+        "readTimeout": {
+          "type": "string"
+        },
+        "writeTimeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticServersTransport": {
+      "additionalProperties": false,
+      "properties": {
+        "forwardingTimeouts": {
+          "$ref": "#/$defs/staticForwardingTimeouts"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
+        },
+        "maxIdleConnsPerHost": {
+          "type": "integer"
+        },
+        "rootCAs": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "spiffe": {
+          "$ref": "#/$defs/staticSpiffe"
+        }
+      },
+      "type": "object"
+    },
+    "staticSpiffe": {
+      "additionalProperties": false,
+      "properties": {
+        "ids": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "trustDomain": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticSpiffeClientConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "workloadAPIAddr": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticTCPServersTransport": {
+      "additionalProperties": false,
+      "properties": {
+        "dialKeepAlive": {
+          "type": "string"
+        },
+        "dialTimeout": {
+          "type": "string"
+        },
+        "terminationDelay": {
+          "type": "string"
+        },
+        "tls": {
+          "$ref": "#/$defs/staticTLSClientConfig"
+        }
+      },
+      "type": "object"
+    },
+    "staticTLSClientConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "insecureSkipVerify": {
+          "type": "boolean"
+        },
+        "rootCAs": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "spiffe": {
+          "$ref": "#/$defs/staticSpiffe"
+        }
+      },
+      "type": "object"
+    },
+    "staticTLSConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "certResolver": {
+          "type": "string"
+        },
+        "domains": {
+          "items": {
+            "$ref": "#/$defs/typesDomain"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticTracing": {
+      "additionalProperties": false,
+      "properties": {
+        "addInternals": {
+          "type": "boolean"
+        },
+        "capturedRequestHeaders": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "capturedResponseHeaders": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "globalAttributes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "otlp": {
+          "$ref": "#/$defs/opentelemetryConfig"
+        },
+        "safeQueryParams": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "sampleRate": {
+          "type": "number"
+        },
+        "serviceName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "staticUDPConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "timeout": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesAccessLog": {
+      "additionalProperties": false,
+      "properties": {
+        "addInternals": {
+          "type": "boolean"
+        },
+        "bufferingSize": {
+          "type": "integer"
+        },
+        "fields": {
+          "$ref": "#/$defs/typesAccessLogFields"
+        },
+        "filePath": {
+          "type": "string"
+        },
+        "filters": {
+          "$ref": "#/$defs/typesAccessLogFilters"
+        },
+        "format": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesAccessLogFields": {
+      "additionalProperties": false,
+      "properties": {
+        "defaultMode": {
+          "type": "string"
+        },
+        "headers": {
+          "$ref": "#/$defs/typesFieldHeaders"
+        },
+        "names": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "typesAccessLogFilters": {
+      "additionalProperties": false,
+      "properties": {
+        "minDuration": {
+          "type": "string"
+        },
+        "retryAttempts": {
+          "type": "boolean"
+        },
+        "statusCodes": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "typesClientTLS": {
+      "additionalProperties": false,
+      "properties": {
+        "ca": {
+          "type": "string"
+        },
+        "cert": {
+          "type": "string"
+        },
+        "insecureSkipVerify": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesDatadog": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "address": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "pushInterval": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesDomain": {
+      "additionalProperties": false,
+      "properties": {
+        "main": {
+          "type": "string"
+        },
+        "sans": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "typesFieldHeaders": {
+      "additionalProperties": false,
+      "properties": {
+        "defaultMode": {
+          "type": "string"
+        },
+        "names": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "typesHostResolverConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "cnameFlattening": {
+          "type": "boolean"
+        },
+        "resolvConfig": {
+          "type": "string"
+        },
+        "resolvDepth": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "typesInfluxDB2": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "additionalLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "address": {
+          "type": "string"
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "org": {
+          "type": "string"
+        },
+        "pushInterval": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesMetrics": {
+      "additionalProperties": false,
+      "properties": {
+        "addInternals": {
+          "type": "boolean"
+        },
+        "datadog": {
+          "$ref": "#/$defs/typesDatadog"
+        },
+        "influxDB2": {
+          "$ref": "#/$defs/typesInfluxDB2"
+        },
+        "otlp": {
+          "$ref": "#/$defs/typesOTLP"
+        },
+        "prometheus": {
+          "$ref": "#/$defs/typesPrometheus"
+        },
+        "statsD": {
+          "$ref": "#/$defs/typesStatsd"
+        }
+      },
+      "type": "object"
+    },
+    "typesOTLP": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "explicitBoundaries": {
+          "items": {
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "grpc": {
+          "$ref": "#/$defs/typesOtelGRPC"
+        },
+        "http": {
+          "$ref": "#/$defs/typesOtelHTTP"
+        },
+        "pushInterval": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesOtelGRPC": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "insecure": {
+          "type": "boolean"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        }
+      },
+      "type": "object"
+    },
+    "typesOtelHTTP": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "tls": {
+          "$ref": "#/$defs/typesClientTLS"
+        }
+      },
+      "type": "object"
+    },
+    "typesPrometheus": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "buckets": {
+          "items": {
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "entryPoint": {
+          "type": "string"
+        },
+        "headerLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "manualRouting": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "typesStatsd": {
+      "additionalProperties": false,
+      "properties": {
+        "addEntryPointsLabels": {
+          "type": "boolean"
+        },
+        "addRoutersLabels": {
+          "type": "boolean"
+        },
+        "addServicesLabels": {
+          "type": "boolean"
+        },
+        "address": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "pushInterval": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "typesTraefikLog": {
+      "additionalProperties": false,
+      "properties": {
+        "compress": {
+          "type": "boolean"
+        },
+        "filePath": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "level": {
+          "type": "string"
+        },
+        "maxAge": {
+          "type": "integer"
+        },
+        "maxBackups": {
+          "type": "integer"
+        },
+        "maxSize": {
+          "type": "integer"
+        },
+        "noColor": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "zkProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "password": {
+          "type": "string"
+        },
+        "rootKey": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/src/schemas/json/traefik-v3.json
+++ b/src/schemas/json/traefik-v3.json
@@ -1,64 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/traefik-v3.json",
-  "title": "Traefik v3 Static Configuration",
-  "properties": {
-    "accessLog": {
-      "$ref": "#/$defs/typesAccessLog"
-    },
-    "api": {
-      "$ref": "#/$defs/staticAPI"
-    },
-    "certificatesResolvers": {
-      "additionalProperties": {
-        "$ref": "#/$defs/staticCertificateResolver"
-      },
-      "type": "object"
-    },
-    "core": {
-      "$ref": "#/$defs/staticCore"
-    },
-    "entryPoints": {
-      "additionalProperties": {
-        "$ref": "#/$defs/staticEntryPoint"
-      },
-      "type": "object"
-    },
-    "experimental": {
-      "$ref": "#/$defs/staticExperimental"
-    },
-    "global": {
-      "$ref": "#/$defs/staticGlobal"
-    },
-    "hostResolver": {
-      "$ref": "#/$defs/typesHostResolverConfig"
-    },
-    "log": {
-      "$ref": "#/$defs/typesTraefikLog"
-    },
-    "metrics": {
-      "$ref": "#/$defs/typesMetrics"
-    },
-    "ping": {
-      "$ref": "#/$defs/pingHandler"
-    },
-    "providers": {
-      "$ref": "#/$defs/staticProviders"
-    },
-    "serversTransport": {
-      "$ref": "#/$defs/staticServersTransport"
-    },
-    "spiffe": {
-      "$ref": "#/$defs/staticSpiffeClientConfig"
-    },
-    "tcpServersTransport": {
-      "$ref": "#/$defs/staticTCPServersTransport"
-    },
-    "tracing": {
-      "$ref": "#/$defs/staticTracing"
-    }
-  },
-  "type": "object",
   "$defs": {
     "CertificateResolverTailscaleStruct": {
       "additionalProperties": false,
@@ -116,10 +58,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -156,19 +95,13 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "namespaces": {
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "rootKey": {
           "type": "string"
@@ -249,10 +182,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "prefix": {
           "type": "string"
@@ -273,10 +203,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "watch": {
           "type": "boolean"
@@ -315,10 +242,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "nativeLBByDefault": {
           "type": "boolean"
@@ -420,10 +344,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "constraints": {
           "type": "string"
@@ -459,10 +380,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "password": {
           "type": "string"
@@ -516,10 +434,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "statusAddress": {
           "$ref": "#/$defs/gatewayStatusAddress"
@@ -582,9 +497,7 @@
           "$ref": "#/$defs/typesClientTLS"
         }
       },
-      "required": [
-        "endpoint"
-      ],
+      "required": ["endpoint"],
       "type": "object"
     },
     "ingressEndpointIngress": {
@@ -636,10 +549,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "nativeLBByDefault": {
           "type": "boolean"
@@ -696,10 +606,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "prefix": {
           "type": "string"
@@ -774,19 +681,13 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "mounts": {
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -801,10 +702,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "password": {
           "type": "string"
@@ -984,10 +882,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1047,10 +942,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "redirections": {
           "$ref": "#/$defs/staticRedirections"
@@ -1144,10 +1036,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1210,10 +1099,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "spiffe": {
           "$ref": "#/$defs/staticSpiffe"
@@ -1228,10 +1114,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "trustDomain": {
           "type": "string"
@@ -1276,10 +1159,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "spiffe": {
           "$ref": "#/$defs/staticSpiffe"
@@ -1297,10 +1177,7 @@
           "items": {
             "$ref": "#/$defs/typesDomain"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "options": {
           "type": "string"
@@ -1318,19 +1195,13 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "capturedResponseHeaders": {
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "globalAttributes": {
           "additionalProperties": {
@@ -1345,10 +1216,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "sampleRate": {
           "type": "number"
@@ -1423,10 +1291,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1483,10 +1348,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         }
       },
       "type": "object"
@@ -1597,10 +1459,7 @@
           "items": {
             "type": "number"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "grpc": {
           "$ref": "#/$defs/typesOtelGRPC"
@@ -1669,10 +1528,7 @@
           "items": {
             "type": "number"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "entryPoint": {
           "type": "string"
@@ -1750,10 +1606,7 @@
           "items": {
             "type": "string"
           },
-          "type": [
-            "array",
-            "null"
-          ]
+          "type": ["array", "null"]
         },
         "password": {
           "type": "string"
@@ -1767,5 +1620,63 @@
       },
       "type": "object"
     }
-  }
+  },
+  "title": "Traefik v3 Static Configuration",
+  "properties": {
+    "accessLog": {
+      "$ref": "#/$defs/typesAccessLog"
+    },
+    "api": {
+      "$ref": "#/$defs/staticAPI"
+    },
+    "certificatesResolvers": {
+      "additionalProperties": {
+        "$ref": "#/$defs/staticCertificateResolver"
+      },
+      "type": "object"
+    },
+    "core": {
+      "$ref": "#/$defs/staticCore"
+    },
+    "entryPoints": {
+      "additionalProperties": {
+        "$ref": "#/$defs/staticEntryPoint"
+      },
+      "type": "object"
+    },
+    "experimental": {
+      "$ref": "#/$defs/staticExperimental"
+    },
+    "global": {
+      "$ref": "#/$defs/staticGlobal"
+    },
+    "hostResolver": {
+      "$ref": "#/$defs/typesHostResolverConfig"
+    },
+    "log": {
+      "$ref": "#/$defs/typesTraefikLog"
+    },
+    "metrics": {
+      "$ref": "#/$defs/typesMetrics"
+    },
+    "ping": {
+      "$ref": "#/$defs/pingHandler"
+    },
+    "providers": {
+      "$ref": "#/$defs/staticProviders"
+    },
+    "serversTransport": {
+      "$ref": "#/$defs/staticServersTransport"
+    },
+    "spiffe": {
+      "$ref": "#/$defs/staticSpiffeClientConfig"
+    },
+    "tcpServersTransport": {
+      "$ref": "#/$defs/staticTCPServersTransport"
+    },
+    "tracing": {
+      "$ref": "#/$defs/staticTracing"
+    }
+  },
+  "type": "object"
 }

--- a/src/test/traefik-v2/example.json
+++ b/src/test/traefik-v2/example.json
@@ -1,85 +1,116 @@
 {
-  "global": {
-    "checkNewVersion": true,
-    "sendAnonymousUsage": true
+  "accessLog": {
+    "bufferingSize": 42,
+    "fields": {
+      "defaultMode": "foobar",
+      "headers": {
+        "defaultMode": "foobar",
+        "names": {
+          "name0": "foobar",
+          "name1": "foobar"
+        }
+      },
+      "names": {
+        "name0": "foobar",
+        "name1": "foobar"
+      }
+    },
+    "filePath": "foobar",
+    "filters": {
+      "minDuration": "42s",
+      "retryAttempts": true,
+      "statusCodes": ["foobar", "foobar"]
+    },
+    "format": "foobar"
   },
-  "serversTransport": {
-    "insecureSkipVerify": true,
-    "rootCAs": [
-      "foobar",
-      "foobar"
-    ],
-    "maxIdleConnsPerHost": 42,
-    "forwardingTimeouts": {
-      "dialTimeout": "42s",
-      "responseHeaderTimeout": "42s",
-      "idleConnTimeout": "42s"
+  "api": {
+    "dashboard": true,
+    "debug": true,
+    "disableDashboardAd": true,
+    "insecure": true
+  },
+  "certificatesResolvers": {
+    "CertificateResolver0": {
+      "acme": {
+        "caServer": "foobar",
+        "certificatesDuration": 42,
+        "dnsChallenge": {
+          "delayBeforeCheck": "42s",
+          "disablePropagationCheck": true,
+          "provider": "foobar",
+          "resolvers": ["foobar", "foobar"]
+        },
+        "eab": {
+          "hmacEncoded": "foobar",
+          "kid": "foobar"
+        },
+        "email": "foobar",
+        "httpChallenge": {
+          "entryPoint": "foobar"
+        },
+        "keyType": "foobar",
+        "preferredChain": "foobar",
+        "storage": "foobar",
+        "tlsChallenge": {}
+      }
+    },
+    "CertificateResolver1": {
+      "acme": {
+        "caServer": "foobar",
+        "certificatesDuration": 42,
+        "dnsChallenge": {
+          "delayBeforeCheck": "42s",
+          "disablePropagationCheck": true,
+          "provider": "foobar",
+          "resolvers": ["foobar", "foobar"]
+        },
+        "eab": {
+          "hmacEncoded": "foobar",
+          "kid": "foobar"
+        },
+        "email": "foobar",
+        "httpChallenge": {
+          "entryPoint": "foobar"
+        },
+        "keyType": "foobar",
+        "preferredChain": "foobar",
+        "storage": "foobar",
+        "tlsChallenge": {}
+      }
     }
   },
   "entryPoints": {
     "EntryPoint0": {
       "address": "foobar",
-      "transport": {
-        "lifeCycle": {
-          "requestAcceptGraceTimeout": "42s",
-          "graceTimeOut": "42s"
-        },
-        "respondingTimeouts": {
-          "readTimeout": "42s",
-          "writeTimeout": "42s",
-          "idleTimeout": "42s"
-        },
-        "keepAliveMaxTime": "42s",
-        "keepAliveMaxRequests": 42
-      },
-      "proxyProtocol": {
-        "insecure": true,
-        "trustedIPs": [
-          "foobar",
-          "foobar"
-        ]
-      },
       "forwardedHeaders": {
         "insecure": true,
-        "trustedIPs": [
-          "foobar",
-          "foobar"
-        ]
+        "trustedIPs": ["foobar", "foobar"]
       },
       "http": {
+        "encodeQuerySemicolons": true,
+        "middlewares": ["foobar", "foobar"],
         "redirections": {
           "entryPoint": {
-            "to": "foobar",
-            "scheme": "foobar",
             "permanent": true,
-            "priority": 42
+            "priority": 42,
+            "scheme": "foobar",
+            "to": "foobar"
           }
         },
-        "middlewares": [
-          "foobar",
-          "foobar"
-        ],
         "tls": {
-          "options": "foobar",
           "certResolver": "foobar",
           "domains": [
             {
               "main": "foobar",
-              "sans": [
-                "foobar",
-                "foobar"
-              ]
+              "sans": ["foobar", "foobar"]
             },
             {
               "main": "foobar",
-              "sans": [
-                "foobar",
-                "foobar"
-              ]
+              "sans": ["foobar", "foobar"]
             }
-          ]
-        },
-        "encodeQuerySemicolons": true
+          ],
+          "options": "foobar"
+        }
       },
       "http2": {
         "maxConcurrentStreams": 42
@@ -87,271 +118,232 @@
       "http3": {
         "advertisedPort": 42
       },
+      "proxyProtocol": {
+        "insecure": true,
+        "trustedIPs": ["foobar", "foobar"]
+      },
+      "transport": {
+        "keepAliveMaxRequests": 42,
+        "keepAliveMaxTime": "42s",
+        "lifeCycle": {
+          "graceTimeOut": "42s",
+          "requestAcceptGraceTimeout": "42s"
+        },
+        "respondingTimeouts": {
+          "idleTimeout": "42s",
+          "readTimeout": "42s",
+          "writeTimeout": "42s"
+        }
+      },
       "udp": {
         "timeout": "42s"
       }
     }
   },
+  "experimental": {
+    "http3": true,
+    "kubernetesGateway": true,
+    "localPlugins": {
+      "LocalDescriptor0": {
+        "moduleName": "foobar"
+      },
+      "LocalDescriptor1": {
+        "moduleName": "foobar"
+      }
+    },
+    "plugins": {
+      "Descriptor0": {
+        "moduleName": "foobar",
+        "version": "foobar"
+      },
+      "Descriptor1": {
+        "moduleName": "foobar",
+        "version": "foobar"
+      }
+    }
+  },
+  "global": {
+    "checkNewVersion": true,
+    "sendAnonymousUsage": true
+  },
+  "hostResolver": {
+    "cnameFlattening": true,
+    "resolvConfig": "foobar",
+    "resolvDepth": 42
+  },
+  "log": {
+    "filePath": "foobar",
+    "format": "foobar",
+    "level": "foobar"
+  },
+  "metrics": {
+    "datadog": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "address": "foobar",
+      "prefix": "foobar",
+      "pushInterval": "42s"
+    },
+    "influxDB": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "additionalLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "address": "foobar",
+      "database": "foobar",
+      "password": "foobar",
+      "protocol": "foobar",
+      "pushInterval": "42s",
+      "retentionPolicy": "foobar",
+      "username": "foobar"
+    },
+    "influxDB2": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "additionalLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "address": "foobar",
+      "bucket": "foobar",
+      "org": "foobar",
+      "pushInterval": "42s",
+      "token": "foobar"
+    },
+    "prometheus": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "buckets": [42, 42],
+      "entryPoint": "foobar",
+      "headerLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "manualRouting": true
+    },
+    "statsD": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "address": "foobar",
+      "prefix": "foobar",
+      "pushInterval": "42s"
+    }
+  },
+  "pilot": {
+    "dashboard": true,
+    "token": "foobar"
+  },
+  "ping": {
+    "entryPoint": "foobar",
+    "manualRouting": true,
+    "terminatingStatusCode": 42
+  },
   "providers": {
-    "providersThrottleDuration": "42s",
-    "docker": {
-      "constraints": "foobar",
-      "watch": true,
-      "endpoint": "foobar",
-      "defaultRule": "foobar",
+    "consul": {
+      "endpoints": ["foobar", "foobar"],
+      "namespace": "foobar",
+      "namespaces": ["foobar", "foobar"],
+      "rootKey": "foobar",
       "tls": {
         "ca": "foobar",
         "caOptional": true,
         "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
+        "insecureSkipVerify": true,
+        "key": "foobar"
       },
-      "exposedByDefault": true,
-      "useBindPortIP": true,
-      "swarmMode": true,
-      "network": "foobar",
-      "swarmModeRefreshSeconds": "42s",
-      "httpClientTimeout": "42s",
-      "allowEmptyServices": true
-    },
-    "file": {
-      "directory": "foobar",
-      "watch": true,
-      "filename": "foobar",
-      "debugLogGeneratedTemplate": true
-    },
-    "marathon": {
-      "constraints": "foobar",
-      "trace": true,
-      "watch": true,
-      "endpoint": "foobar",
-      "defaultRule": "foobar",
-      "exposedByDefault": true,
-      "dcosToken": "foobar",
-      "tls": {
-        "ca": "foobar",
-        "caOptional": true,
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      },
-      "dialerTimeout": "42s",
-      "responseHeaderTimeout": "42s",
-      "tlsHandshakeTimeout": "42s",
-      "keepAlive": "42s",
-      "forceTaskHostname": true,
-      "basic": {
-        "httpBasicAuthUser": "foobar",
-        "httpBasicPassword": "foobar"
-      },
-      "respectReadinessChecks": true
-    },
-    "kubernetesIngress": {
-      "endpoint": "foobar",
-      "token": "foobar",
-      "certAuthFilePath": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ],
-      "labelSelector": "foobar",
-      "ingressClass": "foobar",
-      "ingressEndpoint": {
-        "ip": "foobar",
-        "hostname": "foobar",
-        "publishedService": "foobar"
-      },
-      "throttleDuration": "42s",
-      "allowEmptyServices": true,
-      "allowExternalNameServices": true
-    },
-    "kubernetesCRD": {
-      "endpoint": "foobar",
-      "token": "foobar",
-      "certAuthFilePath": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ],
-      "allowCrossNamespace": true,
-      "allowExternalNameServices": true,
-      "labelSelector": "foobar",
-      "ingressClass": "foobar",
-      "throttleDuration": "42s",
-      "allowEmptyServices": true
-    },
-    "kubernetesGateway": {
-      "endpoint": "foobar",
-      "token": "foobar",
-      "certAuthFilePath": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ],
-      "labelSelector": "foobar",
-      "throttleDuration": "42s"
-    },
-    "rest": {
-      "insecure": true
-    },
-    "rancher": {
-      "constraints": "foobar",
-      "watch": true,
-      "defaultRule": "foobar",
-      "exposedByDefault": true,
-      "enableServiceHealthFilter": true,
-      "refreshSeconds": 42,
-      "intervalPoll": true,
-      "prefix": "foobar"
+      "token": "foobar"
     },
     "consulCatalog": {
+      "cache": true,
+      "connectAware": true,
+      "connectByDefault": true,
       "constraints": "foobar",
+      "defaultRule": "foobar",
       "endpoint": {
         "address": "foobar",
-        "scheme": "foobar",
         "datacenter": "foobar",
-        "token": "foobar",
+        "endpointWaitTime": "42s",
+        "httpAuth": {
+          "password": "foobar",
+          "username": "foobar"
+        },
+        "scheme": "foobar",
         "tls": {
           "ca": "foobar",
           "caOptional": true,
           "cert": "foobar",
-          "key": "foobar",
-          "insecureSkipVerify": true
+          "insecureSkipVerify": true,
+          "key": "foobar"
         },
-        "httpAuth": {
-          "username": "foobar",
-          "password": "foobar"
-        },
-        "endpointWaitTime": "42s"
+        "token": "foobar"
       },
+      "exposedByDefault": true,
+      "namespace": "foobar",
+      "namespaces": ["foobar", "foobar"],
       "prefix": "foobar",
       "refreshInterval": "42s",
       "requireConsistent": true,
-      "stale": true,
-      "cache": true,
-      "exposedByDefault": true,
-      "defaultRule": "foobar",
-      "connectAware": true,
-      "connectByDefault": true,
       "serviceName": "foobar",
-      "watch": true,
-      "namespace": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ]
-    },
-    "nomad": {
-      "defaultRule": "foobar",
-      "constraints": "foobar",
-      "endpoint": {
-        "address": "foobar",
-        "region": "foobar",
-        "token": "foobar",
-        "tls": {
-          "ca": "foobar",
-          "caOptional": true,
-          "cert": "foobar",
-          "key": "foobar",
-          "insecureSkipVerify": true
-        },
-        "endpointWaitTime": "42s"
-      },
-      "prefix": "foobar",
       "stale": true,
+      "watch": true
+    },
+    "docker": {
+      "allowEmptyServices": true,
+      "constraints": "foobar",
+      "defaultRule": "foobar",
+      "endpoint": "foobar",
       "exposedByDefault": true,
-      "refreshInterval": "42s",
-      "namespace": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ]
+      "httpClientTimeout": "42s",
+      "network": "foobar",
+      "swarmMode": true,
+      "swarmModeRefreshSeconds": "42s",
+      "tls": {
+        "ca": "foobar",
+        "caOptional": true,
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "useBindPortIP": true,
+      "watch": true
     },
     "ecs": {
+      "accessKeyID": "foobar",
+      "autoDiscoverClusters": true,
+      "clusters": ["foobar", "foobar"],
       "constraints": "foobar",
+      "defaultRule": "foobar",
+      "ecsAnywhere": true,
       "exposedByDefault": true,
       "refreshSeconds": 42,
-      "defaultRule": "foobar",
-      "clusters": [
-        "foobar",
-        "foobar"
-      ],
-      "autoDiscoverClusters": true,
-      "ecsAnywhere": true,
       "region": "foobar",
-      "accessKeyID": "foobar",
       "secretAccessKey": "foobar"
     },
-    "consul": {
-      "rootKey": "foobar",
-      "endpoints": [
-        "foobar",
-        "foobar"
-      ],
-      "token": "foobar",
-      "tls": {
-        "ca": "foobar",
-        "caOptional": true,
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      },
-      "namespace": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ]
-    },
     "etcd": {
-      "rootKey": "foobar",
-      "endpoints": [
-        "foobar",
-        "foobar"
-      ],
-      "tls": {
-        "ca": "foobar",
-        "caOptional": true,
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      },
-      "username": "foobar",
-      "password": "foobar"
-    },
-    "zooKeeper": {
-      "rootKey": "foobar",
-      "endpoints": [
-        "foobar",
-        "foobar"
-      ],
-      "username": "foobar",
-      "password": "foobar"
-    },
-    "redis": {
-      "rootKey": "foobar",
-      "endpoints": [
-        "foobar",
-        "foobar"
-      ],
-      "tls": {
-        "ca": "foobar",
-        "caOptional": true,
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      },
-      "username": "foobar",
+      "endpoints": ["foobar", "foobar"],
       "password": "foobar",
-      "db": 42,
-      "sentinel": {
-        "masterName": "foobar",
-        "username": "foobar",
-        "password": "foobar",
-        "latencyStrategy": true,
-        "randomStrategy": true,
-        "replicaStrategy": true,
-        "useDisconnectedReplicas": true
-      }
+      "rootKey": "foobar",
+      "tls": {
+        "ca": "foobar",
+        "caOptional": true,
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "username": "foobar"
+    },
+    "file": {
+      "debugLogGeneratedTemplate": true,
+      "directory": "foobar",
+      "filename": "foobar",
+      "watch": true
     },
     "http": {
       "endpoint": "foobar",
@@ -361,9 +353,94 @@
         "ca": "foobar",
         "caOptional": true,
         "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
+        "insecureSkipVerify": true,
+        "key": "foobar"
       }
+    },
+    "kubernetesCRD": {
+      "allowCrossNamespace": true,
+      "allowEmptyServices": true,
+      "allowExternalNameServices": true,
+      "certAuthFilePath": "foobar",
+      "endpoint": "foobar",
+      "ingressClass": "foobar",
+      "labelSelector": "foobar",
+      "namespaces": ["foobar", "foobar"],
+      "throttleDuration": "42s",
+      "token": "foobar"
+    },
+    "kubernetesGateway": {
+      "certAuthFilePath": "foobar",
+      "endpoint": "foobar",
+      "labelSelector": "foobar",
+      "namespaces": ["foobar", "foobar"],
+      "throttleDuration": "42s",
+      "token": "foobar"
+    },
+    "kubernetesIngress": {
+      "allowEmptyServices": true,
+      "allowExternalNameServices": true,
+      "certAuthFilePath": "foobar",
+      "endpoint": "foobar",
+      "ingressClass": "foobar",
+      "ingressEndpoint": {
+        "hostname": "foobar",
+        "ip": "foobar",
+        "publishedService": "foobar"
+      },
+      "labelSelector": "foobar",
+      "namespaces": ["foobar", "foobar"],
+      "throttleDuration": "42s",
+      "token": "foobar"
+    },
+    "marathon": {
+      "basic": {
+        "httpBasicAuthUser": "foobar",
+        "httpBasicPassword": "foobar"
+      },
+      "constraints": "foobar",
+      "dcosToken": "foobar",
+      "defaultRule": "foobar",
+      "dialerTimeout": "42s",
+      "endpoint": "foobar",
+      "exposedByDefault": true,
+      "forceTaskHostname": true,
+      "keepAlive": "42s",
+      "respectReadinessChecks": true,
+      "responseHeaderTimeout": "42s",
+      "tls": {
+        "ca": "foobar",
+        "caOptional": true,
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "tlsHandshakeTimeout": "42s",
+      "trace": true,
+      "watch": true
+    },
+    "nomad": {
+      "constraints": "foobar",
+      "defaultRule": "foobar",
+      "endpoint": {
+        "address": "foobar",
+        "endpointWaitTime": "42s",
+        "region": "foobar",
+        "tls": {
+          "ca": "foobar",
+          "caOptional": true,
+          "cert": "foobar",
+          "insecureSkipVerify": true,
+          "key": "foobar"
+        },
+        "token": "foobar"
+      },
+      "exposedByDefault": true,
+      "namespace": "foobar",
+      "namespaces": ["foobar", "foobar"],
+      "prefix": "foobar",
+      "refreshInterval": "42s",
+      "stale": true
     },
     "plugin": {
       "PluginConf0": {
@@ -374,259 +451,119 @@
         "name0": "foobar",
         "name1": "foobar"
       }
-    }
-  },
-  "api": {
-    "insecure": true,
-    "dashboard": true,
-    "debug": true,
-    "disableDashboardAd": true
-  },
-  "metrics": {
-    "prometheus": {
-      "buckets": [
-        42,
-        42
-      ],
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "entryPoint": "foobar",
-      "manualRouting": true,
-      "headerLabels": {
-        "name0": "foobar",
-        "name1": "foobar"
-      }
     },
-    "datadog": {
-      "address": "foobar",
-      "pushInterval": "42s",
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "prefix": "foobar"
+    "providersThrottleDuration": "42s",
+    "rancher": {
+      "constraints": "foobar",
+      "defaultRule": "foobar",
+      "enableServiceHealthFilter": true,
+      "exposedByDefault": true,
+      "intervalPoll": true,
+      "prefix": "foobar",
+      "refreshSeconds": 42,
+      "watch": true
     },
-    "statsD": {
-      "address": "foobar",
-      "pushInterval": "42s",
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "prefix": "foobar"
-    },
-    "influxDB": {
-      "address": "foobar",
-      "protocol": "foobar",
-      "pushInterval": "42s",
-      "database": "foobar",
-      "retentionPolicy": "foobar",
-      "username": "foobar",
+    "redis": {
+      "db": 42,
+      "endpoints": ["foobar", "foobar"],
       "password": "foobar",
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "additionalLabels": {
-        "name0": "foobar",
-        "name1": "foobar"
-      }
+      "rootKey": "foobar",
+      "sentinel": {
+        "latencyStrategy": true,
+        "masterName": "foobar",
+        "password": "foobar",
+        "randomStrategy": true,
+        "replicaStrategy": true,
+        "useDisconnectedReplicas": true,
+        "username": "foobar"
+      },
+      "tls": {
+        "ca": "foobar",
+        "caOptional": true,
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "username": "foobar"
     },
-    "influxDB2": {
-      "address": "foobar",
-      "token": "foobar",
-      "pushInterval": "42s",
-      "org": "foobar",
-      "bucket": "foobar",
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "additionalLabels": {
-        "name0": "foobar",
-        "name1": "foobar"
-      }
+    "rest": {
+      "insecure": true
+    },
+    "zooKeeper": {
+      "endpoints": ["foobar", "foobar"],
+      "password": "foobar",
+      "rootKey": "foobar",
+      "username": "foobar"
     }
   },
-  "ping": {
-    "entryPoint": "foobar",
-    "manualRouting": true,
-    "terminatingStatusCode": 42
-  },
-  "log": {
-    "level": "foobar",
-    "filePath": "foobar",
-    "format": "foobar"
-  },
-  "accessLog": {
-    "filePath": "foobar",
-    "format": "foobar",
-    "filters": {
-      "statusCodes": [
-        "foobar",
-        "foobar"
-      ],
-      "retryAttempts": true,
-      "minDuration": "42s"
+  "serversTransport": {
+    "forwardingTimeouts": {
+      "dialTimeout": "42s",
+      "idleConnTimeout": "42s",
+      "responseHeaderTimeout": "42s"
     },
-    "fields": {
-      "defaultMode": "foobar",
-      "names": {
-        "name0": "foobar",
-        "name1": "foobar"
-      },
-      "headers": {
-        "defaultMode": "foobar",
-        "names": {
-          "name0": "foobar",
-          "name1": "foobar"
-        }
-      }
-    },
-    "bufferingSize": 42
+    "insecureSkipVerify": true,
+    "maxIdleConnsPerHost": 42,
+    "rootCAs": ["foobar", "foobar"]
   },
   "tracing": {
-    "serviceName": "foobar",
-    "spanNameLimit": 42,
-    "jaeger": {
-      "samplingServerURL": "foobar",
-      "samplingType": "foobar",
-      "samplingParam": 42,
-      "localAgentHostPort": "foobar",
-      "gen128Bit": true,
-      "propagation": "foobar",
-      "traceContextHeaderName": "foobar",
-      "collector": {
-        "endpoint": "foobar",
-        "user": "foobar",
-        "password": "foobar"
-      },
-      "disableAttemptReconnecting": true
-    },
-    "zipkin": {
-      "httpEndpoint": "foobar",
-      "sameSpan": true,
-      "id128Bit": true,
-      "sampleRate": 42
-    },
     "datadog": {
-      "localAgentHostPort": "foobar",
-      "localAgentSocket": "foobar",
+      "bagagePrefixHeaderName": "foobar",
+      "debug": true,
       "globalTag": "foobar",
       "globalTags": {
         "name0": "foobar",
         "name1": "foobar"
       },
-      "debug": true,
+      "localAgentHostPort": "foobar",
+      "localAgentSocket": "foobar",
+      "parentIDHeaderName": "foobar",
       "prioritySampling": true,
-      "traceIDHeaderName": "foobar",
-      "parentIDHeaderName": "foobar",
       "samplingPriorityHeaderName": "foobar",
-      "bagagePrefixHeaderName": "foobar"
-    },
-    "instana": {
-      "localAgentHost": "foobar",
-      "localAgentPort": 42,
-      "logLevel": "foobar",
-      "enableAutoProfile": true
-    },
-    "haystack": {
-      "localAgentHost": "foobar",
-      "localAgentPort": 42,
-      "globalTag": "foobar",
-      "traceIDHeaderName": "foobar",
-      "parentIDHeaderName": "foobar",
-      "spanIDHeaderName": "foobar",
-      "baggagePrefixHeaderName": "foobar"
+      "traceIDHeaderName": "foobar"
     },
     "elastic": {
-      "serverURL": "foobar",
       "secretToken": "foobar",
+      "serverURL": "foobar",
       "serviceEnvironment": "foobar"
-    }
-  },
-  "hostResolver": {
-    "cnameFlattening": true,
-    "resolvConfig": "foobar",
-    "resolvDepth": 42
-  },
-  "certificatesResolvers": {
-    "CertificateResolver0": {
-      "acme": {
-        "email": "foobar",
-        "caServer": "foobar",
-        "preferredChain": "foobar",
-        "storage": "foobar",
-        "keyType": "foobar",
-        "eab": {
-          "kid": "foobar",
-          "hmacEncoded": "foobar"
-        },
-        "certificatesDuration": 42,
-        "dnsChallenge": {
-          "provider": "foobar",
-          "delayBeforeCheck": "42s",
-          "resolvers": [
-            "foobar",
-            "foobar"
-          ],
-          "disablePropagationCheck": true
-        },
-        "httpChallenge": {
-          "entryPoint": "foobar"
-        },
-        "tlsChallenge": {}
-      }
     },
-    "CertificateResolver1": {
-      "acme": {
-        "email": "foobar",
-        "caServer": "foobar",
-        "preferredChain": "foobar",
-        "storage": "foobar",
-        "keyType": "foobar",
-        "eab": {
-          "kid": "foobar",
-          "hmacEncoded": "foobar"
-        },
-        "certificatesDuration": 42,
-        "dnsChallenge": {
-          "provider": "foobar",
-          "delayBeforeCheck": "42s",
-          "resolvers": [
-            "foobar",
-            "foobar"
-          ],
-          "disablePropagationCheck": true
-        },
-        "httpChallenge": {
-          "entryPoint": "foobar"
-        },
-        "tlsChallenge": {}
-      }
-    }
-  },
-  "pilot": {
-    "token": "foobar",
-    "dashboard": true
-  },
-  "experimental": {
-    "plugins": {
-      "Descriptor0": {
-        "moduleName": "foobar",
-        "version": "foobar"
+    "haystack": {
+      "baggagePrefixHeaderName": "foobar",
+      "globalTag": "foobar",
+      "localAgentHost": "foobar",
+      "localAgentPort": 42,
+      "parentIDHeaderName": "foobar",
+      "spanIDHeaderName": "foobar",
+      "traceIDHeaderName": "foobar"
+    },
+    "instana": {
+      "enableAutoProfile": true,
+      "localAgentHost": "foobar",
+      "localAgentPort": 42,
+      "logLevel": "foobar"
+    },
+    "jaeger": {
+      "collector": {
+        "endpoint": "foobar",
+        "password": "foobar",
+        "user": "foobar"
       },
-      "Descriptor1": {
-        "moduleName": "foobar",
-        "version": "foobar"
-      }
+      "disableAttemptReconnecting": true,
+      "gen128Bit": true,
+      "localAgentHostPort": "foobar",
+      "propagation": "foobar",
+      "samplingParam": 42,
+      "samplingServerURL": "foobar",
+      "samplingType": "foobar",
+      "traceContextHeaderName": "foobar"
     },
-    "localPlugins": {
-      "LocalDescriptor0": {
-        "moduleName": "foobar"
-      },
-      "LocalDescriptor1": {
-        "moduleName": "foobar"
-      }
-    },
-    "kubernetesGateway": true,
-    "http3": true
+    "serviceName": "foobar",
+    "spanNameLimit": 42,
+    "zipkin": {
+      "httpEndpoint": "foobar",
+      "id128Bit": true,
+      "sameSpan": true,
+      "sampleRate": 42
+    }
   }
 }

--- a/src/test/traefik-v2/example.json
+++ b/src/test/traefik-v2/example.json
@@ -1,114 +1,85 @@
 {
-  "accessLog": {
-    "bufferingSize": 42,
-    "fields": {
-      "defaultMode": "foobar",
-      "headers": {
-        "defaultMode": "foobar",
-        "names": {
-          "name0": "foobar",
-          "name1": "foobar"
-        }
-      },
-      "names": {
-        "name0": "foobar",
-        "name1": "foobar"
-      }
-    },
-    "filePath": "foobar",
-    "filters": {
-      "minDuration": "42s",
-      "retryAttempts": true,
-      "statusCodes": ["foobar", "foobar"]
-    },
-    "format": "foobar"
+  "global": {
+    "checkNewVersion": true,
+    "sendAnonymousUsage": true
   },
-  "api": {
-    "dashboard": true,
-    "debug": true,
-    "insecure": true
-  },
-  "certificatesResolvers": {
-    "CertificateResolver0": {
-      "acme": {
-        "caServer": "foobar",
-        "certificatesDuration": 42,
-        "dnsChallenge": {
-          "delayBeforeCheck": "42s",
-          "disablePropagationCheck": true,
-          "provider": "foobar",
-          "resolvers": ["foobar", "foobar"]
-        },
-        "eab": {
-          "hmacEncoded": "foobar",
-          "kid": "foobar"
-        },
-        "email": "foobar",
-        "httpChallenge": {
-          "entryPoint": "foobar"
-        },
-        "keyType": "foobar",
-        "preferredChain": "foobar",
-        "storage": "foobar",
-        "tlsChallenge": {}
-      }
-    },
-    "CertificateResolver1": {
-      "acme": {
-        "caServer": "foobar",
-        "certificatesDuration": 42,
-        "dnsChallenge": {
-          "delayBeforeCheck": "42s",
-          "disablePropagationCheck": true,
-          "provider": "foobar",
-          "resolvers": ["foobar", "foobar"]
-        },
-        "eab": {
-          "hmacEncoded": "foobar",
-          "kid": "foobar"
-        },
-        "email": "foobar",
-        "httpChallenge": {
-          "entryPoint": "foobar"
-        },
-        "keyType": "foobar",
-        "preferredChain": "foobar",
-        "storage": "foobar",
-        "tlsChallenge": {}
-      }
+  "serversTransport": {
+    "insecureSkipVerify": true,
+    "rootCAs": [
+      "foobar",
+      "foobar"
+    ],
+    "maxIdleConnsPerHost": 42,
+    "forwardingTimeouts": {
+      "dialTimeout": "42s",
+      "responseHeaderTimeout": "42s",
+      "idleConnTimeout": "42s"
     }
   },
   "entryPoints": {
     "EntryPoint0": {
       "address": "foobar",
+      "transport": {
+        "lifeCycle": {
+          "requestAcceptGraceTimeout": "42s",
+          "graceTimeOut": "42s"
+        },
+        "respondingTimeouts": {
+          "readTimeout": "42s",
+          "writeTimeout": "42s",
+          "idleTimeout": "42s"
+        },
+        "keepAliveMaxTime": "42s",
+        "keepAliveMaxRequests": 42
+      },
+      "proxyProtocol": {
+        "insecure": true,
+        "trustedIPs": [
+          "foobar",
+          "foobar"
+        ]
+      },
       "forwardedHeaders": {
         "insecure": true,
-        "trustedIPs": ["foobar", "foobar"]
+        "trustedIPs": [
+          "foobar",
+          "foobar"
+        ]
       },
       "http": {
-        "middlewares": ["foobar", "foobar"],
         "redirections": {
           "entryPoint": {
-            "permanent": true,
-            "priority": 42,
+            "to": "foobar",
             "scheme": "foobar",
-            "to": "foobar"
+            "permanent": true,
+            "priority": 42
           }
         },
+        "middlewares": [
+          "foobar",
+          "foobar"
+        ],
         "tls": {
+          "options": "foobar",
           "certResolver": "foobar",
           "domains": [
             {
               "main": "foobar",
-              "sans": ["foobar", "foobar"]
+              "sans": [
+                "foobar",
+                "foobar"
+              ]
             },
             {
               "main": "foobar",
-              "sans": ["foobar", "foobar"]
+              "sans": [
+                "foobar",
+                "foobar"
+              ]
             }
-          ],
-          "options": "foobar"
-        }
+          ]
+        },
+        "encodeQuerySemicolons": true
       },
       "http2": {
         "maxConcurrentStreams": 42
@@ -116,235 +87,271 @@
       "http3": {
         "advertisedPort": 42
       },
-      "proxyProtocol": {
-        "insecure": true,
-        "trustedIPs": ["foobar", "foobar"]
-      },
-      "transport": {
-        "lifeCycle": {
-          "graceTimeOut": "42s",
-          "requestAcceptGraceTimeout": "42s"
-        },
-        "respondingTimeouts": {
-          "idleTimeout": "42s",
-          "readTimeout": "42s",
-          "writeTimeout": "42s"
-        }
-      },
       "udp": {
         "timeout": "42s"
       }
     }
   },
-  "experimental": {
-    "http3": true,
-    "hub": true,
-    "kubernetesGateway": true,
-    "localPlugins": {
-      "Descriptor0": {
-        "moduleName": "foobar"
-      },
-      "Descriptor1": {
-        "moduleName": "foobar"
-      }
-    },
-    "plugins": {
-      "Descriptor0": {
-        "moduleName": "foobar",
-        "version": "foobar"
-      },
-      "Descriptor1": {
-        "moduleName": "foobar",
-        "version": "foobar"
-      }
-    }
-  },
-  "global": {
-    "checkNewVersion": true,
-    "sendAnonymousUsage": true
-  },
-  "hostResolver": {
-    "cnameFlattening": true,
-    "resolvConfig": "foobar",
-    "resolvDepth": 42
-  },
-  "hub": {
-    "tls": {
-      "ca": "foobar",
-      "cert": "foobar",
-      "insecure": true,
-      "key": "foobar"
-    }
-  },
-  "log": {
-    "filePath": "foobar",
-    "format": "foobar",
-    "level": "foobar"
-  },
-  "metrics": {
-    "datadog": {
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "address": "foobar",
-      "prefix": "foobar",
-      "pushInterval": "42s"
-    },
-    "influxDB": {
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "additionalLabels": {
-        "name0": "foobar",
-        "name1": "foobar"
-      },
-      "address": "foobar",
-      "database": "foobar",
-      "password": "foobar",
-      "protocol": "foobar",
-      "pushInterval": "42s",
-      "retentionPolicy": "foobar",
-      "username": "foobar"
-    },
-    "influxDB2": {
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "additionalLabels": {
-        "name0": "foobar",
-        "name1": "foobar"
-      },
-      "address": "foobar",
-      "bucket": "foobar",
-      "org": "foobar",
-      "pushInterval": "42s",
-      "token": "foobar"
-    },
-    "prometheus": {
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "buckets": [4.2, 42, 42],
-      "entryPoint": "foobar",
-      "manualRouting": true
-    },
-    "statsD": {
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "address": "foobar",
-      "prefix": "foobar",
-      "pushInterval": "42s"
-    }
-  },
-  "pilot": {
-    "dashboard": true,
-    "token": "foobar"
-  },
-  "ping": {
-    "entryPoint": "foobar",
-    "manualRouting": true,
-    "terminatingStatusCode": 42
-  },
   "providers": {
-    "consul": {
-      "endpoints": ["foobar", "foobar"],
-      "namespace": "foobar",
-      "namespaces": ["foobar", "foobar"],
-      "rootKey": "foobar",
+    "providersThrottleDuration": "42s",
+    "docker": {
+      "constraints": "foobar",
+      "watch": true,
+      "endpoint": "foobar",
+      "defaultRule": "foobar",
       "tls": {
         "ca": "foobar",
         "caOptional": true,
         "cert": "foobar",
-        "insecureSkipVerify": true,
-        "key": "foobar"
+        "key": "foobar",
+        "insecureSkipVerify": true
       },
-      "token": "foobar"
+      "exposedByDefault": true,
+      "useBindPortIP": true,
+      "swarmMode": true,
+      "network": "foobar",
+      "swarmModeRefreshSeconds": "42s",
+      "httpClientTimeout": "42s",
+      "allowEmptyServices": true
+    },
+    "file": {
+      "directory": "foobar",
+      "watch": true,
+      "filename": "foobar",
+      "debugLogGeneratedTemplate": true
+    },
+    "marathon": {
+      "constraints": "foobar",
+      "trace": true,
+      "watch": true,
+      "endpoint": "foobar",
+      "defaultRule": "foobar",
+      "exposedByDefault": true,
+      "dcosToken": "foobar",
+      "tls": {
+        "ca": "foobar",
+        "caOptional": true,
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      },
+      "dialerTimeout": "42s",
+      "responseHeaderTimeout": "42s",
+      "tlsHandshakeTimeout": "42s",
+      "keepAlive": "42s",
+      "forceTaskHostname": true,
+      "basic": {
+        "httpBasicAuthUser": "foobar",
+        "httpBasicPassword": "foobar"
+      },
+      "respectReadinessChecks": true
+    },
+    "kubernetesIngress": {
+      "endpoint": "foobar",
+      "token": "foobar",
+      "certAuthFilePath": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ],
+      "labelSelector": "foobar",
+      "ingressClass": "foobar",
+      "ingressEndpoint": {
+        "ip": "foobar",
+        "hostname": "foobar",
+        "publishedService": "foobar"
+      },
+      "throttleDuration": "42s",
+      "allowEmptyServices": true,
+      "allowExternalNameServices": true
+    },
+    "kubernetesCRD": {
+      "endpoint": "foobar",
+      "token": "foobar",
+      "certAuthFilePath": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ],
+      "allowCrossNamespace": true,
+      "allowExternalNameServices": true,
+      "labelSelector": "foobar",
+      "ingressClass": "foobar",
+      "throttleDuration": "42s",
+      "allowEmptyServices": true
+    },
+    "kubernetesGateway": {
+      "endpoint": "foobar",
+      "token": "foobar",
+      "certAuthFilePath": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ],
+      "labelSelector": "foobar",
+      "throttleDuration": "42s"
+    },
+    "rest": {
+      "insecure": true
+    },
+    "rancher": {
+      "constraints": "foobar",
+      "watch": true,
+      "defaultRule": "foobar",
+      "exposedByDefault": true,
+      "enableServiceHealthFilter": true,
+      "refreshSeconds": 42,
+      "intervalPoll": true,
+      "prefix": "foobar"
     },
     "consulCatalog": {
-      "cache": true,
-      "connectAware": true,
-      "connectByDefault": true,
       "constraints": "foobar",
-      "defaultRule": "foobar",
       "endpoint": {
         "address": "foobar",
-        "datacenter": "foobar",
-        "endpointWaitTime": "42s",
-        "httpAuth": {
-          "password": "foobar",
-          "username": "foobar"
-        },
         "scheme": "foobar",
+        "datacenter": "foobar",
+        "token": "foobar",
         "tls": {
           "ca": "foobar",
           "caOptional": true,
           "cert": "foobar",
-          "insecureSkipVerify": true,
-          "key": "foobar"
+          "key": "foobar",
+          "insecureSkipVerify": true
         },
-        "token": "foobar"
+        "httpAuth": {
+          "username": "foobar",
+          "password": "foobar"
+        },
+        "endpointWaitTime": "42s"
       },
-      "exposedByDefault": true,
-      "namespace": "foobar",
-      "namespaces": ["foobar", "foobar"],
       "prefix": "foobar",
       "refreshInterval": "42s",
       "requireConsistent": true,
-      "serviceName": "foobar",
       "stale": true,
-      "watch": true
-    },
-    "docker": {
-      "allowEmptyServices": true,
-      "constraints": "foobar",
-      "defaultRule": "foobar",
-      "endpoint": "foobar",
+      "cache": true,
       "exposedByDefault": true,
-      "httpClientTimeout": 300,
-      "network": "foobar",
-      "swarmMode": true,
-      "swarmModeRefreshSeconds": "42s",
-      "tls": {
-        "ca": "foobar",
-        "caOptional": true,
-        "cert": "foobar",
-        "insecureSkipVerify": true,
-        "key": "foobar"
+      "defaultRule": "foobar",
+      "connectAware": true,
+      "connectByDefault": true,
+      "serviceName": "foobar",
+      "watch": true,
+      "namespace": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ]
+    },
+    "nomad": {
+      "defaultRule": "foobar",
+      "constraints": "foobar",
+      "endpoint": {
+        "address": "foobar",
+        "region": "foobar",
+        "token": "foobar",
+        "tls": {
+          "ca": "foobar",
+          "caOptional": true,
+          "cert": "foobar",
+          "key": "foobar",
+          "insecureSkipVerify": true
+        },
+        "endpointWaitTime": "42s"
       },
-      "useBindPortIP": true,
-      "watch": true
+      "prefix": "foobar",
+      "stale": true,
+      "exposedByDefault": true,
+      "refreshInterval": "42s",
+      "namespace": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ]
     },
     "ecs": {
-      "accessKeyID": "foobar",
-      "autoDiscoverClusters": true,
-      "clusters": ["foobar", "foobar"],
       "constraints": "foobar",
-      "defaultRule": "foobar",
-      "ecsAnywhere": true,
       "exposedByDefault": true,
       "refreshSeconds": 42,
+      "defaultRule": "foobar",
+      "clusters": [
+        "foobar",
+        "foobar"
+      ],
+      "autoDiscoverClusters": true,
+      "ecsAnywhere": true,
       "region": "foobar",
+      "accessKeyID": "foobar",
       "secretAccessKey": "foobar"
     },
-    "etcd": {
-      "endpoints": ["foobar", "foobar"],
-      "password": "foobar",
+    "consul": {
       "rootKey": "foobar",
+      "endpoints": [
+        "foobar",
+        "foobar"
+      ],
+      "token": "foobar",
       "tls": {
         "ca": "foobar",
         "caOptional": true,
         "cert": "foobar",
-        "insecureSkipVerify": true,
-        "key": "foobar"
+        "key": "foobar",
+        "insecureSkipVerify": true
       },
-      "username": "foobar"
+      "namespace": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ]
     },
-    "file": {
-      "debugLogGeneratedTemplate": true,
-      "directory": "foobar",
-      "filename": "foobar",
-      "watch": true
+    "etcd": {
+      "rootKey": "foobar",
+      "endpoints": [
+        "foobar",
+        "foobar"
+      ],
+      "tls": {
+        "ca": "foobar",
+        "caOptional": true,
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      },
+      "username": "foobar",
+      "password": "foobar"
+    },
+    "zooKeeper": {
+      "rootKey": "foobar",
+      "endpoints": [
+        "foobar",
+        "foobar"
+      ],
+      "username": "foobar",
+      "password": "foobar"
+    },
+    "redis": {
+      "rootKey": "foobar",
+      "endpoints": [
+        "foobar",
+        "foobar"
+      ],
+      "tls": {
+        "ca": "foobar",
+        "caOptional": true,
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      },
+      "username": "foobar",
+      "password": "foobar",
+      "db": 42,
+      "sentinel": {
+        "masterName": "foobar",
+        "username": "foobar",
+        "password": "foobar",
+        "latencyStrategy": true,
+        "randomStrategy": true,
+        "replicaStrategy": true,
+        "useDisconnectedReplicas": true
+      }
     },
     "http": {
       "endpoint": "foobar",
@@ -354,200 +361,272 @@
         "ca": "foobar",
         "caOptional": true,
         "cert": "foobar",
-        "insecureSkipVerify": true,
-        "key": "foobar"
+        "key": "foobar",
+        "insecureSkipVerify": true
       }
     },
-    "kubernetesCRD": {
-      "allowCrossNamespace": true,
-      "allowEmptyServices": true,
-      "allowExternalNameServices": true,
-      "certAuthFilePath": "foobar",
-      "endpoint": "foobar",
-      "ingressClass": "foobar",
-      "labelSelector": "foobar",
-      "namespaces": ["foobar", "foobar"],
-      "throttleDuration": "42s",
-      "token": "foobar"
-    },
-    "kubernetesGateway": {
-      "certAuthFilePath": "foobar",
-      "endpoint": "foobar",
-      "labelSelector": "foobar",
-      "namespaces": ["foobar", "foobar"],
-      "throttleDuration": "42s",
-      "token": "foobar"
-    },
-    "kubernetesIngress": {
-      "allowEmptyServices": true,
-      "allowExternalNameServices": true,
-      "certAuthFilePath": "foobar",
-      "endpoint": "foobar",
-      "ingressClass": "foobar",
-      "ingressEndpoint": {
-        "hostname": "foobar",
-        "ip": "foobar",
-        "publishedService": "foobar"
-      },
-      "labelSelector": "foobar",
-      "namespaces": ["foobar", "foobar"],
-      "throttleDuration": "42s",
-      "token": "foobar"
-    },
-    "marathon": {
-      "basic": {
-        "httpBasicAuthUser": "foobar",
-        "httpBasicPassword": "foobar"
-      },
-      "constraints": "foobar",
-      "dcosToken": "foobar",
-      "defaultRule": "foobar",
-      "dialerTimeout": "42s",
-      "endpoint": "foobar",
-      "exposedByDefault": true,
-      "forceTaskHostname": true,
-      "keepAlive": "42s",
-      "respectReadinessChecks": true,
-      "responseHeaderTimeout": "42s",
-      "tls": {
-        "ca": "foobar",
-        "caOptional": true,
-        "cert": "foobar",
-        "insecureSkipVerify": true,
-        "key": "foobar"
-      },
-      "tlsHandshakeTimeout": "42s",
-      "trace": true,
-      "watch": true
-    },
-    "nomad": {
-      "constraints": "foobar",
-      "defaultRule": "foobar",
-      "endpoint": {
-        "address": "foobar",
-        "endpointWaitTime": "42s",
-        "region": "foobar",
-        "tls": {
-          "ca": "foobar",
-          "caOptional": true,
-          "cert": "foobar",
-          "insecureSkipVerify": true,
-          "key": "foobar"
-        },
-        "token": "foobar"
-      },
-      "exposedByDefault": true,
-      "namespace": "foobar",
-      "prefix": "foobar",
-      "refreshInterval": "42s",
-      "stale": true
-    },
     "plugin": {
-      "Descriptor0": {},
-      "Descriptor1": {}
-    },
-    "providersThrottleDuration": "42s",
-    "rancher": {
-      "constraints": "foobar",
-      "defaultRule": "foobar",
-      "enableServiceHealthFilter": true,
-      "exposedByDefault": true,
-      "intervalPoll": true,
-      "prefix": "foobar",
-      "refreshSeconds": 42,
-      "watch": true
-    },
-    "redis": {
-      "db": 42,
-      "endpoints": ["foobar", "foobar"],
-      "password": "foobar",
-      "rootKey": "foobar",
-      "tls": {
-        "ca": "foobar",
-        "caOptional": true,
-        "cert": "foobar",
-        "insecureSkipVerify": true,
-        "key": "foobar"
+      "PluginConf0": {
+        "name0": "foobar",
+        "name1": "foobar"
       },
-      "username": "foobar"
-    },
-    "rest": {
-      "insecure": true
-    },
-    "zooKeeper": {
-      "endpoints": ["foobar", "foobar"],
-      "password": "foobar",
-      "rootKey": "foobar",
-      "username": "foobar"
+      "PluginConf1": {
+        "name0": "foobar",
+        "name1": "foobar"
+      }
     }
   },
-  "serversTransport": {
-    "forwardingTimeouts": {
-      "dialTimeout": "42s",
-      "idleConnTimeout": "42s",
-      "responseHeaderTimeout": "42s"
+  "api": {
+    "insecure": true,
+    "dashboard": true,
+    "debug": true,
+    "disableDashboardAd": true
+  },
+  "metrics": {
+    "prometheus": {
+      "buckets": [
+        42,
+        42
+      ],
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "entryPoint": "foobar",
+      "manualRouting": true,
+      "headerLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      }
     },
-    "insecureSkipVerify": true,
-    "maxIdleConnsPerHost": 42,
-    "rootCAs": ["foobar", "foobar"]
+    "datadog": {
+      "address": "foobar",
+      "pushInterval": "42s",
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "prefix": "foobar"
+    },
+    "statsD": {
+      "address": "foobar",
+      "pushInterval": "42s",
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "prefix": "foobar"
+    },
+    "influxDB": {
+      "address": "foobar",
+      "protocol": "foobar",
+      "pushInterval": "42s",
+      "database": "foobar",
+      "retentionPolicy": "foobar",
+      "username": "foobar",
+      "password": "foobar",
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "additionalLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      }
+    },
+    "influxDB2": {
+      "address": "foobar",
+      "token": "foobar",
+      "pushInterval": "42s",
+      "org": "foobar",
+      "bucket": "foobar",
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "additionalLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      }
+    }
+  },
+  "ping": {
+    "entryPoint": "foobar",
+    "manualRouting": true,
+    "terminatingStatusCode": 42
+  },
+  "log": {
+    "level": "foobar",
+    "filePath": "foobar",
+    "format": "foobar"
+  },
+  "accessLog": {
+    "filePath": "foobar",
+    "format": "foobar",
+    "filters": {
+      "statusCodes": [
+        "foobar",
+        "foobar"
+      ],
+      "retryAttempts": true,
+      "minDuration": "42s"
+    },
+    "fields": {
+      "defaultMode": "foobar",
+      "names": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "headers": {
+        "defaultMode": "foobar",
+        "names": {
+          "name0": "foobar",
+          "name1": "foobar"
+        }
+      }
+    },
+    "bufferingSize": 42
   },
   "tracing": {
-    "datadog": {
-      "bagagePrefixHeaderName": "foobar",
-      "debug": true,
-      "globalTag": "foobar",
-      "globalTags": {
-        "tag1": "foobar",
-        "tag2": "foobar"
-      },
-      "localAgentHostPort": "foobar",
-      "parentIDHeaderName": "foobar",
-      "prioritySampling": true,
-      "samplingPriorityHeaderName": "foobar",
-      "traceIDHeaderName": "foobar"
-    },
-    "elastic": {
-      "secretToken": "foobar",
-      "serverURL": "foobar",
-      "serviceEnvironment": "foobar"
-    },
-    "haystack": {
-      "baggagePrefixHeaderName": "foobar",
-      "globalTag": "foobar",
-      "localAgentHost": "foobar",
-      "localAgentPort": 42,
-      "parentIDHeaderName": "foobar",
-      "spanIDHeaderName": "foobar",
-      "traceIDHeaderName": "foobar"
-    },
-    "instana": {
-      "enableAutoProfile": true,
-      "localAgentHost": "foobar",
-      "localAgentPort": 42,
-      "logLevel": "foobar"
-    },
-    "jaeger": {
-      "collector": {
-        "endpoint": "foobar",
-        "password": "foobar",
-        "user": "foobar"
-      },
-      "disableAttemptReconnecting": true,
-      "gen128Bit": true,
-      "localAgentHostPort": "foobar",
-      "propagation": "foobar",
-      "samplingParam": 42,
-      "samplingServerURL": "foobar",
-      "samplingType": "foobar",
-      "traceContextHeaderName": "foobar"
-    },
     "serviceName": "foobar",
     "spanNameLimit": 42,
+    "jaeger": {
+      "samplingServerURL": "foobar",
+      "samplingType": "foobar",
+      "samplingParam": 42,
+      "localAgentHostPort": "foobar",
+      "gen128Bit": true,
+      "propagation": "foobar",
+      "traceContextHeaderName": "foobar",
+      "collector": {
+        "endpoint": "foobar",
+        "user": "foobar",
+        "password": "foobar"
+      },
+      "disableAttemptReconnecting": true
+    },
     "zipkin": {
       "httpEndpoint": "foobar",
-      "id128Bit": true,
       "sameSpan": true,
+      "id128Bit": true,
       "sampleRate": 42
+    },
+    "datadog": {
+      "localAgentHostPort": "foobar",
+      "localAgentSocket": "foobar",
+      "globalTag": "foobar",
+      "globalTags": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "debug": true,
+      "prioritySampling": true,
+      "traceIDHeaderName": "foobar",
+      "parentIDHeaderName": "foobar",
+      "samplingPriorityHeaderName": "foobar",
+      "bagagePrefixHeaderName": "foobar"
+    },
+    "instana": {
+      "localAgentHost": "foobar",
+      "localAgentPort": 42,
+      "logLevel": "foobar",
+      "enableAutoProfile": true
+    },
+    "haystack": {
+      "localAgentHost": "foobar",
+      "localAgentPort": 42,
+      "globalTag": "foobar",
+      "traceIDHeaderName": "foobar",
+      "parentIDHeaderName": "foobar",
+      "spanIDHeaderName": "foobar",
+      "baggagePrefixHeaderName": "foobar"
+    },
+    "elastic": {
+      "serverURL": "foobar",
+      "secretToken": "foobar",
+      "serviceEnvironment": "foobar"
     }
+  },
+  "hostResolver": {
+    "cnameFlattening": true,
+    "resolvConfig": "foobar",
+    "resolvDepth": 42
+  },
+  "certificatesResolvers": {
+    "CertificateResolver0": {
+      "acme": {
+        "email": "foobar",
+        "caServer": "foobar",
+        "preferredChain": "foobar",
+        "storage": "foobar",
+        "keyType": "foobar",
+        "eab": {
+          "kid": "foobar",
+          "hmacEncoded": "foobar"
+        },
+        "certificatesDuration": 42,
+        "dnsChallenge": {
+          "provider": "foobar",
+          "delayBeforeCheck": "42s",
+          "resolvers": [
+            "foobar",
+            "foobar"
+          ],
+          "disablePropagationCheck": true
+        },
+        "httpChallenge": {
+          "entryPoint": "foobar"
+        },
+        "tlsChallenge": {}
+      }
+    },
+    "CertificateResolver1": {
+      "acme": {
+        "email": "foobar",
+        "caServer": "foobar",
+        "preferredChain": "foobar",
+        "storage": "foobar",
+        "keyType": "foobar",
+        "eab": {
+          "kid": "foobar",
+          "hmacEncoded": "foobar"
+        },
+        "certificatesDuration": 42,
+        "dnsChallenge": {
+          "provider": "foobar",
+          "delayBeforeCheck": "42s",
+          "resolvers": [
+            "foobar",
+            "foobar"
+          ],
+          "disablePropagationCheck": true
+        },
+        "httpChallenge": {
+          "entryPoint": "foobar"
+        },
+        "tlsChallenge": {}
+      }
+    }
+  },
+  "pilot": {
+    "token": "foobar",
+    "dashboard": true
+  },
+  "experimental": {
+    "plugins": {
+      "Descriptor0": {
+        "moduleName": "foobar",
+        "version": "foobar"
+      },
+      "Descriptor1": {
+        "moduleName": "foobar",
+        "version": "foobar"
+      }
+    },
+    "localPlugins": {
+      "LocalDescriptor0": {
+        "moduleName": "foobar"
+      },
+      "LocalDescriptor1": {
+        "moduleName": "foobar"
+      }
+    },
+    "kubernetesGateway": true,
+    "http3": true
   }
 }

--- a/src/test/traefik-v3/example.json
+++ b/src/test/traefik-v3/example.json
@@ -1,0 +1,715 @@
+{
+  "global": {
+    "checkNewVersion": true,
+    "sendAnonymousUsage": true
+  },
+  "serversTransport": {
+    "insecureSkipVerify": true,
+    "rootCAs": [
+      "foobar",
+      "foobar"
+    ],
+    "maxIdleConnsPerHost": 42,
+    "forwardingTimeouts": {
+      "dialTimeout": "42s",
+      "responseHeaderTimeout": "42s",
+      "idleConnTimeout": "42s"
+    },
+    "spiffe": {
+      "ids": [
+        "foobar",
+        "foobar"
+      ],
+      "trustDomain": "foobar"
+    }
+  },
+  "tcpServersTransport": {
+    "dialKeepAlive": "42s",
+    "dialTimeout": "42s",
+    "terminationDelay": "42s",
+    "tls": {
+      "insecureSkipVerify": true,
+      "rootCAs": [
+        "foobar",
+        "foobar"
+      ],
+      "spiffe": {
+        "ids": [
+          "foobar",
+          "foobar"
+        ],
+        "trustDomain": "foobar"
+      }
+    }
+  },
+  "entryPoints": {
+    "EntryPoint0": {
+      "address": "foobar",
+      "reusePort": true,
+      "asDefault": true,
+      "transport": {
+        "lifeCycle": {
+          "requestAcceptGraceTimeout": "42s",
+          "graceTimeOut": "42s"
+        },
+        "respondingTimeouts": {
+          "readTimeout": "42s",
+          "writeTimeout": "42s",
+          "idleTimeout": "42s"
+        },
+        "keepAliveMaxTime": "42s",
+        "keepAliveMaxRequests": 42
+      },
+      "proxyProtocol": {
+        "insecure": true,
+        "trustedIPs": [
+          "foobar",
+          "foobar"
+        ]
+      },
+      "forwardedHeaders": {
+        "insecure": true,
+        "trustedIPs": [
+          "foobar",
+          "foobar"
+        ]
+      },
+      "http": {
+        "redirections": {
+          "entryPoint": {
+            "to": "foobar",
+            "scheme": "foobar",
+            "permanent": true,
+            "priority": 42
+          }
+        },
+        "middlewares": [
+          "foobar",
+          "foobar"
+        ],
+        "tls": {
+          "options": "foobar",
+          "certResolver": "foobar",
+          "domains": [
+            {
+              "main": "foobar",
+              "sans": [
+                "foobar",
+                "foobar"
+              ]
+            },
+            {
+              "main": "foobar",
+              "sans": [
+                "foobar",
+                "foobar"
+              ]
+            }
+          ]
+        },
+        "encodeQuerySemicolons": true
+      },
+      "http2": {
+        "maxConcurrentStreams": 42
+      },
+      "http3": {
+        "advertisedPort": 42
+      },
+      "udp": {
+        "timeout": "42s"
+      }
+    }
+  },
+  "providers": {
+    "providersThrottleDuration": "42s",
+    "docker": {
+      "exposedByDefault": true,
+      "constraints": "foobar",
+      "allowEmptyServices": true,
+      "network": "foobar",
+      "useBindPortIP": true,
+      "watch": true,
+      "defaultRule": "foobar",
+      "endpoint": "foobar",
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      },
+      "httpClientTimeout": "42s"
+    },
+    "swarm": {
+      "exposedByDefault": true,
+      "constraints": "foobar",
+      "allowEmptyServices": true,
+      "network": "foobar",
+      "useBindPortIP": true,
+      "watch": true,
+      "defaultRule": "foobar",
+      "endpoint": "foobar",
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      },
+      "httpClientTimeout": "42s",
+      "refreshSeconds": "42s"
+    },
+    "file": {
+      "directory": "foobar",
+      "watch": true,
+      "filename": "foobar",
+      "debugLogGeneratedTemplate": true
+    },
+    "kubernetesIngress": {
+      "endpoint": "foobar",
+      "token": "foobar",
+      "certAuthFilePath": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ],
+      "labelSelector": "foobar",
+      "ingressClass": "foobar",
+      "ingressEndpoint": {
+        "ip": "foobar",
+        "hostname": "foobar",
+        "publishedService": "foobar"
+      },
+      "throttleDuration": "42s",
+      "allowEmptyServices": true,
+      "allowExternalNameServices": true,
+      "disableIngressClassLookup": true,
+      "disableClusterScopeResources": true,
+      "nativeLBByDefault": true
+    },
+    "kubernetesCRD": {
+      "endpoint": "foobar",
+      "token": "foobar",
+      "certAuthFilePath": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ],
+      "allowCrossNamespace": true,
+      "allowExternalNameServices": true,
+      "labelSelector": "foobar",
+      "ingressClass": "foobar",
+      "throttleDuration": "42s",
+      "allowEmptyServices": true,
+      "nativeLBByDefault": true,
+      "disableClusterScopeResources": true
+    },
+    "kubernetesGateway": {
+      "endpoint": "foobar",
+      "token": "foobar",
+      "certAuthFilePath": "foobar",
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ],
+      "labelSelector": "foobar",
+      "throttleDuration": "42s",
+      "experimentalChannel": true,
+      "statusAddress": {
+        "ip": "foobar",
+        "hostname": "foobar",
+        "service": {
+          "name": "foobar",
+          "namespace": "foobar"
+        }
+      }
+    },
+    "rest": {
+      "insecure": true
+    },
+    "consulCatalog": {
+      "constraints": "foobar",
+      "endpoint": {
+        "address": "foobar",
+        "scheme": "foobar",
+        "datacenter": "foobar",
+        "token": "foobar",
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "key": "foobar",
+          "insecureSkipVerify": true
+        },
+        "httpAuth": {
+          "username": "foobar",
+          "password": "foobar"
+        },
+        "endpointWaitTime": "42s"
+      },
+      "prefix": "foobar",
+      "refreshInterval": "42s",
+      "requireConsistent": true,
+      "stale": true,
+      "cache": true,
+      "exposedByDefault": true,
+      "defaultRule": "foobar",
+      "connectAware": true,
+      "connectByDefault": true,
+      "serviceName": "foobar",
+      "watch": true,
+      "strictChecks": [
+        "foobar",
+        "foobar"
+      ],
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ]
+    },
+    "nomad": {
+      "defaultRule": "foobar",
+      "constraints": "foobar",
+      "endpoint": {
+        "address": "foobar",
+        "region": "foobar",
+        "token": "foobar",
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "key": "foobar",
+          "insecureSkipVerify": true
+        },
+        "endpointWaitTime": "42s"
+      },
+      "prefix": "foobar",
+      "stale": true,
+      "exposedByDefault": true,
+      "refreshInterval": "42s",
+      "allowEmptyServices": true,
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ]
+    },
+    "ecs": {
+      "constraints": "foobar",
+      "exposedByDefault": true,
+      "refreshSeconds": 42,
+      "defaultRule": "foobar",
+      "clusters": [
+        "foobar",
+        "foobar"
+      ],
+      "autoDiscoverClusters": true,
+      "healthyTasksOnly": true,
+      "ecsAnywhere": true,
+      "region": "foobar",
+      "accessKeyID": "foobar",
+      "secretAccessKey": "foobar"
+    },
+    "consul": {
+      "rootKey": "foobar",
+      "endpoints": [
+        "foobar",
+        "foobar"
+      ],
+      "token": "foobar",
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      },
+      "namespaces": [
+        "foobar",
+        "foobar"
+      ]
+    },
+    "etcd": {
+      "rootKey": "foobar",
+      "endpoints": [
+        "foobar",
+        "foobar"
+      ],
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      },
+      "username": "foobar",
+      "password": "foobar"
+    },
+    "zooKeeper": {
+      "rootKey": "foobar",
+      "endpoints": [
+        "foobar",
+        "foobar"
+      ],
+      "username": "foobar",
+      "password": "foobar"
+    },
+    "redis": {
+      "rootKey": "foobar",
+      "endpoints": [
+        "foobar",
+        "foobar"
+      ],
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      },
+      "username": "foobar",
+      "password": "foobar",
+      "db": 42,
+      "sentinel": {
+        "masterName": "foobar",
+        "username": "foobar",
+        "password": "foobar",
+        "latencyStrategy": true,
+        "randomStrategy": true,
+        "replicaStrategy": true,
+        "useDisconnectedReplicas": true
+      }
+    },
+    "http": {
+      "endpoint": "foobar",
+      "pollInterval": "42s",
+      "pollTimeout": "42s",
+      "headers": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "key": "foobar",
+        "insecureSkipVerify": true
+      }
+    },
+    "plugin": {
+      "PluginConf0": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "PluginConf1": {
+        "name0": "foobar",
+        "name1": "foobar"
+      }
+    }
+  },
+  "api": {
+    "insecure": true,
+    "dashboard": true,
+    "debug": true,
+    "disableDashboardAd": true
+  },
+  "metrics": {
+    "addInternals": true,
+    "prometheus": {
+      "buckets": [
+        42,
+        42
+      ],
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "entryPoint": "foobar",
+      "manualRouting": true,
+      "headerLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      }
+    },
+    "datadog": {
+      "address": "foobar",
+      "pushInterval": "42s",
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "prefix": "foobar"
+    },
+    "statsD": {
+      "address": "foobar",
+      "pushInterval": "42s",
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "prefix": "foobar"
+    },
+    "influxDB2": {
+      "address": "foobar",
+      "token": "foobar",
+      "pushInterval": "42s",
+      "org": "foobar",
+      "bucket": "foobar",
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "additionalLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      }
+    },
+    "otlp": {
+      "grpc": {
+        "endpoint": "foobar",
+        "insecure": true,
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "key": "foobar",
+          "insecureSkipVerify": true
+        },
+        "headers": {
+          "name0": "foobar",
+          "name1": "foobar"
+        }
+      },
+      "http": {
+        "endpoint": "foobar",
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "key": "foobar",
+          "insecureSkipVerify": true
+        },
+        "headers": {
+          "name0": "foobar",
+          "name1": "foobar"
+        }
+      },
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "explicitBoundaries": [
+        42,
+        42
+      ],
+      "pushInterval": "42s"
+    }
+  },
+  "ping": {
+    "entryPoint": "foobar",
+    "manualRouting": true,
+    "terminatingStatusCode": 42
+  },
+  "log": {
+    "level": "foobar",
+    "format": "foobar",
+    "noColor": true,
+    "filePath": "foobar",
+    "maxSize": 42,
+    "maxAge": 42,
+    "maxBackups": 42,
+    "compress": true
+  },
+  "accessLog": {
+    "filePath": "foobar",
+    "format": "foobar",
+    "filters": {
+      "statusCodes": [
+        "foobar",
+        "foobar"
+      ],
+      "retryAttempts": true,
+      "minDuration": "42s"
+    },
+    "fields": {
+      "defaultMode": "foobar",
+      "names": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "headers": {
+        "defaultMode": "foobar",
+        "names": {
+          "name0": "foobar",
+          "name1": "foobar"
+        }
+      }
+    },
+    "bufferingSize": 42,
+    "addInternals": true
+  },
+  "tracing": {
+    "serviceName": "foobar",
+    "globalAttributes": {
+      "name0": "foobar",
+      "name1": "foobar"
+    },
+    "capturedRequestHeaders": [
+      "foobar",
+      "foobar"
+    ],
+    "capturedResponseHeaders": [
+      "foobar",
+      "foobar"
+    ],
+    "safeQueryParams": [
+      "foobar",
+      "foobar"
+    ],
+    "sampleRate": 42,
+    "addInternals": true,
+    "otlp": {
+      "grpc": {
+        "endpoint": "foobar",
+        "insecure": true,
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "key": "foobar",
+          "insecureSkipVerify": true
+        },
+        "headers": {
+          "name0": "foobar",
+          "name1": "foobar"
+        }
+      },
+      "http": {
+        "endpoint": "foobar",
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "key": "foobar",
+          "insecureSkipVerify": true
+        },
+        "headers": {
+          "name0": "foobar",
+          "name1": "foobar"
+        }
+      }
+    }
+  },
+  "hostResolver": {
+    "cnameFlattening": true,
+    "resolvConfig": "foobar",
+    "resolvDepth": 42
+  },
+  "certificatesResolvers": {
+    "CertificateResolver0": {
+      "acme": {
+        "email": "foobar",
+        "caServer": "foobar",
+        "preferredChain": "foobar",
+        "storage": "foobar",
+        "keyType": "foobar",
+        "eab": {
+          "kid": "foobar",
+          "hmacEncoded": "foobar"
+        },
+        "certificatesDuration": 42,
+        "dnsChallenge": {
+          "provider": "foobar",
+          "delayBeforeCheck": "42s",
+          "resolvers": [
+            "foobar",
+            "foobar"
+          ],
+          "disablePropagationCheck": true
+        },
+        "httpChallenge": {
+          "entryPoint": "foobar"
+        },
+        "tlsChallenge": {}
+      },
+      "tailscale": {}
+    },
+    "CertificateResolver1": {
+      "acme": {
+        "email": "foobar",
+        "caServer": "foobar",
+        "preferredChain": "foobar",
+        "storage": "foobar",
+        "keyType": "foobar",
+        "eab": {
+          "kid": "foobar",
+          "hmacEncoded": "foobar"
+        },
+        "certificatesDuration": 42,
+        "dnsChallenge": {
+          "provider": "foobar",
+          "delayBeforeCheck": "42s",
+          "resolvers": [
+            "foobar",
+            "foobar"
+          ],
+          "disablePropagationCheck": true
+        },
+        "httpChallenge": {
+          "entryPoint": "foobar"
+        },
+        "tlsChallenge": {}
+      },
+      "tailscale": {}
+    }
+  },
+  "experimental": {
+    "plugins": {
+      "Descriptor0": {
+        "moduleName": "foobar",
+        "version": "foobar",
+        "settings": {
+          "envs": [
+            "foobar",
+            "foobar"
+          ],
+          "mounts": [
+            "foobar",
+            "foobar"
+          ]
+        }
+      },
+      "Descriptor1": {
+        "moduleName": "foobar",
+        "version": "foobar",
+        "settings": {
+          "envs": [
+            "foobar",
+            "foobar"
+          ],
+          "mounts": [
+            "foobar",
+            "foobar"
+          ]
+        }
+      }
+    },
+    "localPlugins": {
+      "LocalDescriptor0": {
+        "moduleName": "foobar",
+        "settings": {
+          "envs": [
+            "foobar",
+            "foobar"
+          ],
+          "mounts": [
+            "foobar",
+            "foobar"
+          ]
+        }
+      },
+      "LocalDescriptor1": {
+        "moduleName": "foobar",
+        "settings": {
+          "envs": [
+            "foobar",
+            "foobar"
+          ],
+          "mounts": [
+            "foobar",
+            "foobar"
+          ]
+        }
+      }
+    },
+    "kubernetesGateway": true
+  },
+  "core": {
+    "defaultRuleSyntax": "foobar"
+  },
+  "spiffe": {
+    "workloadAPIAddr": "foobar"
+  }
+}

--- a/src/test/traefik-v3/example.json
+++ b/src/test/traefik-v3/example.json
@@ -1,113 +1,123 @@
 {
-  "global": {
-    "checkNewVersion": true,
-    "sendAnonymousUsage": true
-  },
-  "serversTransport": {
-    "insecureSkipVerify": true,
-    "rootCAs": [
-      "foobar",
-      "foobar"
-    ],
-    "maxIdleConnsPerHost": 42,
-    "forwardingTimeouts": {
-      "dialTimeout": "42s",
-      "responseHeaderTimeout": "42s",
-      "idleConnTimeout": "42s"
-    },
-    "spiffe": {
-      "ids": [
-        "foobar",
-        "foobar"
-      ],
-      "trustDomain": "foobar"
-    }
-  },
-  "tcpServersTransport": {
-    "dialKeepAlive": "42s",
-    "dialTimeout": "42s",
-    "terminationDelay": "42s",
-    "tls": {
-      "insecureSkipVerify": true,
-      "rootCAs": [
-        "foobar",
-        "foobar"
-      ],
-      "spiffe": {
-        "ids": [
-          "foobar",
-          "foobar"
-        ],
-        "trustDomain": "foobar"
+  "accessLog": {
+    "addInternals": true,
+    "bufferingSize": 42,
+    "fields": {
+      "defaultMode": "foobar",
+      "headers": {
+        "defaultMode": "foobar",
+        "names": {
+          "name0": "foobar",
+          "name1": "foobar"
+        }
+      },
+      "names": {
+        "name0": "foobar",
+        "name1": "foobar"
       }
+    },
+    "filePath": "foobar",
+    "filters": {
+      "minDuration": "42s",
+      "retryAttempts": true,
+      "statusCodes": ["foobar", "foobar"]
+    },
+    "format": "foobar"
+  },
+  "api": {
+    "dashboard": true,
+    "debug": true,
+    "disableDashboardAd": true,
+    "insecure": true
+  },
+  "certificatesResolvers": {
+    "CertificateResolver0": {
+      "acme": {
+        "caServer": "foobar",
+        "certificatesDuration": 42,
+        "dnsChallenge": {
+          "delayBeforeCheck": "42s",
+          "disablePropagationCheck": true,
+          "provider": "foobar",
+          "resolvers": ["foobar", "foobar"]
+        },
+        "eab": {
+          "hmacEncoded": "foobar",
+          "kid": "foobar"
+        },
+        "email": "foobar",
+        "httpChallenge": {
+          "entryPoint": "foobar"
+        },
+        "keyType": "foobar",
+        "preferredChain": "foobar",
+        "storage": "foobar",
+        "tlsChallenge": {}
+      },
+      "tailscale": {}
+    },
+    "CertificateResolver1": {
+      "acme": {
+        "caServer": "foobar",
+        "certificatesDuration": 42,
+        "dnsChallenge": {
+          "delayBeforeCheck": "42s",
+          "disablePropagationCheck": true,
+          "provider": "foobar",
+          "resolvers": ["foobar", "foobar"]
+        },
+        "eab": {
+          "hmacEncoded": "foobar",
+          "kid": "foobar"
+        },
+        "email": "foobar",
+        "httpChallenge": {
+          "entryPoint": "foobar"
+        },
+        "keyType": "foobar",
+        "preferredChain": "foobar",
+        "storage": "foobar",
+        "tlsChallenge": {}
+      },
+      "tailscale": {}
     }
+  },
+  "core": {
+    "defaultRuleSyntax": "foobar"
   },
   "entryPoints": {
     "EntryPoint0": {
       "address": "foobar",
-      "reusePort": true,
       "asDefault": true,
-      "transport": {
-        "lifeCycle": {
-          "requestAcceptGraceTimeout": "42s",
-          "graceTimeOut": "42s"
-        },
-        "respondingTimeouts": {
-          "readTimeout": "42s",
-          "writeTimeout": "42s",
-          "idleTimeout": "42s"
-        },
-        "keepAliveMaxTime": "42s",
-        "keepAliveMaxRequests": 42
-      },
-      "proxyProtocol": {
-        "insecure": true,
-        "trustedIPs": [
-          "foobar",
-          "foobar"
-        ]
-      },
       "forwardedHeaders": {
         "insecure": true,
-        "trustedIPs": [
-          "foobar",
-          "foobar"
-        ]
+        "trustedIPs": ["foobar", "foobar"]
       },
       "http": {
+        "encodeQuerySemicolons": true,
+        "middlewares": ["foobar", "foobar"],
         "redirections": {
           "entryPoint": {
-            "to": "foobar",
-            "scheme": "foobar",
             "permanent": true,
-            "priority": 42
+            "priority": 42,
+            "scheme": "foobar",
+            "to": "foobar"
           }
         },
-        "middlewares": [
-          "foobar",
-          "foobar"
-        ],
         "tls": {
-          "options": "foobar",
           "certResolver": "foobar",
           "domains": [
             {
               "main": "foobar",
-              "sans": [
-                "foobar",
-                "foobar"
-              ]
+              "sans": ["foobar", "foobar"]
             },
             {
               "main": "foobar",
-              "sans": [
-                "foobar",
-                "foobar"
-              ]
+              "sans": ["foobar", "foobar"]
             }
-          ]
-        },
-        "encodeQuerySemicolons": true
+          ],
+          "options": "foobar"
+        }
       },
       "http2": {
         "maxConcurrentStreams": 42
@@ -115,277 +125,349 @@
       "http3": {
         "advertisedPort": 42
       },
+      "proxyProtocol": {
+        "insecure": true,
+        "trustedIPs": ["foobar", "foobar"]
+      },
+      "reusePort": true,
+      "transport": {
+        "keepAliveMaxRequests": 42,
+        "keepAliveMaxTime": "42s",
+        "lifeCycle": {
+          "graceTimeOut": "42s",
+          "requestAcceptGraceTimeout": "42s"
+        },
+        "respondingTimeouts": {
+          "idleTimeout": "42s",
+          "readTimeout": "42s",
+          "writeTimeout": "42s"
+        }
+      },
       "udp": {
         "timeout": "42s"
       }
     }
   },
-  "providers": {
-    "providersThrottleDuration": "42s",
-    "docker": {
-      "exposedByDefault": true,
-      "constraints": "foobar",
-      "allowEmptyServices": true,
-      "network": "foobar",
-      "useBindPortIP": true,
-      "watch": true,
-      "defaultRule": "foobar",
-      "endpoint": "foobar",
-      "tls": {
-        "ca": "foobar",
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
+  "experimental": {
+    "kubernetesGateway": true,
+    "localPlugins": {
+      "LocalDescriptor0": {
+        "moduleName": "foobar",
+        "settings": {
+          "envs": ["foobar", "foobar"],
+          "mounts": ["foobar", "foobar"]
+        }
       },
-      "httpClientTimeout": "42s"
-    },
-    "swarm": {
-      "exposedByDefault": true,
-      "constraints": "foobar",
-      "allowEmptyServices": true,
-      "network": "foobar",
-      "useBindPortIP": true,
-      "watch": true,
-      "defaultRule": "foobar",
-      "endpoint": "foobar",
-      "tls": {
-        "ca": "foobar",
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      },
-      "httpClientTimeout": "42s",
-      "refreshSeconds": "42s"
-    },
-    "file": {
-      "directory": "foobar",
-      "watch": true,
-      "filename": "foobar",
-      "debugLogGeneratedTemplate": true
-    },
-    "kubernetesIngress": {
-      "endpoint": "foobar",
-      "token": "foobar",
-      "certAuthFilePath": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ],
-      "labelSelector": "foobar",
-      "ingressClass": "foobar",
-      "ingressEndpoint": {
-        "ip": "foobar",
-        "hostname": "foobar",
-        "publishedService": "foobar"
-      },
-      "throttleDuration": "42s",
-      "allowEmptyServices": true,
-      "allowExternalNameServices": true,
-      "disableIngressClassLookup": true,
-      "disableClusterScopeResources": true,
-      "nativeLBByDefault": true
-    },
-    "kubernetesCRD": {
-      "endpoint": "foobar",
-      "token": "foobar",
-      "certAuthFilePath": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ],
-      "allowCrossNamespace": true,
-      "allowExternalNameServices": true,
-      "labelSelector": "foobar",
-      "ingressClass": "foobar",
-      "throttleDuration": "42s",
-      "allowEmptyServices": true,
-      "nativeLBByDefault": true,
-      "disableClusterScopeResources": true
-    },
-    "kubernetesGateway": {
-      "endpoint": "foobar",
-      "token": "foobar",
-      "certAuthFilePath": "foobar",
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ],
-      "labelSelector": "foobar",
-      "throttleDuration": "42s",
-      "experimentalChannel": true,
-      "statusAddress": {
-        "ip": "foobar",
-        "hostname": "foobar",
-        "service": {
-          "name": "foobar",
-          "namespace": "foobar"
+      "LocalDescriptor1": {
+        "moduleName": "foobar",
+        "settings": {
+          "envs": ["foobar", "foobar"],
+          "mounts": ["foobar", "foobar"]
         }
       }
     },
-    "rest": {
-      "insecure": true
+    "plugins": {
+      "Descriptor0": {
+        "moduleName": "foobar",
+        "settings": {
+          "envs": ["foobar", "foobar"],
+          "mounts": ["foobar", "foobar"]
+        },
+        "version": "foobar"
+      },
+      "Descriptor1": {
+        "moduleName": "foobar",
+        "settings": {
+          "envs": ["foobar", "foobar"],
+          "mounts": ["foobar", "foobar"]
+        },
+        "version": "foobar"
+      }
+    }
+  },
+  "global": {
+    "checkNewVersion": true,
+    "sendAnonymousUsage": true
+  },
+  "hostResolver": {
+    "cnameFlattening": true,
+    "resolvConfig": "foobar",
+    "resolvDepth": 42
+  },
+  "log": {
+    "compress": true,
+    "filePath": "foobar",
+    "format": "foobar",
+    "level": "foobar",
+    "maxAge": 42,
+    "maxBackups": 42,
+    "maxSize": 42,
+    "noColor": true
+  },
+  "metrics": {
+    "addInternals": true,
+    "datadog": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "address": "foobar",
+      "prefix": "foobar",
+      "pushInterval": "42s"
     },
-    "consulCatalog": {
-      "constraints": "foobar",
-      "endpoint": {
-        "address": "foobar",
-        "scheme": "foobar",
-        "datacenter": "foobar",
-        "token": "foobar",
+    "influxDB2": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "additionalLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "address": "foobar",
+      "bucket": "foobar",
+      "org": "foobar",
+      "pushInterval": "42s",
+      "token": "foobar"
+    },
+    "otlp": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "explicitBoundaries": [42, 42],
+      "grpc": {
+        "endpoint": "foobar",
+        "headers": {
+          "name0": "foobar",
+          "name1": "foobar"
+        },
+        "insecure": true,
         "tls": {
           "ca": "foobar",
           "cert": "foobar",
-          "key": "foobar",
-          "insecureSkipVerify": true
-        },
-        "httpAuth": {
-          "username": "foobar",
-          "password": "foobar"
-        },
-        "endpointWaitTime": "42s"
+          "insecureSkipVerify": true,
+          "key": "foobar"
+        }
       },
+      "http": {
+        "endpoint": "foobar",
+        "headers": {
+          "name0": "foobar",
+          "name1": "foobar"
+        },
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "insecureSkipVerify": true,
+          "key": "foobar"
+        }
+      },
+      "pushInterval": "42s"
+    },
+    "prometheus": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "buckets": [42, 42],
+      "entryPoint": "foobar",
+      "headerLabels": {
+        "name0": "foobar",
+        "name1": "foobar"
+      },
+      "manualRouting": true
+    },
+    "statsD": {
+      "addEntryPointsLabels": true,
+      "addRoutersLabels": true,
+      "addServicesLabels": true,
+      "address": "foobar",
+      "prefix": "foobar",
+      "pushInterval": "42s"
+    }
+  },
+  "ping": {
+    "entryPoint": "foobar",
+    "manualRouting": true,
+    "terminatingStatusCode": 42
+  },
+  "providers": {
+    "consul": {
+      "endpoints": ["foobar", "foobar"],
+      "namespaces": ["foobar", "foobar"],
+      "rootKey": "foobar",
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "token": "foobar"
+    },
+    "consulCatalog": {
+      "cache": true,
+      "connectAware": true,
+      "connectByDefault": true,
+      "constraints": "foobar",
+      "defaultRule": "foobar",
+      "endpoint": {
+        "address": "foobar",
+        "datacenter": "foobar",
+        "endpointWaitTime": "42s",
+        "httpAuth": {
+          "password": "foobar",
+          "username": "foobar"
+        },
+        "scheme": "foobar",
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "insecureSkipVerify": true,
+          "key": "foobar"
+        },
+        "token": "foobar"
+      },
+      "exposedByDefault": true,
+      "namespaces": ["foobar", "foobar"],
       "prefix": "foobar",
       "refreshInterval": "42s",
       "requireConsistent": true,
-      "stale": true,
-      "cache": true,
-      "exposedByDefault": true,
-      "defaultRule": "foobar",
-      "connectAware": true,
-      "connectByDefault": true,
       "serviceName": "foobar",
-      "watch": true,
-      "strictChecks": [
-        "foobar",
-        "foobar"
-      ],
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ]
-    },
-    "nomad": {
-      "defaultRule": "foobar",
-      "constraints": "foobar",
-      "endpoint": {
-        "address": "foobar",
-        "region": "foobar",
-        "token": "foobar",
-        "tls": {
-          "ca": "foobar",
-          "cert": "foobar",
-          "key": "foobar",
-          "insecureSkipVerify": true
-        },
-        "endpointWaitTime": "42s"
-      },
-      "prefix": "foobar",
       "stale": true,
-      "exposedByDefault": true,
-      "refreshInterval": "42s",
+      "strictChecks": ["foobar", "foobar"],
+      "watch": true
+    },
+    "docker": {
       "allowEmptyServices": true,
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ]
+      "constraints": "foobar",
+      "defaultRule": "foobar",
+      "endpoint": "foobar",
+      "exposedByDefault": true,
+      "httpClientTimeout": "42s",
+      "network": "foobar",
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "useBindPortIP": true,
+      "watch": true
     },
     "ecs": {
-      "constraints": "foobar",
-      "exposedByDefault": true,
-      "refreshSeconds": 42,
-      "defaultRule": "foobar",
-      "clusters": [
-        "foobar",
-        "foobar"
-      ],
-      "autoDiscoverClusters": true,
-      "healthyTasksOnly": true,
-      "ecsAnywhere": true,
-      "region": "foobar",
       "accessKeyID": "foobar",
+      "autoDiscoverClusters": true,
+      "clusters": ["foobar", "foobar"],
+      "constraints": "foobar",
+      "defaultRule": "foobar",
+      "ecsAnywhere": true,
+      "exposedByDefault": true,
+      "healthyTasksOnly": true,
+      "refreshSeconds": 42,
+      "region": "foobar",
       "secretAccessKey": "foobar"
     },
-    "consul": {
-      "rootKey": "foobar",
-      "endpoints": [
-        "foobar",
-        "foobar"
-      ],
-      "token": "foobar",
-      "tls": {
-        "ca": "foobar",
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      },
-      "namespaces": [
-        "foobar",
-        "foobar"
-      ]
-    },
     "etcd": {
-      "rootKey": "foobar",
-      "endpoints": [
-        "foobar",
-        "foobar"
-      ],
-      "tls": {
-        "ca": "foobar",
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      },
-      "username": "foobar",
-      "password": "foobar"
-    },
-    "zooKeeper": {
-      "rootKey": "foobar",
-      "endpoints": [
-        "foobar",
-        "foobar"
-      ],
-      "username": "foobar",
-      "password": "foobar"
-    },
-    "redis": {
-      "rootKey": "foobar",
-      "endpoints": [
-        "foobar",
-        "foobar"
-      ],
-      "tls": {
-        "ca": "foobar",
-        "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
-      },
-      "username": "foobar",
+      "endpoints": ["foobar", "foobar"],
       "password": "foobar",
-      "db": 42,
-      "sentinel": {
-        "masterName": "foobar",
-        "username": "foobar",
-        "password": "foobar",
-        "latencyStrategy": true,
-        "randomStrategy": true,
-        "replicaStrategy": true,
-        "useDisconnectedReplicas": true
-      }
+      "rootKey": "foobar",
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "username": "foobar"
+    },
+    "file": {
+      "debugLogGeneratedTemplate": true,
+      "directory": "foobar",
+      "filename": "foobar",
+      "watch": true
     },
     "http": {
       "endpoint": "foobar",
-      "pollInterval": "42s",
-      "pollTimeout": "42s",
       "headers": {
         "name0": "foobar",
         "name1": "foobar"
       },
+      "pollInterval": "42s",
+      "pollTimeout": "42s",
       "tls": {
         "ca": "foobar",
         "cert": "foobar",
-        "key": "foobar",
-        "insecureSkipVerify": true
+        "insecureSkipVerify": true,
+        "key": "foobar"
       }
+    },
+    "kubernetesCRD": {
+      "allowCrossNamespace": true,
+      "allowEmptyServices": true,
+      "allowExternalNameServices": true,
+      "certAuthFilePath": "foobar",
+      "disableClusterScopeResources": true,
+      "endpoint": "foobar",
+      "ingressClass": "foobar",
+      "labelSelector": "foobar",
+      "namespaces": ["foobar", "foobar"],
+      "nativeLBByDefault": true,
+      "throttleDuration": "42s",
+      "token": "foobar"
+    },
+    "kubernetesGateway": {
+      "certAuthFilePath": "foobar",
+      "endpoint": "foobar",
+      "experimentalChannel": true,
+      "labelSelector": "foobar",
+      "namespaces": ["foobar", "foobar"],
+      "statusAddress": {
+        "hostname": "foobar",
+        "ip": "foobar",
+        "service": {
+          "name": "foobar",
+          "namespace": "foobar"
+        }
+      },
+      "throttleDuration": "42s",
+      "token": "foobar"
+    },
+    "kubernetesIngress": {
+      "allowEmptyServices": true,
+      "allowExternalNameServices": true,
+      "certAuthFilePath": "foobar",
+      "disableClusterScopeResources": true,
+      "disableIngressClassLookup": true,
+      "endpoint": "foobar",
+      "ingressClass": "foobar",
+      "ingressEndpoint": {
+        "hostname": "foobar",
+        "ip": "foobar",
+        "publishedService": "foobar"
+      },
+      "labelSelector": "foobar",
+      "namespaces": ["foobar", "foobar"],
+      "nativeLBByDefault": true,
+      "throttleDuration": "42s",
+      "token": "foobar"
+    },
+    "nomad": {
+      "allowEmptyServices": true,
+      "constraints": "foobar",
+      "defaultRule": "foobar",
+      "endpoint": {
+        "address": "foobar",
+        "endpointWaitTime": "42s",
+        "region": "foobar",
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "insecureSkipVerify": true,
+          "key": "foobar"
+        },
+        "token": "foobar"
+      },
+      "exposedByDefault": true,
+      "namespaces": ["foobar", "foobar"],
+      "prefix": "foobar",
+      "refreshInterval": "42s",
+      "stale": true
     },
     "plugin": {
       "PluginConf0": {
@@ -396,320 +478,127 @@
         "name0": "foobar",
         "name1": "foobar"
       }
+    },
+    "providersThrottleDuration": "42s",
+    "redis": {
+      "db": 42,
+      "endpoints": ["foobar", "foobar"],
+      "password": "foobar",
+      "rootKey": "foobar",
+      "sentinel": {
+        "latencyStrategy": true,
+        "masterName": "foobar",
+        "password": "foobar",
+        "randomStrategy": true,
+        "replicaStrategy": true,
+        "useDisconnectedReplicas": true,
+        "username": "foobar"
+      },
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "username": "foobar"
+    },
+    "rest": {
+      "insecure": true
+    },
+    "swarm": {
+      "allowEmptyServices": true,
+      "constraints": "foobar",
+      "defaultRule": "foobar",
+      "endpoint": "foobar",
+      "exposedByDefault": true,
+      "httpClientTimeout": "42s",
+      "network": "foobar",
+      "refreshSeconds": "42s",
+      "tls": {
+        "ca": "foobar",
+        "cert": "foobar",
+        "insecureSkipVerify": true,
+        "key": "foobar"
+      },
+      "useBindPortIP": true,
+      "watch": true
+    },
+    "zooKeeper": {
+      "endpoints": ["foobar", "foobar"],
+      "password": "foobar",
+      "rootKey": "foobar",
+      "username": "foobar"
     }
   },
-  "api": {
-    "insecure": true,
-    "dashboard": true,
-    "debug": true,
-    "disableDashboardAd": true
-  },
-  "metrics": {
-    "addInternals": true,
-    "prometheus": {
-      "buckets": [
-        42,
-        42
-      ],
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "entryPoint": "foobar",
-      "manualRouting": true,
-      "headerLabels": {
-        "name0": "foobar",
-        "name1": "foobar"
-      }
+  "serversTransport": {
+    "forwardingTimeouts": {
+      "dialTimeout": "42s",
+      "idleConnTimeout": "42s",
+      "responseHeaderTimeout": "42s"
     },
-    "datadog": {
-      "address": "foobar",
-      "pushInterval": "42s",
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "prefix": "foobar"
-    },
-    "statsD": {
-      "address": "foobar",
-      "pushInterval": "42s",
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "prefix": "foobar"
-    },
-    "influxDB2": {
-      "address": "foobar",
-      "token": "foobar",
-      "pushInterval": "42s",
-      "org": "foobar",
-      "bucket": "foobar",
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "additionalLabels": {
-        "name0": "foobar",
-        "name1": "foobar"
-      }
-    },
-    "otlp": {
-      "grpc": {
-        "endpoint": "foobar",
-        "insecure": true,
-        "tls": {
-          "ca": "foobar",
-          "cert": "foobar",
-          "key": "foobar",
-          "insecureSkipVerify": true
-        },
-        "headers": {
-          "name0": "foobar",
-          "name1": "foobar"
-        }
-      },
-      "http": {
-        "endpoint": "foobar",
-        "tls": {
-          "ca": "foobar",
-          "cert": "foobar",
-          "key": "foobar",
-          "insecureSkipVerify": true
-        },
-        "headers": {
-          "name0": "foobar",
-          "name1": "foobar"
-        }
-      },
-      "addEntryPointsLabels": true,
-      "addRoutersLabels": true,
-      "addServicesLabels": true,
-      "explicitBoundaries": [
-        42,
-        42
-      ],
-      "pushInterval": "42s"
+    "insecureSkipVerify": true,
+    "maxIdleConnsPerHost": 42,
+    "rootCAs": ["foobar", "foobar"],
+    "spiffe": {
+      "ids": ["foobar", "foobar"],
+      "trustDomain": "foobar"
     }
   },
-  "ping": {
-    "entryPoint": "foobar",
-    "manualRouting": true,
-    "terminatingStatusCode": 42
+  "spiffe": {
+    "workloadAPIAddr": "foobar"
   },
-  "log": {
-    "level": "foobar",
-    "format": "foobar",
-    "noColor": true,
-    "filePath": "foobar",
-    "maxSize": 42,
-    "maxAge": 42,
-    "maxBackups": 42,
-    "compress": true
-  },
-  "accessLog": {
-    "filePath": "foobar",
-    "format": "foobar",
-    "filters": {
-      "statusCodes": [
-        "foobar",
-        "foobar"
-      ],
-      "retryAttempts": true,
-      "minDuration": "42s"
-    },
-    "fields": {
-      "defaultMode": "foobar",
-      "names": {
-        "name0": "foobar",
-        "name1": "foobar"
-      },
-      "headers": {
-        "defaultMode": "foobar",
-        "names": {
-          "name0": "foobar",
-          "name1": "foobar"
-        }
+  "tcpServersTransport": {
+    "dialKeepAlive": "42s",
+    "dialTimeout": "42s",
+    "terminationDelay": "42s",
+    "tls": {
+      "insecureSkipVerify": true,
+      "rootCAs": ["foobar", "foobar"],
+      "spiffe": {
+        "ids": ["foobar", "foobar"],
+        "trustDomain": "foobar"
       }
-    },
-    "bufferingSize": 42,
-    "addInternals": true
+    }
   },
   "tracing": {
-    "serviceName": "foobar",
+    "addInternals": true,
+    "capturedRequestHeaders": ["foobar", "foobar"],
+    "capturedResponseHeaders": ["foobar", "foobar"],
     "globalAttributes": {
       "name0": "foobar",
       "name1": "foobar"
     },
-    "capturedRequestHeaders": [
-      "foobar",
-      "foobar"
-    ],
-    "capturedResponseHeaders": [
-      "foobar",
-      "foobar"
-    ],
-    "safeQueryParams": [
-      "foobar",
-      "foobar"
-    ],
-    "sampleRate": 42,
-    "addInternals": true,
     "otlp": {
       "grpc": {
         "endpoint": "foobar",
+        "headers": {
+          "name0": "foobar",
+          "name1": "foobar"
+        },
         "insecure": true,
         "tls": {
           "ca": "foobar",
           "cert": "foobar",
-          "key": "foobar",
-          "insecureSkipVerify": true
-        },
-        "headers": {
-          "name0": "foobar",
-          "name1": "foobar"
+          "insecureSkipVerify": true,
+          "key": "foobar"
         }
       },
       "http": {
         "endpoint": "foobar",
-        "tls": {
-          "ca": "foobar",
-          "cert": "foobar",
-          "key": "foobar",
-          "insecureSkipVerify": true
-        },
         "headers": {
           "name0": "foobar",
           "name1": "foobar"
-        }
-      }
-    }
-  },
-  "hostResolver": {
-    "cnameFlattening": true,
-    "resolvConfig": "foobar",
-    "resolvDepth": 42
-  },
-  "certificatesResolvers": {
-    "CertificateResolver0": {
-      "acme": {
-        "email": "foobar",
-        "caServer": "foobar",
-        "preferredChain": "foobar",
-        "storage": "foobar",
-        "keyType": "foobar",
-        "eab": {
-          "kid": "foobar",
-          "hmacEncoded": "foobar"
         },
-        "certificatesDuration": 42,
-        "dnsChallenge": {
-          "provider": "foobar",
-          "delayBeforeCheck": "42s",
-          "resolvers": [
-            "foobar",
-            "foobar"
-          ],
-          "disablePropagationCheck": true
-        },
-        "httpChallenge": {
-          "entryPoint": "foobar"
-        },
-        "tlsChallenge": {}
-      },
-      "tailscale": {}
-    },
-    "CertificateResolver1": {
-      "acme": {
-        "email": "foobar",
-        "caServer": "foobar",
-        "preferredChain": "foobar",
-        "storage": "foobar",
-        "keyType": "foobar",
-        "eab": {
-          "kid": "foobar",
-          "hmacEncoded": "foobar"
-        },
-        "certificatesDuration": 42,
-        "dnsChallenge": {
-          "provider": "foobar",
-          "delayBeforeCheck": "42s",
-          "resolvers": [
-            "foobar",
-            "foobar"
-          ],
-          "disablePropagationCheck": true
-        },
-        "httpChallenge": {
-          "entryPoint": "foobar"
-        },
-        "tlsChallenge": {}
-      },
-      "tailscale": {}
-    }
-  },
-  "experimental": {
-    "plugins": {
-      "Descriptor0": {
-        "moduleName": "foobar",
-        "version": "foobar",
-        "settings": {
-          "envs": [
-            "foobar",
-            "foobar"
-          ],
-          "mounts": [
-            "foobar",
-            "foobar"
-          ]
-        }
-      },
-      "Descriptor1": {
-        "moduleName": "foobar",
-        "version": "foobar",
-        "settings": {
-          "envs": [
-            "foobar",
-            "foobar"
-          ],
-          "mounts": [
-            "foobar",
-            "foobar"
-          ]
+        "tls": {
+          "ca": "foobar",
+          "cert": "foobar",
+          "insecureSkipVerify": true,
+          "key": "foobar"
         }
       }
     },
-    "localPlugins": {
-      "LocalDescriptor0": {
-        "moduleName": "foobar",
-        "settings": {
-          "envs": [
-            "foobar",
-            "foobar"
-          ],
-          "mounts": [
-            "foobar",
-            "foobar"
-          ]
-        }
-      },
-      "LocalDescriptor1": {
-        "moduleName": "foobar",
-        "settings": {
-          "envs": [
-            "foobar",
-            "foobar"
-          ],
-          "mounts": [
-            "foobar",
-            "foobar"
-          ]
-        }
-      }
-    },
-    "kubernetesGateway": true
-  },
-  "core": {
-    "defaultRuleSyntax": "foobar"
-  },
-  "spiffe": {
-    "workloadAPIAddr": "foobar"
+    "safeQueryParams": ["foobar", "foobar"],
+    "sampleRate": 42,
+    "serviceName": "foobar"
   }
 }


### PR DESCRIPTION
This PR updates the JSON schema for Traefik V2 _(based on Traefik v2.11.8)_ and adds the one for Traefik V3 _(based on Traefik V3.1.2)_. 
These changes also undo my previous changes (https://github.com/SchemaStore/schemastore/pull/3954), as the `statusAddress` is only available on Traefik V3.

For more information on how these JSON schemas were built, everything is available at https://github.com/xunleii/traefik-json-schema, which uses Traefik's source code to build the schemas.

I've also updated the tests using the official documentation, [which provides examples](https://github.com/traefik/traefik/tree/v3.1.2/docs/content/reference/static-configuration).

_EDIT: fix https://github.com/traefik/traefik/issues/10889_