### PR TITLE
fix(sigma): update broken schema url

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4535,10 +4535,10 @@
       "url": "https://raw.githubusercontent.com/hardisgroupcom/sfdx-hardis/main/config/sfdx-hardis.jsonschema.json"
     },
     {
-      "name": "Sigma",
-      "description": "The Sigma detection format. Documentation: https://github.com/SigmaHQ/sigma-specification and https://github.com/SigmaHQ/sigma",
+      "name": "Sigma Detection Rule",
+      "description": "The Sigma detection rule format. Documentation: https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md and https://github.com/SigmaHQ/sigma",
       "fileMatch": ["**/sigma/**/*.yml"],
-      "url": "https://raw.githubusercontent.com/SigmaHQ/sigma-specification/main/sigma-schema.json"
+      "url": "https://raw.githubusercontent.com/SigmaHQ/sigma-specification/main/json-schema/sigma-detection-rule-schema.json"
     },
     {
       "name": "Sigrid scope configuration file",


### PR DESCRIPTION
This PR fixes the Sigma schema introduced in #3455. The schema referenced in that PR has since been renamed and updated, and additional schemas now exist (correlation [meta] rules and global filters).

This PR is limited to updating the Sigma rule schema to the current link, as well as clarifying the name and description to avoid ambiguity in the presence of multiple schemas in the SigmaHQ/sigma-specification repo.

I'm not sure whether it would be feasible to implement matching for the other Sigma schemas. Maybe someone more knowledgeable could chime in, but I'm presently unaware of any standard file naming convention that could reliably differentiate between Sigma-associated file subtypes. For now, my goal is to fix the existing Sigma detection rule schema present in SchemaStore.