### PR TITLE
Add ipAllowList middleware to be compliant to traefik 2.11

### DIFF
--- a/src/schemas/json/traefik-v2-file-provider.json
+++ b/src/schemas/json/traefik-v2-file-provider.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/traefik-v2-file-provider.json",
   "additionalProperties": false,
   "definitions": {
     "httpRouter": {
@@ -763,7 +764,24 @@
     },
     "ipWhiteListMiddleware": {
       "type": "object",
-      "description": "IPWhitelist accepts / refuses requests based on the client IP.",
+      "description": "DEPRECATED: IPWhitelist accepts / refuses requests based on the client IP.",
+      "properties": {
+        "sourceRange": {
+          "type": "array",
+          "description": "The sourceRange option sets the allowed IPs (or ranges of allowed IPs by using CIDR notation).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ipStrategy": {
+          "$ref": "#/definitions/ipStrategy"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ipAllowListMiddleware": {
+      "type": "object",
+      "description": "IPAllowList accepts / refuses requests based on the client IP.",
       "properties": {
         "sourceRange": {
           "type": "array",
@@ -1165,6 +1183,14 @@
         },
         {
           "properties": {
+            "ipAllowList": {
+              "$ref": "#/definitions/ipAllowListMiddleware"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "properties": {
             "inFlightReq": {
               "$ref": "#/definitions/inFlightReqMiddleware"
             }
@@ -1494,7 +1520,6 @@
     }
   },
   "description": "Traefik v2 Dynamic Configuration File Provider",
-  "id": "https://json.schemastore.org/traefik-v2-file-provider.json",
   "properties": {
     "http": {
       "type": "object",

--- a/src/test/traefik-v2-file-provider/example.json
+++ b/src/test/traefik-v2-file-provider/example.json
@@ -1,12 +1,12 @@
 {
   "http": {
     "middlewares": {
-      "Middleware00": {
+      "Middleware01": {
         "addPrefix": {
           "prefix": "foobar"
         }
       },
-      "Middleware01": {
+      "Middleware02": {
         "basicAuth": {
           "headerField": "foobar",
           "realm": "foobar",
@@ -15,7 +15,7 @@
           "usersFile": "foobar"
         }
       },
-      "Middleware02": {
+      "Middleware03": {
         "buffering": {
           "maxRequestBodyBytes": 42,
           "maxResponseBodyBytes": 42,
@@ -24,12 +24,12 @@
           "retryExpression": "foobar"
         }
       },
-      "Middleware03": {
+      "Middleware04": {
         "chain": {
           "middlewares": ["foobar", "foobar"]
         }
       },
-      "Middleware04": {
+      "Middleware05": {
         "circuitBreaker": {
           "checkPeriod": "42s",
           "expression": "foobar",
@@ -37,18 +37,18 @@
           "recoveryDuration": "42s"
         }
       },
-      "Middleware05": {
+      "Middleware06": {
         "compress": {
           "excludedContentTypes": ["foobar", "foobar"],
           "minResponseBodyBytes": 42
         }
       },
-      "Middleware06": {
+      "Middleware07": {
         "contentType": {
           "autoDetect": true
         }
       },
-      "Middleware07": {
+      "Middleware08": {
         "digestAuth": {
           "headerField": "foobar",
           "realm": "foobar",
@@ -57,14 +57,14 @@
           "usersFile": "foobar"
         }
       },
-      "Middleware08": {
+      "Middleware09": {
         "errors": {
           "query": "foobar",
           "service": "foobar",
           "status": ["foobar", "foobar"]
         }
       },
-      "Middleware09": {
+      "Middleware10": {
         "forwardAuth": {
           "address": "foobar",
           "authRequestHeaders": ["foobar", "foobar"],
@@ -80,7 +80,7 @@
           "trustForwardHeader": true
         }
       },
-      "Middleware10": {
+      "Middleware11": {
         "headers": {
           "accessControlAllowCredentials": true,
           "accessControlAllowHeaders": ["foobar", "foobar"],
@@ -125,7 +125,16 @@
           "stsSeconds": 42
         }
       },
-      "Middleware11": {
+      "Middleware12": {
+        "ipAllowList": {
+          "ipStrategy": {
+            "depth": 42,
+            "excludedIPs": ["foobar", "foobar"]
+          },
+          "sourceRange": ["foobar", "foobar"]
+        }
+      },
+      "Middleware13": {
         "ipWhiteList": {
           "ipStrategy": {
             "depth": 42,
@@ -134,7 +143,7 @@
           "sourceRange": ["foobar", "foobar"]
         }
       },
-      "Middleware12": {
+      "Middleware14": {
         "inFlightReq": {
           "amount": 42,
           "sourceCriterion": {
@@ -147,7 +156,7 @@
           }
         }
       },
-      "Middleware13": {
+      "Middleware15": {
         "passTLSClientCert": {
           "info": {
             "issuer": {
@@ -177,14 +186,19 @@
           "pem": true
         }
       },
-      "Middleware14": {
+      "Middleware16": {
         "plugin": {
-          "PluginConf": {
-            "foo": "bar"
+          "PluginConf0": {
+            "name0": "foobar",
+            "name1": "foobar"
+          },
+          "PluginConf1": {
+            "name0": "foobar",
+            "name1": "foobar"
           }
         }
       },
-      "Middleware15": {
+      "Middleware17": {
         "rateLimit": {
           "average": 42,
           "burst": 42,
@@ -199,44 +213,44 @@
           }
         }
       },
-      "Middleware16": {
+      "Middleware18": {
         "redirectRegex": {
           "permanent": true,
           "regex": "foobar",
           "replacement": "foobar"
         }
       },
-      "Middleware17": {
+      "Middleware19": {
         "redirectScheme": {
           "permanent": true,
           "port": "foobar",
           "scheme": "foobar"
         }
       },
-      "Middleware18": {
+      "Middleware20": {
         "replacePath": {
           "path": "foobar"
         }
       },
-      "Middleware19": {
+      "Middleware21": {
         "replacePathRegex": {
           "regex": "foobar",
           "replacement": "foobar"
         }
       },
-      "Middleware20": {
+      "Middleware22": {
         "retry": {
           "attempts": 42,
           "initialInterval": "42s"
         }
       },
-      "Middleware21": {
+      "Middleware23": {
         "stripPrefix": {
           "forceSlash": true,
           "prefixes": ["foobar", "foobar"]
         }
       },
-      "Middleware22": {
+      "Middleware24": {
         "stripPrefixRegex": {
           "regex": ["foobar", "foobar"]
         }
@@ -340,6 +354,13 @@
     },
     "services": {
       "Service01": {
+        "failover": {
+          "fallback": "foobar",
+          "healthCheck": {},
+          "service": "foobar"
+        }
+      },
+      "Service02": {
         "loadBalancer": {
           "healthCheck": {
             "followRedirects": true,
@@ -378,7 +399,7 @@
           }
         }
       },
-      "Service02": {
+      "Service03": {
         "mirroring": {
           "healthCheck": {},
           "maxBodySize": 42,
@@ -395,7 +416,7 @@
           "service": "foobar"
         }
       },
-      "Service03": {
+      "Service04": {
         "weighted": {
           "healthCheck": {},
           "services": [
@@ -417,24 +438,22 @@
             }
           }
         }
-      },
-      "Service04": {
-        "failover": {
-          "fallback": "foobar",
-          "healthCheck": {},
-          "service": "foobar"
-        }
       }
     }
   },
   "tcp": {
     "middlewares": {
-      "TCPMiddleware00": {
+      "TCPMiddleware01": {
+        "ipAllowList": {
+          "sourceRange": ["foobar", "foobar"]
+        }
+      },
+      "TCPMiddleware02": {
         "ipWhiteList": {
           "sourceRange": ["foobar", "foobar"]
         }
       },
-      "TCPMiddleware01": {
+      "TCPMiddleware03": {
         "inFlightConn": {
           "amount": 42
         }


### PR DESCRIPTION
This PR updates Traefik schemas to satisfy v2.11 dynamic configuration requirements. Namely the IPAllowList middleware