### PR TITLE
Add missing properties to mypy schema

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -574,6 +574,33 @@
       "default": false,
       "description": "UNDOCUMENTED: show links for error codes."
     },
+    "disable_bytearray_promotion": {
+      "type": "boolean",
+      "default": false,
+      "description": "UNDOCUMENTED. Disables automatic promotion of `bytearray` to `bytes` type. Is set to `true` in strict mode.",
+      "x-intellij-html-description": "UNDOCUMENTED. Disables automatic promotion of <code>bytearray</code> to <code>bytes</code> type. Is set to <code>true</code> in strict mode."
+    },
+    "disable_memoryview_promotion": {
+      "type": "boolean",
+      "default": false,
+      "description": "UNDOCUMENTED. Disables automatic promotion of `memoryview` to `bytes` type. Is set to `true` in strict mode.",
+      "x-intellij-html-description": "UNDOCUMENTED. Disables automatic promotion of <code>memoryview</code> to <code>bytes</code> type. Is set to <code>true</code> in strict mode."
+    },
+    "enable_incomplete_feature": {
+      "description": "Enable a preview of incomplete features that are not yet enabled by default by the current version of mypy. Note that it is not guaranteed that all features will be ultimately enabled by default.",
+      "x-intellij-html-description": "Enable a preview of incomplete features that are not yet enabled by default by the current version of mypy. Note that it is not guaranteed that all features will be ultimately enabled by default.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "overrides": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Add `disable_bytearray_promotion`, `disable_memoryview_promotion` and `enable_incomplete_feature` to the mypy schema.

The two first properties are undocumented, but are discussed in this PR: https://github.com/python/mypy/pull/13952

The latter option is described in the mypy documentation: https://mypy.readthedocs.io/en/stable/command_line.html#enabling-incomplete-experimental-features

This PR closes #3933.
