### PR TITLE
Add k9s schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2951,10 +2951,46 @@
       "url": "https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json"
     },
     {
-      "name": "k9s plugin.yml",
-      "description": "k9s CLI plugin.yml file. Documentation: https://k9scli.io/topics/plugins",
-      "fileMatch": ["**/k9s/plugin.yml"],
-      "url": "https://raw.githubusercontent.com/derailed/k9s/master/plugins/schema.json"
+      "name": "k9s aliases.yaml",
+      "description": "k9s CLI aliases.yaml file. Documentation: https://k9scli.io/topics/aliases",
+      "fileMatch": ["**/k9s/aliases.yaml"],
+      "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/aliases.json"
+    },
+    {
+      "name": "k9s config.yaml",
+      "description": "k9s CLI config.yaml file. Documentation: https://k9scli.io/topics/config",
+      "fileMatch": ["**/k9s/config.yaml"],
+      "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/k9s.json"
+    },
+    {
+      "name": "k9s cluster-config.yaml",
+      "description": "k9s CLI cluster-config.yaml file. Documentation: https://k9scli.io/topics/config",
+      "fileMatch": ["**/k9s/clusters/*/*/config.yaml"],
+      "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/context.json"
+    },
+    {
+      "name": "k9s hotkeys.yaml",
+      "description": "k9s CLI hotkeys.yaml file. Documentation: https://k9scli.io/topics/hotkeys",
+      "fileMatch": ["**/k9s/hotkeys.yaml"],
+      "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/hotkeys.json"
+    },
+    {
+      "name": "k9s plugins.yaml",
+      "description": "k9s CLI plugins.yaml file. Documentation: https://k9scli.io/topics/plugins",
+      "fileMatch": ["**/k9s/plugins.yaml"],
+      "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/plugins.json"
+    },
+    {
+      "name": "k9s skin.yaml",
+      "description": "k9s CLI skin.yaml file. Documentation: https://k9scli.io/topics/skins",
+      "fileMatch": ["**/k9s/skins/*.yaml"],
+      "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/skin.json"
+    },
+    {
+      "name": "k9s views.yaml",
+      "description": "k9s CLI views.yaml file. Documentation: https://k9scli.io/topics/columns",
+      "fileMatch": ["**/k9s/views.yaml"],
+      "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/views.json"
     },
     {
       "name": "KIMMDY config file",


### PR DESCRIPTION
Currently only the k9s plugin schema is listed with an outdated link.
This PR updates the listing with all available k9s schemas.