### PR TITLE
Add Cloud Run v1 Schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,5 @@ repos:
         args:
           [
             '--ignore-words-list',
-            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn',
+            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use',
           ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6762,6 +6762,12 @@
       "description": "elm.json file",
       "fileMatch": ["elm.json"],
       "url": "https://json.schemastore.org/elm.json"
+    },
+    {
+      "name": "Cloud Run Spec v1",
+      "description": "Specification for Cloud Run Admin API v1",
+      "fileMatch": ["cloud-run-v1.yml", "cloud-run-v1.yaml"],
+      "url": "https://json.schemastore.org/cloud-run-v1.json"
     }
   ]
 }

--- a/src/negative_test/cloud-run-v1/incorrect-name.yaml
+++ b/src/negative_test/cloud-run-v1/incorrect-name.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: 1234
+  labels:
+    cloud.googleapis.com/location: TheLocation
+  annotations:
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/container-dependencies: '{theContainer1Name: [theContainer2Name]}'
+        run.googleapis.com/vpc-access-connector: theNetwork
+    spec:
+      serviceAccountName: serviceAccountName
+      containers:
+        - image: theImageHere1
+          name: theContainer1Name
+          env:
+            - name: ENV1
+              value: envValue1
+          ports:
+            - name: http1
+              containerPort: 8080
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: mount1
+              readOnly: true
+              mountPath: /etc/mount1
+        - image: theImageHere2
+          name: theContainer2Name
+          env:
+            - name: PORT
+              value: '80'
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: mount1
+          secret:
+            secretName: theSecretName
+            items:
+              - key: latest
+                path: thePath.conf

--- a/src/negative_test/cloud-run-v1/incorrect-port.yaml
+++ b/src/negative_test/cloud-run-v1/incorrect-port.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: 1234
+  labels:
+    cloud.googleapis.com/location: TheLocation
+  annotations:
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/container-dependencies: '{theContainer1Name: [theContainer2Name]}'
+        run.googleapis.com/vpc-access-connector: theNetwork
+    spec:
+      serviceAccountName: serviceAccountName
+      containers:
+        - image: theImageHere1
+          name: theContainer1Name
+          env:
+            - name: ENV1
+              value: envValue1
+          ports:
+            - name: http1
+              containerPort: '8080'
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: mount1
+              readOnly: true
+              mountPath: /etc/mount1
+        - image: theImageHere2
+          name: theContainer2Name
+          env:
+            - name: PORT
+              value: '80'
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: mount1
+          secret:
+            secretName: theSecretName
+            items:
+              - key: latest
+                path: thePath.conf

--- a/src/schemas/json/cloud-run-v1.json
+++ b/src/schemas/json/cloud-run-v1.json
@@ -1,0 +1,3822 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/cloud-run-v1.json",
+  "$defs": {
+    "ListLocationsResponse": {
+      "description": "The response message for Locations.ListLocations.",
+      "type": "object",
+      "properties": {
+        "locations": {
+          "description": "A list of locations that matches the specified filter in the request.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Location"
+          }
+        },
+        "nextPageToken": {
+          "description": "The standard List next-page token.",
+          "type": "string"
+        }
+      }
+    },
+    "Location": {
+      "description": "A resource that represents a Google Cloud location.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Resource name for the location, which may vary between implementations. For example: `\"projects/example-project/locations/us-east1\"`",
+          "type": "string"
+        },
+        "locationId": {
+          "description": "The canonical id for this location. For example: `\"us-east1\"`.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "The friendly name for this location, typically a nearby city name. For example, \"Tokyo\".",
+          "type": "string"
+        },
+        "labels": {
+          "description": "Cross-service attributes for the location. For example {\"cloud.googleapis.com/region\": \"us-east1\"}",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "metadata": {
+          "description": "Service-specific metadata. For example the available capacity at the given location.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Properties of the object. Contains field @type with type URL."
+          }
+        }
+      }
+    },
+    "GoogleLongrunningListOperationsResponse": {
+      "description": "The response message for Operations.ListOperations.",
+      "type": "object",
+      "properties": {
+        "operations": {
+          "description": "A list of operations that matches the specified filter in the request.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleLongrunningOperation"
+          }
+        },
+        "nextPageToken": {
+          "description": "The standard List next-page token.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleLongrunningOperation": {
+      "description": "This resource represents a long-running operation that is the result of a network API call.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`.",
+          "type": "string"
+        },
+        "metadata": {
+          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Properties of the object. Contains field @type with type URL."
+          }
+        },
+        "done": {
+          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available.",
+          "type": "boolean"
+        },
+        "error": {
+          "$ref": "#/$defs/GoogleRpcStatus",
+          "description": "The error result of the operation in case of failure or cancellation."
+        },
+        "response": {
+          "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "Properties of the object. Contains field @type with type URL."
+          }
+        }
+      }
+    },
+    "GoogleRpcStatus": {
+      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "type": "integer"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        },
+        "details": {
+          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          }
+        }
+      }
+    },
+    "Empty": {
+      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
+      "type": "object",
+      "properties": {}
+    },
+    "GoogleLongrunningWaitOperationRequest": {
+      "description": "The request message for Operations.WaitOperation.",
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "description": "The maximum duration to wait before timing out. If left blank, the wait will be at most the time permitted by the underlying HTTP/RPC protocol. If RPC context deadline is also specified, the shorter one will be used.",
+          "type": "string"
+        }
+      }
+    },
+    "ListAuthorizedDomainsResponse": {
+      "description": "A list of Authorized Domains.",
+      "type": "object",
+      "properties": {
+        "domains": {
+          "description": "The authorized domains belonging to the user.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AuthorizedDomain"
+          }
+        },
+        "nextPageToken": {
+          "description": "Continuation token for fetching the next page of results.",
+          "type": "string"
+        }
+      }
+    },
+    "AuthorizedDomain": {
+      "description": "A domain that a user has been authorized to administer. To authorize use of a domain, verify ownership via [Search Console](https://search.google.com/search-console/welcome).",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Deprecated Read only. Full path to the `AuthorizedDomain` resource in the API. Example: `projects/myproject/authorizedDomains/example.com`.",
+          "deprecated": true,
+          "type": "string"
+        },
+        "id": {
+          "description": "Relative name of the domain authorized for use. Example: `example.com`.",
+          "type": "string"
+        }
+      }
+    },
+    "ListRevisionsResponse": {
+      "description": "ListRevisionsResponse is a list of Revision resources.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call such as \"serving.knative.dev/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case \"RevisionList\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Metadata associated with this revision list."
+        },
+        "items": {
+          "description": "List of Revisions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Revision"
+          }
+        },
+        "unreachable": {
+          "description": "Locations that could not be reached.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ListMeta": {
+      "description": "Metadata for synthetic resources like List. In Cloud Run, all List Resources Responses will have a ListMeta instead of ObjectMeta.",
+      "type": "object",
+      "properties": {
+        "selfLink": {
+          "description": "URL representing this object.",
+          "type": "string"
+        },
+        "resourceVersion": {
+          "description": "Opaque string that identifies the server's internal version of this object. It can be used by clients to determine when objects have changed. If the message is passed back to the server, it must be left unmodified.",
+          "type": "string"
+        },
+        "continue": {
+          "description": "Continuation token is a value emitted when the count of items is larger than the user/system limit. To retrieve the next page of items, pass the value of `continue` as the next request's `page_token`.",
+          "type": "string"
+        }
+      }
+    },
+    "Revision": {
+      "description": "Revision is an immutable snapshot of code and configuration. A revision references a container image. Revisions are created by updates to a Configuration. See also: https://github.com/knative/specs/blob/main/specs/serving/overview.md#revision",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call such as \"serving.knative.dev/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case \"Revision\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Metadata associated with this Revision, including name, namespace, labels, and annotations."
+        },
+        "spec": {
+          "$ref": "#/$defs/RevisionSpec",
+          "description": "Spec holds the desired state of the Revision (from the client)."
+        },
+        "status": {
+          "$ref": "#/$defs/RevisionStatus",
+          "description": "Status communicates the observed state of the Revision (from the controller)."
+        }
+      }
+    },
+    "ObjectMeta": {
+      "description": "google.cloud.run.meta.v1.ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Required. The name of the resource. Name is required when creating top-level resources (Service, Job), must be unique within a Cloud Run project/region, and cannot be changed once created.",
+          "type": "string"
+        },
+        "generateName": {
+          "description": "Not supported by Cloud Run",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Required. Defines the space within each name must be unique within a Cloud Run region. In Cloud Run, it must be project ID or number.",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "URL representing this object.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "Unique, system-generated identifier for this resource.",
+          "type": "string"
+        },
+        "resourceVersion": {
+          "description": "Opaque, system-generated value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server or omit the value to disable conflict-detection.",
+          "type": "string"
+        },
+        "generation": {
+          "description": "A system-provided sequence number representing a specific generation of the desired state.",
+          "type": "integer"
+        },
+        "creationTimestamp": {
+          "description": "UTC timestamp representing the server time when this object was created.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and routes.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "description": "Unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. In Cloud Run, annotations with 'run.googleapis.com/' and 'autoscaling.knative.dev' are restricted, and the accepted annotations will be different depending on the resource type. * `autoscaling.knative.dev/maxScale`: Revision. * `autoscaling.knative.dev/minScale`: Revision. * `run.googleapis.com/base-images`: Service, Revision. * `run.googleapis.com/binary-authorization-breakglass`: Service, Job, * `run.googleapis.com/binary-authorization`: Service, Job, Execution. * `run.googleapis.com/build-base-image`: Service. * `run.googleapis.com/build-environment-variables`: Service. * `run.googleapis.com/build-id`: Service. * `run.googleapis.com/build-name`: Service. * `run.googleapis.com/build-service-account`: Service. * `run.googleapis.com/build-worker-pool`: Service. * `run.googleapis.com/client-name`: All resources. * `run.googleapis.com/cloudsql-instances`: Revision, Execution. * `run.googleapis.com/container-dependencies`: Revision . * `run.googleapis.com/cpu-throttling`: Revision. * `run.googleapis.com/custom-audiences`: Service. * `run.googleapis.com/default-url-disabled`: Service. * `run.googleapis.com/description`: Service. * `run.googleapis.com/enable-automatic-updates`: Service. * `run.googleapis.com/encryption-key-shutdown-hours`: Revision * `run.googleapis.com/encryption-key`: Revision, Execution. * `run.googleapis.com/execution-environment`: Revision, Execution. * `run.googleapis.com/function-target`: Service. * `run.googleapis.com/gc-traffic-tags`: Service. * `run.googleapis.com/image-uri`: Service. * `run.googleapis.com/ingress`: Service. * `run.googleapis.com/launch-stage`: Service, Job. * `run.googleapis.com/minScale`: Service (ALPHA) * `run.googleapis.com/network-interfaces`: Revision, Execution. * `run.googleapis.com/post-key-revocation-action-type`: Revision. * `run.googleapis.com/secrets`: Revision, Execution. * `run.googleapis.com/secure-session-agent`: Revision. * `run.googleapis.com/sessionAffinity`: Revision. * `run.googleapis.com/source-location`: Service. * `run.googleapis.com/startup-cpu-boost`: Revision. * `run.googleapis.com/vpc-access-connector`: Revision, Execution. * `run.googleapis.com/vpc-access-egress`: Revision, Execution.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "ownerReferences": {
+          "description": "Not supported by Cloud Run",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/OwnerReference"
+          }
+        },
+        "deletionTimestamp": {
+          "description": "The read-only soft deletion timestamp for this resource. In Cloud Run, users are not able to set this field. Instead, they must call the corresponding Delete API.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Not supported by Cloud Run",
+          "type": "integer"
+        },
+        "finalizers": {
+          "description": "Not supported by Cloud Run",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "clusterName": {
+          "description": "Not supported by Cloud Run",
+          "type": "string"
+        }
+      }
+    },
+    "OwnerReference": {
+      "description": "This is not supported or used by Cloud Run.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "This is not supported or used by Cloud Run.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "This is not supported or used by Cloud Run.",
+          "type": "string"
+        },
+        "name": {
+          "description": "This is not supported or used by Cloud Run.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "This is not supported or used by Cloud Run.",
+          "type": "string"
+        },
+        "controller": {
+          "description": "This is not supported or used by Cloud Run.",
+          "type": "boolean"
+        },
+        "blockOwnerDeletion": {
+          "description": "This is not supported or used by Cloud Run.",
+          "type": "boolean"
+        }
+      }
+    },
+    "RevisionSpec": {
+      "description": "RevisionSpec holds the desired state of the Revision (from the client).",
+      "type": "object",
+      "properties": {
+        "containerConcurrency": {
+          "description": "ContainerConcurrency specifies the maximum allowed in-flight (concurrent) requests per container instance of the Revision. If not specified or 0, defaults to 80 when requested CPU >= 1 and defaults to 1 when requested CPU < 1.",
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "description": "TimeoutSeconds holds the max duration the instance is allowed for responding to a request. Cloud Run: defaults to 300 seconds (5 minutes). Maximum allowed value is 3600 seconds (1 hour).",
+          "type": "integer"
+        },
+        "serviceAccountName": {
+          "description": "Email address of the IAM service account associated with the revision of the service. The service account represents the identity of the running revision, and determines what permissions the revision has. If not provided, the revision will use the project's default service account.",
+          "type": "string"
+        },
+        "containers": {
+          "description": "Required. Containers holds the list which define the units of execution for this Revision. In the context of a Revision, we disallow a number of fields on this Container, including: name and lifecycle.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Container"
+          }
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Volume"
+          }
+        },
+        "runtimeClassName": {
+          "description": "Runtime. Leave unset for default.",
+          "type": "string"
+        },
+        "enableServiceLinks": {
+          "description": "Not supported by Cloud Run.",
+          "type": "boolean"
+        },
+        "imagePullSecrets": {
+          "description": "Not supported by Cloud Run.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LocalObjectReference"
+          }
+        },
+        "nodeSelector": {
+          "description": "Optional. The Node Selector configuration. Map of selector key to a value which matches a node.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Container": {
+      "description": "A single application container. This specifies both the container to run, the command to run in the container and the arguments to supply to it. Note that additional arguments may be supplied by the system to the container at runtime.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the container specified as a DNS_LABEL (RFC 1123).",
+          "type": "string"
+        },
+        "image": {
+          "description": "Required. Name of the container image in Dockerhub, Google Artifact Registry, or Google Container Registry. If the host is not provided, Dockerhub is assumed.",
+          "type": "string"
+        },
+        "command": {
+          "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references are not supported in Cloud Run.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references are not supported in Cloud Run.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "description": "List of environment variables to set in the container. EnvVar with duplicate names are generally allowed; if referencing a secret, the name must be unique for the container. For non-secret EnvVar names, the Container will only get the last-declared one.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EnvVar"
+          }
+        },
+        "resources": {
+          "$ref": "#/$defs/ResourceRequirements",
+          "description": "Compute Resources required by this container."
+        },
+        "workingDir": {
+          "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image.",
+          "type": "string"
+        },
+        "ports": {
+          "description": "List of ports to expose from the container. Only a single port can be specified. The specified ports must be listening on all interfaces (0.0.0.0) within the container to be accessible. If omitted, a port number will be chosen and passed to the container through the PORT environment variable for the container to listen on.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ContainerPort"
+          }
+        },
+        "envFrom": {
+          "description": "Not supported by Cloud Run.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EnvFromSource"
+          }
+        },
+        "volumeMounts": {
+          "description": "Volume to mount into the container's filesystem. Only supports SecretVolumeSources. Pod volumes to mount into the container's filesystem.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VolumeMount"
+          }
+        },
+        "livenessProbe": {
+          "$ref": "#/$defs/Probe",
+          "description": "Periodic probe of container liveness. Container will be restarted if the probe fails."
+        },
+        "readinessProbe": {
+          "$ref": "#/$defs/Probe",
+          "description": "Not supported by Cloud Run."
+        },
+        "startupProbe": {
+          "$ref": "#/$defs/Probe",
+          "description": "Startup probe of application within the container. All other probes are disabled if a startup probe is provided, until it succeeds. Container will not receive traffic if the probe fails. If not provided, a default startup probe with TCP socket action is used."
+        },
+        "terminationMessagePath": {
+          "description": "Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log.",
+          "type": "string"
+        },
+        "terminationMessagePolicy": {
+          "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+          "type": "string"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/SecurityContext",
+          "description": "Not supported by Cloud Run."
+        }
+      }
+    },
+    "EnvVar": {
+      "description": "EnvVar represents an environment variable present in a Container.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Required. Name of the environment variable.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of the environment variable. Defaults to \"\". Variable references are not supported in Cloud Run.",
+          "type": "string"
+        },
+        "valueFrom": {
+          "$ref": "#/$defs/EnvVarSource",
+          "description": "Source for the environment variable's value. Only supports secret_key_ref. Cannot be used if value is not empty."
+        }
+      }
+    },
+    "EnvVarSource": {
+      "description": "EnvVarSource represents a source for the value of an EnvVar.",
+      "type": "object",
+      "properties": {
+        "configMapKeyRef": {
+          "$ref": "#/$defs/ConfigMapKeySelector",
+          "description": "Not supported by Cloud Run. Not supported in Cloud Run."
+        },
+        "secretKeyRef": {
+          "$ref": "#/$defs/SecretKeySelector",
+          "description": "Selects a key (version) of a secret in Secret Manager."
+        }
+      }
+    },
+    "ConfigMapKeySelector": {
+      "description": "Not supported by Cloud Run.",
+      "type": "object",
+      "properties": {
+        "localObjectReference": {
+          "$ref": "#/$defs/LocalObjectReference",
+          "description": "Not supported by Cloud Run.",
+          "deprecated": true
+        },
+        "key": {
+          "description": "Required. Not supported by Cloud Run.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Not supported by Cloud Run.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Required. Not supported by Cloud Run.",
+          "type": "string"
+        }
+      }
+    },
+    "LocalObjectReference": {
+      "description": "Not supported by Cloud Run. LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the referent.",
+          "type": "string"
+        }
+      }
+    },
+    "SecretKeySelector": {
+      "description": "SecretKeySelector selects a key of a Secret.",
+      "type": "object",
+      "properties": {
+        "localObjectReference": {
+          "$ref": "#/$defs/LocalObjectReference",
+          "description": "This field should not be used directly as it is meant to be inlined directly into the message. Use the \"name\" field instead.",
+          "deprecated": true
+        },
+        "key": {
+          "description": "Required. A Cloud Secret Manager secret version. Must be 'latest' for the latest version, an integer for a specific version, or a version alias. The key of the secret to select from. Must be a valid secret key.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the Secret or its key must be defined.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The name of the secret in Cloud Secret Manager. By default, the secret is assumed to be in the same project. If the secret is in another project, you must define an alias. An alias definition has the form: :projects//secrets/. If multiple alias definitions are needed, they must be separated by commas. The alias definitions must be set on the run.googleapis.com/secrets annotation. The name of the secret in the pod's namespace to select from.",
+          "type": "string"
+        }
+      }
+    },
+    "ResourceRequirements": {
+      "description": "ResourceRequirements describes the compute resource requirements.",
+      "type": "object",
+      "properties": {
+        "limits": {
+          "description": "Limits describes the maximum amount of compute resources allowed. Only 'cpu' and 'memory' keys are supported. * For supported 'cpu' values, go to https://cloud.google.com/run/docs/configuring/cpu. * For supported 'memory' values and syntax, go to https://cloud.google.com/run/docs/configuring/memory-limits",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "requests": {
+          "description": "Requests describes the minimum amount of compute resources required. Only `cpu` and `memory` are supported. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. * For supported 'cpu' values, go to https://cloud.google.com/run/docs/configuring/cpu. * For supported 'memory' values and syntax, go to https://cloud.google.com/run/docs/configuring/memory-limits",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ContainerPort": {
+      "description": "ContainerPort represents a network port in a single container.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "If specified, used to specify which protocol to use. Allowed values are \"http1\" and \"h2c\".",
+          "type": "string"
+        },
+        "containerPort": {
+          "description": "Port number the container listens on. If present, this must be a valid port number, 0 < x < 65536. If not present, it will default to port 8080. For more information, see https://cloud.google.com/run/docs/container-contract#port",
+          "type": "integer"
+        },
+        "protocol": {
+          "description": "Protocol for port. Must be \"TCP\". Defaults to \"TCP\".",
+          "type": "string"
+        }
+      }
+    },
+    "EnvFromSource": {
+      "description": "Not supported by Cloud Run. EnvFromSource represents the source of a set of ConfigMaps",
+      "type": "object",
+      "properties": {
+        "prefix": {
+          "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+          "type": "string"
+        },
+        "configMapRef": {
+          "$ref": "#/$defs/ConfigMapEnvSource",
+          "description": "The ConfigMap to select from"
+        },
+        "secretRef": {
+          "$ref": "#/$defs/SecretEnvSource",
+          "description": "The Secret to select from"
+        }
+      }
+    },
+    "ConfigMapEnvSource": {
+      "description": "Not supported by Cloud Run. ConfigMapEnvSource selects a ConfigMap to populate the environment variables with. The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+      "type": "object",
+      "properties": {
+        "localObjectReference": {
+          "$ref": "#/$defs/LocalObjectReference",
+          "description": "This field should not be used directly as it is meant to be inlined directly into the message. Use the \"name\" field instead.",
+          "deprecated": true
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap must be defined.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The ConfigMap to select from.",
+          "type": "string"
+        }
+      }
+    },
+    "SecretEnvSource": {
+      "description": "Not supported by Cloud Run. SecretEnvSource selects a Secret to populate the environment variables with. The contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+      "type": "object",
+      "properties": {
+        "localObjectReference": {
+          "$ref": "#/$defs/LocalObjectReference",
+          "description": "This field should not be used directly as it is meant to be inlined directly into the message. Use the \"name\" field instead.",
+          "deprecated": true
+        },
+        "optional": {
+          "description": "Specify whether the Secret must be defined",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The Secret to select from.",
+          "type": "string"
+        }
+      }
+    },
+    "VolumeMount": {
+      "description": "VolumeMount describes a mounting of a Volume within a container.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Required. The name of the volume. There must be a corresponding Volume with the same name.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Sets the mount to be read-only or read-write. Not used by Cloud Run.",
+          "type": "boolean"
+        },
+        "mountPath": {
+          "description": "Required. Path within the container at which the volume should be mounted. Must not contain ':'.",
+          "type": "string"
+        },
+        "subPath": {
+          "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+          "type": "string"
+        }
+      }
+    },
+    "Probe": {
+      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+      "type": "object",
+      "properties": {
+        "initialDelaySeconds": {
+          "description": "Number of seconds after the container has started before the probe is initiated. Defaults to 0 seconds. Minimum value is 0. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240.",
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 3600. Must be smaller than period_seconds; if period_seconds is not set, must be less or equal than 10.",
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. Must be greater or equal than timeout_seconds.",
+          "type": "integer"
+        },
+        "successThreshold": {
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Must be 1 if set.",
+          "type": "integer"
+        },
+        "failureThreshold": {
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+          "type": "integer"
+        },
+        "exec": {
+          "$ref": "#/$defs/ExecAction",
+          "description": "Not supported by Cloud Run."
+        },
+        "httpGet": {
+          "$ref": "#/$defs/HTTPGetAction",
+          "description": "HTTPGet specifies the http request to perform."
+        },
+        "tcpSocket": {
+          "$ref": "#/$defs/TCPSocketAction",
+          "description": "TCPSocket specifies an action involving a TCP port."
+        },
+        "grpc": {
+          "$ref": "#/$defs/GRPCAction",
+          "description": "GRPCAction specifies an action involving a GRPC port."
+        }
+      }
+    },
+    "ExecAction": {
+      "description": "Not supported by Cloud Run. ExecAction describes a \"run in container\" action.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "Command is the command line to execute inside the container, the working directory for the command is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "HTTPGetAction": {
+      "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Path to access on the HTTP server.",
+          "type": "string"
+        },
+        "host": {
+          "description": "Not supported by Cloud Run.",
+          "type": "string"
+        },
+        "scheme": {
+          "description": "Not supported by Cloud Run.",
+          "type": "string"
+        },
+        "httpHeaders": {
+          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HTTPHeader"
+          }
+        },
+        "port": {
+          "description": "Port number to access on the container. Number must be in the range 1 to 65535.",
+          "type": "integer"
+        }
+      }
+    },
+    "HTTPHeader": {
+      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Required. The header field name",
+          "type": "string"
+        },
+        "value": {
+          "description": "The header field value",
+          "type": "string"
+        }
+      }
+    },
+    "TCPSocketAction": {
+      "description": "TCPSocketAction describes an action based on opening a socket",
+      "type": "object",
+      "properties": {
+        "port": {
+          "description": "Port number to access on the container. Number must be in the range 1 to 65535.",
+          "type": "integer"
+        },
+        "host": {
+          "description": "Not supported by Cloud Run.",
+          "type": "string"
+        }
+      }
+    },
+    "GRPCAction": {
+      "description": "GRPCAction describes an action involving a GRPC port.",
+      "type": "object",
+      "properties": {
+        "port": {
+          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+          "type": "integer"
+        },
+        "service": {
+          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest. If this is not specified, the default behavior is defined by gRPC.",
+          "type": "string"
+        }
+      }
+    },
+    "SecurityContext": {
+      "description": "Not supported by Cloud Run. SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext. When both are set, the values in SecurityContext take precedence.",
+      "type": "object",
+      "properties": {
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "integer"
+        }
+      }
+    },
+    "Volume": {
+      "description": "Volume represents a named volume in a container.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Volume's name. In Cloud Run Fully Managed, the name 'cloudsql' is reserved.",
+          "type": "string"
+        },
+        "secret": {
+          "$ref": "#/$defs/SecretVolumeSource",
+          "description": "The secret's value will be presented as the content of a file whose name is defined in the item path. If no items are defined, the name of the file is the secretName."
+        },
+        "configMap": {
+          "$ref": "#/$defs/ConfigMapVolumeSource",
+          "description": "Not supported in Cloud Run."
+        },
+        "emptyDir": {
+          "$ref": "#/$defs/EmptyDirVolumeSource",
+          "description": "Ephemeral storage used as a shared volume."
+        },
+        "nfs": {
+          "$ref": "#/$defs/NFSVolumeSource"
+        },
+        "csi": {
+          "$ref": "#/$defs/CSIVolumeSource",
+          "description": "Volume specified by the Container Storage Interface driver"
+        }
+      }
+    },
+    "SecretVolumeSource": {
+      "description": "A volume representing a secret stored in Google Secret Manager. The secret's value will be presented as the content of a file whose name is defined in the item path. If no items are defined, the name of the file is the secret_name. The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names.",
+      "type": "object",
+      "properties": {
+        "secretName": {
+          "description": "The name of the secret in Cloud Secret Manager. By default, the secret is assumed to be in the same project. If the secret is in another project, you must define an alias. An alias definition has the form: :projects//secrets/. If multiple alias definitions are needed, they must be separated by commas. The alias definitions must be set on the run.googleapis.com/secrets annotation. Name of the secret in the container's namespace to use.",
+          "type": "string"
+        },
+        "items": {
+          "description": "A list of secret versions to mount in the volume. If no items are specified, the volume will expose a file with the same name as the secret name. The contents of the file will be the data in the latest version of the secret. If items are specified, the key will be used as the version to fetch from Cloud Secret Manager and the path will be the name of the file exposed in the volume. When items are defined, they must specify both a key and a path.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/KeyToPath"
+          }
+        },
+        "defaultMode": {
+          "description": "Integer representation of mode bits to use on created files by default. Must be a value between 01 and 0777 (octal). If 0 or not set, it will default to 0444. Directories within the path are not affected by this setting. Notes * Internally, a umask of 0222 will be applied to any non-zero value. * This is an integer representation of the mode bits. So, the octal integer value should look exactly as the chmod numeric notation with a leading zero. Some examples: for chmod 777 (a=rwx), set to 0777 (octal) or 511 (base-10). For chmod 640 (u=rw,g=r), set to 0640 (octal) or 416 (base-10). For chmod 755 (u=rwx,g=rx,o=rx), set to 0755 (octal) or 493 (base-10). * This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "type": "integer"
+        },
+        "optional": {
+          "description": "Not supported by Cloud Run.",
+          "type": "boolean"
+        }
+      }
+    },
+    "KeyToPath": {
+      "description": "Maps a string key to a path within a volume.",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "The Cloud Secret Manager secret version. Can be 'latest' for the latest value, or an integer or a secret alias for a specific version. The key to project.",
+          "type": "string"
+        },
+        "path": {
+          "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "(Optional) Mode bits to use on this file, must be a value between 01 and 0777 (octal). If 0 or not set, the Volume's default mode will be used. Notes * Internally, a umask of 0222 will be applied to any non-zero value. * This is an integer representation of the mode bits. So, the octal integer value should look exactly as the chmod numeric notation with a leading zero. Some examples: for chmod 777 (a=rwx), set to 0777 (octal) or 511 (base-10). For chmod 640 (u=rw,g=r), set to 0640 (octal) or 416 (base-10). For chmod 755 (u=rwx,g=rx,o=rx), set to 0755 (octal) or 493 (base-10). * This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "type": "integer"
+        }
+      }
+    },
+    "ConfigMapVolumeSource": {
+      "description": "Not supported by Cloud Run. Adapts a ConfigMap into a volume. The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the config.",
+          "type": "string"
+        },
+        "items": {
+          "description": "(Optional) If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified that is not present in the Secret, the volume setup will error unless it is marked optional.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/KeyToPath"
+          }
+        },
+        "defaultMode": {
+          "description": "(Optional) Integer representation of mode bits to use on created files by default. Must be a value between 01 and 0777 (octal). If 0 or not set, it will default to 0644. Directories within the path are not affected by this setting. Notes * Internally, a umask of 0222 will be applied to any non-zero value. * This is an integer representation of the mode bits. So, the octal integer value should look exactly as the chmod numeric notation with a leading zero. Some examples: for chmod 777 (a=rwx), set to 0777 (octal) or 511 (base-10). For chmod 640 (u=rw,g=r), set to 0640 (octal) or 416 (base-10). For chmod 755 (u=rwx,g=rx,o=rx), set to 0755 (octal) or 493 (base-10). * This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "type": "integer"
+        },
+        "optional": {
+          "description": "(Optional) Specify whether the Secret or its keys must be defined.",
+          "type": "boolean"
+        }
+      }
+    },
+    "EmptyDirVolumeSource": {
+      "description": "In memory (tmpfs) ephemeral storage. It is ephemeral in the sense that when the sandbox is taken down, the data is destroyed with it (it does not persist across sandbox runs).",
+      "type": "object",
+      "properties": {
+        "medium": {
+          "description": "The medium on which the data is stored. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+          "type": "string"
+        },
+        "sizeLimit": {
+          "description": "Limit on the storage usable by this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers. The default is nil which means that the limit is undefined. More info: https://cloud.google.com/run/docs/configuring/in-memory-volumes#configure-volume. Info in Kubernetes: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir",
+          "type": "string"
+        }
+      }
+    },
+    "NFSVolumeSource": {
+      "description": "Represents a persistent volume that will be mounted using NFS. This volume will be shared between all instances of the resource and data will not be deleted when the instance is shut down.",
+      "type": "object",
+      "properties": {
+        "server": {
+          "description": "Hostname or IP address of the NFS server.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path that is exported by the NFS server.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "If true, mount the NFS volume as read only. Defaults to false.",
+          "type": "boolean"
+        }
+      }
+    },
+    "CSIVolumeSource": {
+      "description": "Storage volume source using the Container Storage Interface.",
+      "type": "object",
+      "properties": {
+        "driver": {
+          "description": "name of the CSI driver for the requested storage system. Cloud Run supports the following drivers: * gcsfuse.run.googleapis.com : Mount a Cloud Storage Bucket as a volume.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "If true, mount the volume as read only. Defaults to false.",
+          "type": "boolean"
+        },
+        "volumeAttributes": {
+          "description": "stores driver specific attributes. For Google Cloud Storage volumes, the following attributes are supported: * bucketName: the name of the Cloud Storage bucket to mount. The Cloud Run Service identity must have access to this bucket.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RevisionStatus": {
+      "description": "RevisionStatus communicates the observed state of the Revision (from the controller).",
+      "type": "object",
+      "properties": {
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Revision that was last processed by the controller. Clients polling for completed reconciliation should poll until observedGeneration = metadata.generation, and the Ready condition's status is True or False.",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Conditions communicate information about ongoing/complete reconciliation processes that bring the \"spec\" inline with the observed state of the world. As a Revision is being prepared, it will incrementally update conditions. Revision-specific conditions include: * `ResourcesAvailable`: `True` when underlying resources have been provisioned. * `ContainerHealthy`: `True` when the Revision readiness check completes. * `Active`: `True` when the Revision may receive traffic.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleCloudRunV1Condition"
+          }
+        },
+        "logUrl": {
+          "description": "Optional. Specifies the generated logging url for this particular revision based on the revision url template specified in the controller's config.",
+          "type": "string"
+        },
+        "serviceName": {
+          "description": "Not currently used by Cloud Run.",
+          "type": "string"
+        },
+        "imageDigest": {
+          "description": "ImageDigest holds the resolved digest for the image specified within .Spec.Container.Image. The digest is resolved during the creation of Revision. This field holds the digest value regardless of whether a tag or digest was originally specified in the Container object.",
+          "type": "string"
+        },
+        "desiredReplicas": {
+          "description": "Output only. The configured number of instances running this revision. For Cloud Run, this only includes instances provisioned using the minScale annotation. It does not include instances created by autoscaling.",
+          "readOnly": true,
+          "type": "integer"
+        }
+      }
+    },
+    "GoogleCloudRunV1Condition": {
+      "description": "Conditions show the status of reconciliation progress on a given resource. Most resource use a top-level condition type \"Ready\" or \"Completed\" to show overall status with other conditions to checkpoint each stage of reconciliation. Note that if metadata.Generation does not equal status.ObservedGeneration, the conditions shown may not be relevant for the current spec.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "type is used to communicate the status of the reconciliation process. Types common to all resources include: * \"Ready\" or \"Completed\": True when the Resource is ready.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Optional. One-word CamelCase reason for the condition's last transition. These are intended to be stable, unique values which the client may use to trigger error handling logic, whereas messages which may be changed later by the server.",
+          "type": "string"
+        },
+        "message": {
+          "description": "Optional. Human readable message indicating details about the current status.",
+          "type": "string"
+        },
+        "lastTransitionTime": {
+          "description": "Optional. Last time the condition transitioned from one status to another.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "severity": {
+          "description": "Optional. How to interpret this condition. One of Error, Warning, or Info. Conditions of severity Info do not contribute to resource readiness.",
+          "type": "string"
+        }
+      }
+    },
+    "Status": {
+      "description": "Status is a return value for calls that don't return other objects.",
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Standard list metadata."
+        },
+        "status": {
+          "description": "Status of the operation. One of: \"Success\" or \"Failure\".",
+          "type": "string"
+        },
+        "message": {
+          "description": "A human-readable description of the status of this operation.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+          "type": "string"
+        },
+        "details": {
+          "$ref": "#/$defs/StatusDetails",
+          "description": "Extended data associated with the reason. Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+        },
+        "code": {
+          "description": "Suggested HTTP return code for this status, 0 if not set.",
+          "type": "integer"
+        }
+      }
+    },
+    "StatusDetails": {
+      "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+          "type": "string"
+        },
+        "group": {
+          "description": "The group attribute of the resource associated with the status StatusReason.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID of the resource. (when there is a single resource which can be described).",
+          "type": "string"
+        },
+        "causes": {
+          "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/StatusCause"
+          }
+        },
+        "retryAfterSeconds": {
+          "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+          "type": "integer"
+        }
+      }
+    },
+    "StatusCause": {
+      "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+      "type": "object",
+      "properties": {
+        "reason": {
+          "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+          "type": "string"
+        },
+        "message": {
+          "description": "A human-readable description of the cause of the error. This field may be presented as-is to a reader.",
+          "type": "string"
+        },
+        "field": {
+          "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed. Fields may appear more than once in an array of causes due to fields having multiple errors. Examples: \"name\" - the field \"name\" on the current resource \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+          "type": "string"
+        }
+      }
+    },
+    "ListConfigurationsResponse": {
+      "description": "ListConfigurationsResponse is a list of Configuration resources.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call such as \"serving.knative.dev/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case \"ConfigurationList\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Metadata associated with this Configuration list."
+        },
+        "items": {
+          "description": "List of Configurations.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Configuration"
+          }
+        },
+        "unreachable": {
+          "description": "Locations that could not be reached.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Configuration": {
+      "description": "Configuration represents the \"floating HEAD\" of a linear history of Revisions, and optionally how the containers those revisions reference are built. Users create new Revisions by updating the Configuration's spec. The \"latest created\" revision's name is available under status, as is the \"latest ready\" revision's name.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call such as \"serving.knative.dev/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of resource, in this case always \"Configuration\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Metadata associated with this Configuration, including name, namespace, labels, and annotations."
+        },
+        "spec": {
+          "$ref": "#/$defs/ConfigurationSpec",
+          "description": "Spec holds the desired state of the Configuration (from the client)."
+        },
+        "status": {
+          "$ref": "#/$defs/ConfigurationStatus",
+          "description": "Status communicates the observed state of the Configuration (from the controller)."
+        }
+      }
+    },
+    "ConfigurationSpec": {
+      "description": "ConfigurationSpec holds the desired state of the Configuration (from the client).",
+      "type": "object",
+      "properties": {
+        "template": {
+          "$ref": "#/$defs/RevisionTemplate",
+          "description": "Template holds the latest specification for the Revision to be stamped out."
+        }
+      }
+    },
+    "RevisionTemplate": {
+      "description": "RevisionTemplateSpec describes the data a revision should have when created from a template.",
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Optional metadata for this Revision, including labels and annotations. Name will be generated by the Configuration. The following annotation keys set properties of the created revision: * `autoscaling.knative.dev/minScale` sets the minimum number of instances. * `autoscaling.knative.dev/maxScale` sets the maximum number of instances. * `run.googleapis.com/cloudsql-instances` sets Cloud SQL connections. Multiple values should be comma separated. * `run.googleapis.com/vpc-access-connector` sets a Serverless VPC Access connector. * `run.googleapis.com/vpc-access-egress` sets VPC egress. Supported values are `all-traffic`, `all` (deprecated), and `private-ranges-only`. `all-traffic` and `all` provide the same functionality. `all` is deprecated but will continue to be supported. Prefer `all-traffic`."
+        },
+        "spec": {
+          "$ref": "#/$defs/RevisionSpec",
+          "description": "RevisionSpec holds the desired state of the Revision (from the client)."
+        }
+      }
+    },
+    "ConfigurationStatus": {
+      "description": "ConfigurationStatus communicates the observed state of the Configuration (from the controller).",
+      "type": "object",
+      "properties": {
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Configuration that was last processed by the controller. The observed generation is updated even if the controller failed to process the spec and create the Revision. Clients polling for completed reconciliation should poll until observedGeneration = metadata.generation, and the Ready condition's status is True or False.",
+          "type": "integer"
+        },
+        "latestCreatedRevisionName": {
+          "description": "LatestCreatedRevisionName is the last revision that was created from this Configuration. It might not be ready yet, so for the latest ready revision, use LatestReadyRevisionName.",
+          "type": "string"
+        },
+        "latestReadyRevisionName": {
+          "description": "LatestReadyRevisionName holds the name of the latest Revision stamped out from this Configuration that has had its \"Ready\" condition become \"True\".",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions communicate information about ongoing/complete reconciliation processes that bring the \"spec\" inline with the observed state of the world.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleCloudRunV1Condition"
+          }
+        }
+      }
+    },
+    "DomainMapping": {
+      "description": "Resource to hold the state and status of a user's domain mapping. NOTE: This resource is currently in Beta.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call such as \"domains.cloudrun.com/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of resource, in this case \"DomainMapping\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Metadata associated with this BuildTemplate."
+        },
+        "spec": {
+          "$ref": "#/$defs/DomainMappingSpec",
+          "description": "The spec for this DomainMapping."
+        },
+        "status": {
+          "$ref": "#/$defs/DomainMappingStatus",
+          "description": "The current status of the DomainMapping."
+        }
+      }
+    },
+    "DomainMappingSpec": {
+      "description": "The desired state of the Domain Mapping.",
+      "type": "object",
+      "properties": {
+        "routeName": {
+          "description": "The name of the Knative Route that this DomainMapping applies to. The route must exist.",
+          "type": "string"
+        },
+        "certificateMode": {
+          "description": "The mode of the certificate.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "CERTIFICATE_MODE_UNSPECIFIED",
+              "title": ""
+            },
+            {
+              "const": "NONE",
+              "title": "Do not provision an HTTPS certificate."
+            },
+            {
+              "const": "AUTOMATIC",
+              "title": "Automatically provisions an HTTPS certificate via GoogleCA."
+            }
+          ]
+        },
+        "forceOverride": {
+          "description": "If set, the mapping will override any mapping set before this spec was set. It is recommended that the user leaves this empty to receive an error warning about a potential conflict and only set it once the respective UI has given such a warning.",
+          "type": "boolean"
+        }
+      }
+    },
+    "DomainMappingStatus": {
+      "description": "The current state of the Domain Mapping.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Array of observed DomainMappingConditions, indicating the current state of the DomainMapping.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleCloudRunV1Condition"
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the DomainMapping that was last processed by the controller. Clients polling for completed reconciliation should poll until observedGeneration = metadata.generation and the Ready condition's status is True or False.",
+          "type": "integer"
+        },
+        "resourceRecords": {
+          "description": "The resource records required to configure this domain mapping. These records must be added to the domain's DNS configuration in order to serve the application via this domain mapping.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ResourceRecord"
+          }
+        },
+        "mappedRouteName": {
+          "description": "The name of the route that the mapping currently points to.",
+          "type": "string"
+        },
+        "url": {
+          "description": "Optional. Not supported by Cloud Run.",
+          "type": "string"
+        }
+      }
+    },
+    "ResourceRecord": {
+      "description": "A DNS resource record.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Relative name of the object affected by this record. Only applicable for `CNAME` records. Example: 'www'.",
+          "type": "string"
+        },
+        "rrdata": {
+          "description": "Data for this record. Values vary by record type, as defined in RFC 1035 (section 5) and RFC 1034 (section 3.6.1).",
+          "type": "string"
+        },
+        "type": {
+          "description": "Resource record type. Example: `AAAA`.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "RECORD_TYPE_UNSPECIFIED",
+              "title": "An unknown resource record."
+            },
+            {
+              "const": "A",
+              "title": "An A resource record. Data is an IPv4 address."
+            },
+            {
+              "const": "AAAA",
+              "title": "An AAAA resource record. Data is an IPv6 address."
+            },
+            {
+              "const": "CNAME",
+              "title": "A CNAME resource record. Data is a domain name to be aliased."
+            }
+          ]
+        }
+      }
+    },
+    "ListDomainMappingsResponse": {
+      "description": "ListDomainMappingsResponse is a list of DomainMapping resources.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call such as \"domains.cloudrun.com/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case \"DomainMappingList\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Metadata associated with this DomainMapping list."
+        },
+        "items": {
+          "description": "List of DomainMappings.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DomainMapping"
+          }
+        },
+        "unreachable": {
+          "description": "Locations that could not be reached.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Task": {
+      "description": "Task represents a single run of a container to completion.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "Optional. APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Optional. Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase.",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Optional. Standard object's metadata."
+        },
+        "spec": {
+          "$ref": "#/$defs/TaskSpec",
+          "description": "Optional. Specification of the desired behavior of a task."
+        },
+        "status": {
+          "$ref": "#/$defs/TaskStatus",
+          "description": "Output only. Current status of a task.",
+          "readOnly": true
+        }
+      }
+    },
+    "TaskSpec": {
+      "description": "TaskSpec is a description of a task.",
+      "type": "object",
+      "properties": {
+        "volumes": {
+          "description": "Optional. List of volumes that can be mounted by containers belonging to the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Volume"
+          }
+        },
+        "containers": {
+          "description": "Optional. List of containers belonging to the task. We disallow a number of fields on this Container.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Container"
+          }
+        },
+        "maxRetries": {
+          "description": "Optional. Number of retries allowed per task, before marking this job failed. Defaults to 3.",
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "description": "Optional. Duration in seconds the task may be active before the system will actively try to mark it failed and kill associated containers. This applies per attempt of a task, meaning each retry can run for the full timeout. Defaults to 600 seconds.",
+          "type": "string"
+        },
+        "serviceAccountName": {
+          "description": "Optional. Email address of the IAM service account associated with the task of a job execution. The service account represents the identity of the running task, and determines what permissions the task has. If not provided, the task will use the project's default service account.",
+          "type": "string"
+        }
+      }
+    },
+    "TaskStatus": {
+      "description": "TaskStatus represents the status of a task.",
+      "type": "object",
+      "properties": {
+        "observedGeneration": {
+          "description": "Optional. The 'generation' of the task that was last processed by the controller.",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Optional. Conditions communicate information about ongoing/complete reconciliation processes that bring the \"spec\" inline with the observed state of the world. Task-specific conditions include: * `Started`: `True` when the task has started to execute. * `Completed`: `True` when the task has succeeded. `False` when the task has failed.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleCloudRunV1Condition"
+          }
+        },
+        "index": {
+          "description": "Required. Index of the task, unique per execution, and beginning at 0.",
+          "type": "integer"
+        },
+        "startTime": {
+          "description": "Optional. Represents time when the task started to run. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "completionTime": {
+          "description": "Optional. Represents time when the task was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "retried": {
+          "description": "Optional. The number of times this task was retried. Instances are retried when they fail up to the maxRetries limit.",
+          "type": "integer"
+        },
+        "lastAttemptResult": {
+          "$ref": "#/$defs/TaskAttemptResult",
+          "description": "Optional. Result of the last attempt of this task."
+        },
+        "logUri": {
+          "description": "Optional. URI where logs for this task can be found in Cloud Console.",
+          "type": "string"
+        }
+      }
+    },
+    "TaskAttemptResult": {
+      "description": "Result of a task attempt.",
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/$defs/GoogleRpcStatus",
+          "description": "Optional. The status of this attempt. If the status code is OK, then the attempt succeeded."
+        },
+        "exitCode": {
+          "description": "Optional. The exit code of this attempt. This may be unset if the container was unable to exit cleanly with a code due to some other failure. See status field for possible failure details.",
+          "type": "integer"
+        }
+      }
+    },
+    "ListTasksResponse": {
+      "description": "ListTasksResponse is a list of Tasks resources.",
+      "type": "object",
+      "properties": {
+        "items": {
+          "description": "List of Tasks.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Task"
+          }
+        },
+        "apiVersion": {
+          "description": "The API version for this call such as \"run.googleapis.com/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case \"TasksList\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Metadata associated with this tasks list."
+        },
+        "unreachable": {
+          "description": "Locations that could not be reached.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Execution": {
+      "description": "Execution represents the configuration of a single execution. An execution is an immutable resource that references a container image which is run to completion.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "Optional. APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Optional. Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase.",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Optional. Standard object's metadata."
+        },
+        "spec": {
+          "$ref": "#/$defs/ExecutionSpec",
+          "description": "Optional. Specification of the desired behavior of an execution."
+        },
+        "status": {
+          "$ref": "#/$defs/ExecutionStatus",
+          "description": "Output only. Current status of an execution.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExecutionSpec": {
+      "description": "ExecutionSpec describes how the execution will look.",
+      "type": "object",
+      "properties": {
+        "parallelism": {
+          "description": "Optional. Specifies the maximum desired number of tasks the execution should run at given time. Must be <= task_count. When the job is run, if this field is 0 or unset, the maximum possible value will be used for that execution. The actual number of tasks running in steady state will be less than this number when there are fewer tasks waiting to be completed, i.e. when the work left to do is less than max parallelism.",
+          "type": "integer"
+        },
+        "taskCount": {
+          "description": "Optional. Specifies the desired number of tasks the execution should run. Setting to 1 means that parallelism is limited to 1 and the success of that task signals the success of the execution. Defaults to 1.",
+          "type": "integer"
+        },
+        "template": {
+          "$ref": "#/$defs/TaskTemplateSpec",
+          "description": "Optional. The template used to create tasks for this execution."
+        }
+      }
+    },
+    "TaskTemplateSpec": {
+      "description": "TaskTemplateSpec describes the data a task should have when created from a template.",
+      "type": "object",
+      "properties": {
+        "spec": {
+          "$ref": "#/$defs/TaskSpec",
+          "description": "Optional. Specification of the desired behavior of the task."
+        }
+      }
+    },
+    "ExecutionStatus": {
+      "description": "ExecutionStatus represents the current state of an Execution.",
+      "type": "object",
+      "properties": {
+        "observedGeneration": {
+          "description": "Optional. The 'generation' of the execution that was last processed by the controller.",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Optional. Conditions communicate information about ongoing/complete reconciliation processes that bring the \"spec\" inline with the observed state of the world. Execution-specific conditions include: * `ResourcesAvailable`: `True` when underlying resources have been provisioned. * `Started`: `True` when the execution has started to execute. * `Completed`: `True` when the execution has succeeded. `False` when the execution has failed.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleCloudRunV1Condition"
+          }
+        },
+        "startTime": {
+          "description": "Optional. Represents the time that the execution started to run. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "completionTime": {
+          "description": "Optional. Represents the time that the execution was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC. +optional",
+          "type": "string",
+          "format": "date-time"
+        },
+        "runningCount": {
+          "description": "Optional. The number of actively running tasks.",
+          "type": "integer"
+        },
+        "succeededCount": {
+          "description": "Optional. The number of tasks which reached phase Succeeded.",
+          "type": "integer"
+        },
+        "failedCount": {
+          "description": "Optional. The number of tasks which reached phase Failed.",
+          "type": "integer"
+        },
+        "cancelledCount": {
+          "description": "Optional. The number of tasks which reached phase Cancelled.",
+          "type": "integer"
+        },
+        "retriedCount": {
+          "description": "Optional. The number of tasks which have retried at least once.",
+          "type": "integer"
+        },
+        "logUri": {
+          "description": "Optional. URI where logs for this execution can be found in Cloud Console.",
+          "type": "string"
+        }
+      }
+    },
+    "ListExecutionsResponse": {
+      "description": "ListExecutionsResponse is a list of Executions resources.",
+      "type": "object",
+      "properties": {
+        "items": {
+          "description": "List of Executions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Execution"
+          }
+        },
+        "apiVersion": {
+          "description": "The API version for this call such as \"run.googleapis.com/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case \"ExecutionsList\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Metadata associated with this executions list."
+        },
+        "unreachable": {
+          "description": "Locations that could not be reached.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CancelExecutionRequest": {
+      "description": "Request message for cancelling an execution.",
+      "type": "object",
+      "properties": {}
+    },
+    "Job": {
+      "description": "Job represents the configuration of a single job, which references a container image which is run to completion.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "Optional. APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Optional. Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase.",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Optional. Standard object's metadata."
+        },
+        "spec": {
+          "$ref": "#/$defs/JobSpec",
+          "description": "Optional. Specification of the desired behavior of a job."
+        },
+        "status": {
+          "$ref": "#/$defs/JobStatus",
+          "description": "Output only. Current status of a job.",
+          "readOnly": true
+        }
+      }
+    },
+    "JobSpec": {
+      "description": "JobSpec describes how the job will look.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "$ref": "#/$defs/ExecutionTemplateSpec",
+          "description": "Optional. Describes the execution that will be created when running a job."
+        },
+        "startExecutionToken": {
+          "description": "A unique string used as a suffix for creating a new execution. The Job will become ready when the execution is successfully started. The sum of job name and token length must be fewer than 63 characters.",
+          "type": "string"
+        },
+        "runExecutionToken": {
+          "description": "A unique string used as a suffix for creating a new execution. The Job will become ready when the execution is successfully completed. The sum of job name and token length must be fewer than 63 characters.",
+          "type": "string"
+        }
+      }
+    },
+    "ExecutionTemplateSpec": {
+      "description": "ExecutionTemplateSpec describes the metadata and spec an Execution should have when created from a job.",
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Optional. Optional metadata for this Execution, including labels and annotations. The following annotation keys set properties of the created execution: * `run.googleapis.com/cloudsql-instances` sets Cloud SQL connections. Multiple values should be comma separated. * `run.googleapis.com/vpc-access-connector` sets a Serverless VPC Access connector. * `run.googleapis.com/vpc-access-egress` sets VPC egress. Supported values are `all-traffic`, `all` (deprecated), and `private-ranges-only`. `all-traffic` and `all` provide the same functionality. `all` is deprecated but will continue to be supported. Prefer `all-traffic`."
+        },
+        "spec": {
+          "$ref": "#/$defs/ExecutionSpec",
+          "description": "Required. ExecutionSpec holds the desired configuration for executions of this job."
+        }
+      }
+    },
+    "JobStatus": {
+      "description": "JobStatus represents the current state of a Job.",
+      "type": "object",
+      "properties": {
+        "observedGeneration": {
+          "description": "The 'generation' of the job that was last processed by the controller.",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Conditions communicate information about ongoing/complete reconciliation processes that bring the \"spec\" inline with the observed state of the world. Job-specific conditions include: * `Ready`: `True` when the job is ready to be executed.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleCloudRunV1Condition"
+          }
+        },
+        "executionCount": {
+          "description": "Number of executions created for this job.",
+          "type": "integer"
+        },
+        "latestCreatedExecution": {
+          "$ref": "#/$defs/ExecutionReference",
+          "description": "A pointer to the most recently created execution for this job. This is set regardless of the eventual state of the execution."
+        }
+      }
+    },
+    "ExecutionReference": {
+      "description": "Reference to an Execution. Use /Executions.GetExecution with the given name to get full execution including the latest status.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Optional. Name of the execution.",
+          "type": "string"
+        },
+        "creationTimestamp": {
+          "description": "Optional. Creation timestamp of the execution.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "completionTimestamp": {
+          "description": "Optional. Completion timestamp of the execution.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "deletionTimestamp": {
+          "description": "Optional. The read-only soft deletion timestamp of the execution.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "completionStatus": {
+          "description": "Optional. Status for the execution completion.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "COMPLETION_STATUS_UNSPECIFIED",
+              "title": "The default value. This value is used if the state is omitted."
+            },
+            {
+              "const": "EXECUTION_SUCCEEDED",
+              "title": "Job execution has succeeded."
+            },
+            {
+              "const": "EXECUTION_FAILED",
+              "title": "Job execution has failed."
+            },
+            {
+              "const": "EXECUTION_RUNNING",
+              "title": "Job execution is running normally."
+            },
+            {
+              "const": "EXECUTION_PENDING",
+              "title": "Waiting for backing resources to be provisioned."
+            },
+            {
+              "const": "EXECUTION_CANCELLED",
+              "title": "Job execution has been cancelled by the user."
+            }
+          ]
+        }
+      }
+    },
+    "ListJobsResponse": {
+      "description": "ListJobsResponse is a list of Jobs resources.",
+      "type": "object",
+      "properties": {
+        "items": {
+          "description": "List of Jobs.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Job"
+          }
+        },
+        "apiVersion": {
+          "description": "The API version for this call such as \"run.googleapis.com/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case \"JobsList\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Metadata associated with this jobs list."
+        },
+        "unreachable": {
+          "description": "Locations that could not be reached.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Policy": {
+      "description": "An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** ``` { \"bindings\": [ { \"role\": \"roles/resourcemanager.organizationAdmin\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-project-id@appspot.gserviceaccount.com\" ] }, { \"role\": \"roles/resourcemanager.organizationViewer\", \"members\": [ \"user:eve@example.com\" ], \"condition\": { \"title\": \"expirable access\", \"description\": \"Does not grant access after Sep 2020\", \"expression\": \"request.time < timestamp('2020-10-01T00:00:00.000Z')\", } } ], \"etag\": \"BwWWja0YfJA=\", \"version\": 3 } ``` **YAML example:** ``` bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 ``` For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/).",
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+          "type": "integer"
+        },
+        "bindings": {
+          "description": "Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Binding"
+          }
+        },
+        "auditConfigs": {
+          "description": "Specifies cloud audit logging configuration for this policy.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AuditConfig"
+          }
+        },
+        "etag": {
+          "description": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost.",
+          "type": "string"
+        }
+      }
+    },
+    "Binding": {
+      "description": "Associates `members`, or principals, with a `role`.",
+      "type": "object",
+      "properties": {
+        "role": {
+          "description": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles).",
+          "type": "string"
+        },
+        "members": {
+          "description": "Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "condition": {
+          "$ref": "#/$defs/Expr",
+          "description": "The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+        }
+      }
+    },
+    "Expr": {
+      "description": "Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: \"Summary size limit\" description: \"Determines if a summary is less than 100 chars\" expression: \"document.summary.size() < 100\" Example (Equality): title: \"Requestor is owner\" description: \"Determines if requestor is the document owner\" expression: \"document.owner == request.auth.claims.email\" Example (Logic): title: \"Public documents\" description: \"Determine whether the document should be publicly visible\" expression: \"document.type != 'private' && document.type != 'internal'\" Example (Data Manipulation): title: \"Notification string\" description: \"Create a notification string with a timestamp.\" expression: \"'New message received at ' + string(document.create_time)\" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.",
+      "type": "object",
+      "properties": {
+        "expression": {
+          "description": "Textual representation of an expression in Common Expression Language syntax.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.",
+          "type": "string"
+        },
+        "location": {
+          "description": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.",
+          "type": "string"
+        }
+      }
+    },
+    "AuditConfig": {
+      "description": "Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { \"audit_configs\": [ { \"service\": \"allServices\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\", \"exempted_members\": [ \"user:jose@example.com\" ] }, { \"log_type\": \"DATA_WRITE\" }, { \"log_type\": \"ADMIN_READ\" } ] }, { \"service\": \"sampleservice.googleapis.com\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\" }, { \"log_type\": \"DATA_WRITE\", \"exempted_members\": [ \"user:aliya@example.com\" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts `jose@example.com` from DATA_READ logging, and `aliya@example.com` from DATA_WRITE logging.",
+      "type": "object",
+      "properties": {
+        "service": {
+          "description": "Specifies a service that will be enabled for audit logging. For example, `storage.googleapis.com`, `cloudsql.googleapis.com`. `allServices` is a special value that covers all services.",
+          "type": "string"
+        },
+        "auditLogConfigs": {
+          "description": "The configuration for logging of each type of permission.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AuditLogConfig"
+          }
+        }
+      }
+    },
+    "AuditLogConfig": {
+      "description": "Provides the configuration for logging a type of permissions. Example: { \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\", \"exempted_members\": [ \"user:jose@example.com\" ] }, { \"log_type\": \"DATA_WRITE\" } ] } This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting jose@example.com from DATA_READ logging.",
+      "type": "object",
+      "properties": {
+        "logType": {
+          "description": "The log type that this config enables.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "LOG_TYPE_UNSPECIFIED",
+              "title": "Default case. Should never be this."
+            },
+            {
+              "const": "ADMIN_READ",
+              "title": "Admin reads. Example: CloudIAM getIamPolicy"
+            },
+            {
+              "const": "DATA_WRITE",
+              "title": "Data writes. Example: CloudSQL Users create"
+            },
+            {
+              "const": "DATA_READ",
+              "title": "Data reads. Example: CloudSQL Users list"
+            }
+          ]
+        },
+        "exemptedMembers": {
+          "description": "Specifies the identities that do not cause logging for this type of permission. Follows the same format of Binding.members.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SetIamPolicyRequest": {
+      "description": "Request message for `SetIamPolicy` method.",
+      "type": "object",
+      "properties": {
+        "policy": {
+          "$ref": "#/$defs/Policy",
+          "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them."
+        },
+        "updateMask": {
+          "description": "OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only the fields in the mask will be modified. If no mask is provided, the following default mask is used: `paths: \"bindings, etag\"`",
+          "type": "string"
+        }
+      }
+    },
+    "TestIamPermissionsRequest": {
+      "description": "Request message for `TestIamPermissions` method.",
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "description": "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TestIamPermissionsResponse": {
+      "description": "Response message for `TestIamPermissions` method.",
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "description": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RunJobRequest": {
+      "description": "Request message for creating a new execution of a job.",
+      "type": "object",
+      "properties": {
+        "overrides": {
+          "$ref": "#/$defs/Overrides",
+          "description": "Optional. Overrides existing job configuration for one specific new job execution only, using the specified values to update the job configuration for the new execution."
+        }
+      }
+    },
+    "Overrides": {
+      "description": "RunJob Overrides that contains Execution fields to be overridden on the go.",
+      "type": "object",
+      "properties": {
+        "containerOverrides": {
+          "description": "Per container override specification.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ContainerOverride"
+          }
+        },
+        "taskCount": {
+          "description": "The desired number of tasks the execution should run. Will replace existing task_count value.",
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "description": "Duration in seconds the task may be active before the system will actively try to mark it failed and kill associated containers. Will replace existing timeout_seconds value.",
+          "type": "integer"
+        }
+      }
+    },
+    "ContainerOverride": {
+      "description": "Per container override specification.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the container specified as a DNS_LABEL.",
+          "type": "string"
+        },
+        "args": {
+          "description": "Arguments to the entrypoint. The specified arguments replace and override any existing entrypoint arguments. Must be empty if `clear_args` is set to true.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "description": "List of environment variables to set in the container. All specified environment variables are merged with existing environment variables. When the specified environment variables exist, these values override any existing values.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EnvVar"
+          }
+        },
+        "clearArgs": {
+          "description": "Optional. Set to True to clear all existing arguments.",
+          "type": "boolean"
+        }
+      }
+    },
+    "ListRoutesResponse": {
+      "description": "ListRoutesResponse is a list of Route resources.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call such as \"serving.knative.dev/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case always \"RouteList\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Metadata associated with this Route list."
+        },
+        "items": {
+          "description": "List of Routes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Route"
+          }
+        },
+        "unreachable": {
+          "description": "Locations that could not be reached.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Route": {
+      "description": "Route is responsible for configuring ingress over a collection of Revisions. Some of the Revisions a Route distributes traffic over may be specified by referencing the Configuration responsible for creating them; in these cases the Route is additionally responsible for monitoring the Configuration for \"latest ready\" revision changes, and smoothly rolling out latest revisions. Cloud Run currently supports referencing a single Configuration to automatically deploy the \"latest ready\" Revision from that Configuration.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call such as \"serving.knative.dev/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource, in this case always \"Route\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Metadata associated with this Route, including name, namespace, labels, and annotations."
+        },
+        "spec": {
+          "$ref": "#/$defs/RouteSpec",
+          "description": "Spec holds the desired state of the Route (from the client)."
+        },
+        "status": {
+          "$ref": "#/$defs/RouteStatus",
+          "description": "Status communicates the observed state of the Route (from the controller)."
+        }
+      }
+    },
+    "RouteSpec": {
+      "description": "RouteSpec holds the desired state of the Route (from the client).",
+      "type": "object",
+      "properties": {
+        "traffic": {
+          "description": "Traffic specifies how to distribute traffic over a collection of Knative Revisions and Configurations. Cloud Run currently supports a single configurationName.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TrafficTarget"
+          }
+        }
+      }
+    },
+    "TrafficTarget": {
+      "description": "TrafficTarget holds a single entry of the routing table for a Route.",
+      "type": "object",
+      "properties": {
+        "configurationName": {
+          "description": "[Deprecated] Not supported in Cloud Run. It must be empty.",
+          "deprecated": true,
+          "type": "string"
+        },
+        "revisionName": {
+          "description": "Points this traffic target to a specific Revision. This field is mutually exclusive with latest_revision.",
+          "type": "string"
+        },
+        "percent": {
+          "description": "Percent specifies percent of the traffic to this Revision or Configuration. This defaults to zero if unspecified.",
+          "type": "integer"
+        },
+        "tag": {
+          "description": "Tag is used to expose a dedicated url for referencing this target exclusively.",
+          "type": "string"
+        },
+        "latestRevision": {
+          "description": "Uses the \"status.latestReadyRevisionName\" of the Service to determine the traffic target. When it changes, traffic will automatically migrate from the prior \"latest ready\" revision to the new one. This field must be false if RevisionName is set. This field defaults to true otherwise. If the field is set to true on Status, this means that the Revision was resolved from the Service's latest ready revision.",
+          "type": "boolean"
+        },
+        "url": {
+          "description": "Output only. URL displays the URL for accessing tagged traffic targets. URL is displayed in status, and is disallowed on spec. URL must contain a scheme (e.g. https://) and a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)",
+          "readOnly": true,
+          "type": "string"
+        }
+      }
+    },
+    "RouteStatus": {
+      "description": "RouteStatus communicates the observed state of the Route (from the controller).",
+      "type": "object",
+      "properties": {
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Route that was last processed by the controller. Clients polling for completed reconciliation should poll until observedGeneration = metadata.generation and the Ready condition's status is True or False. Note that providing a TrafficTarget that has latest_revision=True will result in a Route that does not increment either its metadata.generation or its observedGeneration, as new \"latest ready\" revisions from the Configuration are processed without an update to the Route's spec.",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Conditions communicates information about ongoing/complete reconciliation processes that bring the \"spec\" inline with the observed state of the world.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleCloudRunV1Condition"
+          }
+        },
+        "traffic": {
+          "description": "Traffic holds the configured traffic distribution. These entries will always contain RevisionName references. When ConfigurationName appears in the spec, this will hold the LatestReadyRevisionName that was last observed.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TrafficTarget"
+          }
+        },
+        "url": {
+          "description": "URL holds the url that will distribute traffic over the provided traffic targets. It generally has the form: `https://{route-hash}-{project-hash}-{cluster-level-suffix}.a.run.app`",
+          "type": "string"
+        },
+        "address": {
+          "$ref": "#/$defs/Addressable",
+          "description": "Similar to url, information on where the service is available on HTTP."
+        }
+      }
+    },
+    "Addressable": {
+      "description": "Information for connecting over HTTP(s).",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "ListServicesResponse": {
+      "description": "A list of Service resources.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call; returns \"serving.knative.dev/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of this resource; returns \"ServiceList\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ListMeta",
+          "description": "Metadata associated with this Service list."
+        },
+        "items": {
+          "description": "List of Services.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Service"
+          }
+        },
+        "unreachable": {
+          "description": "For calls against the global endpoint, returns the list of Cloud locations that could not be reached. For regional calls, this field is not used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Service": {
+      "description": "Service acts as a top-level container that manages a set of Routes and Configurations which implement a network service. Service exists to provide a singular abstraction which can be access controlled, reasoned about, and which encapsulates software lifecycle decisions such as rollout policy and team resource ownership. Service acts only as an orchestrator of the underlying Routes and Configurations (much as a kubernetes Deployment orchestrates ReplicaSets). The Service's controller will track the statuses of its owned Configuration and Route, reflecting their statuses and conditions as its own.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "The API version for this call. It must be \"serving.knative.dev/v1\".",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of resource. It must be \"Service\".",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Metadata associated with this Service, including name, namespace, labels, and annotations. In Cloud Run, annotations with 'run.googleapis.com/' and 'autoscaling.knative.dev' are restricted, and the accepted annotations will be different depending on the resource type. The following Cloud Run-specific annotations are accepted in Service.metadata.annotations. * `run.googleapis.com/binary-authorization-breakglass` * `run.googleapis.com/binary-authorization` * `run.googleapis.com/client-name` * `run.googleapis.com/custom-audiences` * `run.googleapis.com/default-url-disabled` * `run.googleapis.com/description` * `run.googleapis.com/gc-traffic-tags` * `run.googleapis.com/ingress` * `run.googleapis.com/ingress` sets the ingress settings for the Service. See [the ingress settings documentation](/run/docs/securing/ingress) for details on configuring ingress settings. * `run.googleapis.com/ingress-status` is output-only and contains the currently active ingress settings for the Service. `run.googleapis.com/ingress-status` may differ from `run.googleapis.com/ingress` while the system is processing a change to `run.googleapis.com/ingress` or if the system failed to process a change to `run.googleapis.com/ingress`. When the system has processed all changes successfully `run.googleapis.com/ingress-status` and `run.googleapis.com/ingress` are equal."
+        },
+        "spec": {
+          "$ref": "#/$defs/ServiceSpec",
+          "description": "Holds the desired state of the Service (from the client)."
+        },
+        "status": {
+          "$ref": "#/$defs/ServiceStatus",
+          "description": "Communicates the system-controlled state of the Service."
+        }
+      }
+    },
+    "ServiceSpec": {
+      "description": "ServiceSpec holds the desired state of the Route (from the client), which is used to manipulate the underlying Route and Configuration(s).",
+      "type": "object",
+      "properties": {
+        "template": {
+          "$ref": "#/$defs/RevisionTemplate",
+          "description": "Holds the latest specification for the Revision to be stamped out."
+        },
+        "traffic": {
+          "description": "Specifies how to distribute traffic over a collection of Knative Revisions and Configurations to the Service's main URL.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TrafficTarget"
+          }
+        }
+      }
+    },
+    "ServiceStatus": {
+      "description": "The current state of the Service. Output only.",
+      "type": "object",
+      "properties": {
+        "observedGeneration": {
+          "description": "Returns the generation last seen by the system. Clients polling for completed reconciliation should poll until observedGeneration = metadata.generation and the Ready condition's status is True or False.",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Conditions communicate information about ongoing/complete reconciliation processes that bring the `spec` inline with the observed state of the world. Service-specific conditions include: * `ConfigurationsReady`: `True` when the underlying Configuration is ready. * `RoutesReady`: `True` when the underlying Route is ready. * `Ready`: `True` when all underlying resources are ready.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleCloudRunV1Condition"
+          }
+        },
+        "latestReadyRevisionName": {
+          "description": "Name of the latest Revision from this Service's Configuration that has had its `Ready` condition become `True`.",
+          "type": "string"
+        },
+        "latestCreatedRevisionName": {
+          "description": "Name of the last revision that was created from this Service's Configuration. It might not be ready yet, for that use LatestReadyRevisionName.",
+          "type": "string"
+        },
+        "traffic": {
+          "description": "Holds the configured traffic distribution. These entries will always contain RevisionName references. When ConfigurationName appears in the spec, this will hold the LatestReadyRevisionName that we last observed.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TrafficTarget"
+          }
+        },
+        "url": {
+          "description": "URL that will distribute traffic over the provided traffic targets. It generally has the form `https://{route-hash}-{project-hash}-{cluster-level-suffix}.a.run.app`",
+          "type": "string"
+        },
+        "address": {
+          "$ref": "#/$defs/Addressable",
+          "description": "Similar to url, information on where the service is available on HTTP."
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1BuildOperationMetadata": {
+      "description": "Metadata for build operations.",
+      "type": "object",
+      "properties": {
+        "build": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Build",
+          "description": "The build that the operation is tracking."
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Build": {
+      "description": "A build resource in the Cloud Build API. At a high level, a `Build` describes where to find source code, how to build it (for example, the builder image to run on the source), and where to store the built artifacts. Fields can include the following variables, which will be expanded when the build is created: - $PROJECT_ID: the project ID of the build. - $PROJECT_NUMBER: the project number of the build. - $LOCATION: the location/region of the build. - $BUILD_ID: the autogenerated ID of the build. - $REPO_NAME: the source repository name specified by RepoSource. - $BRANCH_NAME: the branch name specified by RepoSource. - $TAG_NAME: the tag name specified by RepoSource. - $REVISION_ID or $COMMIT_SHA: the commit SHA specified by RepoSource or resolved from the specified branch or tag. - $SHORT_SHA: first 7 characters of $REVISION_ID or $COMMIT_SHA.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Output only. The 'Build' name with format: `projects/{project}/locations/{location}/builds/{build}`, where {build} is a unique identifier generated by the service.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "id": {
+          "description": "Output only. Unique identifier of the build.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "projectId": {
+          "description": "Output only. ID of the project.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "status": {
+          "description": "Output only. Status of the build.",
+          "readOnly": true,
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "STATUS_UNKNOWN",
+              "title": "Status of the build is unknown."
+            },
+            {
+              "const": "PENDING",
+              "title": "Build has been created and is pending execution and queuing. It has not been queued."
+            },
+            {
+              "const": "QUEUED",
+              "title": "Build or step is queued; work has not yet begun."
+            },
+            {
+              "const": "WORKING",
+              "title": "Build or step is being executed."
+            },
+            {
+              "const": "SUCCESS",
+              "title": "Build or step finished successfully."
+            },
+            {
+              "const": "FAILURE",
+              "title": "Build or step failed to complete successfully."
+            },
+            {
+              "const": "INTERNAL_ERROR",
+              "title": "Build or step failed due to an internal cause."
+            },
+            {
+              "const": "TIMEOUT",
+              "title": "Build or step took longer than was allowed."
+            },
+            {
+              "const": "CANCELLED",
+              "title": "Build or step was canceled by a user."
+            },
+            {
+              "const": "EXPIRED",
+              "title": "Build was enqueued for longer than the value of `queue_ttl`."
+            }
+          ]
+        },
+        "statusDetail": {
+          "description": "Output only. Customer-readable message about the current status.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Source",
+          "description": "Optional. The location of the source files to build."
+        },
+        "steps": {
+          "description": "Required. The operations to be performed on the workspace.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1BuildStep"
+          }
+        },
+        "results": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Results",
+          "description": "Output only. Results of the build.",
+          "readOnly": true
+        },
+        "createTime": {
+          "description": "Output only. Time at which the request to create the build was received.",
+          "readOnly": true,
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "description": "Output only. Time at which execution of the build was started.",
+          "readOnly": true,
+          "type": "string",
+          "format": "date-time"
+        },
+        "finishTime": {
+          "description": "Output only. Time at which execution of the build was finished. The difference between finish_time and start_time is the duration of the build's execution.",
+          "readOnly": true,
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeout": {
+          "description": "Amount of time that this build should be allowed to run, to second granularity. If this amount of time elapses, work on the build will cease and the build status will be `TIMEOUT`. `timeout` starts ticking from `startTime`. Default time is 60 minutes.",
+          "type": "string"
+        },
+        "images": {
+          "description": "A list of images to be pushed upon the successful completion of all build steps. The images are pushed using the builder service account's credentials. The digests of the pushed images will be stored in the `Build` resource's results field. If any of the images fail to be pushed, the build status is marked `FAILURE`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "queueTtl": {
+          "description": "TTL in queue for this build. If provided and the build is enqueued longer than this value, the build will expire and the build status will be `EXPIRED`. The TTL starts ticking from create_time.",
+          "type": "string"
+        },
+        "artifacts": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Artifacts",
+          "description": "Artifacts produced by the build that should be uploaded upon successful completion of all build steps."
+        },
+        "logsBucket": {
+          "description": "Cloud Storage bucket where logs should be written (see [Bucket Name Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)). Logs file names will be of the format `${logs_bucket}/log-${build_id}.txt`.",
+          "type": "string"
+        },
+        "sourceProvenance": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1SourceProvenance",
+          "description": "Output only. A permanent fixed identifier for source.",
+          "readOnly": true
+        },
+        "buildTriggerId": {
+          "description": "Output only. The ID of the `BuildTrigger` that triggered this build, if it was triggered automatically.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1BuildOptions",
+          "description": "Special options for this build."
+        },
+        "logUrl": {
+          "description": "Output only. URL to logs for this build in Google Cloud Console.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "substitutions": {
+          "description": "Substitutions data for `Build` resource.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "description": "Tags for annotation of a `Build`. These are not docker tags.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "secrets": {
+          "description": "Secrets to decrypt using Cloud Key Management Service. Note: Secret Manager is the recommended technique for managing sensitive data with Cloud Build. Use `available_secrets` to configure builds to access secrets from Secret Manager. For instructions, see: https://cloud.google.com/cloud-build/docs/securing-builds/use-secrets",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Secret"
+          }
+        },
+        "timing": {
+          "description": "Output only. Stores timing information for phases of the build. Valid keys are: * BUILD: time to execute all build steps. * PUSH: time to push all artifacts including docker images and non docker artifacts. * FETCHSOURCE: time to fetch source. * SETUPBUILD: time to set up build. If the build does not specify source or images, these keys will not be included.",
+          "readOnly": true,
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan"
+          }
+        },
+        "approval": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1BuildApproval",
+          "description": "Output only. Describes this build's approval configuration, status, and result.",
+          "readOnly": true
+        },
+        "serviceAccount": {
+          "description": "IAM service account whose credentials will be used at build runtime. Must be of the format `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}`. ACCOUNT can be email address or uniqueId of the service account. ",
+          "type": "string"
+        },
+        "availableSecrets": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Secrets",
+          "description": "Secrets and secret environment variables."
+        },
+        "warnings": {
+          "description": "Output only. Non-fatal problems encountered during the execution of the build.",
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Warning"
+          }
+        },
+        "gitConfig": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1GitConfig",
+          "description": "Optional. Configuration for git operations."
+        },
+        "failureInfo": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1FailureInfo",
+          "description": "Output only. Contains information about the build when status=FAILURE.",
+          "readOnly": true
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Source": {
+      "description": "Location of the source in a supported storage service.",
+      "type": "object",
+      "properties": {
+        "storageSource": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1StorageSource",
+          "description": "If provided, get the source from this location in Cloud Storage."
+        },
+        "repoSource": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1RepoSource",
+          "description": "If provided, get the source from this location in a Cloud Source Repository."
+        },
+        "gitSource": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1GitSource",
+          "description": "If provided, get the source from this Git repository."
+        },
+        "storageSourceManifest": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1StorageSourceManifest",
+          "description": "If provided, get the source from this manifest in Cloud Storage. This feature is in Preview; see description [here](https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/gcs-fetcher)."
+        },
+        "connectedRepository": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1ConnectedRepository",
+          "description": "Optional. If provided, get the source from this 2nd-gen Google Cloud Build repository resource."
+        },
+        "developerConnectConfig": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1DeveloperConnectConfig",
+          "description": "If provided, get the source from this Developer Connect config."
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1StorageSource": {
+      "description": "Location of the source in an archive file in Cloud Storage.",
+      "type": "object",
+      "properties": {
+        "bucket": {
+          "description": "Cloud Storage bucket containing the source (see [Bucket Name Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).",
+          "type": "string"
+        },
+        "object": {
+          "description": "Required. Cloud Storage object containing the source. This object must be a zipped (`.zip`) or gzipped archive file (`.tar.gz`) containing source to build.",
+          "type": "string"
+        },
+        "generation": {
+          "description": "Optional. Cloud Storage generation for the object. If the generation is omitted, the latest generation will be used.",
+          "type": "string"
+        },
+        "sourceFetcher": {
+          "description": "Optional. Option to specify the tool to fetch the source file for the build.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "SOURCE_FETCHER_UNSPECIFIED",
+              "title": "Unspecified defaults to GSUTIL."
+            },
+            {
+              "const": "GSUTIL",
+              "title": "Use the \"gsutil\" tool to download the source file."
+            },
+            {
+              "const": "GCS_FETCHER",
+              "title": "Use the Cloud Storage Fetcher tool to download the source file."
+            }
+          ]
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1RepoSource": {
+      "description": "Location of the source in a Google Cloud Source Repository.",
+      "type": "object",
+      "properties": {
+        "projectId": {
+          "description": "Optional. ID of the project that owns the Cloud Source Repository. If omitted, the project ID requesting the build is assumed.",
+          "type": "string"
+        },
+        "repoName": {
+          "description": "Required. Name of the Cloud Source Repository.",
+          "type": "string"
+        },
+        "branchName": {
+          "description": "Regex matching branches to build. The syntax of the regular expressions accepted is the syntax accepted by RE2 and described at https://github.com/google/re2/wiki/Syntax",
+          "type": "string"
+        },
+        "tagName": {
+          "description": "Regex matching tags to build. The syntax of the regular expressions accepted is the syntax accepted by RE2 and described at https://github.com/google/re2/wiki/Syntax",
+          "type": "string"
+        },
+        "commitSha": {
+          "description": "Explicit commit SHA to build.",
+          "type": "string"
+        },
+        "dir": {
+          "description": "Optional. Directory, relative to the source root, in which to run the build. This must be a relative path. If a step's `dir` is specified and is an absolute path, this value is ignored for that step's execution.",
+          "type": "string"
+        },
+        "invertRegex": {
+          "description": "Optional. Only trigger a build if the revision regex does NOT match the revision regex.",
+          "type": "boolean"
+        },
+        "substitutions": {
+          "description": "Optional. Substitutions to use in a triggered build. Should only be used with RunBuildTrigger",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1GitSource": {
+      "description": "Location of the source in any accessible Git repository.",
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "Required. Location of the Git repo to build. This will be used as a `git remote`, see https://git-scm.com/docs/git-remote.",
+          "type": "string"
+        },
+        "dir": {
+          "description": "Optional. Directory, relative to the source root, in which to run the build. This must be a relative path. If a step's `dir` is specified and is an absolute path, this value is ignored for that step's execution.",
+          "type": "string"
+        },
+        "revision": {
+          "description": "Optional. The revision to fetch from the Git repository such as a branch, a tag, a commit SHA, or any Git ref. Cloud Build uses `git fetch` to fetch the revision from the Git repository; therefore make sure that the string you provide for `revision` is parsable by the command. For information on string values accepted by `git fetch`, see https://git-scm.com/docs/gitrevisions#_specifying_revisions. For information on `git fetch`, see https://git-scm.com/docs/git-fetch.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1StorageSourceManifest": {
+      "description": "Location of the source manifest in Cloud Storage. This feature is in Preview; see description [here](https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/gcs-fetcher).",
+      "type": "object",
+      "properties": {
+        "bucket": {
+          "description": "Required. Cloud Storage bucket containing the source manifest (see [Bucket Name Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).",
+          "type": "string"
+        },
+        "object": {
+          "description": "Required. Cloud Storage object containing the source manifest. This object must be a JSON file.",
+          "type": "string"
+        },
+        "generation": {
+          "description": "Cloud Storage generation for the object. If the generation is omitted, the latest generation will be used.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1ConnectedRepository": {
+      "description": "Location of the source in a 2nd-gen Google Cloud Build repository resource.",
+      "type": "object",
+      "properties": {
+        "repository": {
+          "description": "Required. Name of the Google Cloud Build repository, formatted as `projects/*/locations/*/connections/*/repositories/*`.",
+          "type": "string"
+        },
+        "dir": {
+          "description": "Optional. Directory, relative to the source root, in which to run the build.",
+          "type": "string"
+        },
+        "revision": {
+          "description": "Required. The revision to fetch from the Git repository such as a branch, a tag, a commit SHA, or any Git ref.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1DeveloperConnectConfig": {
+      "description": "This config defines the location of a source through Developer Connect.",
+      "type": "object",
+      "properties": {
+        "gitRepositoryLink": {
+          "description": "Required. The Developer Connect Git repository link, formatted as `projects/*/locations/*/connections/*/gitRepositoryLink/*`.",
+          "type": "string"
+        },
+        "dir": {
+          "description": "Required. Directory, relative to the source root, in which to run the build.",
+          "type": "string"
+        },
+        "revision": {
+          "description": "Required. The revision to fetch from the Git repository such as a branch, a tag, a commit SHA, or any Git ref.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1BuildStep": {
+      "description": "A step in the build pipeline.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Required. The name of the container image that will run this particular build step. If the image is available in the host's Docker daemon's cache, it will be run directly. If not, the host will attempt to pull the image first, using the builder service account's credentials if necessary. The Docker daemon's cache will already have the latest versions of all of the officially supported build steps ([https://github.com/GoogleCloudPlatform/cloud-builders](https://github.com/GoogleCloudPlatform/cloud-builders)). The Docker daemon will also have cached many of the layers for some popular images, like \"ubuntu\", \"debian\", but they will be refreshed at the time you attempt to use them. If you built an image in a previous build step, it will be stored in the host's Docker daemon's cache and is available to use as the name for a later build step.",
+          "type": "string"
+        },
+        "env": {
+          "description": "A list of environment variable definitions to be used when running a step. The elements are of the form \"KEY=VALUE\" for the environment variable \"KEY\" being given the value \"VALUE\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "description": "A list of arguments that will be presented to the step when it is started. If the image used to run the step's container has an entrypoint, the `args` are used as arguments to that entrypoint. If the image does not define an entrypoint, the first element in args is used as the entrypoint, and the remainder will be used as arguments.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dir": {
+          "description": "Working directory to use when running this step's container. If this value is a relative path, it is relative to the build's working directory. If this value is absolute, it may be outside the build's working directory, in which case the contents of the path may not be persisted across build step executions, unless a `volume` for that path is specified. If the build specifies a `RepoSource` with `dir` and a step with a `dir`, which specifies an absolute path, the `RepoSource` `dir` is ignored for the step's execution.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Unique identifier for this build step, used in `wait_for` to reference this build step as a dependency.",
+          "type": "string"
+        },
+        "waitFor": {
+          "description": "The ID(s) of the step(s) that this build step depends on. This build step will not start until all the build steps in `wait_for` have completed successfully. If `wait_for` is empty, this build step will start when all previous build steps in the `Build.Steps` list have completed successfully.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "entrypoint": {
+          "description": "Entrypoint to be used instead of the build step image's default entrypoint. If unset, the image's default entrypoint is used.",
+          "type": "string"
+        },
+        "secretEnv": {
+          "description": "A list of environment variables which are encrypted using a Cloud Key Management Service crypto key. These values must be specified in the build's `Secret`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "volumes": {
+          "description": "List of volumes to mount into the build step. Each volume is created as an empty volume prior to execution of the build step. Upon completion of the build, volumes and their contents are discarded. Using a named volume in only one step is not valid as it is indicative of a build request with an incorrect configuration.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Volume"
+          }
+        },
+        "timing": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan",
+          "description": "Output only. Stores timing information for executing this build step.",
+          "readOnly": true
+        },
+        "pullTiming": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan",
+          "description": "Output only. Stores timing information for pulling this build step's builder image only.",
+          "readOnly": true
+        },
+        "timeout": {
+          "description": "Time limit for executing this build step. If not defined, the step has no time limit and will be allowed to continue to run until either it completes or the build itself times out.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Output only. Status of the build step. At this time, build step status is only updated on build completion; step status is not updated in real-time as the build progresses.",
+          "readOnly": true,
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "STATUS_UNKNOWN",
+              "title": "Status of the build is unknown."
+            },
+            {
+              "const": "PENDING",
+              "title": "Build has been created and is pending execution and queuing. It has not been queued."
+            },
+            {
+              "const": "QUEUED",
+              "title": "Build or step is queued; work has not yet begun."
+            },
+            {
+              "const": "WORKING",
+              "title": "Build or step is being executed."
+            },
+            {
+              "const": "SUCCESS",
+              "title": "Build or step finished successfully."
+            },
+            {
+              "const": "FAILURE",
+              "title": "Build or step failed to complete successfully."
+            },
+            {
+              "const": "INTERNAL_ERROR",
+              "title": "Build or step failed due to an internal cause."
+            },
+            {
+              "const": "TIMEOUT",
+              "title": "Build or step took longer than was allowed."
+            },
+            {
+              "const": "CANCELLED",
+              "title": "Build or step was canceled by a user."
+            },
+            {
+              "const": "EXPIRED",
+              "title": "Build was enqueued for longer than the value of `queue_ttl`."
+            }
+          ]
+        },
+        "allowFailure": {
+          "description": "Allow this build step to fail without failing the entire build. If false, the entire build will fail if this step fails. Otherwise, the build will succeed, but this step will still have a failure status. Error information will be reported in the failure_detail field.",
+          "type": "boolean"
+        },
+        "exitCode": {
+          "description": "Output only. Return code from running the step.",
+          "readOnly": true,
+          "type": "integer"
+        },
+        "allowExitCodes": {
+          "description": "Allow this build step to fail without failing the entire build if and only if the exit code is one of the specified codes. If allow_failure is also specified, this field will take precedence.",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "script": {
+          "description": "A shell script to be executed in the step. When script is provided, the user cannot specify the entrypoint or args.",
+          "type": "string"
+        },
+        "automapSubstitutions": {
+          "description": "Option to include built-in and custom substitutions as env variables for this build step. This option will override the global option in BuildOption.",
+          "type": "boolean"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Volume": {
+      "description": "Volume describes a Docker container volume which is mounted into build steps in order to persist files across build step execution.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the volume to mount. Volume names must be unique per build step and must be valid names for Docker volumes. Each named volume must be used by at least two build steps.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path at which to mount the volume. Paths must be absolute and cannot conflict with other volume paths on the same build step or with certain reserved volume paths.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1TimeSpan": {
+      "description": "Start and end times for a build execution phase.",
+      "type": "object",
+      "properties": {
+        "startTime": {
+          "description": "Start of time span.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "description": "End of time span.",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Results": {
+      "description": "Artifacts created by the build pipeline.",
+      "type": "object",
+      "properties": {
+        "images": {
+          "description": "Container images that were built as a part of the build.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1BuiltImage"
+          }
+        },
+        "buildStepImages": {
+          "description": "List of build step digests, in the order corresponding to build step indices.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "artifactManifest": {
+          "description": "Path to the artifact manifest for non-container artifacts uploaded to Cloud Storage. Only populated when artifacts are uploaded to Cloud Storage.",
+          "type": "string"
+        },
+        "numArtifacts": {
+          "description": "Number of non-container artifacts uploaded to Cloud Storage. Only populated when artifacts are uploaded to Cloud Storage.",
+          "type": "string"
+        },
+        "buildStepOutputs": {
+          "description": "List of build step outputs, produced by builder images, in the order corresponding to build step indices. [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders) can produce this output by writing to `$BUILDER_OUTPUT/output`. Only the first 50KB of data is stored. Note that the `$BUILDER_OUTPUT` variable is read-only and can't be substituted.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "artifactTiming": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan",
+          "description": "Time to push all non-container artifacts to Cloud Storage."
+        },
+        "pythonPackages": {
+          "description": "Python artifacts uploaded to Artifact Registry at the end of the build.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1UploadedPythonPackage"
+          }
+        },
+        "mavenArtifacts": {
+          "description": "Maven artifacts uploaded to Artifact Registry at the end of the build.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1UploadedMavenArtifact"
+          }
+        },
+        "npmPackages": {
+          "description": "Npm packages uploaded to Artifact Registry at the end of the build.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1UploadedNpmPackage"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1BuiltImage": {
+      "description": "An image built by the pipeline.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name used to push the container image to Google Container Registry, as presented to `docker push`.",
+          "type": "string"
+        },
+        "digest": {
+          "description": "Docker Registry 2.0 digest.",
+          "type": "string"
+        },
+        "pushTiming": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan",
+          "description": "Output only. Stores timing information for pushing the specified image.",
+          "readOnly": true
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1UploadedPythonPackage": {
+      "description": "Artifact uploaded using the PythonPackage directive.",
+      "type": "object",
+      "properties": {
+        "uri": {
+          "description": "URI of the uploaded artifact.",
+          "type": "string"
+        },
+        "fileHashes": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1FileHashes",
+          "description": "Hash types and values of the Python Artifact."
+        },
+        "pushTiming": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan",
+          "description": "Output only. Stores timing information for pushing the specified artifact.",
+          "readOnly": true
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1FileHashes": {
+      "description": "Container message for hashes of byte content of files, used in SourceProvenance messages to verify integrity of source input to the build.",
+      "type": "object",
+      "properties": {
+        "fileHash": {
+          "description": "Collection of file hashes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Hash"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Hash": {
+      "description": "Container message for hash values.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of hash that was performed.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "NONE",
+              "title": "No hash requested."
+            },
+            {
+              "const": "SHA256",
+              "title": "Use a sha256 hash."
+            },
+            {
+              "const": "MD5",
+              "title": "Use a md5 hash."
+            },
+            {
+              "const": "SHA512",
+              "title": "Use a sha512 hash."
+            }
+          ]
+        },
+        "value": {
+          "description": "The hash value.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1UploadedMavenArtifact": {
+      "description": "A Maven artifact uploaded using the MavenArtifact directive.",
+      "type": "object",
+      "properties": {
+        "uri": {
+          "description": "URI of the uploaded artifact.",
+          "type": "string"
+        },
+        "fileHashes": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1FileHashes",
+          "description": "Hash types and values of the Maven Artifact."
+        },
+        "pushTiming": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan",
+          "description": "Output only. Stores timing information for pushing the specified artifact.",
+          "readOnly": true
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1UploadedNpmPackage": {
+      "description": "An npm package uploaded to Artifact Registry using the NpmPackage directive.",
+      "type": "object",
+      "properties": {
+        "uri": {
+          "description": "URI of the uploaded npm package.",
+          "type": "string"
+        },
+        "fileHashes": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1FileHashes",
+          "description": "Hash types and values of the npm package."
+        },
+        "pushTiming": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan",
+          "description": "Output only. Stores timing information for pushing the specified artifact.",
+          "readOnly": true
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Artifacts": {
+      "description": "Artifacts produced by a build that should be uploaded upon successful completion of all build steps.",
+      "type": "object",
+      "properties": {
+        "images": {
+          "description": "A list of images to be pushed upon the successful completion of all build steps. The images will be pushed using the builder service account's credentials. The digests of the pushed images will be stored in the Build resource's results field. If any of the images fail to be pushed, the build is marked FAILURE.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "objects": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1ArtifactObjects",
+          "description": "A list of objects to be uploaded to Cloud Storage upon successful completion of all build steps. Files in the workspace matching specified paths globs will be uploaded to the specified Cloud Storage location using the builder service account's credentials. The location and generation of the uploaded objects will be stored in the Build resource's results field. If any objects fail to be pushed, the build is marked FAILURE."
+        },
+        "mavenArtifacts": {
+          "description": "A list of Maven artifacts to be uploaded to Artifact Registry upon successful completion of all build steps. Artifacts in the workspace matching specified paths globs will be uploaded to the specified Artifact Registry repository using the builder service account's credentials. If any artifacts fail to be pushed, the build is marked FAILURE.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1MavenArtifact"
+          }
+        },
+        "pythonPackages": {
+          "description": "A list of Python packages to be uploaded to Artifact Registry upon successful completion of all build steps. The build service account credentials will be used to perform the upload. If any objects fail to be pushed, the build is marked FAILURE.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1PythonPackage"
+          }
+        },
+        "npmPackages": {
+          "description": "A list of npm packages to be uploaded to Artifact Registry upon successful completion of all build steps. Npm packages in the specified paths will be uploaded to the specified Artifact Registry repository using the builder service account's credentials. If any packages fail to be pushed, the build is marked FAILURE.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1NpmPackage"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1ArtifactObjects": {
+      "description": "Files in the workspace to upload to Cloud Storage upon successful completion of all build steps.",
+      "type": "object",
+      "properties": {
+        "location": {
+          "description": "Cloud Storage bucket and optional object path, in the form \"gs://bucket/path/to/somewhere/\". (see [Bucket Name Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)). Files in the workspace matching any path pattern will be uploaded to Cloud Storage with this location as a prefix.",
+          "type": "string"
+        },
+        "paths": {
+          "description": "Path globs used to match files in the build's workspace.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "timing": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1TimeSpan",
+          "description": "Output only. Stores timing information for pushing all artifact objects.",
+          "readOnly": true
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1MavenArtifact": {
+      "description": "A Maven artifact to upload to Artifact Registry upon successful completion of all build steps.",
+      "type": "object",
+      "properties": {
+        "repository": {
+          "description": "Artifact Registry repository, in the form \"https://$REGION-maven.pkg.dev/$PROJECT/$REPOSITORY\" Artifact in the workspace specified by path will be uploaded to Artifact Registry with this location as a prefix.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path to an artifact in the build's workspace to be uploaded to Artifact Registry. This can be either an absolute path, e.g. /workspace/my-app/target/my-app-1.0.SNAPSHOT.jar or a relative path from /workspace, e.g. my-app/target/my-app-1.0.SNAPSHOT.jar.",
+          "type": "string"
+        },
+        "artifactId": {
+          "description": "Maven `artifactId` value used when uploading the artifact to Artifact Registry.",
+          "type": "string"
+        },
+        "groupId": {
+          "description": "Maven `groupId` value used when uploading the artifact to Artifact Registry.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Maven `version` value used when uploading the artifact to Artifact Registry.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1PythonPackage": {
+      "description": "Python package to upload to Artifact Registry upon successful completion of all build steps. A package can encapsulate multiple objects to be uploaded to a single repository.",
+      "type": "object",
+      "properties": {
+        "repository": {
+          "description": "Artifact Registry repository, in the form \"https://$REGION-python.pkg.dev/$PROJECT/$REPOSITORY\" Files in the workspace matching any path pattern will be uploaded to Artifact Registry with this location as a prefix.",
+          "type": "string"
+        },
+        "paths": {
+          "description": "Path globs used to match files in the build's workspace. For Python/ Twine, this is usually `dist/*`, and sometimes additionally an `.asc` file.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1NpmPackage": {
+      "description": "Npm package to upload to Artifact Registry upon successful completion of all build steps.",
+      "type": "object",
+      "properties": {
+        "repository": {
+          "description": "Artifact Registry repository, in the form \"https://$REGION-npm.pkg.dev/$PROJECT/$REPOSITORY\" Npm package in the workspace specified by path will be zipped and uploaded to Artifact Registry with this location as a prefix.",
+          "type": "string"
+        },
+        "packagePath": {
+          "description": "Path to the package.json. e.g. workspace/path/to/package",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1SourceProvenance": {
+      "description": "Provenance of the source. Ways to find the original source, or verify that some source was used for this build.",
+      "type": "object",
+      "properties": {
+        "resolvedStorageSource": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1StorageSource",
+          "description": "A copy of the build's `source.storage_source`, if exists, with any generations resolved."
+        },
+        "resolvedRepoSource": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1RepoSource",
+          "description": "A copy of the build's `source.repo_source`, if exists, with any revisions resolved."
+        },
+        "resolvedStorageSourceManifest": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1StorageSourceManifest",
+          "description": "A copy of the build's `source.storage_source_manifest`, if exists, with any revisions resolved. This feature is in Preview."
+        },
+        "resolvedConnectedRepository": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1ConnectedRepository",
+          "description": "Output only. A copy of the build's `source.connected_repository`, if exists, with any revisions resolved.",
+          "readOnly": true
+        },
+        "resolvedGitSource": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1GitSource",
+          "description": "Output only. A copy of the build's `source.git_source`, if exists, with any revisions resolved.",
+          "readOnly": true
+        },
+        "fileHashes": {
+          "description": "Output only. Hash(es) of the build source, which can be used to verify that the original source integrity was maintained in the build. Note that `FileHashes` will only be populated if `BuildOptions` has requested a `SourceProvenanceHash`. The keys to this map are file paths used as build source and the values contain the hash values for those files. If the build source came in a single package such as a gzipped tarfile (`.tar.gz`), the `FileHash` will be for the single path to that file.",
+          "readOnly": true,
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1FileHashes"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1BuildOptions": {
+      "description": "Optional arguments to enable specific features of builds.",
+      "type": "object",
+      "properties": {
+        "sourceProvenanceHash": {
+          "description": "Requested hash for SourceProvenance.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "const": "NONE",
+                "title": "No hash requested."
+              },
+              {
+                "const": "SHA256",
+                "title": "Use a sha256 hash."
+              },
+              {
+                "const": "MD5",
+                "title": "Use a md5 hash."
+              },
+              {
+                "const": "SHA512",
+                "title": "Use a sha512 hash."
+              }
+            ]
+          }
+        },
+        "requestedVerifyOption": {
+          "description": "Requested verifiability options.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "NOT_VERIFIED",
+              "title": "Not a verifiable build (the default)."
+            },
+            {
+              "const": "VERIFIED",
+              "title": "Build must be verified."
+            }
+          ]
+        },
+        "machineType": {
+          "description": "Compute Engine machine type on which to run the build.",
+          "type": "string",
+          "enumDeprecated": [false, true, true, false, false, false],
+          "anyOf": [
+            {
+              "const": "UNSPECIFIED",
+              "title": "Standard machine type."
+            },
+            {
+              "const": "N1_HIGHCPU_8",
+              "title": "Highcpu machine with 8 CPUs."
+            },
+            {
+              "const": "N1_HIGHCPU_32",
+              "title": "Highcpu machine with 32 CPUs."
+            },
+            {
+              "const": "E2_HIGHCPU_8",
+              "title": "Highcpu e2 machine with 8 CPUs."
+            },
+            {
+              "const": "E2_HIGHCPU_32",
+              "title": "Highcpu e2 machine with 32 CPUs."
+            },
+            {
+              "const": "E2_MEDIUM",
+              "title": "E2 machine with 1 CPU."
+            }
+          ]
+        },
+        "diskSizeGb": {
+          "description": "Requested disk size for the VM that runs the build. Note that this is *NOT* \"disk free\"; some of the space will be used by the operating system and build utilities. Also note that this is the minimum disk size that will be allocated for the build -- the build may run with a larger disk than requested. At present, the maximum disk size is 4000GB; builds that request more than the maximum are rejected with an error.",
+          "type": "string"
+        },
+        "substitutionOption": {
+          "description": "Option to specify behavior when there is an error in the substitution checks. NOTE: this is always set to ALLOW_LOOSE for triggered builds and cannot be overridden in the build configuration file.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "MUST_MATCH",
+              "title": "Fails the build if error in substitutions checks, like missing a substitution in the template or in the map."
+            },
+            {
+              "const": "ALLOW_LOOSE",
+              "title": "Do not fail the build if error in substitutions checks."
+            }
+          ]
+        },
+        "dynamicSubstitutions": {
+          "description": "Option to specify whether or not to apply bash style string operations to the substitutions. NOTE: this is always enabled for triggered builds and cannot be overridden in the build configuration file.",
+          "type": "boolean"
+        },
+        "automapSubstitutions": {
+          "description": "Option to include built-in and custom substitutions as env variables for all build steps.",
+          "type": "boolean"
+        },
+        "logStreamingOption": {
+          "description": "Option to define build log streaming behavior to Cloud Storage.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "STREAM_DEFAULT",
+              "title": "Service may automatically determine build log streaming behavior."
+            },
+            {
+              "const": "STREAM_ON",
+              "title": "Build logs should be streamed to Cloud Storage."
+            },
+            {
+              "const": "STREAM_OFF",
+              "title": "Build logs should not be streamed to Cloud Storage; they will be written when the build is completed."
+            }
+          ]
+        },
+        "workerPool": {
+          "description": "This field deprecated; please use `pool.name` instead.",
+          "deprecated": true,
+          "type": "string"
+        },
+        "pool": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1PoolOption",
+          "description": "Optional. Specification for execution on a `WorkerPool`. See [running builds in a private pool](https://cloud.google.com/build/docs/private-pools/run-builds-in-private-pool) for more information."
+        },
+        "logging": {
+          "description": "Option to specify the logging mode, which determines if and where build logs are stored.",
+          "type": "string",
+          "enumDeprecated": [false, false, false, true, false, false],
+          "anyOf": [
+            {
+              "const": "LOGGING_UNSPECIFIED",
+              "title": "The service determines the logging mode. The default is `LEGACY`. Do not rely on the default logging behavior as it may change in the future."
+            },
+            {
+              "const": "LEGACY",
+              "title": "Build logs are stored in Cloud Logging and Cloud Storage."
+            },
+            {
+              "const": "GCS_ONLY",
+              "title": "Build logs are stored in Cloud Storage."
+            },
+            {
+              "const": "STACKDRIVER_ONLY",
+              "title": "This option is the same as CLOUD_LOGGING_ONLY."
+            },
+            {
+              "const": "CLOUD_LOGGING_ONLY",
+              "title": "Build logs are stored in Cloud Logging. Selecting this option will not allow [logs streaming](https://cloud.google.com/sdk/gcloud/reference/builds/log)."
+            },
+            {
+              "const": "NONE",
+              "title": "Turn off all logging. No build logs will be captured."
+            }
+          ]
+        },
+        "env": {
+          "description": "A list of global environment variable definitions that will exist for all build steps in this build. If a variable is defined in both globally and in a build step, the variable will use the build step value. The elements are of the form \"KEY=VALUE\" for the environment variable \"KEY\" being given the value \"VALUE\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "secretEnv": {
+          "description": "A list of global environment variables, which are encrypted using a Cloud Key Management Service crypto key. These values must be specified in the build's `Secret`. These variables will be available to all build steps in this build.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "volumes": {
+          "description": "Global list of volumes to mount for ALL build steps Each volume is created as an empty volume prior to starting the build process. Upon completion of the build, volumes and their contents are discarded. Global volume names and paths cannot conflict with the volumes defined a build step. Using a global volume in a build with only one step is not valid as it is indicative of a build request with an incorrect configuration.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1Volume"
+          }
+        },
+        "defaultLogsBucketBehavior": {
+          "description": "Optional. Option to specify how default logs buckets are setup.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED",
+              "title": "Unspecified."
+            },
+            {
+              "const": "REGIONAL_USER_OWNED_BUCKET",
+              "title": "Bucket is located in user-owned project in the same region as the build. The builder service account must have access to create and write to Cloud Storage buckets in the build project."
+            }
+          ]
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1PoolOption": {
+      "description": "Details about how a build should be executed on a `WorkerPool`. See [running builds in a private pool](https://cloud.google.com/build/docs/private-pools/run-builds-in-private-pool) for more information.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The `WorkerPool` resource to execute the build on. You must have `cloudbuild.workerpools.use` on the project hosting the WorkerPool. Format projects/{project}/locations/{location}/workerPools/{workerPoolId}",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Secret": {
+      "description": "Pairs a set of secret environment variables containing encrypted values with the Cloud KMS key to use to decrypt the value. Note: Use `kmsKeyName` with `available_secrets` instead of using `kmsKeyName` with `secret`. For instructions see: https://cloud.google.com/cloud-build/docs/securing-builds/use-encrypted-credentials.",
+      "type": "object",
+      "properties": {
+        "kmsKeyName": {
+          "description": "Cloud KMS key name to use to decrypt these envs.",
+          "type": "string"
+        },
+        "secretEnv": {
+          "description": "Map of environment variable name to its encrypted value. Secret environment variables must be unique across all of a build's secrets, and must be used by at least one build step. Values can be at most 64 KB in size. There can be at most 100 secret values across all of a build's secrets.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1BuildApproval": {
+      "description": "BuildApproval describes a build's approval configuration, state, and result.",
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "Output only. The state of this build's approval.",
+          "readOnly": true,
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "STATE_UNSPECIFIED",
+              "title": "Default enum type. This should not be used."
+            },
+            {
+              "const": "PENDING",
+              "title": "Build approval is pending."
+            },
+            {
+              "const": "APPROVED",
+              "title": "Build approval has been approved."
+            },
+            {
+              "const": "REJECTED",
+              "title": "Build approval has been rejected."
+            },
+            {
+              "const": "CANCELLED",
+              "title": "Build was cancelled while it was still pending approval."
+            }
+          ]
+        },
+        "config": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1ApprovalConfig",
+          "description": "Output only. Configuration for manual approval of this build.",
+          "readOnly": true
+        },
+        "result": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1ApprovalResult",
+          "description": "Output only. Result of manual approval for this Build.",
+          "readOnly": true
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1ApprovalConfig": {
+      "description": "ApprovalConfig describes configuration for manual approval of a build.",
+      "type": "object",
+      "properties": {
+        "approvalRequired": {
+          "description": "Whether or not approval is needed. If this is set on a build, it will become pending when created, and will need to be explicitly approved to start.",
+          "type": "boolean"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1ApprovalResult": {
+      "description": "ApprovalResult describes the decision and associated metadata of a manual approval of a build.",
+      "type": "object",
+      "properties": {
+        "approverAccount": {
+          "description": "Output only. Email of the user that called the ApproveBuild API to approve or reject a build at the time that the API was called.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "approvalTime": {
+          "description": "Output only. The time when the approval decision was made.",
+          "readOnly": true,
+          "type": "string",
+          "format": "date-time"
+        },
+        "decision": {
+          "description": "Required. The decision of this manual approval.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "DECISION_UNSPECIFIED",
+              "title": "Default enum type. This should not be used."
+            },
+            {
+              "const": "APPROVED",
+              "title": "Build is approved."
+            },
+            {
+              "const": "REJECTED",
+              "title": "Build is rejected."
+            }
+          ]
+        },
+        "comment": {
+          "description": "Optional. An optional comment for this manual approval result.",
+          "type": "string"
+        },
+        "url": {
+          "description": "Optional. An optional URL tied to this manual approval result. This field is essentially the same as comment, except that it will be rendered by the UI differently. An example use case is a link to an external job that approved this Build.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Secrets": {
+      "description": "Secrets and secret environment variables.",
+      "type": "object",
+      "properties": {
+        "secretManager": {
+          "description": "Secrets in Secret Manager and associated secret environment variable.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1SecretManagerSecret"
+          }
+        },
+        "inline": {
+          "description": "Secrets encrypted with KMS key and the associated secret environment variable.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1InlineSecret"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1SecretManagerSecret": {
+      "description": "Pairs a secret environment variable with a SecretVersion in Secret Manager.",
+      "type": "object",
+      "properties": {
+        "versionName": {
+          "description": "Resource name of the SecretVersion. In format: projects/*/secrets/*/versions/*",
+          "type": "string"
+        },
+        "env": {
+          "description": "Environment variable name to associate with the secret. Secret environment variables must be unique across all of a build's secrets, and must be used by at least one build step.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1InlineSecret": {
+      "description": "Pairs a set of secret environment variables mapped to encrypted values with the Cloud KMS key to use to decrypt the value.",
+      "type": "object",
+      "properties": {
+        "kmsKeyName": {
+          "description": "Resource name of Cloud KMS crypto key to decrypt the encrypted value. In format: projects/*/locations/*/keyRings/*/cryptoKeys/*",
+          "type": "string"
+        },
+        "envMap": {
+          "description": "Map of environment variable name to its encrypted value. Secret environment variables must be unique across all of a build's secrets, and must be used by at least one build step. Values can be at most 64 KB in size. There can be at most 100 secret values across all of a build's secrets.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1Warning": {
+      "description": "A non-fatal problem encountered during the execution of the build.",
+      "type": "object",
+      "properties": {
+        "text": {
+          "description": "Explanation of the warning generated.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "The priority for this warning.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "PRIORITY_UNSPECIFIED",
+              "title": "Should not be used."
+            },
+            {
+              "const": "INFO",
+              "title": "e.g. deprecation warnings and alternative feature highlights."
+            },
+            {
+              "const": "WARNING",
+              "title": "e.g. automated detection of possible issues with the build."
+            },
+            {
+              "const": "ALERT",
+              "title": "e.g. alerts that a feature used in the build is pending removal"
+            }
+          ]
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1GitConfig": {
+      "description": "GitConfig is a configuration for git operations.",
+      "type": "object",
+      "properties": {
+        "http": {
+          "$ref": "#/$defs/GoogleDevtoolsCloudbuildV1HttpConfig",
+          "description": "Configuration for HTTP related git operations."
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1HttpConfig": {
+      "description": "HttpConfig is a configuration for HTTP related git operations.",
+      "type": "object",
+      "properties": {
+        "proxySecretVersionName": {
+          "description": "SecretVersion resource of the HTTP proxy URL. The Service Account used in the build (either the default Service Account or user-specified Service Account) should have `secretmanager.versions.access` permissions on this secret. The proxy URL should be in format `protocol://@]proxyhost[:port]`.",
+          "type": "string"
+        }
+      }
+    },
+    "GoogleDevtoolsCloudbuildV1FailureInfo": {
+      "description": "A fatal problem encountered during the execution of the build.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The name of the failure.",
+          "type": "string",
+          "anyOf": [
+            {
+              "const": "FAILURE_TYPE_UNSPECIFIED",
+              "title": "Type unspecified"
+            },
+            {
+              "const": "PUSH_FAILED",
+              "title": "Unable to push the image to the repository."
+            },
+            {
+              "const": "PUSH_IMAGE_NOT_FOUND",
+              "title": "Final image not found."
+            },
+            {
+              "const": "PUSH_NOT_AUTHORIZED",
+              "title": "Unauthorized push of the final image."
+            },
+            {
+              "const": "LOGGING_FAILURE",
+              "title": "Backend logging failures. Should retry."
+            },
+            {
+              "const": "USER_BUILD_STEP",
+              "title": "A build step has failed."
+            },
+            {
+              "const": "FETCH_SOURCE_FAILED",
+              "title": "The source fetching has failed."
+            }
+          ]
+        },
+        "detail": {
+          "description": "Explains the failure issue in more detail using hard-coded text.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "title": "Cloud Run Admin API",
+  "type": "object",
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Revision"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/Revision"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Configuration"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/Configuration"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "DomainMapping"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/DomainMapping"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Task"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/Task"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Execution"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/Execution"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Job"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/Job"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Route"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/Route"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "Service"
+          }
+        }
+      },
+      "then": {
+        "$ref": "#/$defs/Service"
+      }
+    }
+  ]
+}

--- a/src/test/cloud-run-v1/correct1.yaml
+++ b/src/test/cloud-run-v1/correct1.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: TheServiceName
+  labels:
+    cloud.googleapis.com/location: TheLocation
+  annotations:
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/container-dependencies: '{theContainer1Name: [theContainer2Name]}'
+        run.googleapis.com/vpc-access-connector: theNetwork
+    spec:
+      serviceAccountName: serviceAccountName
+      containers:
+        - image: theImageHere1
+          name: theContainer1Name
+          env:
+            - name: ENV1
+              value: envValue1
+          ports:
+            - name: http1
+              containerPort: 8080
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: mount1
+              readOnly: true
+              mountPath: /etc/mount1
+        - image: theImageHere2
+          name: theContainer2Name
+          env:
+            - name: PORT
+              value: '80'
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: mount1
+          secret:
+            secretName: theSecretName
+            items:
+              - key: latest
+                path: thePath.conf


### PR DESCRIPTION
Add schema for [Cloud Run Spec](https://cloud.google.com/run/docs/reference/yaml/v1)

[Cloud Run](https://cloud.google.com/run?hl=en) is a managed compute platform that allows you to run serverless containers on GCP.

I created this schema using a custom tool I developed (check it out [here](https://github.com/itolosa/discovery-converter)). The tool converts the available Discovery spec (found [here](https://cloud.google.com/run/docs/reference/yaml/v1)) into a JSON schema.

There were some issues with `any` types, which I replaced with `object` types. I'm unsure how much this will affect validation, but it involved only a few fields. Based on the field descriptions, I believe this approach makes sense, as the original spec may not be entirely accurate for some fields.