### PR TITLE
Add lazygit's local (per-repository) config files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6352,11 +6352,7 @@
     {
       "name": "lazygit",
       "description": "lazygit settings",
-      "fileMatch": [
-        "**/lazygit/config.yml",
-        "lazygit.yml",
-        ".lazygit.yml"
-      ],
+      "fileMatch": ["**/lazygit/config.yml", "lazygit.yml", ".lazygit.yml"],
       "url": "https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6352,7 +6352,11 @@
     {
       "name": "lazygit",
       "description": "lazygit settings",
-      "fileMatch": ["**/lazygit/config.yml"],
+      "fileMatch": [
+        "**/lazygit/config.yml",
+        "lazygit.yml",
+        ".lazygit.yml"
+      ],
       "url": "https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json"
     },
     {

--- a/src/schemas/json/lazygit.json
+++ b/src/schemas/json/lazygit.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$ref": "https://github.com/jesseduffield/lazygit/blob/master/schema/config.json"
+  "$ref": "https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json"
 }


### PR DESCRIPTION
Lazygit recently added supported for local config files, which have different names than the global one. See https://github.com/jesseduffield/lazygit/pull/3787.

Along the way, fix a bug in the hosted lazygit schema.