### PR TITLE
Promote new Ubuntu 24.04 linux machine image

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -1244,6 +1244,7 @@
       "description": "The LinuxVM image to use. View available images for [Ubuntu 20.04](https://circleci.com/developer/machine/image/ubuntu-2004), [Ubuntu 22.04](https://circleci.com/developer/machine/image/ubuntu-2204), or [Android](https://circleci.com/developer/machine/image/android). **Note:** This key is **not** supported on the installable CircleCI. For information about customizing machine executor images on CircleCI installed on your servers, see our [VM Service documentation](https://circleci.com/docs/vm-service).",
       "type": "string",
       "enum": [
+        "ubuntu-2004:2024.05.1",
         "ubuntu-2004:2024.04.4",
         "ubuntu-2004:2024.01.2",
         "ubuntu-2004:2024.01.1",
@@ -1266,6 +1267,7 @@
         "ubuntu-2004:202010-01",
         "ubuntu-2004:current",
         "ubuntu-2004:edge",
+        "ubuntu-2204:2024.05.1",
         "ubuntu-2204:2024.04.4",
         "ubuntu-2204:2024.01.2",
         "ubuntu-2204:2024.01.1",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

As of Aug 6 2024 at least, this should be considered the latest version of Ubuntu: [New Ubuntu 24.04 Linux Machine Executor image](https://discuss.circleci.com/t/new-ubuntu-24-04-linux-machine-executor-image/51018/2)