### PR TITLE
Introduced abc-inventory-module-data-2.0.0.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -105,9 +105,10 @@
       "name": "ABCInventoryModuleData",
       "description": "ABCInventoryModuleData defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module",
       "fileMatch": ["abc-inventory-module-data-*.json"],
-      "url": "https://json.schemastore.org/abc-inventory-module-data-1.0.0.json",
+      "url": "https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
       "versions": {
-        "1.0.0": "https://json.schemastore.org/abc-inventory-module-data-1.0.0.json"
+        "1.0.0": "https://json.schemastore.org/abc-inventory-module-data-1.0.0.json",
+        "2.0.0": "https://json.schemastore.org/abc-inventory-module-data-2.0.0.json"
       }
     },
     {

--- a/src/negative_test/abc-inventory-module-data-2.0.0/abc-inventory-module-data-missing-schema-property.json
+++ b/src/negative_test/abc-inventory-module-data-2.0.0/abc-inventory-module-data-missing-schema-property.json
@@ -1,0 +1,10 @@
+{
+  "ABCInventoryEntries": {},
+  "ABCLocations": {},
+  "ABCMaterialCategories": {},
+  "ABCMaterialNumbers": {},
+  "ABCProducts": {},
+  "ABCReasonCodes": {},
+  "ABCTransactions": [],
+  "ABCVendors": {}
+}

--- a/src/schemas/json/abc-inventory-module-data-2.0.0.json
+++ b/src/schemas/json/abc-inventory-module-data-2.0.0.json
@@ -1,949 +1,975 @@
 {
-  "$id": "https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
   "title": "ABCInventoryModuleData JSON Schema",
   "description": "Schema defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module.",
   "type": "object",
   "definitions": {
-      "ABCStatus": {
+    "ABCStatus": {
+      "type": "string",
+      "enum": [
+        "RELEASED",
+        "CONDITIONAL_RELEASED",
+        "QUARANTINE",
+        "ON_HOLD",
+        "EXPIRED",
+        "DAMAGED"
+      ]
+    },
+    "ABCInventoryReceiveTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
           "type": "string",
-          "enum": [
-              "RELEASED",
-              "CONDITIONAL_RELEASED",
-              "QUARANTINE",
-              "ON_HOLD",
-              "EXPIRED",
-              "DAMAGED"
-          ]
-      },
-      "ABCInventoryReceiveTransaction": {
+          "enum": ["receive"]
+        },
+        "transactionData": {
           "type": "object",
           "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["receive"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "quantity": {
-                          "type": "number"
-                      },
-                      "dateOfExpiry": {
-                          "type": "string",
-                          "format": "date"
-                      },
-                      "dateOfManufacture": {
-                          "type": "string",
-                          "format": "date"
-                      },
-                      "poNumber": {
-                          "type": "string"
-                      },
-                      "statusID": {
-                          "$ref": "#/definitions/ABCStatus"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotNumber",
-                      "materialNumberID",
-                      "quantity",
-                      "dateOfExpiry",
-                      "dateOfManufacture",
-                      "poNumber",
-                      "statusID",
-                      "locationID",
-                      "productID",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              },
-              "targetLotID": {
-                  "type": "string"
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData", "targetLotID"],
-          "additionalProperties": false
-      },
-      "ABCInventoryBuildTransaction": {
-          "type": "object",
-          "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["build"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "quantity": {
-                          "type": "number"
-                      },
-                      "dateOfExpiry": {
-                          "type": "string",
-                          "format": "date"
-                      },
-                      "dateOfManufacture": {
-                          "type": "string",
-                          "format": "date"
-                      },
-                      "poNumber": {
-                          "type": "string"
-                      },
-                      "statusID": {
-                          "$ref": "#/definitions/ABCStatus"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "upstreams": {
-                          "type": "array",
-                          "items": {
-                              "type": "object",
-                              "properties": {
-                                  "lotID": {
-                                      "type": "string"
-                                  },
-                                  "quantity": {
-                                      "type": "number"
-                                  }
-                              },
-                              "required": ["lotID", "quantity"],
-                              "additionalProperties": false
-                          }
-                      },
-                      "upstreamIDs": {
-                          "type": "array",
-                          "items": {
-                              "type": "string"
-                          }
-                      },
-                      "upstreamLotNumbers": {
-                          "type": "array",
-                          "items": {
-                              "type": "string"
-                          }
-                      },
-                      "upstreamQuantities": {
-                          "type": "array",
-                          "items": {
-                              "type": "number"
-                          }
-                      },
-                      "upstreamMaterialNumberIDs": {
-                          "type": "array",
-                          "items": {
-                              "type": "string"
-                          }
-                      },
-                      "upstreamLocationIDs": {
-                          "type": "array",
-                          "items": {
-                              "type": "string"
-                          }
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "upstreamProductIDs": {
-                          "type": "array",
-                          "items": {
-                              "type": ["string", "null"]
-                          }
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotNumber",
-                      "materialNumberID",
-                      "quantity",
-                      "dateOfExpiry",
-                      "dateOfManufacture",
-                      "poNumber",
-                      "statusID",
-                      "locationID",
-                      "upstreams",
-                      "upstreamIDs",
-                      "upstreamLotNumbers",
-                      "upstreamQuantities",
-                      "upstreamMaterialNumberIDs",
-                      "upstreamLocationIDs",
-                      "productID",
-                      "upstreamProductIDs",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              },
-              "targetLotID": {
-                  "type": "string"
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData", "targetLotID"],
-          "additionalProperties": false
-      },
-      "ABCInventoryTransferTransaction": {
-          "type": "object",
-          "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["transfer"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotID": {
-                          "type": "string"
-                      },
-                      "newLocationID": {
-                          "type": "string"
-                      },
-                      "quantity": {
-                          "type": "number"
-                      },
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotID",
-                      "newLocationID",
-                      "quantity",
-                      "lotNumber",
-                      "materialNumberID",
-                      "locationID",
-                      "productID",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              },
-              "targetLotID": {
-                  "type": "string"
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData", "targetLotID"],
-          "additionalProperties": false
-      },
-      "ABCInventoryStatusChangeTransaction": {
-          "type": "object",
-          "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["statusChange"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotID": {
-                          "type": "string"
-                      },
-                      "newStatusID": {
-                          "$ref": "#/definitions/ABCStatus"
-                      },
-                      "quantity": {
-                          "type": "number"
-                      },
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotID",
-                      "newStatusID",
-                      "quantity",
-                      "lotNumber",
-                      "materialNumberID",
-                      "locationID",
-                      "productID",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              },
-              "targetLotID": {
-                  "type": "string"
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData", "targetLotID"],
-          "additionalProperties": false
-      },
-      "ABCInventoryDistributeTransaction": {
-          "type": "object",
-          "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["distribute"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotID": {
-                          "type": "string"
-                      },
-                      "quantity": {
-                          "type": "number"
-                      },
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotID",
-                      "quantity",
-                      "lotNumber",
-                      "materialNumberID",
-                      "locationID",
-                      "productID",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData"],
-          "additionalProperties": false
-      },
-      "ABCInventoryDestroyTransaction": {
-          "type": "object",
-          "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["destroy"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotID": {
-                          "type": "string"
-                      },
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotID",
-                      "lotNumber",
-                      "materialNumberID",
-                      "locationID",
-                      "productID",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData"],
-          "additionalProperties": false
-      },
-      "ABCInventorySellTransaction": {
-          "type": "object",
-          "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["sell"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotID": {
-                          "type": "string"
-                      },
-                      "quantity": {
-                          "type": "number"
-                      },
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotID",
-                      "quantity",
-                      "lotNumber",
-                      "materialNumberID",
-                      "locationID",
-                      "productID",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData"],
-          "additionalProperties": false
-      },
-      "ABCInventoryAdjustTransaction": {
-          "type": "object",
-          "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["adjust"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotID": {
-                          "type": "string"
-                      },
-                      "newQuantity": {
-                          "type": "number"
-                      },
-                      "reasonCodeID": {
-                          "type": "string"
-                      },
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotID",
-                      "newQuantity",
-                      "reasonCodeID",
-                      "lotNumber",
-                      "materialNumberID",
-                      "locationID",
-                      "productID",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData"],
-          "additionalProperties": false
-      },
-      "ABCInventoryChangeExpiryTransaction": {
-          "type": "object",
-          "properties": {
-              "uid": {
-                  "type": "string"
-              },
-              "timestamp": {
-                  "type": "number"
-              },
-              "transactionType": {
-                  "type": "string",
-                  "enum": ["changeExpiry"]
-              },
-              "transactionData": {
-                  "type": "object",
-                  "properties": {
-                      "lotID": {
-                          "type": "string"
-                      },
-                      "newDateOfExpiry": {
-                          "type": "string"
-                      },
-                      "lotNumber": {
-                          "type": "string"
-                      },
-                      "materialNumberID": {
-                          "type": "string"
-                      },
-                      "locationID": {
-                          "type": "string"
-                      },
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "notes": {
-                          "type": "string"
-                      }
-                  },
-                  "required": [
-                      "lotID",
-                      "newDateOfExpiry",
-                      "lotNumber",
-                      "materialNumberID",
-                      "locationID",
-                      "productID",
-                      "notes"
-                  ],
-                  "additionalProperties": false
-              }
-          },
-          "required": ["uid", "timestamp", "transactionType", "transactionData"],
-          "additionalProperties": false
-      },
-      "ABCInventoryTransaction": {
-          "oneOf": [
-              { "$ref": "#/definitions/ABCInventoryReceiveTransaction" },
-              { "$ref": "#/definitions/ABCInventoryBuildTransaction" },
-              { "$ref": "#/definitions/ABCInventoryTransferTransaction" },
-              { "$ref": "#/definitions/ABCInventoryStatusChangeTransaction" },
-              { "$ref": "#/definitions/ABCInventoryDistributeTransaction" },
-              { "$ref": "#/definitions/ABCInventoryDestroyTransaction" },
-              { "$ref": "#/definitions/ABCInventorySellTransaction" },
-              { "$ref": "#/definitions/ABCInventoryAdjustTransaction" },
-              { "$ref": "#/definitions/ABCInventoryChangeExpiryTransaction" }
-          ]
-      },
-      "ABCInventoryEntryWithoutUpstreams": {
-          "type": "object",
-          "properties": {
-              "lotNumber": {
-                  "type": "string"
-              },
-              "materialNumberID": {
-                  "type": "string"
-              },
-              "productID": {
-                  "type": ["string", "null"]
-              },
-              "quantity": {
-                  "type": "number"
-              },
-              "dateOfExpiry": {
-                  "type": "string",
-                  "format": "date"
-              },
-              "dateOfManufacture": {
-                  "type": "string",
-                  "format": "date"
-              },
-              "poNumber": {
-                  "type": "string"
-              },
-              "statusID": {
-                  "$ref": "#/definitions/ABCStatus"
-              },
-              "locationID": {
-                  "type": "string"
-              },
-              "hasUpstreams": {
-                  "type": "boolean",
-                  "enum": [false]
-              },
-              "transactionNotes": {
-                  "type": "array",
-                  "items": {
-                      "type": "string"
-                  }
-              },
-              "lotNumberLowercase": {
-                  "type": "string"
-              }
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "dateOfExpiry": {
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfManufacture": {
+              "type": "string",
+              "format": "date"
+            },
+            "poNumber": {
+              "type": "string"
+            },
+            "statusID": {
+              "$ref": "#/definitions/ABCStatus"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
+            }
           },
           "required": [
-              "lotNumber",
-              "materialNumberID",
-              "productID",
-              "quantity",
-              "dateOfExpiry",
-              "dateOfManufacture",
-              "poNumber",
-              "statusID",
-              "locationID",
-              "hasUpstreams",
-              "transactionNotes",
-              "lotNumberLowercase"
+            "lotNumber",
+            "materialNumberID",
+            "quantity",
+            "dateOfExpiry",
+            "dateOfManufacture",
+            "poNumber",
+            "statusID",
+            "locationID",
+            "productID",
+            "notes"
           ],
           "additionalProperties": false
+        },
+        "targetLotID": {
+          "type": "string"
+        }
       },
-      "ABCInventoryEntryWithUpstreams": {
+      "required": [
+        "uid",
+        "timestamp",
+        "transactionType",
+        "transactionData",
+        "targetLotID"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryBuildTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["build"]
+        },
+        "transactionData": {
           "type": "object",
           "properties": {
-              "lotNumber": {
-                  "type": "string"
-              },
-              "materialNumberID": {
-                  "type": "string"
-              },
-              "productID": {
-                  "type": ["string", "null"]
-              },
-              "quantity": {
-                  "type": "number"
-              },
-              "dateOfExpiry": {
-                  "type": "string",
-                  "format": "date"
-              },
-              "dateOfManufacture": {
-                  "type": "string",
-                  "format": "date"
-              },
-              "poNumber": {
-                  "type": "string"
-              },
-              "statusID": {
-                  "$ref": "#/definitions/ABCStatus"
-              },
-              "locationID": {
-                  "type": "string"
-              },
-              "hasUpstreams": {
-                  "type": "boolean",
-                  "enum": [true]
-              },
-              "upstreamIDs": {
-                  "type": "array",
-                  "items": {
-                      "type": "string"
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "dateOfExpiry": {
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfManufacture": {
+              "type": "string",
+              "format": "date"
+            },
+            "poNumber": {
+              "type": "string"
+            },
+            "statusID": {
+              "$ref": "#/definitions/ABCStatus"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "upstreams": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "lotID": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
                   }
-              },
-              "upstreamQuantities": {
-                  "type": "array",
-                  "items": {
-                      "type": "number"
-                  }
-              },
-              "upstreamLotNumbers": {
-                  "type": "array",
-                  "items": {
-                      "type": "string"
-                  }
-              },
-              "transactionNotes": {
-                  "type": "array",
-                  "items": {
-                      "type": "string"
-                  }
-              },
-              "lotNumberLowercase": {
-                  "type": "string"
+                },
+                "required": ["lotID", "quantity"],
+                "additionalProperties": false
               }
+            },
+            "upstreamIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "upstreamLotNumbers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "upstreamQuantities": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "upstreamMaterialNumberIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "upstreamLocationIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "upstreamProductIDs": {
+              "type": "array",
+              "items": {
+                "type": ["string", "null"]
+              }
+            },
+            "notes": {
+              "type": "string"
+            }
           },
           "required": [
-              "lotNumber",
-              "materialNumberID",
-              "productID",
-              "quantity",
-              "dateOfExpiry",
-              "dateOfManufacture",
-              "poNumber",
-              "statusID",
-              "locationID",
-              "hasUpstreams",
-              "upstreamIDs",
-              "upstreamQuantities",
-              "upstreamLotNumbers",
-              "transactionNotes",
-              "lotNumberLowercase"
+            "lotNumber",
+            "materialNumberID",
+            "quantity",
+            "dateOfExpiry",
+            "dateOfManufacture",
+            "poNumber",
+            "statusID",
+            "locationID",
+            "upstreams",
+            "upstreamIDs",
+            "upstreamLotNumbers",
+            "upstreamQuantities",
+            "upstreamMaterialNumberIDs",
+            "upstreamLocationIDs",
+            "productID",
+            "upstreamProductIDs",
+            "notes"
           ],
           "additionalProperties": false
+        },
+        "targetLotID": {
+          "type": "string"
+        }
       },
-      "ABCInventoryEntry": {
-          "oneOf": [
-              { "$ref": "#/definitions/ABCInventoryEntryWithoutUpstreams" },
-              { "$ref": "#/definitions/ABCInventoryEntryWithUpstreams" }
-          ]
-      }
-  },
-  "properties": {
-      "$schema": {
-          "description": "Link to https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
+      "required": [
+        "uid",
+        "timestamp",
+        "transactionType",
+        "transactionData",
+        "targetLotID"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryTransferTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
           "type": "string",
-          "enum": ["https://json.schemastore.org/abc-inventory-module-data-2.0.0.json"]
-      },
-      "ABCProducts": {
+          "enum": ["transfer"]
+        },
+        "transactionData": {
           "type": "object",
-          "patternProperties": {
-              "^[a-zA-Z0-9_-]+$": {
-                  "type": "object",
-                  "properties": {
-                      "name": {
-                          "type": "string"
-                      },
-                      "isActive": {
-                          "type": "boolean"
-                      }
-                  },
-                  "required": ["name", "isActive"],
-                  "additionalProperties": false
-              }
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "newLocationID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
+            }
           },
+          "required": [
+            "lotID",
+            "newLocationID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "additionalProperties": false
+        },
+        "targetLotID": {
+          "type": "string"
+        }
       },
-      "ABCVendors": {
+      "required": [
+        "uid",
+        "timestamp",
+        "transactionType",
+        "transactionData",
+        "targetLotID"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryStatusChangeTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["statusChange"]
+        },
+        "transactionData": {
           "type": "object",
-          "patternProperties": {
-              "^[a-zA-Z0-9_-]+$": {
-                  "type": "object",
-                  "properties": {
-                      "name": {
-                          "type": "string"
-                      },
-                      "isActive": {
-                          "type": "boolean"
-                      }
-                  },
-                  "required": ["name", "isActive"],
-                  "additionalProperties": false
-              }
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "newStatusID": {
+              "$ref": "#/definitions/ABCStatus"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
+            }
           },
+          "required": [
+            "lotID",
+            "newStatusID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "additionalProperties": false
+        },
+        "targetLotID": {
+          "type": "string"
+        }
       },
-      "ABCMaterialCategories": {
+      "required": [
+        "uid",
+        "timestamp",
+        "transactionType",
+        "transactionData",
+        "targetLotID"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryDistributeTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["distribute"]
+        },
+        "transactionData": {
           "type": "object",
-          "patternProperties": {
-              "^[a-zA-Z0-9_-]+$": {
-                  "type": "object",
-                  "properties": {
-                      "name": {
-                          "type": "string"
-                      },
-                      "prefix": {
-                          "type": "string"
-                      },
-                      "isActive": {
-                          "type": "boolean"
-                      }
-                  },
-                  "required": ["name", "isActive", "prefix"],
-                  "additionalProperties": false
-              }
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
+            }
           },
+          "required": [
+            "lotID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "additionalProperties": false
+        }
       },
-      "ABCMaterialNumbers": {
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryDestroyTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["destroy"]
+        },
+        "transactionData": {
           "type": "object",
-          "patternProperties": {
-              "^[a-zA-Z0-9_-]+$": {
-                  "type": "object",
-                  "properties": {
-                      "productID": {
-                          "type": ["string", "null"]
-                      },
-                      "vendorID": {
-                          "type": ["string", "null"]
-                      },
-                      "materialCategoryID": {
-                          "type": "string"
-                      },
-                      "number": {
-                          "type": "number"
-                      },
-                      "name": {
-                          "type": "string"
-                      },
-                      "description": {
-                          "type": "string"
-                      },
-                      "unitOfMeasure": {
-                          "type": "string"
-                      },
-                      "isActive": {
-                          "type": "boolean"
-                      }
-                  },
-                  "required": [
-                      "productID",
-                      "vendorID",
-                      "materialCategoryID",
-                      "number",
-                      "name",
-                      "description",
-                      "unitOfMeasure",
-                      "isActive"
-                  ],
-                  "additionalProperties": false
-              }
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
+            }
           },
+          "required": [
+            "lotID",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "additionalProperties": false
+        }
       },
-      "ABCLocations": {
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventorySellTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["sell"]
+        },
+        "transactionData": {
           "type": "object",
-          "patternProperties": {
-              "^[a-zA-Z0-9_-]+$": {
-                  "type": "object",
-                  "properties": {
-                      "name": {
-                          "type": "string"
-                      },
-                      "isActive": {
-                          "type": "boolean"
-                      }
-                  },
-                  "required": ["name", "isActive"],
-                  "additionalProperties": false
-              }
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
+            }
           },
+          "required": [
+            "lotID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "additionalProperties": false
+        }
       },
-      "ABCReasonCodes": {
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryAdjustTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["adjust"]
+        },
+        "transactionData": {
           "type": "object",
-          "patternProperties": {
-              "^[a-zA-Z0-9_-]+$": {
-                  "type": "object",
-                  "properties": {
-                      "code": {
-                          "type": "string"
-                      },
-                      "description": {
-                          "type": "string"
-                      },
-                      "isActive": {
-                          "type": "boolean"
-                      }
-                  },
-                  "required": ["code", "description", "isActive"],
-                  "additionalProperties": false
-              }
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "newQuantity": {
+              "type": "number"
+            },
+            "reasonCodeID": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
+            }
           },
+          "required": [
+            "lotID",
+            "newQuantity",
+            "reasonCodeID",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "additionalProperties": false
+        }
       },
-      "ABCTransactions": {
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryChangeExpiryTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["changeExpiry"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "newDateOfExpiry": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "newDateOfExpiry",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryTransaction": {
+      "oneOf": [
+        { "$ref": "#/definitions/ABCInventoryReceiveTransaction" },
+        { "$ref": "#/definitions/ABCInventoryBuildTransaction" },
+        { "$ref": "#/definitions/ABCInventoryTransferTransaction" },
+        { "$ref": "#/definitions/ABCInventoryStatusChangeTransaction" },
+        { "$ref": "#/definitions/ABCInventoryDistributeTransaction" },
+        { "$ref": "#/definitions/ABCInventoryDestroyTransaction" },
+        { "$ref": "#/definitions/ABCInventorySellTransaction" },
+        { "$ref": "#/definitions/ABCInventoryAdjustTransaction" },
+        { "$ref": "#/definitions/ABCInventoryChangeExpiryTransaction" }
+      ]
+    },
+    "ABCInventoryEntryWithoutUpstreams": {
+      "type": "object",
+      "properties": {
+        "lotNumber": {
+          "type": "string"
+        },
+        "materialNumberID": {
+          "type": "string"
+        },
+        "productID": {
+          "type": ["string", "null"]
+        },
+        "quantity": {
+          "type": "number"
+        },
+        "dateOfExpiry": {
+          "type": "string",
+          "format": "date"
+        },
+        "dateOfManufacture": {
+          "type": "string",
+          "format": "date"
+        },
+        "poNumber": {
+          "type": "string"
+        },
+        "statusID": {
+          "$ref": "#/definitions/ABCStatus"
+        },
+        "locationID": {
+          "type": "string"
+        },
+        "hasUpstreams": {
+          "type": "boolean",
+          "enum": [false]
+        },
+        "transactionNotes": {
           "type": "array",
           "items": {
-              "$ref": "#/definitions/ABCInventoryTransaction"
+            "type": "string"
           }
+        },
+        "lotNumberLowercase": {
+          "type": "string"
+        }
       },
-      "ABCInventoryEntries": {
+      "required": [
+        "lotNumber",
+        "materialNumberID",
+        "productID",
+        "quantity",
+        "dateOfExpiry",
+        "dateOfManufacture",
+        "poNumber",
+        "statusID",
+        "locationID",
+        "hasUpstreams",
+        "transactionNotes",
+        "lotNumberLowercase"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryEntryWithUpstreams": {
+      "type": "object",
+      "properties": {
+        "lotNumber": {
+          "type": "string"
+        },
+        "materialNumberID": {
+          "type": "string"
+        },
+        "productID": {
+          "type": ["string", "null"]
+        },
+        "quantity": {
+          "type": "number"
+        },
+        "dateOfExpiry": {
+          "type": "string",
+          "format": "date"
+        },
+        "dateOfManufacture": {
+          "type": "string",
+          "format": "date"
+        },
+        "poNumber": {
+          "type": "string"
+        },
+        "statusID": {
+          "$ref": "#/definitions/ABCStatus"
+        },
+        "locationID": {
+          "type": "string"
+        },
+        "hasUpstreams": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "upstreamIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "upstreamQuantities": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "upstreamLotNumbers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transactionNotes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "lotNumberLowercase": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "lotNumber",
+        "materialNumberID",
+        "productID",
+        "quantity",
+        "dateOfExpiry",
+        "dateOfManufacture",
+        "poNumber",
+        "statusID",
+        "locationID",
+        "hasUpstreams",
+        "upstreamIDs",
+        "upstreamQuantities",
+        "upstreamLotNumbers",
+        "transactionNotes",
+        "lotNumberLowercase"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryEntry": {
+      "oneOf": [
+        { "$ref": "#/definitions/ABCInventoryEntryWithoutUpstreams" },
+        { "$ref": "#/definitions/ABCInventoryEntryWithUpstreams" }
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "description": "Link to https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
+      "type": "string",
+      "enum": [
+        "https://json.schemastore.org/abc-inventory-module-data-2.0.0.json"
+      ]
+    },
+    "ABCProducts": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
           "type": "object",
-          "patternProperties": {
-              "^[a-zA-Z0-9_-]+$": {
-                  "$ref": "#/definitions/ABCInventoryEntry"
-              }
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
           },
+          "required": ["name", "isActive"],
           "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCVendors": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["name", "isActive"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCMaterialCategories": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "prefix": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["name", "isActive", "prefix"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCMaterialNumbers": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "vendorID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "number": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "unitOfMeasure": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "productID",
+            "vendorID",
+            "materialCategoryID",
+            "number",
+            "name",
+            "description",
+            "unitOfMeasure",
+            "isActive"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCLocations": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["name", "isActive"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCReasonCodes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["code", "description", "isActive"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCTransactions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ABCInventoryTransaction"
       }
+    },
+    "ABCInventoryEntries": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/definitions/ABCInventoryEntry"
+        }
+      },
+      "additionalProperties": false
+    }
   },
   "required": [
-      "$schema",
-      "ABCProducts",
-      "ABCVendors",
-      "ABCMaterialCategories",
-      "ABCMaterialNumbers",
-      "ABCLocations",
-      "ABCReasonCodes",
-      "ABCTransactions",
-      "ABCInventoryEntries"
+    "$schema",
+    "ABCProducts",
+    "ABCVendors",
+    "ABCMaterialCategories",
+    "ABCMaterialNumbers",
+    "ABCLocations",
+    "ABCReasonCodes",
+    "ABCTransactions",
+    "ABCInventoryEntries"
   ],
   "additionalProperties": false
 }

--- a/src/schemas/json/abc-inventory-module-data-2.0.0.json
+++ b/src/schemas/json/abc-inventory-module-data-2.0.0.json
@@ -1,0 +1,949 @@
+{
+  "$id": "https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ABCInventoryModuleData JSON Schema",
+  "description": "Schema defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module.",
+  "type": "object",
+  "definitions": {
+      "ABCStatus": {
+          "type": "string",
+          "enum": [
+              "RELEASED",
+              "CONDITIONAL_RELEASED",
+              "QUARANTINE",
+              "ON_HOLD",
+              "EXPIRED",
+              "DAMAGED"
+          ]
+      },
+      "ABCInventoryReceiveTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["receive"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "quantity": {
+                          "type": "number"
+                      },
+                      "dateOfExpiry": {
+                          "type": "string",
+                          "format": "date"
+                      },
+                      "dateOfManufacture": {
+                          "type": "string",
+                          "format": "date"
+                      },
+                      "poNumber": {
+                          "type": "string"
+                      },
+                      "statusID": {
+                          "$ref": "#/definitions/ABCStatus"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotNumber",
+                      "materialNumberID",
+                      "quantity",
+                      "dateOfExpiry",
+                      "dateOfManufacture",
+                      "poNumber",
+                      "statusID",
+                      "locationID",
+                      "productID",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              },
+              "targetLotID": {
+                  "type": "string"
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData", "targetLotID"],
+          "additionalProperties": false
+      },
+      "ABCInventoryBuildTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["build"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "quantity": {
+                          "type": "number"
+                      },
+                      "dateOfExpiry": {
+                          "type": "string",
+                          "format": "date"
+                      },
+                      "dateOfManufacture": {
+                          "type": "string",
+                          "format": "date"
+                      },
+                      "poNumber": {
+                          "type": "string"
+                      },
+                      "statusID": {
+                          "$ref": "#/definitions/ABCStatus"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "upstreams": {
+                          "type": "array",
+                          "items": {
+                              "type": "object",
+                              "properties": {
+                                  "lotID": {
+                                      "type": "string"
+                                  },
+                                  "quantity": {
+                                      "type": "number"
+                                  }
+                              },
+                              "required": ["lotID", "quantity"],
+                              "additionalProperties": false
+                          }
+                      },
+                      "upstreamIDs": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
+                      },
+                      "upstreamLotNumbers": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
+                      },
+                      "upstreamQuantities": {
+                          "type": "array",
+                          "items": {
+                              "type": "number"
+                          }
+                      },
+                      "upstreamMaterialNumberIDs": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
+                      },
+                      "upstreamLocationIDs": {
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "upstreamProductIDs": {
+                          "type": "array",
+                          "items": {
+                              "type": ["string", "null"]
+                          }
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotNumber",
+                      "materialNumberID",
+                      "quantity",
+                      "dateOfExpiry",
+                      "dateOfManufacture",
+                      "poNumber",
+                      "statusID",
+                      "locationID",
+                      "upstreams",
+                      "upstreamIDs",
+                      "upstreamLotNumbers",
+                      "upstreamQuantities",
+                      "upstreamMaterialNumberIDs",
+                      "upstreamLocationIDs",
+                      "productID",
+                      "upstreamProductIDs",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              },
+              "targetLotID": {
+                  "type": "string"
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData", "targetLotID"],
+          "additionalProperties": false
+      },
+      "ABCInventoryTransferTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["transfer"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotID": {
+                          "type": "string"
+                      },
+                      "newLocationID": {
+                          "type": "string"
+                      },
+                      "quantity": {
+                          "type": "number"
+                      },
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotID",
+                      "newLocationID",
+                      "quantity",
+                      "lotNumber",
+                      "materialNumberID",
+                      "locationID",
+                      "productID",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              },
+              "targetLotID": {
+                  "type": "string"
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData", "targetLotID"],
+          "additionalProperties": false
+      },
+      "ABCInventoryStatusChangeTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["statusChange"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotID": {
+                          "type": "string"
+                      },
+                      "newStatusID": {
+                          "$ref": "#/definitions/ABCStatus"
+                      },
+                      "quantity": {
+                          "type": "number"
+                      },
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotID",
+                      "newStatusID",
+                      "quantity",
+                      "lotNumber",
+                      "materialNumberID",
+                      "locationID",
+                      "productID",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              },
+              "targetLotID": {
+                  "type": "string"
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData", "targetLotID"],
+          "additionalProperties": false
+      },
+      "ABCInventoryDistributeTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["distribute"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotID": {
+                          "type": "string"
+                      },
+                      "quantity": {
+                          "type": "number"
+                      },
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotID",
+                      "quantity",
+                      "lotNumber",
+                      "materialNumberID",
+                      "locationID",
+                      "productID",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData"],
+          "additionalProperties": false
+      },
+      "ABCInventoryDestroyTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["destroy"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotID": {
+                          "type": "string"
+                      },
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotID",
+                      "lotNumber",
+                      "materialNumberID",
+                      "locationID",
+                      "productID",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData"],
+          "additionalProperties": false
+      },
+      "ABCInventorySellTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["sell"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotID": {
+                          "type": "string"
+                      },
+                      "quantity": {
+                          "type": "number"
+                      },
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotID",
+                      "quantity",
+                      "lotNumber",
+                      "materialNumberID",
+                      "locationID",
+                      "productID",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData"],
+          "additionalProperties": false
+      },
+      "ABCInventoryAdjustTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["adjust"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotID": {
+                          "type": "string"
+                      },
+                      "newQuantity": {
+                          "type": "number"
+                      },
+                      "reasonCodeID": {
+                          "type": "string"
+                      },
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotID",
+                      "newQuantity",
+                      "reasonCodeID",
+                      "lotNumber",
+                      "materialNumberID",
+                      "locationID",
+                      "productID",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData"],
+          "additionalProperties": false
+      },
+      "ABCInventoryChangeExpiryTransaction": {
+          "type": "object",
+          "properties": {
+              "uid": {
+                  "type": "string"
+              },
+              "timestamp": {
+                  "type": "number"
+              },
+              "transactionType": {
+                  "type": "string",
+                  "enum": ["changeExpiry"]
+              },
+              "transactionData": {
+                  "type": "object",
+                  "properties": {
+                      "lotID": {
+                          "type": "string"
+                      },
+                      "newDateOfExpiry": {
+                          "type": "string"
+                      },
+                      "lotNumber": {
+                          "type": "string"
+                      },
+                      "materialNumberID": {
+                          "type": "string"
+                      },
+                      "locationID": {
+                          "type": "string"
+                      },
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "notes": {
+                          "type": "string"
+                      }
+                  },
+                  "required": [
+                      "lotID",
+                      "newDateOfExpiry",
+                      "lotNumber",
+                      "materialNumberID",
+                      "locationID",
+                      "productID",
+                      "notes"
+                  ],
+                  "additionalProperties": false
+              }
+          },
+          "required": ["uid", "timestamp", "transactionType", "transactionData"],
+          "additionalProperties": false
+      },
+      "ABCInventoryTransaction": {
+          "oneOf": [
+              { "$ref": "#/definitions/ABCInventoryReceiveTransaction" },
+              { "$ref": "#/definitions/ABCInventoryBuildTransaction" },
+              { "$ref": "#/definitions/ABCInventoryTransferTransaction" },
+              { "$ref": "#/definitions/ABCInventoryStatusChangeTransaction" },
+              { "$ref": "#/definitions/ABCInventoryDistributeTransaction" },
+              { "$ref": "#/definitions/ABCInventoryDestroyTransaction" },
+              { "$ref": "#/definitions/ABCInventorySellTransaction" },
+              { "$ref": "#/definitions/ABCInventoryAdjustTransaction" },
+              { "$ref": "#/definitions/ABCInventoryChangeExpiryTransaction" }
+          ]
+      },
+      "ABCInventoryEntryWithoutUpstreams": {
+          "type": "object",
+          "properties": {
+              "lotNumber": {
+                  "type": "string"
+              },
+              "materialNumberID": {
+                  "type": "string"
+              },
+              "productID": {
+                  "type": ["string", "null"]
+              },
+              "quantity": {
+                  "type": "number"
+              },
+              "dateOfExpiry": {
+                  "type": "string",
+                  "format": "date"
+              },
+              "dateOfManufacture": {
+                  "type": "string",
+                  "format": "date"
+              },
+              "poNumber": {
+                  "type": "string"
+              },
+              "statusID": {
+                  "$ref": "#/definitions/ABCStatus"
+              },
+              "locationID": {
+                  "type": "string"
+              },
+              "hasUpstreams": {
+                  "type": "boolean",
+                  "enum": [false]
+              },
+              "transactionNotes": {
+                  "type": "array",
+                  "items": {
+                      "type": "string"
+                  }
+              },
+              "lotNumberLowercase": {
+                  "type": "string"
+              }
+          },
+          "required": [
+              "lotNumber",
+              "materialNumberID",
+              "productID",
+              "quantity",
+              "dateOfExpiry",
+              "dateOfManufacture",
+              "poNumber",
+              "statusID",
+              "locationID",
+              "hasUpstreams",
+              "transactionNotes",
+              "lotNumberLowercase"
+          ],
+          "additionalProperties": false
+      },
+      "ABCInventoryEntryWithUpstreams": {
+          "type": "object",
+          "properties": {
+              "lotNumber": {
+                  "type": "string"
+              },
+              "materialNumberID": {
+                  "type": "string"
+              },
+              "productID": {
+                  "type": ["string", "null"]
+              },
+              "quantity": {
+                  "type": "number"
+              },
+              "dateOfExpiry": {
+                  "type": "string",
+                  "format": "date"
+              },
+              "dateOfManufacture": {
+                  "type": "string",
+                  "format": "date"
+              },
+              "poNumber": {
+                  "type": "string"
+              },
+              "statusID": {
+                  "$ref": "#/definitions/ABCStatus"
+              },
+              "locationID": {
+                  "type": "string"
+              },
+              "hasUpstreams": {
+                  "type": "boolean",
+                  "enum": [true]
+              },
+              "upstreamIDs": {
+                  "type": "array",
+                  "items": {
+                      "type": "string"
+                  }
+              },
+              "upstreamQuantities": {
+                  "type": "array",
+                  "items": {
+                      "type": "number"
+                  }
+              },
+              "upstreamLotNumbers": {
+                  "type": "array",
+                  "items": {
+                      "type": "string"
+                  }
+              },
+              "transactionNotes": {
+                  "type": "array",
+                  "items": {
+                      "type": "string"
+                  }
+              },
+              "lotNumberLowercase": {
+                  "type": "string"
+              }
+          },
+          "required": [
+              "lotNumber",
+              "materialNumberID",
+              "productID",
+              "quantity",
+              "dateOfExpiry",
+              "dateOfManufacture",
+              "poNumber",
+              "statusID",
+              "locationID",
+              "hasUpstreams",
+              "upstreamIDs",
+              "upstreamQuantities",
+              "upstreamLotNumbers",
+              "transactionNotes",
+              "lotNumberLowercase"
+          ],
+          "additionalProperties": false
+      },
+      "ABCInventoryEntry": {
+          "oneOf": [
+              { "$ref": "#/definitions/ABCInventoryEntryWithoutUpstreams" },
+              { "$ref": "#/definitions/ABCInventoryEntryWithUpstreams" }
+          ]
+      }
+  },
+  "properties": {
+      "$schema": {
+          "description": "Link to https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
+          "type": "string",
+          "enum": ["https://json.schemastore.org/abc-inventory-module-data-2.0.0.json"]
+      },
+      "ABCProducts": {
+          "type": "object",
+          "patternProperties": {
+              "^[a-zA-Z0-9_-]+$": {
+                  "type": "object",
+                  "properties": {
+                      "name": {
+                          "type": "string"
+                      },
+                      "isActive": {
+                          "type": "boolean"
+                      }
+                  },
+                  "required": ["name", "isActive"],
+                  "additionalProperties": false
+              }
+          },
+          "additionalProperties": false
+      },
+      "ABCVendors": {
+          "type": "object",
+          "patternProperties": {
+              "^[a-zA-Z0-9_-]+$": {
+                  "type": "object",
+                  "properties": {
+                      "name": {
+                          "type": "string"
+                      },
+                      "isActive": {
+                          "type": "boolean"
+                      }
+                  },
+                  "required": ["name", "isActive"],
+                  "additionalProperties": false
+              }
+          },
+          "additionalProperties": false
+      },
+      "ABCMaterialCategories": {
+          "type": "object",
+          "patternProperties": {
+              "^[a-zA-Z0-9_-]+$": {
+                  "type": "object",
+                  "properties": {
+                      "name": {
+                          "type": "string"
+                      },
+                      "prefix": {
+                          "type": "string"
+                      },
+                      "isActive": {
+                          "type": "boolean"
+                      }
+                  },
+                  "required": ["name", "isActive", "prefix"],
+                  "additionalProperties": false
+              }
+          },
+          "additionalProperties": false
+      },
+      "ABCMaterialNumbers": {
+          "type": "object",
+          "patternProperties": {
+              "^[a-zA-Z0-9_-]+$": {
+                  "type": "object",
+                  "properties": {
+                      "productID": {
+                          "type": ["string", "null"]
+                      },
+                      "vendorID": {
+                          "type": ["string", "null"]
+                      },
+                      "materialCategoryID": {
+                          "type": "string"
+                      },
+                      "number": {
+                          "type": "number"
+                      },
+                      "name": {
+                          "type": "string"
+                      },
+                      "description": {
+                          "type": "string"
+                      },
+                      "unitOfMeasure": {
+                          "type": "string"
+                      },
+                      "isActive": {
+                          "type": "boolean"
+                      }
+                  },
+                  "required": [
+                      "productID",
+                      "vendorID",
+                      "materialCategoryID",
+                      "number",
+                      "name",
+                      "description",
+                      "unitOfMeasure",
+                      "isActive"
+                  ],
+                  "additionalProperties": false
+              }
+          },
+          "additionalProperties": false
+      },
+      "ABCLocations": {
+          "type": "object",
+          "patternProperties": {
+              "^[a-zA-Z0-9_-]+$": {
+                  "type": "object",
+                  "properties": {
+                      "name": {
+                          "type": "string"
+                      },
+                      "isActive": {
+                          "type": "boolean"
+                      }
+                  },
+                  "required": ["name", "isActive"],
+                  "additionalProperties": false
+              }
+          },
+          "additionalProperties": false
+      },
+      "ABCReasonCodes": {
+          "type": "object",
+          "patternProperties": {
+              "^[a-zA-Z0-9_-]+$": {
+                  "type": "object",
+                  "properties": {
+                      "code": {
+                          "type": "string"
+                      },
+                      "description": {
+                          "type": "string"
+                      },
+                      "isActive": {
+                          "type": "boolean"
+                      }
+                  },
+                  "required": ["code", "description", "isActive"],
+                  "additionalProperties": false
+              }
+          },
+          "additionalProperties": false
+      },
+      "ABCTransactions": {
+          "type": "array",
+          "items": {
+              "$ref": "#/definitions/ABCInventoryTransaction"
+          }
+      },
+      "ABCInventoryEntries": {
+          "type": "object",
+          "patternProperties": {
+              "^[a-zA-Z0-9_-]+$": {
+                  "$ref": "#/definitions/ABCInventoryEntry"
+              }
+          },
+          "additionalProperties": false
+      }
+  },
+  "required": [
+      "$schema",
+      "ABCProducts",
+      "ABCVendors",
+      "ABCMaterialCategories",
+      "ABCMaterialNumbers",
+      "ABCLocations",
+      "ABCReasonCodes",
+      "ABCTransactions",
+      "ABCInventoryEntries"
+  ],
+  "additionalProperties": false
+}

--- a/src/test/abc-inventory-module-data-2.0.0/abc-inventory-module-data.json
+++ b/src/test/abc-inventory-module-data-2.0.0/abc-inventory-module-data.json
@@ -1,0 +1,725 @@
+{
+  "$schema": "https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
+  "ABCInventoryEntries": {
+    "FPkvlnFrGMomlM0tYCAR": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "GFgcsuUkIe7ymD7r20K6",
+      "lotNumber": "SubJul24002",
+      "lotNumberLowercase": "subjul24002",
+      "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+      "poNumber": "XXX",
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "quantity": 55,
+      "statusID": "QUARANTINE",
+      "transactionNotes": [""],
+      "upstreamIDs": ["QNFkPDOS2dLT9A0ePejm", "TF5aQDuEy2gTsjvUhDA3"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [100, 100]
+    },
+    "Kp71g0HGXVnHgujYiqnw": {
+      "dateOfExpiry": "2024-10-10",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "961O18l0ByZYXkWVZlBo",
+      "lotNumber": "PowJul24002",
+      "lotNumberLowercase": "powjul24002",
+      "materialNumberID": "kAftjoSoCIRZlnMTpkR3",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 300,
+      "statusID": "QUARANTINE",
+      "transactionNotes": ["received 400 grams of powder @ PCI", ""]
+    },
+    "QNFkPDOS2dLT9A0ePejm": {
+      "dateOfExpiry": "2025-08-19",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "GFgcsuUkIe7ymD7r20K6",
+      "lotNumber": "PowJul24001",
+      "lotNumberLowercase": "powjul24001",
+      "materialNumberID": "kAftjoSoCIRZlnMTpkR3",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 200,
+      "statusID": "CONDITIONAL_RELEASED",
+      "transactionNotes": ["received 500 grams of powder"]
+    },
+    "TF5aQDuEy2gTsjvUhDA3": {
+      "dateOfExpiry": "2027-08-19",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "GFgcsuUkIe7ymD7r20K6",
+      "lotNumber": "FilJul24001",
+      "lotNumberLowercase": "filjul24001",
+      "materialNumberID": "xS5uGQrH1854opdmHoQs",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 100,
+      "statusID": "RELEASED",
+      "transactionNotes": ["received 500 filters immediately released"]
+    },
+    "YbtzvSUCj8eBp1zE7O8q": {
+      "dateOfExpiry": "2024-10-10",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "961O18l0ByZYXkWVZlBo",
+      "lotNumber": "PowJul24002",
+      "lotNumberLowercase": "powjul24002",
+      "materialNumberID": "kAftjoSoCIRZlnMTpkR3",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 100,
+      "statusID": "RELEASED",
+      "transactionNotes": ["received 400 grams of powder @ PCI", ""]
+    },
+    "aCTyZbfUKbjrzaf9D6Rq": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "961O18l0ByZYXkWVZlBo",
+      "lotNumber": "SubJul24001",
+      "lotNumberLowercase": "subjul24001",
+      "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+      "poNumber": "XXX",
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "quantity": 100,
+      "statusID": "CONDITIONAL_RELEASED",
+      "transactionNotes": [""],
+      "upstreamIDs": ["QNFkPDOS2dLT9A0ePejm", "TF5aQDuEy2gTsjvUhDA3"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [200, 200]
+    },
+    "fnZk9AgHmF6hGuognj1D": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "GFgcsuUkIe7ymD7r20K6",
+      "lotNumber": "SubJul24002",
+      "lotNumberLowercase": "subjul24002",
+      "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+      "poNumber": "XXX",
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "quantity": 20,
+      "statusID": "CONDITIONAL_RELEASED",
+      "transactionNotes": [""],
+      "upstreamIDs": ["QNFkPDOS2dLT9A0ePejm", "TF5aQDuEy2gTsjvUhDA3"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [100, 100]
+    },
+    "hPrKSVsylJQAB9PREIKZ": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "GFgcsuUkIe7ymD7r20K6",
+      "lotNumber": "SubJul24002",
+      "lotNumberLowercase": "subjul24002",
+      "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+      "poNumber": "XXX",
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "quantity": 25,
+      "statusID": "RELEASED",
+      "transactionNotes": [""],
+      "upstreamIDs": ["QNFkPDOS2dLT9A0ePejm", "TF5aQDuEy2gTsjvUhDA3"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [100, 100]
+    },
+    "hlVgspFTAQQf5NtUXmy2": {
+      "dateOfExpiry": "2024-09-30",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "GFgcsuUkIe7ymD7r20K6",
+      "lotNumber": "DrugJul24001",
+      "lotNumberLowercase": "drugjul24001",
+      "materialNumberID": "g6FY8ycoh3JFrMkgUanX",
+      "poNumber": "XXX",
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "quantity": 100,
+      "statusID": "ON_HOLD",
+      "transactionNotes": [""],
+      "upstreamIDs": ["1GBivOszVaVBlGzr9SMW", "TF5aQDuEy2gTsjvUhDA3"],
+      "upstreamLotNumbers": ["RawJul24001", "FilJul24001"],
+      "upstreamQuantities": [100, 100]
+    },
+    "l1RNNSdvfeLy7t6iVwa8": {
+      "dateOfExpiry": "2027-08-19",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "961O18l0ByZYXkWVZlBo",
+      "lotNumber": "FilJul24002",
+      "lotNumberLowercase": "filjul24002",
+      "materialNumberID": "xS5uGQrH1854opdmHoQs",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 400,
+      "statusID": "RELEASED",
+      "transactionNotes": [""]
+    },
+    "z4aStBFhmQczqUXvVnow": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "961O18l0ByZYXkWVZlBo",
+      "lotNumber": "SubJul24001",
+      "lotNumberLowercase": "subjul24001",
+      "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+      "poNumber": "XXX",
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "quantity": 100,
+      "statusID": "RELEASED",
+      "transactionNotes": [""],
+      "upstreamIDs": ["QNFkPDOS2dLT9A0ePejm", "TF5aQDuEy2gTsjvUhDA3"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [200, 200]
+    },
+    "1GBivOszVaVBlGzr9SMW": {
+      "dateOfExpiry": "2024-10-03",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "HAvgQrYW8V12ZXLA43NF",
+      "lotNumber": "RawJul24001",
+      "lotNumberLowercase": "rawjul24001",
+      "materialNumberID": "fNmIPEt7pZtZKZrgRrsT",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 395,
+      "statusID": "RELEASED",
+      "transactionNotes": [""]
+    }
+  },
+  "ABCLocations": {
+    "GFgcsuUkIe7ymD7r20K6": {
+      "isActive": true,
+      "name": "Lonza"
+    },
+    "HAvgQrYW8V12ZXLA43NF": {
+      "isActive": true,
+      "name": "Vetter Pharma"
+    },
+    "RQHKtp1IGGxtNyhInTsL": {
+      "isActive": true,
+      "name": "WH001"
+    },
+    "961O18l0ByZYXkWVZlBo": {
+      "isActive": true,
+      "name": "PCI"
+    }
+  },
+  "ABCMaterialCategories": {
+    "C8ICDG3sEHfToQQOzGkh": {
+      "isActive": true,
+      "name": "Raw Materials",
+      "prefix": "RM"
+    },
+    "MsF9w8QwMBi1gqSQuDrz": {
+      "isActive": true,
+      "name": "Finished Goods",
+      "prefix": "FG"
+    },
+    "sKjwbvAjSv6t7j1WwhHE": {
+      "isActive": true,
+      "name": "Drug Products",
+      "prefix": "DP"
+    },
+    "zxb67dV3W18BXcnaHkJU": {
+      "isActive": true,
+      "name": "Drug Substances",
+      "prefix": "DS"
+    }
+  },
+  "ABCMaterialNumbers": {
+    "AO5P5zZA6C0EjK3LeLyd": {
+      "description": "Finished Goods 3",
+      "isActive": true,
+      "materialCategoryID": "MsF9w8QwMBi1gqSQuDrz",
+      "name": "Finished Drug Product 3",
+      "number": 3,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Carton",
+      "vendorID": "ipBea62n8teUIsJS5xQe"
+    },
+    "En7FK66YP6AOKtD5PO3h": {
+      "description": "Titanium dioxide",
+      "isActive": true,
+      "materialCategoryID": "C8ICDG3sEHfToQQOzGkh",
+      "name": "Raw Material 6",
+      "number": 6,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "ipBea62n8teUIsJS5xQe"
+    },
+    "NlbaZL4lSjPfiOk8gYSG": {
+      "description": "Ethanol",
+      "isActive": true,
+      "materialCategoryID": "C8ICDG3sEHfToQQOzGkh",
+      "name": "Raw Material 4",
+      "number": 4,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "ipBea62n8teUIsJS5xQe"
+    },
+    "U00M572I3h9rdFKfgCbE": {
+      "description": "Drug Product 2",
+      "isActive": true,
+      "materialCategoryID": "sKjwbvAjSv6t7j1WwhHE",
+      "name": "Drug Product 2",
+      "number": 2,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Vial",
+      "vendorID": "ok4Z2ZHoh7LiXMTlIGZ0"
+    },
+    "VG2tess9YMu2aBgZLyF4": {
+      "description": "Polyvinylpyrrolidone",
+      "isActive": true,
+      "materialCategoryID": "C8ICDG3sEHfToQQOzGkh",
+      "name": "Raw Material 5",
+      "number": 5,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "ipBea62n8teUIsJS5xQe"
+    },
+    "YsaWzdBZPSWVWcEJDM1k": {
+      "description": "Drug Product 3",
+      "isActive": true,
+      "materialCategoryID": "sKjwbvAjSv6t7j1WwhHE",
+      "name": "Drug Product 3",
+      "number": 3,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Vial",
+      "vendorID": "ok4Z2ZHoh7LiXMTlIGZ0"
+    },
+    "fNmIPEt7pZtZKZrgRrsT": {
+      "description": "Raw Material 3",
+      "isActive": true,
+      "materialCategoryID": "C8ICDG3sEHfToQQOzGkh",
+      "name": "Raw Material 3",
+      "number": 3,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "oxQIzBxetPRW4G8Xu1v6"
+    },
+    "g6FY8ycoh3JFrMkgUanX": {
+      "description": "Drug Substance 2",
+      "isActive": true,
+      "materialCategoryID": "zxb67dV3W18BXcnaHkJU",
+      "name": "Drug Substance 2",
+      "number": 2,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Gram",
+      "vendorID": "ZqDS5pMHaQhfo4snE8Cd"
+    },
+    "kAftjoSoCIRZlnMTpkR3": {
+      "description": "CDC Powder",
+      "isActive": true,
+      "materialCategoryID": "C8ICDG3sEHfToQQOzGkh",
+      "name": "Raw Material 1",
+      "number": 1,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "oxQIzBxetPRW4G8Xu1v6"
+    },
+    "mJkQ9nXxKcDelktJZcJ9": {
+      "description": "Drug Substance 1",
+      "isActive": true,
+      "materialCategoryID": "zxb67dV3W18BXcnaHkJU",
+      "name": "Drug Substance 1",
+      "number": 1,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Gram",
+      "vendorID": "ZqDS5pMHaQhfo4snE8Cd"
+    },
+    "n85wwi58yBVATXXNWC8a": {
+      "description": "Finished Goods 1",
+      "isActive": true,
+      "materialCategoryID": "MsF9w8QwMBi1gqSQuDrz",
+      "name": "Finished Drug Product 1",
+      "number": 1,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Carton",
+      "vendorID": "ipBea62n8teUIsJS5xQe"
+    },
+    "xS5uGQrH1854opdmHoQs": {
+      "description": "Filter",
+      "isActive": true,
+      "materialCategoryID": "C8ICDG3sEHfToQQOzGkh",
+      "name": "Raw Material 2",
+      "number": 2,
+      "productID": null,
+      "unitOfMeasure": "Each",
+      "vendorID": "oxQIzBxetPRW4G8Xu1v6"
+    },
+    "xdUrtBGbwYiY0yvGqiIs": {
+      "description": "Finished Goods 2",
+      "isActive": true,
+      "materialCategoryID": "MsF9w8QwMBi1gqSQuDrz",
+      "name": "Finished Drug Product 2",
+      "number": 2,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Carton",
+      "vendorID": "ipBea62n8teUIsJS5xQe"
+    },
+    "1OhAyPqaDGrehhuoRvD0": {
+      "description": "Drug Product 1",
+      "isActive": true,
+      "materialCategoryID": "sKjwbvAjSv6t7j1WwhHE",
+      "name": "Drug Product 1",
+      "number": 1,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Vial",
+      "vendorID": "ok4Z2ZHoh7LiXMTlIGZ0"
+    },
+    "8pUEBFXKYrmisHH0u2ov": {
+      "description": "Drug Substance 3",
+      "isActive": true,
+      "materialCategoryID": "zxb67dV3W18BXcnaHkJU",
+      "name": "Drug Substance 3",
+      "number": 3,
+      "productID": "ANDxFkVFRBVnsvdczXso",
+      "unitOfMeasure": "Gram",
+      "vendorID": "ZqDS5pMHaQhfo4snE8Cd"
+    }
+  },
+  "ABCProducts": {
+    "ANDxFkVFRBVnsvdczXso": {
+      "isActive": true,
+      "name": "Cerebrin"
+    },
+    "APjQO1TOw6jNFNjJMggV": {
+      "isActive": true,
+      "name": "Cogniva"
+    }
+  },
+  "ABCReasonCodes": {
+    "DJJdptzr1ceaeiii49rG": {
+      "code": "RC00005",
+      "description": "Better yield",
+      "isActive": true
+    },
+    "Pgi7cQHGsJszaueWoQII": {
+      "code": "RC00001",
+      "description": "Material damaged",
+      "isActive": true
+    },
+    "lcLTu3fRDPy7E29MlG1Z": {
+      "code": "RC00003",
+      "description": "Temperature excursion",
+      "isActive": true
+    },
+    "wCCJtO7ADbUl1oVAZdEQ": {
+      "code": "RC00002",
+      "description": "Deviation",
+      "isActive": true
+    },
+    "8FyvHe5WGKxZeUHKOceC": {
+      "code": "RC00004",
+      "description": "Recount",
+      "isActive": true
+    }
+  },
+  "ABCTransactions": [
+    {
+      "targetLotID": "QNFkPDOS2dLT9A0ePejm",
+      "timestamp": 1724091626161,
+      "transactionData": {
+        "dateOfExpiry": "2025-08-19",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "GFgcsuUkIe7ymD7r20K6",
+        "lotNumber": "PowJul24001",
+        "materialNumberID": "kAftjoSoCIRZlnMTpkR3",
+        "notes": "received 500 grams of powder",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 500,
+        "statusID": "CONDITIONAL_RELEASED"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "TF5aQDuEy2gTsjvUhDA3",
+      "timestamp": 1724091662949,
+      "transactionData": {
+        "dateOfExpiry": "2027-08-19",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "GFgcsuUkIe7ymD7r20K6",
+        "lotNumber": "FilJul24001",
+        "materialNumberID": "xS5uGQrH1854opdmHoQs",
+        "notes": "received 500 filters immediately released",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 500,
+        "statusID": "RELEASED"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "Kp71g0HGXVnHgujYiqnw",
+      "timestamp": 1724091750976,
+      "transactionData": {
+        "dateOfExpiry": "2024-10-10",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "961O18l0ByZYXkWVZlBo",
+        "lotNumber": "PowJul24002",
+        "materialNumberID": "kAftjoSoCIRZlnMTpkR3",
+        "notes": "received 400 grams of powder @ PCI",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 400,
+        "statusID": "QUARANTINE"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "l1RNNSdvfeLy7t6iVwa8",
+      "timestamp": 1724091809137,
+      "transactionData": {
+        "dateOfExpiry": "2027-08-19",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "961O18l0ByZYXkWVZlBo",
+        "lotNumber": "FilJul24002",
+        "materialNumberID": "xS5uGQrH1854opdmHoQs",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 400,
+        "statusID": "RELEASED"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "aCTyZbfUKbjrzaf9D6Rq",
+      "timestamp": 1724091965795,
+      "transactionData": {
+        "dateOfExpiry": "2024-10-01",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "961O18l0ByZYXkWVZlBo",
+        "lotNumber": "SubJul24001",
+        "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": "ANDxFkVFRBVnsvdczXso",
+        "quantity": 200,
+        "statusID": "CONDITIONAL_RELEASED",
+        "upstreamIDs": ["QNFkPDOS2dLT9A0ePejm", "TF5aQDuEy2gTsjvUhDA3"],
+        "upstreamLocationIDs": ["GFgcsuUkIe7ymD7r20K6", "GFgcsuUkIe7ymD7r20K6"],
+        "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+        "upstreamMaterialNumberIDs": [
+          "kAftjoSoCIRZlnMTpkR3",
+          "xS5uGQrH1854opdmHoQs"
+        ],
+        "upstreamProductIDs": [null, null],
+        "upstreamQuantities": [200, 200],
+        "upstreams": [
+          {
+            "lotID": "QNFkPDOS2dLT9A0ePejm",
+            "quantity": 200
+          },
+          {
+            "lotID": "TF5aQDuEy2gTsjvUhDA3",
+            "quantity": 200
+          }
+        ]
+      },
+      "transactionType": "build",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "YbtzvSUCj8eBp1zE7O8q",
+      "timestamp": 1724091987560,
+      "transactionData": {
+        "locationID": "961O18l0ByZYXkWVZlBo",
+        "lotID": "Kp71g0HGXVnHgujYiqnw",
+        "lotNumber": "PowJul24002",
+        "materialNumberID": "kAftjoSoCIRZlnMTpkR3",
+        "newStatusID": "RELEASED",
+        "notes": "",
+        "productID": null,
+        "quantity": 100
+      },
+      "transactionType": "statusChange",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "FPkvlnFrGMomlM0tYCAR",
+      "timestamp": 1724092097319,
+      "transactionData": {
+        "dateOfExpiry": "2024-10-01",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "GFgcsuUkIe7ymD7r20K6",
+        "lotNumber": "SubJul24002",
+        "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": "ANDxFkVFRBVnsvdczXso",
+        "quantity": 100,
+        "statusID": "QUARANTINE",
+        "upstreamIDs": ["QNFkPDOS2dLT9A0ePejm", "TF5aQDuEy2gTsjvUhDA3"],
+        "upstreamLocationIDs": ["GFgcsuUkIe7ymD7r20K6", "GFgcsuUkIe7ymD7r20K6"],
+        "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+        "upstreamMaterialNumberIDs": [
+          "kAftjoSoCIRZlnMTpkR3",
+          "xS5uGQrH1854opdmHoQs"
+        ],
+        "upstreamProductIDs": [null, null],
+        "upstreamQuantities": [100, 100],
+        "upstreams": [
+          {
+            "lotID": "QNFkPDOS2dLT9A0ePejm",
+            "quantity": 100
+          },
+          {
+            "lotID": "TF5aQDuEy2gTsjvUhDA3",
+            "quantity": 100
+          }
+        ]
+      },
+      "transactionType": "build",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "z4aStBFhmQczqUXvVnow",
+      "timestamp": 1724092133502,
+      "transactionData": {
+        "locationID": "961O18l0ByZYXkWVZlBo",
+        "lotID": "aCTyZbfUKbjrzaf9D6Rq",
+        "lotNumber": "SubJul24001",
+        "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+        "newStatusID": "RELEASED",
+        "notes": "",
+        "productID": "ANDxFkVFRBVnsvdczXso",
+        "quantity": 100
+      },
+      "transactionType": "statusChange",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "fnZk9AgHmF6hGuognj1D",
+      "timestamp": 1724192167647,
+      "transactionData": {
+        "locationID": "GFgcsuUkIe7ymD7r20K6",
+        "lotID": "FPkvlnFrGMomlM0tYCAR",
+        "lotNumber": "SubJul24002",
+        "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+        "newStatusID": "CONDITIONAL_RELEASED",
+        "notes": "",
+        "productID": "ANDxFkVFRBVnsvdczXso",
+        "quantity": 20
+      },
+      "transactionType": "statusChange",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "hPrKSVsylJQAB9PREIKZ",
+      "timestamp": 1724192190300,
+      "transactionData": {
+        "locationID": "GFgcsuUkIe7ymD7r20K6",
+        "lotID": "FPkvlnFrGMomlM0tYCAR",
+        "lotNumber": "SubJul24002",
+        "materialNumberID": "mJkQ9nXxKcDelktJZcJ9",
+        "newStatusID": "RELEASED",
+        "notes": "",
+        "productID": "ANDxFkVFRBVnsvdczXso",
+        "quantity": 25
+      },
+      "transactionType": "statusChange",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "1GBivOszVaVBlGzr9SMW",
+      "timestamp": 1724193323613,
+      "transactionData": {
+        "dateOfExpiry": "2024-10-03",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "HAvgQrYW8V12ZXLA43NF",
+        "lotNumber": "RawJul24001",
+        "materialNumberID": "fNmIPEt7pZtZKZrgRrsT",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 495,
+        "statusID": "RELEASED"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "hlVgspFTAQQf5NtUXmy2",
+      "timestamp": 1724195724040,
+      "transactionData": {
+        "dateOfExpiry": "2024-09-30",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "GFgcsuUkIe7ymD7r20K6",
+        "lotNumber": "DrugJul24001",
+        "materialNumberID": "g6FY8ycoh3JFrMkgUanX",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": "ANDxFkVFRBVnsvdczXso",
+        "quantity": 100,
+        "statusID": "ON_HOLD",
+        "upstreamIDs": ["1GBivOszVaVBlGzr9SMW", "TF5aQDuEy2gTsjvUhDA3"],
+        "upstreamLocationIDs": ["HAvgQrYW8V12ZXLA43NF", "GFgcsuUkIe7ymD7r20K6"],
+        "upstreamLotNumbers": ["RawJul24001", "FilJul24001"],
+        "upstreamMaterialNumberIDs": [
+          "fNmIPEt7pZtZKZrgRrsT",
+          "xS5uGQrH1854opdmHoQs"
+        ],
+        "upstreamProductIDs": [null, null],
+        "upstreamQuantities": [100, 100],
+        "upstreams": [
+          {
+            "lotID": "1GBivOszVaVBlGzr9SMW",
+            "quantity": 100
+          },
+          {
+            "lotID": "TF5aQDuEy2gTsjvUhDA3",
+            "quantity": 100
+          }
+        ]
+      },
+      "transactionType": "build",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    }
+  ],
+  "ABCVendors": {
+    "LHHDL8QBYFfNqKNUISUf": {
+      "isActive": true,
+      "name": "XY"
+    },
+    "PdZt6MRz8xvxFOH47kLm": {
+      "isActive": true,
+      "name": "PCI"
+    },
+    "Y0BuPpvH7aErANyFZFgi": {
+      "isActive": true,
+      "name": "Lonza"
+    },
+    "ZqDS5pMHaQhfo4snE8Cd": {
+      "isActive": true,
+      "name": "Catalent"
+    },
+    "g06PpqbF1NPNPIdMDWmc": {
+      "isActive": true,
+      "name": "ICS"
+    },
+    "ipBea62n8teUIsJS5xQe": {
+      "isActive": true,
+      "name": "AbVial"
+    },
+    "ok4Z2ZHoh7LiXMTlIGZ0": {
+      "isActive": true,
+      "name": "AGC Biologics"
+    },
+    "oxQIzBxetPRW4G8Xu1v6": {
+      "isActive": true,
+      "name": "FM"
+    },
+    "z7AEcWy6rXJOhyqJzWy7": {
+      "isActive": true,
+      "name": "Vetter Pharma"
+    }
+  }
+}


### PR DESCRIPTION
Removed `cost` from transaction (`ABCTransactions`) and on-hand inventory data (`ABCInventoryEntries`).  If there is customer demand we'll reintroduce cost more holistically.

Testing:
- npm run check -- --SchemaName=abc-inventory-module-data-2.0.0.json
- npm run check
