### PR TITLE
New version 1.2.1 of IBM ZAPP schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2690,7 +2690,7 @@
       "name": "IBM Zapp document",
       "description": "IBM Z APPlication configuration file for IBM zDevOps development tools such as Z Open Editor",
       "fileMatch": ["zapp.yaml", "zapp.json"],
-      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.0.0.json"
+      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.2.1.json"
     },
     {
       "name": "IBM zCodeFormatSettings",


### PR DESCRIPTION
A new version of the JSON schema first introduced with this PR: https://github.com/SchemaStore/schemastore/pull/2860

This schema is used by free development tools provided by IBM: https://ibm.github.io/zopeneditor-about/Docs/zapp.html
