### PR TITLE
Fix typo in jscpd schema

### DIFF
--- a/src/schemas/json/jscpd.json
+++ b/src/schemas/json/jscpd.json
@@ -321,7 +321,7 @@
       "default": false,
       "description": "use absolute paths in reports"
     },
-    "noSymLinks": {
+    "noSymlinks": {
       "type": "boolean",
       "default": false,
       "description": "do not follow symlinks"

--- a/src/test/jscpd/jscpd.json
+++ b/src/test/jscpd/jscpd.json
@@ -25,7 +25,7 @@
   "minLines": 0,
   "minTokens": 0,
   "mode": "strict",
-  "noSymLinks": true,
+  "noSymlinks": true,
   "output": "./report/jscpd",
   "path": ["./src"],
   "pattern": "**/*.tsx?",


### PR DESCRIPTION
Fix according to upstream code.

https://github.com/kucherenko/jscpd/blob/jscpd%404.0.1/apps/jscpd/README.md#no-symlinks https://github.com/kucherenko/jscpd/blob/jscpd%404.0.1/apps/jscpd/src/init/cli.ts#L45

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
