### PR TITLE
src/schemas/json: fix spurious `$id` definitions

### DIFF
--- a/src/schemas/json/base.json
+++ b/src/schemas/json/base.json
@@ -3,39 +3,31 @@
   "$id": "https://json.schemastore.org/base.json",
   "definitions": {
     "nullable-array": {
-      "$id": "nullable-array",
       "type": ["array", "null"]
     },
     "nullable-boolean": {
-      "$id": "nullable-boolean",
       "type": ["boolean", "null"]
     },
     "nullable-integer": {
-      "$id": "nullable-integer",
       "type": ["integer", "null"]
     },
     "nullable-number": {
-      "$id": "nullable-number",
       "type": ["number", "null"]
     },
     "nullable-object": {
-      "$id": "nullable-object",
       "type": ["object", "null"]
     },
     "nullable-string": {
-      "$id": "nullable-string",
       "type": ["string", "null"]
     },
     "path": {
-      "$id": "path",
       "type": "string",
       "minLength": 1
     },
     "nullable-path": {
-      "$id": "nullable-path",
       "oneOf": [
         {
-          "$ref": "path"
+          "$ref": "#/definitions/path"
         },
         {
           "type": "null"
@@ -43,7 +35,6 @@
       ]
     },
     "editor": {
-      "$id": "editor",
       "type": "string",
       "oneOf": [
         {
@@ -53,10 +44,9 @@
       ]
     },
     "nullable-editor": {
-      "$id": "nullable-editor",
       "oneOf": [
         {
-          "$ref": "editor"
+          "$ref": "#/definitions/editor"
         },
         {
           "type": "null"
@@ -64,10 +54,9 @@
       ]
     },
     "license": {
-      "$id": "license",
       "anyOf": [
         {
-          "$ref": "osi-license"
+          "$ref": "#/definitions/osi-license"
         },
         {
           "type": "string"
@@ -75,7 +64,6 @@
       ]
     },
     "osi-license": {
-      "$id": "spdx-license",
       "$comment": "Extracted on January 15, 2024.",
       "type": "string",
       "enum": [
@@ -225,7 +213,6 @@
       ]
     },
     "timezone": {
-      "$id": "timezone",
       "type": "string",
       "enum": [
         "Africa/Abidjan",
@@ -814,10 +801,9 @@
       ]
     },
     "nullable-timezone": {
-      "$id": "nullable-timezone",
       "oneOf": [
         {
-          "$ref": "timezone"
+          "$ref": "#/definitions/timezone"
         },
         {
           "type": "null"

--- a/src/schemas/json/catalog-info.json
+++ b/src/schemas/json/catalog-info.json
@@ -4,7 +4,6 @@
   "anyOf": [
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "ApiV1alpha1",
       "description": "An API describes an interface that can be exposed by a component. The API can be defined in different formats, like OpenAPI, AsyncAPI, GraphQL, gRPC, or other formats.",
       "examples": [
         {
@@ -102,7 +101,6 @@
     },
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "ComponentV1alpha1",
       "description": "A Component describes a software component. It is typically intimately linked to the source code that constitutes the component, and should be what a developer may regard a \"unit of software\", usually with a distinct deployable or linkable artifact.",
       "examples": [
         {
@@ -203,7 +201,6 @@
     },
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "DomainV1alpha1",
       "description": "A Domain groups a collection of systems that share terminology, domain models, business purpose, or documentation, i.e. form a bounded context.",
       "examples": [
         {
@@ -250,7 +247,6 @@
     },
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "GroupV1alpha1",
       "description": "A group describes an organizational entity, such as for example a team, a business unit, or a loose collection of people in an interest group. Members of these groups are modeled in the catalog as kind User.",
       "examples": [
         {
@@ -354,7 +350,6 @@
     },
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "LocationV1alpha1",
       "description": "A location is a marker that references other places to look for catalog data.",
       "examples": [
         {
@@ -422,7 +417,6 @@
     },
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "ResourceV1alpha1",
       "description": "A resource describes the infrastructure a system needs to operate, like BigTable databases, Pub/Sub topics, S3 buckets or CDNs. Modelling them together with components and systems allows to visualize resource footprint, and create tooling around them.",
       "examples": [
         {
@@ -490,7 +484,6 @@
     },
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "SystemV1alpha1",
       "description": "A system is a collection of resources and components. The system may expose or consume one or several APIs. It is viewed as abstraction level that provides potential consumers insights into exposed features without needing a too detailed view into the details of all components. This also gives the owning team the possibility to decide about published artifacts and APIs.",
       "examples": [
         {
@@ -544,7 +537,6 @@
     },
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "TemplateV1beta2",
       "description": "A Template describes a scaffolding task for use with the Scaffolder. It describes the required parameters as well as a series of steps that will be taken to execute the scaffolding task.",
       "examples": [
         {
@@ -728,7 +720,6 @@
     },
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "UserV1alpha1",
       "description": "A user describes a person, such as an employee, a contractor, or similar. Users belong to Group entities in the catalog. These catalog user entries are connected to the way that authentication within the Backstage ecosystem works. See the auth section of the docs for a discussion of these concepts.",
       "examples": [
         {
@@ -810,7 +801,6 @@
   "definitions": {
     "entity": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "Entity",
       "description": "The parts of the format that's common to all versions/kinds of entity.",
       "examples": [
         {
@@ -861,7 +851,6 @@
         },
         "metadata": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "$id": "EntityMeta",
           "description": "Metadata fields common to all versions/kinds of entity.",
           "examples": [
             {
@@ -1015,7 +1004,6 @@
     },
     "common": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "common",
       "type": "object",
       "description": "Common definitions to import from other schemas",
       "definitions": {

--- a/src/schemas/json/cryproj.52.schema.json
+++ b/src/schemas/json/cryproj.52.schema.json
@@ -3,7 +3,6 @@
   "$comment": "JSON Schema for CRYENGINE 5.2",
   "definitions": {
     "cvars": {
-      "$id": "/definitions/cvars",
       "type": "string",
       "title": "Variable name",
       "description": "CVar name",
@@ -2454,7 +2453,6 @@
       ]
     },
     "commands": {
-      "$id": "/definitions/commands",
       "type": "string",
       "title": "Command name",
       "description": "Console command name",
@@ -2647,19 +2645,15 @@
   "id": "https://json.schemastore.org/cryproj.52.schema",
   "properties": {
     "console_variables": {
-      "$id": "/properties/console_variables",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_variables/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_variables/items/properties/name",
             "$ref": "#/definitions/cvars"
           },
           "value": {
-            "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
             "title": "Value of the CVar",
             "description": "The default value of the CVar",
@@ -2670,14 +2664,11 @@
       }
     },
     "content": {
-      "$id": "/properties/content",
       "type": "object",
       "properties": {
         "assets": {
-          "$id": "/properties/content/properties/assets",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/assets/items",
             "type": "string",
             "title": "Assets folder",
             "description": "This indicates where the assets are stored",
@@ -2686,10 +2677,8 @@
           }
         },
         "code": {
-          "$id": "/properties/content/properties/code",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/code/items",
             "type": "string",
             "title": "Code folder",
             "description": "This indicates where the code is stored",
@@ -2698,39 +2687,32 @@
           }
         },
         "libs": {
-          "$id": "/properties/content/properties/libs",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/libs/items",
             "type": "object",
             "properties": {
               "name": {
-                "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
                 "title": "Lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
               "shared": {
-                "$id": "/properties/content/properties/libs/items/properties/shared",
                 "type": "object",
                 "properties": {
                   "any": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
                     "title": "Lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
                     "title": "Lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
                     "title": "Lib's name to import for the win_x86 platform",
                     "default": "",
@@ -2745,11 +2727,9 @@
       "required": ["code"]
     },
     "info": {
-      "$id": "/properties/info",
       "type": "object",
       "properties": {
         "name": {
-          "$id": "/properties/info/properties/name",
           "type": "string",
           "title": "Project name",
           "description": "This indicates the project name",
@@ -2757,7 +2737,6 @@
           "examples": ["MyFancyProject"]
         },
         "guid": {
-          "$id": "/properties/info/properties/guid",
           "type": "string",
           "title": "Project GUID",
           "default": "",
@@ -2767,11 +2746,9 @@
       "required": ["name"]
     },
     "require": {
-      "$id": "/properties/require",
       "type": "object",
       "properties": {
         "engine": {
-          "$id": "/properties/require/properties/engine",
           "type": "string",
           "title": "Engine version",
           "description": "This indicates which engine version will be used",
@@ -2780,14 +2757,11 @@
           "enum": ["engine-5.2"]
         },
         "plugins": {
-          "$id": "/properties/require/properties/plugins",
           "type": "array",
           "items": {
-            "$id": "/properties/require/properties/plugins/items",
             "type": "object",
             "properties": {
               "path": {
-                "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
                 "title": "Plugin name",
                 "description": "Required plugin's name",
@@ -2803,7 +2777,6 @@
                 ]
               },
               "type": {
-                "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
                 "title": "Plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
@@ -2812,10 +2785,8 @@
                 "enum": ["EPluginType::Native", "EPluginType::Managed"]
               },
               "platforms": {
-                "$id": "/properties/plugins/items/properties/platforms",
                 "type": "array",
                 "items": {
-                  "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
                   "title": "This plugin will be used only by these platforms",
                   "default": "",
@@ -2831,33 +2802,27 @@
       "required": ["engine"]
     },
     "type": {
-      "$id": "/properties/type",
       "type": "string",
       "title": "",
       "default": "",
       "examples": [""]
     },
     "version": {
-      "$id": "/properties/version",
       "type": "integer",
       "title": "Project version",
       "default": 1,
       "examples": [1]
     },
     "console_commands": {
-      "$id": "/properties/console_commands",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_commands/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_commands/items/properties/name",
             "$ref": "#/definitions/commands"
           },
           "value": {
-            "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
             "title": "Value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",

--- a/src/schemas/json/cryproj.53.schema.json
+++ b/src/schemas/json/cryproj.53.schema.json
@@ -3,7 +3,6 @@
   "$comment": "JSON Schema for CRYENGINE 5.3",
   "definitions": {
     "cvars": {
-      "$id": "/definitions/cvars",
       "type": "string",
       "title": "Variable name",
       "description": "CVar name",
@@ -2462,7 +2461,6 @@
       ]
     },
     "commands": {
-      "$id": "/definitions/commands",
       "type": "string",
       "title": "Command name",
       "description": "Console command name",
@@ -2662,19 +2660,15 @@
   "id": "https://json.schemastore.org/cryproj.53.schema",
   "properties": {
     "console_variables": {
-      "$id": "/properties/console_variables",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_variables/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_variables/items/properties/name",
             "$ref": "#/definitions/cvars"
           },
           "value": {
-            "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
             "title": "Value of the CVar",
             "description": "The default value of the CVar",
@@ -2685,14 +2679,11 @@
       }
     },
     "content": {
-      "$id": "/properties/content",
       "type": "object",
       "properties": {
         "assets": {
-          "$id": "/properties/content/properties/assets",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/assets/items",
             "type": "string",
             "title": "Assets folder",
             "description": "This indicates where the assets are stored",
@@ -2701,10 +2692,8 @@
           }
         },
         "code": {
-          "$id": "/properties/content/properties/code",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/code/items",
             "type": "string",
             "title": "Code folder",
             "description": "This indicates where the code is stored",
@@ -2713,39 +2702,32 @@
           }
         },
         "libs": {
-          "$id": "/properties/content/properties/libs",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/libs/items",
             "type": "object",
             "properties": {
               "name": {
-                "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
                 "title": "Lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
               "shared": {
-                "$id": "/properties/content/properties/libs/items/properties/shared",
                 "type": "object",
                 "properties": {
                   "any": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
                     "title": "Lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
                     "title": "Lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
                     "title": "Lib's name to import for the win_x86 platform",
                     "default": "",
@@ -2760,11 +2742,9 @@
       "required": ["code"]
     },
     "info": {
-      "$id": "/properties/info",
       "type": "object",
       "properties": {
         "name": {
-          "$id": "/properties/info/properties/name",
           "type": "string",
           "title": "Project name",
           "description": "This indicates the project name",
@@ -2772,7 +2752,6 @@
           "examples": ["MyFancyProject"]
         },
         "guid": {
-          "$id": "/properties/info/properties/guid",
           "type": "string",
           "title": "Project GUID",
           "default": "",
@@ -2782,11 +2761,9 @@
       "required": ["name"]
     },
     "require": {
-      "$id": "/properties/require",
       "type": "object",
       "properties": {
         "engine": {
-          "$id": "/properties/require/properties/engine",
           "type": "string",
           "title": "Engine version",
           "description": "This indicates which engine version will be used",
@@ -2795,14 +2772,11 @@
           "enum": ["engine-5.3"]
         },
         "plugins": {
-          "$id": "/properties/require/properties/plugins",
           "type": "array",
           "items": {
-            "$id": "/properties/require/properties/plugins/items",
             "type": "object",
             "properties": {
               "path": {
-                "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
                 "title": "Plugin name",
                 "description": "Required plugin's name",
@@ -2818,7 +2792,6 @@
                 ]
               },
               "type": {
-                "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
                 "title": "Plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
@@ -2827,10 +2800,8 @@
                 "enum": ["EPluginType::Native", "EPluginType::Managed"]
               },
               "platforms": {
-                "$id": "/properties/plugins/items/properties/platforms",
                 "type": "array",
                 "items": {
-                  "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
                   "title": "This plugin will be used only by these platforms",
                   "default": "",
@@ -2846,33 +2817,27 @@
       "required": ["engine"]
     },
     "type": {
-      "$id": "/properties/type",
       "type": "string",
       "title": "",
       "default": "",
       "examples": [""]
     },
     "version": {
-      "$id": "/properties/version",
       "type": "integer",
       "title": "Project version",
       "default": 1,
       "examples": [1]
     },
     "console_commands": {
-      "$id": "/properties/console_commands",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_commands/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_commands/items/properties/name",
             "$ref": "#/definitions/commands"
           },
           "value": {
-            "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
             "title": "Value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",

--- a/src/schemas/json/cryproj.54.schema.json
+++ b/src/schemas/json/cryproj.54.schema.json
@@ -3,7 +3,6 @@
   "$comment": "JSON Schema for CRYENGINE 5.4",
   "definitions": {
     "cvars": {
-      "$id": "/definitions/cvars",
       "type": "string",
       "title": "Variable name",
       "description": "CVar name",
@@ -2469,7 +2468,6 @@
       ]
     },
     "commands": {
-      "$id": "/definitions/commands",
       "type": "string",
       "title": "Command name",
       "description": "Console command name",
@@ -2668,19 +2666,15 @@
   "id": "https://json.schemastore.org/cryproj.54.schema",
   "properties": {
     "console_variables": {
-      "$id": "/properties/console_variables",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_variables/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_variables/items/properties/name",
             "$ref": "#/definitions/cvars"
           },
           "value": {
-            "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
             "title": "Value of the CVar",
             "description": "The default value of the CVar",
@@ -2691,14 +2685,11 @@
       }
     },
     "content": {
-      "$id": "/properties/content",
       "type": "object",
       "properties": {
         "assets": {
-          "$id": "/properties/content/properties/assets",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/assets/items",
             "type": "string",
             "title": "Assets folder",
             "description": "This indicates where the assets are stored",
@@ -2707,10 +2698,8 @@
           }
         },
         "code": {
-          "$id": "/properties/content/properties/code",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/code/items",
             "type": "string",
             "title": "Code folder",
             "description": "This indicates where the code is stored",
@@ -2719,39 +2708,32 @@
           }
         },
         "libs": {
-          "$id": "/properties/content/properties/libs",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/libs/items",
             "type": "object",
             "properties": {
               "name": {
-                "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
                 "title": "Lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
               "shared": {
-                "$id": "/properties/content/properties/libs/items/properties/shared",
                 "type": "object",
                 "properties": {
                   "any": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
                     "title": "Lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
                     "title": "Lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
                     "title": "Lib's name to import for the win_x86 platform",
                     "default": "",
@@ -2766,11 +2748,9 @@
       "required": ["code"]
     },
     "info": {
-      "$id": "/properties/info",
       "type": "object",
       "properties": {
         "name": {
-          "$id": "/properties/info/properties/name",
           "type": "string",
           "title": "Project name",
           "description": "This indicates the project name",
@@ -2778,7 +2758,6 @@
           "examples": ["MyFancyProject"]
         },
         "guid": {
-          "$id": "/properties/info/properties/guid",
           "type": "string",
           "title": "Project GUID",
           "default": "",
@@ -2788,11 +2767,9 @@
       "required": ["name"]
     },
     "require": {
-      "$id": "/properties/require",
       "type": "object",
       "properties": {
         "engine": {
-          "$id": "/properties/require/properties/engine",
           "type": "string",
           "title": "Engine version",
           "description": "This indicates which engine version will be used",
@@ -2801,14 +2778,11 @@
           "enum": ["engine-5.4"]
         },
         "plugins": {
-          "$id": "/properties/require/properties/plugins",
           "type": "array",
           "items": {
-            "$id": "/properties/require/properties/plugins/items",
             "type": "object",
             "properties": {
               "path": {
-                "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
                 "title": "Plugin name",
                 "description": "Required plugin's name",
@@ -2824,7 +2798,6 @@
                 ]
               },
               "type": {
-                "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
                 "title": "Plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
@@ -2833,10 +2806,8 @@
                 "enum": ["EPluginType::Native", "EPluginType::Managed"]
               },
               "platforms": {
-                "$id": "/properties/plugins/items/properties/platforms",
                 "type": "array",
                 "items": {
-                  "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
                   "title": "This plugin will be used only by these platforms",
                   "default": "",
@@ -2852,33 +2823,27 @@
       "required": ["engine"]
     },
     "type": {
-      "$id": "/properties/type",
       "type": "string",
       "title": "",
       "default": "",
       "examples": [""]
     },
     "version": {
-      "$id": "/properties/version",
       "type": "integer",
       "title": "Project version",
       "default": 1,
       "examples": [1]
     },
     "console_commands": {
-      "$id": "/properties/console_commands",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_commands/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_commands/items/properties/name",
             "$ref": "#/definitions/commands"
           },
           "value": {
-            "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
             "title": "Value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",

--- a/src/schemas/json/cryproj.55.schema.json
+++ b/src/schemas/json/cryproj.55.schema.json
@@ -3,7 +3,6 @@
   "$comment": "JSON Schema for CRYENGINE 5.5",
   "definitions": {
     "cvars": {
-      "$id": "/definitions/cvars",
       "type": "string",
       "title": "Variable name",
       "description": "CVar name",
@@ -2473,7 +2472,6 @@
       ]
     },
     "commands": {
-      "$id": "/definitions/commands",
       "type": "string",
       "title": "Command name",
       "description": "Console command name",
@@ -2674,19 +2672,15 @@
   "id": "https://json.schemastore.org/cryproj.55.schema",
   "properties": {
     "console_variables": {
-      "$id": "/properties/console_variables",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_variables/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_variables/items/properties/name",
             "$ref": "#/definitions/cvars"
           },
           "value": {
-            "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
             "title": "Value of the CVar",
             "description": "The default value of the CVar",
@@ -2697,14 +2691,11 @@
       }
     },
     "content": {
-      "$id": "/properties/content",
       "type": "object",
       "properties": {
         "assets": {
-          "$id": "/properties/content/properties/assets",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/assets/items",
             "type": "string",
             "title": "Assets folder",
             "description": "This indicates where the assets are stored",
@@ -2713,10 +2704,8 @@
           }
         },
         "code": {
-          "$id": "/properties/content/properties/code",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/code/items",
             "type": "string",
             "title": "Code folder",
             "description": "This indicates where the code is stored",
@@ -2725,39 +2714,32 @@
           }
         },
         "libs": {
-          "$id": "/properties/content/properties/libs",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/libs/items",
             "type": "object",
             "properties": {
               "name": {
-                "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
                 "title": "Lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
               "shared": {
-                "$id": "/properties/content/properties/libs/items/properties/shared",
                 "type": "object",
                 "properties": {
                   "any": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
                     "title": "Lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
                     "title": "Lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
                     "title": "Lib's name to import for the win_x86 platform",
                     "default": "",
@@ -2772,11 +2754,9 @@
       "required": ["code"]
     },
     "info": {
-      "$id": "/properties/info",
       "type": "object",
       "properties": {
         "name": {
-          "$id": "/properties/info/properties/name",
           "type": "string",
           "title": "Project name",
           "description": "This indicates the project name",
@@ -2784,7 +2764,6 @@
           "examples": ["MyFancyProject"]
         },
         "guid": {
-          "$id": "/properties/info/properties/guid",
           "type": "string",
           "title": "Project GUID",
           "default": "",
@@ -2794,11 +2773,9 @@
       "required": ["name"]
     },
     "require": {
-      "$id": "/properties/require",
       "type": "object",
       "properties": {
         "engine": {
-          "$id": "/properties/require/properties/engine",
           "type": "string",
           "title": "Engine version",
           "description": "This indicates which engine version will be used",
@@ -2807,14 +2784,11 @@
           "enum": ["engine-5.5"]
         },
         "plugins": {
-          "$id": "/properties/require/properties/plugins",
           "type": "array",
           "items": {
-            "$id": "/properties/require/properties/plugins/items",
             "type": "object",
             "properties": {
               "path": {
-                "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
                 "title": "Plugin name",
                 "description": "Required plugin's name",
@@ -2830,7 +2804,6 @@
                 ]
               },
               "type": {
-                "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
                 "title": "Plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
@@ -2839,10 +2812,8 @@
                 "enum": ["EPluginType::Native", "EPluginType::Managed"]
               },
               "platforms": {
-                "$id": "/properties/plugins/items/properties/platforms",
                 "type": "array",
                 "items": {
-                  "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
                   "title": "This plugin will be used only by these platforms",
                   "default": "",
@@ -2858,33 +2829,27 @@
       "required": ["engine"]
     },
     "type": {
-      "$id": "/properties/type",
       "type": "string",
       "title": "",
       "default": "",
       "examples": [""]
     },
     "version": {
-      "$id": "/properties/version",
       "type": "integer",
       "title": "Project version",
       "default": 1,
       "examples": [1]
     },
     "console_commands": {
-      "$id": "/properties/console_commands",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_commands/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_commands/items/properties/name",
             "$ref": "#/definitions/commands"
           },
           "value": {
-            "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
             "title": "Value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",

--- a/src/schemas/json/cryproj.dev.schema.json
+++ b/src/schemas/json/cryproj.dev.schema.json
@@ -3,7 +3,6 @@
   "$comment": "JSON Schema for CRYENGINE dev",
   "definitions": {
     "cvars": {
-      "$id": "/definitions/cvars",
       "type": "string",
       "title": "Variable name",
       "description": "CVar name",
@@ -2473,7 +2472,6 @@
       ]
     },
     "commands": {
-      "$id": "/definitions/commands",
       "type": "string",
       "title": "Command name",
       "description": "Console command name",
@@ -2674,19 +2672,15 @@
   "id": "https://json.schemastore.org/cryproj.dev.schema",
   "properties": {
     "console_variables": {
-      "$id": "/properties/console_variables",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_variables/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_variables/items/properties/name",
             "$ref": "#/definitions/cvars"
           },
           "value": {
-            "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
             "title": "Value of the CVar",
             "description": "The default value of the CVar",
@@ -2697,14 +2691,11 @@
       }
     },
     "content": {
-      "$id": "/properties/content",
       "type": "object",
       "properties": {
         "assets": {
-          "$id": "/properties/content/properties/assets",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/assets/items",
             "type": "string",
             "title": "Assets folder",
             "description": "This indicates where the assets are stored",
@@ -2713,10 +2704,8 @@
           }
         },
         "code": {
-          "$id": "/properties/content/properties/code",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/code/items",
             "type": "string",
             "title": "Code folder",
             "description": "This indicates where the code is stored",
@@ -2725,39 +2714,32 @@
           }
         },
         "libs": {
-          "$id": "/properties/content/properties/libs",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/libs/items",
             "type": "object",
             "properties": {
               "name": {
-                "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
                 "title": "Lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
               "shared": {
-                "$id": "/properties/content/properties/libs/items/properties/shared",
                 "type": "object",
                 "properties": {
                   "any": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
                     "title": "Lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
                     "title": "Lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
                     "title": "Lib's name to import for the win_x86 platform",
                     "default": "",
@@ -2772,11 +2754,9 @@
       "required": ["code"]
     },
     "info": {
-      "$id": "/properties/info",
       "type": "object",
       "properties": {
         "name": {
-          "$id": "/properties/info/properties/name",
           "type": "string",
           "title": "Project name",
           "description": "This indicates the project name",
@@ -2784,7 +2764,6 @@
           "examples": ["MyFancyProject"]
         },
         "guid": {
-          "$id": "/properties/info/properties/guid",
           "type": "string",
           "title": "Project GUID",
           "default": "",
@@ -2794,11 +2773,9 @@
       "required": ["name"]
     },
     "require": {
-      "$id": "/properties/require",
       "type": "object",
       "properties": {
         "engine": {
-          "$id": "/properties/require/properties/engine",
           "type": "string",
           "title": "Engine version",
           "description": "This indicates which engine version will be used",
@@ -2807,14 +2784,11 @@
           "enum": ["engine-dev"]
         },
         "plugins": {
-          "$id": "/properties/require/properties/plugins",
           "type": "array",
           "items": {
-            "$id": "/properties/require/properties/plugins/items",
             "type": "object",
             "properties": {
               "path": {
-                "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
                 "title": "Plugin name",
                 "description": "Required plugin's name",
@@ -2830,7 +2804,6 @@
                 ]
               },
               "type": {
-                "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
                 "title": "Plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
@@ -2839,10 +2812,8 @@
                 "enum": ["EPluginType::Native", "EPluginType::Managed"]
               },
               "platforms": {
-                "$id": "/properties/plugins/items/properties/platforms",
                 "type": "array",
                 "items": {
-                  "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
                   "title": "This plugin will be used only by these platforms",
                   "default": "",
@@ -2858,33 +2829,27 @@
       "required": ["engine"]
     },
     "type": {
-      "$id": "/properties/type",
       "type": "string",
       "title": "",
       "default": "",
       "examples": [""]
     },
     "version": {
-      "$id": "/properties/version",
       "type": "integer",
       "title": "Project version",
       "default": 1,
       "examples": [1]
     },
     "console_commands": {
-      "$id": "/properties/console_commands",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_commands/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_commands/items/properties/name",
             "$ref": "#/definitions/commands"
           },
           "value": {
-            "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
             "title": "Value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",

--- a/src/schemas/json/cryproj.json
+++ b/src/schemas/json/cryproj.json
@@ -3,7 +3,6 @@
   "$comment": "JSON Schema for CRYENGINE *",
   "definitions": {
     "cvars": {
-      "$id": "/definitions/cvars",
       "type": "string",
       "title": "Variable name",
       "description": "CVar name",
@@ -2473,7 +2472,6 @@
       ]
     },
     "commands": {
-      "$id": "/definitions/commands",
       "type": "string",
       "title": "Command name",
       "description": "Console command name",
@@ -2674,19 +2672,15 @@
   "id": "https://json.schemastore.org/cryproj",
   "properties": {
     "console_variables": {
-      "$id": "/properties/console_variables",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_variables/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_variables/items/properties/name",
             "$ref": "#/definitions/cvars"
           },
           "value": {
-            "$id": "/properties/console_variables/items/properties/value",
             "type": "string",
             "title": "Value of the CVar",
             "description": "The default value of the CVar",
@@ -2697,14 +2691,11 @@
       }
     },
     "content": {
-      "$id": "/properties/content",
       "type": "object",
       "properties": {
         "assets": {
-          "$id": "/properties/content/properties/assets",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/assets/items",
             "type": "string",
             "title": "Assets folder",
             "description": "This indicates where the assets are stored",
@@ -2713,10 +2704,8 @@
           }
         },
         "code": {
-          "$id": "/properties/content/properties/code",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/code/items",
             "type": "string",
             "title": "Code folder",
             "description": "This indicates where the code is stored",
@@ -2725,39 +2714,32 @@
           }
         },
         "libs": {
-          "$id": "/properties/content/properties/libs",
           "type": "array",
           "items": {
-            "$id": "/properties/content/properties/libs/items",
             "type": "object",
             "properties": {
               "name": {
-                "$id": "/properties/content/properties/libs/items/properties/name",
                 "type": "string",
                 "title": "Lib's name",
                 "default": "",
                 "examples": ["Blank"]
               },
               "shared": {
-                "$id": "/properties/content/properties/libs/items/properties/shared",
                 "type": "object",
                 "properties": {
                   "any": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/any",
                     "type": "string",
                     "title": "Lib's name to import for all the supported platforms",
                     "default": "",
                     "examples": ["CryGameSDK"]
                   },
                   "win_x64": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x64",
                     "type": "string",
                     "title": "Lib's name to import for the win_x64 platform",
                     "default": "",
                     "examples": ["bin/win_x64/Game.dll"]
                   },
                   "win_x86": {
-                    "$id": "/properties/content/properties/libs/items/properties/shared/properties/win_x86",
                     "type": "string",
                     "title": "Lib's name to import for the win_x86 platform",
                     "default": "",
@@ -2772,11 +2754,9 @@
       "required": ["code"]
     },
     "info": {
-      "$id": "/properties/info",
       "type": "object",
       "properties": {
         "name": {
-          "$id": "/properties/info/properties/name",
           "type": "string",
           "title": "Project name",
           "description": "This indicates the project name",
@@ -2784,7 +2764,6 @@
           "examples": ["MyFancyProject"]
         },
         "guid": {
-          "$id": "/properties/info/properties/guid",
           "type": "string",
           "title": "Project GUID",
           "default": "",
@@ -2794,11 +2773,9 @@
       "required": ["name"]
     },
     "require": {
-      "$id": "/properties/require",
       "type": "object",
       "properties": {
         "engine": {
-          "$id": "/properties/require/properties/engine",
           "type": "string",
           "title": "Engine version",
           "description": "This indicates which engine version will be used",
@@ -2813,14 +2790,11 @@
           ]
         },
         "plugins": {
-          "$id": "/properties/require/properties/plugins",
           "type": "array",
           "items": {
-            "$id": "/properties/require/properties/plugins/items",
             "type": "object",
             "properties": {
               "path": {
-                "$id": "/properties/require/properties/plugins/items/properties/path",
                 "type": "string",
                 "title": "Plugin name",
                 "description": "Required plugin's name",
@@ -2836,7 +2810,6 @@
                 ]
               },
               "type": {
-                "$id": "/properties/require/properties/plugins/items/properties/type",
                 "type": "string",
                 "title": "Plugin type",
                 "description": "EPluginType::Native if it's a C++ plugin, EPluginType::Managed if it's a C# one",
@@ -2845,10 +2818,8 @@
                 "enum": ["EPluginType::Native", "EPluginType::Managed"]
               },
               "platforms": {
-                "$id": "/properties/plugins/items/properties/platforms",
                 "type": "array",
                 "items": {
-                  "$id": "/properties/plugins/items/properties/platforms/items",
                   "type": "string",
                   "title": "This plugin will be used only by these platforms",
                   "default": "",
@@ -2864,33 +2835,27 @@
       "required": ["engine"]
     },
     "type": {
-      "$id": "/properties/type",
       "type": "string",
       "title": "",
       "default": "",
       "examples": [""]
     },
     "version": {
-      "$id": "/properties/version",
       "type": "integer",
       "title": "Project version",
       "default": 1,
       "examples": [1]
     },
     "console_commands": {
-      "$id": "/properties/console_commands",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "$id": "/properties/console_commands/items",
         "type": "object",
         "properties": {
           "name": {
-            "$id": "/properties/console_commands/items/properties/name",
             "$ref": "#/definitions/commands"
           },
           "value": {
-            "$id": "/properties/console_commands/items/properties/value",
             "type": "string",
             "title": "Value of the command",
             "description": "Arguments that has to be passed to the command. Leave empty if it has not parameters",

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "definitions": {
     "timezone": {
-      "$id": "timezone",
       "type": "string",
       "enum": [
         "Africa/Abidjan",

--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -4,12 +4,10 @@
   "$comment": "https://jekyllrb.com/docs/configuration/",
   "definitions": {
     "nullable-boolean": {
-      "$id": "nullable-boolean",
       "description": "Copy of definition from https://json.schemastore.org/base.json#/definitions/nullable-boolean",
       "type": ["boolean", "null"]
     },
     "nullable-timezone": {
-      "$id": "nullable-timezone",
       "description": "Copy of definition from https://json.schemastore.org/base.json#/definitions/nullable-timezone",
       "oneOf": [
         {

--- a/src/schemas/json/pgap_yaml_input_reader.json
+++ b/src/schemas/json/pgap_yaml_input_reader.json
@@ -6,7 +6,6 @@
   "description": "NCBI Prokaryotic Genome Annotation Pipeline (PGAP) input metadata (submol) JSON/YAML configuration file",
   "properties": {
     "$schema": {
-      "$id": "/$schema",
       "type": "string",
       "title": "Schema",
       "description": "The value of this keyword MUST be a URI (containing a scheme) and this URI MUST be normalized. ",
@@ -14,7 +13,6 @@
       "examples": ["https://json.schemastore.org/pgap_yaml_input_reader"]
     },
     "consortium": {
-      "$id": "/properties/consortium",
       "type": "string",
       "title": "Consortium",
       "description": "Name of the project that generated the genome assembly",
@@ -22,7 +20,6 @@
       "examples": ["SkyNet"]
     },
     "comment": {
-      "$id": "/properties/comment",
       "type": "string",
       "title": "Free text comment about the genome assembly",
       "description": "Appears in the COMMENT section of each GenBank sequence record.",
@@ -32,7 +29,6 @@
       ]
     },
     "tp_assembly": {
-      "$id": "/properties/tp_assembly",
       "type": "boolean",
       "title": "Reserved",
       "description": "NCBI internal flag used for testing.",
@@ -40,18 +36,15 @@
       "examples": [false]
     },
     "sra": {
-      "$id": "/properties/sra",
       "type": "array",
       "title": "SRA assembly data",
       "description": "Sequence reads used to build the assembly",
       "items": {
-        "$id": "/properties/sra/items",
         "type": "object",
         "additionalProperties": false,
         "required": ["accession"],
         "properties": {
           "accession": {
-            "$id": "/properties/sra/items/properties/accession",
             "type": "string",
             "title": "SRA Accession",
             "description": "Sequence Read Archive (SRA) accession for the run (with SRR, ERR or DRR prefix)",
@@ -62,38 +55,32 @@
       }
     },
     "authors": {
-      "$id": "/properties/authors",
       "type": "array",
       "title": "Author(s) of the genome assembly",
       "description": "Optional, but include if intending to submit to GenBank. Authors can be different from the contact.",
       "items": {
-        "$id": "/properties/authors/items",
         "type": "object",
         "additionalProperties": false,
         "required": ["author"],
         "properties": {
           "author": {
-            "$id": "/properties/authors/items/properties/author",
             "type": "object",
             "additionalProperties": false,
             "required": ["first_name", "last_name"],
             "properties": {
               "first_name": {
-                "$id": "/properties/authors/items/properties/author/properties/first_name",
                 "type": "string",
                 "title": "First name",
                 "default": "",
                 "examples": ["Arnold"]
               },
               "last_name": {
-                "$id": "/properties/authors/items/properties/author/properties/last_name",
                 "type": "string",
                 "title": "Last name",
                 "default": "",
                 "examples": ["Schwarzenegger"]
               },
               "middle_initial": {
-                "$id": "/properties/authors/items/properties/author/properties/middle_initial",
                 "type": "string",
                 "title": "First letter of middle name",
                 "default": "",
@@ -105,21 +92,18 @@
       }
     },
     "bioproject": {
-      "$id": "/properties/bioproject",
       "type": "string",
       "title": "BioProject ID (PRJXX) for the project, if available",
       "default": "",
       "examples": ["PRJ9999999"]
     },
     "biosample": {
-      "$id": "/properties/biosample",
       "type": "string",
       "title": "BioSample ID (SAMXXX) for the sequenced sample, if available",
       "default": "",
       "examples": ["SAMN99999999"]
     },
     "contact_info": {
-      "$id": "/properties/contact_info",
       "type": "object",
       "title": "Submitter contact information",
       "description": "Optional, but include if intending to submit to GenBank. The main contact for this genome assembly.",
@@ -137,91 +121,78 @@
       ],
       "properties": {
         "state": {
-          "$id": "/properties/contact_info/properties/state",
           "type": "string",
           "title": "State or region",
           "default": "",
           "examples": ["MD", "Florida"]
         },
         "fax": {
-          "$id": "/properties/contact_info/properties/fax",
           "type": "string",
           "title": "Fax number",
           "default": "",
           "examples": ["301-555-1234", "+7 095 555 1234"]
         },
         "city": {
-          "$id": "/properties/contact_info/properties/city",
           "type": "string",
           "title": "City",
           "default": "",
           "examples": ["Docker"]
         },
         "country": {
-          "$id": "/properties/contact_info/properties/country",
           "type": "string",
           "title": "Country",
           "default": "",
           "examples": ["Lappland"]
         },
         "department": {
-          "$id": "/properties/contact_info/properties/department",
           "type": "string",
           "title": "Department or division submitting the genome assembly",
           "default": "",
           "examples": ["Department of Using NCBI"]
         },
         "email": {
-          "$id": "/properties/contact_info/properties/email",
           "type": "string",
           "title": "Email address",
           "default": "",
           "examples": ["jane_doe@gmail.com"]
         },
         "first_name": {
-          "$id": "/properties/contact_info/properties/first_name",
           "type": "string",
           "title": "First name",
           "default": "",
           "examples": ["Jane"]
         },
         "middle_initial": {
-          "$id": "/properties/contact_info/properties/middle_initial",
           "type": "string",
           "title": "First letter of middle name",
           "default": "",
           "examples": ["N"]
         },
         "last_name": {
-          "$id": "/properties/contact_info/properties/last_name",
           "type": "string",
           "title": "Last name",
           "default": "",
           "examples": ["Doe"]
         },
         "organization": {
-          "$id": "/properties/contact_info/properties/organization",
           "type": "string",
           "title": "Organization or consortium submitting the genome assembly",
           "default": "",
           "examples": ["Institute of Klebsiella foobarensis research"]
         },
         "phone": {
-          "$id": "/properties/contact_info/properties/phone",
           "type": "string",
           "title": "Phone number",
           "default": "",
           "examples": ["301-555-0245"]
         },
         "postal_code": {
-          "$id": "/properties/contact_info/properties/postal_code",
           "type": "string",
           "title": "Postal code",
           "default": "",
           "examples": ["12345"]
         },
         "street": {
-          "$id": "/properties/contact_info/properties/street",
           "type": "string",
           "title": "Street address",
           "default": "",
@@ -230,19 +201,16 @@
       }
     },
     "fasta": {
-      "$id": "/properties/fasta",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "class": {
-          "$id": "/properties/fasta/properties/class",
           "type": "string",
           "title": "Class of input type",
           "default": "",
           "examples": ["File"]
         },
         "location": {
-          "$id": "/properties/fasta/properties/location",
           "type": "string",
           "title": "Location of input file",
           "default": "",
@@ -251,7 +219,6 @@
       }
     },
     "locus_tag_prefix": {
-      "$id": "/properties/locus_tag_prefix",
       "type": "string",
       "title": "Locus tag prefix",
       "description": "One to 9-letter prefix to use for naming genes on this genome assembly. If an official locus tag prefix was already reserved from an INSDC organization (GenBank, ENA or DDBJ) for the given BioSample and BioProject pair, provide here. Otherwise, provide a string of your choice. If no value is provided, the prefix 'pgaptmp' will be used. See more details in this Note about locus tags at: https://github.com/ncbi/pgap/wiki/Input-Files#Note-about-locus-tags",
@@ -259,12 +226,10 @@
       "examples": ["tmp"]
     },
     "organism": {
-      "$id": "/properties/organism",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "strain": {
-          "$id": "/properties/organism/properties/strain",
           "type": "string",
           "title": "Strain",
           "description": "Strain of the sequenced organism",
@@ -272,7 +237,6 @@
           "examples": ["my_strain"]
         },
         "genus_species": {
-          "$id": "/properties/organism/properties/genus_species",
           "type": "string",
           "title": "Genus and species",
           "description": "Binomial name or, if the species is unknown, genus for the sequenced organism. This identifier must be valid in NCBI Taxonomy. See Taxonomy information for how to find out if the name is valid: https://github.com/ncbi/pgap/wiki/Input-Files#Taxonomy-information",
@@ -282,51 +246,42 @@
       }
     },
     "publications": {
-      "$id": "/properties/publications",
       "type": "array",
       "title": "Publication describing the genome assembly",
       "items": {
-        "$id": "/properties/publications/items",
         "type": "object",
         "additionalProperties": false,
         "required": ["publication"],
         "properties": {
           "publication": {
-            "$id": "/properties/publications/items/properties/publication",
             "type": "object",
             "additionalProperties": false,
             "properties": {
               "authors": {
-                "$id": "/properties/publications/items/properties/publication/properties/authors",
                 "title": "Author(s)",
                 "type": "array",
                 "items": {
-                  "$id": "/properties/publications/items/properties/publication/properties/authors/items",
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
                     "author": {
-                      "$id": "/properties/publications/items/properties/publication/properties/authors/items/properties/author",
                       "type": "object",
                       "additionalProperties": false,
                       "required": ["first_name", "last_name"],
                       "properties": {
                         "first_name": {
-                          "$id": "/properties/publications/items/properties/publication/properties/authors/items/properties/author/properties/first_name",
                           "type": "string",
                           "title": "First name",
                           "default": "",
                           "examples": ["Arnold"]
                         },
                         "last_name": {
-                          "$id": "/properties/publications/items/properties/publication/properties/authors/items/properties/author/properties/last_name",
                           "type": "string",
                           "title": "Last name",
                           "default": "",
                           "examples": ["Schwarzenegger"]
                         },
                         "middle_initial": {
-                          "$id": "/properties/publications/items/properties/publication/properties/authors/items/properties/author/properties/middle_initial",
                           "type": "string",
                           "title": "First letter of middle name",
                           "default": "",
@@ -338,7 +293,6 @@
                 }
               },
               "status": {
-                "$id": "/properties/publications/items/properties/publication/properties/status",
                 "type": "string",
                 "title": "Publication status",
                 "description": "Can be only one of: published, in-press, unpublished",
@@ -346,13 +300,11 @@
                 "enum": ["published", "in-press", "unpublished"]
               },
               "pmid": {
-                "$id": "/properties/publications/items/properties/publication/properties/pmid",
                 "type": "integer",
                 "title": "PubMed ID for the publication",
                 "default": ""
               },
               "title": {
-                "$id": "/properties/publications/items/properties/publication/properties/title",
                 "type": "string",
                 "title": "Title",
                 "default": "",
@@ -366,7 +318,6 @@
       }
     },
     "topology": {
-      "$id": "/properties/topology",
       "type": "string",
       "title": "Topology of the sequences included in the fasta file",
       "description": "Possible values are linear or circular. Circular means that the first base in the sequence is adjacent to the last base. Please provide the topology in the metadata YAML file only if it is applicable to ALL sequences in the fasta file. If some sequences in the assembled genome are circular and others linear, include the topology in the definition line of each sequence in the fasta file with the tag value pair [topology=circular] or [topology=linear], after the SeqID and a space (e.g. >seq1 [topology=circular]). If the topology is provided in neither the metadata YAML nor the fasta file, the sequences will be presumed to be linear.",
@@ -374,7 +325,6 @@
       "examples": ["circular", "linear"]
     },
     "location": {
-      "$id": "/properties/location",
       "type": "string",
       "title": "Location of the sequences included in the fasta file",
       "description": "Possible values are chromosome or plasmid. Please provide the location in the metadata YAML file only if it is applicable to ALL sequences in the fasta file. If some sequences in the assembled genome are chromosomes and others plasmids, include the location in the definition line of each sequence in the fasta file with the tag value pair [location=chromosome] or [location=plasmid], after the SeqID and a space (e.g. >seq1 [location=plasmid]). In plasmid case add [plasmid-name=<plasmidname>]. If the location is provided in neither the metadata YAML nor the fasta file, the sequences will be presumed to be chromosome. Note: since 2021 releases of PGAPx this will affect noticeably the annotation on the molecule",

--- a/src/schemas/json/xs-app.json
+++ b/src/schemas/json/xs-app.json
@@ -64,7 +64,6 @@
       }
     },
     "scopeTemplate": {
-      "$id": "scopeTemplate",
       "type": ["string", "array"],
       "minLength": 1,
       "minItems": 1,

--- a/src/schemas/json/youtrack-app.json
+++ b/src/schemas/json/youtrack-app.json
@@ -6,21 +6,18 @@
   "description": "Schema for the JetBrains YouTrack app manifest file",
   "definitions": {
     "semver": {
-      "$id": "semver",
       "type": "string",
       "minLength": 5,
       "maxLength": 14,
       "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$"
     },
     "url": {
-      "$id": "url",
       "type": "string",
       "format": "url",
       "minLength": 1,
       "maxLength": 255
     },
     "expectedDimensions": {
-      "$id": "expectedDimensions",
       "type": "object",
       "description": "The expected dimensions of the widget in pixels. YouTrack will try to display the widget according to these dimensions if the monitor settings allow.",
       "properties": {
@@ -29,33 +26,27 @@
       }
     },
     "defaultDimensions": {
-      "$id": "defaultDimensions",
       "type": "object",
       "description": "The default width and height of the widget."
     },
     "settingsSchemaPath": {
-      "$id": "settingsSchemaPath",
       "type": "string",
       "description": "The path to the JSON file that stores the settings scheme for Markdown and dashboard widgets.",
       "pattern": ".*\\.json$"
     },
     "icon": {
-      "$id": "icon",
       "type": "string",
       "pattern": ".*\\.(svg|png|jpg|jpeg|ico)$"
     },
     "pixelOrPercentValue": {
-      "$id": "pixelOrPercentValue",
       "type": "string",
       "pattern": "^(\\d+px|\\d+%$)"
     },
     "fractionValue": {
-      "$id": "fractionValue",
       "type": "string",
       "pattern": "^[1-9]\\d*fr$"
     },
     "permissions": {
-      "$id": "permissions",
       "type": "string",
       "enum": [
         "READ_PROJECT_BASIC",
@@ -111,7 +102,6 @@
       ]
     },
     "extensionPoints": {
-      "$id": "extensionPoints",
       "type": "string",
       "enum": [
         "ADMINISTRATION_MENU_ITEM",


### PR DESCRIPTION
This removes `$id` definitions from schemas where
those IDs are defining schemas outside of the schema URI itself.

The problem this is fixing is summarized in #4073.

Fixes #4073.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
