### PR TITLE
Fix "yntax" typo in `jekyll.json`

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -586,7 +586,7 @@
       "minLength": 1
     },
     "highlighter": {
-      "description": "A yntax highlighter for the current site\nhttps://jekyllrb.com/docs/configuration/default/",
+      "description": "A syntax highlighter for the current site\nhttps://jekyllrb.com/docs/configuration/default/",
       "type": "string",
       "default": "rouge",
       "minLength": 1


### PR DESCRIPTION
This is my first time contributing, but this should be a relatively straightforward change (typo fix). Doesn't seem to cause any validation issues.

(let me know if I should be doing anything else on top of this - didn't notice anything in `CONTRIBUTING.md`)