### PR TITLE
Add Tauticord config schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4780,6 +4780,12 @@
       "url": "https://json.schemastore.org/taurus.json"
     },
     {
+      "name": "Tauticord",
+      "description": "Tauticord configuration (v2)",
+      "fileMatch": ["tauticord.yml", "tauticord.yaml"],
+      "url": "https://raw.githubusercontent.com/nwithan8/tauticord/master/.schema/config_v2.schema.json"
+    },
+    {
       "name": "template.json",
       "description": ".NET template files",
       "fileMatch": ["**/.template.config/template.json"],


### PR DESCRIPTION
Add externally-hosted schema for [Tauticord](https://raw.githubusercontent.com/nwithan8/tauticord/master/.schema/config_v2.schema.json) configuration files
