### PR TITLE
Updating prometheus.json body_size_limit type to a string, can be 100MB, etc.

### DIFF
--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -863,7 +863,7 @@
         },
         "body_size_limit": {
           "description": "An uncompressed response body larger than this many bytes will cause the scrape to fail. 0 means no limit. Example: 100MB.",
-          "type": ["integer", "null"],
+          "type": ["string", "null"],
           "default": 0
         },
         "sample_limit": {
@@ -1296,7 +1296,7 @@
           },
           "body_size_limit": {
             "description": "An uncompressed response body larger than this many bytes will cause the scrape to fail. 0 means no limit. Example: 100MB.",
-            "type": ["integer", "null"],
+            "type": ["string", "null"],
             "default": 0
           },
           "sample_limit": {


### PR DESCRIPTION
body_size_limit is a string, can be 100MB, etc.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
