### PR TITLE
Added NIST OSCAL Schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3723,6 +3723,132 @@
       "url": "https://raw.githubusercontent.com/ory/kratos/master/.schema/version.schema.json"
     },
     {
+      "name": "OSCAL Assessment Plan (AP)",
+      "description": "NIST Open Security Controls Assessment Language (OSCAL) Assessment Plan. (https://pages.nist.gov/OSCAL-Reference)",
+      "fileMatch": ["oscal*assessment-plan.json", "oscal*assessment_plan.json", "*ap.json"],
+      "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-plan_schema.json",
+      "versions": {
+        "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-plan_schema.json",
+        "1.1.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_assessment-plan_schema.json",
+        "1.1.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_assessment-plan_schema.json",
+        "1.0.6": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.6/oscal_assessment-plan_schema.json",
+        "1.0.5": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.5/oscal_assessment-plan_schema.json",
+        "1.0.4": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.4/oscal_assessment-plan_schema.json",
+        "1.0.3": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.3/oscal_assessment-plan_schema.json",
+        "1.0.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.2/oscal_assessment-plan_schema.json",
+        "1.0.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.1/oscal_assessment-plan_schema.json",
+        "1.0.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.0/oscal_assessment-plan_schema.json"
+      }
+    },
+    {
+      "name": "OSCAL Assessment Results (AR)",
+      "description": "NIST Open Security Controls Assessment Language (OSCAL) Assessment Results. (https://pages.nist.gov/OSCAL-Reference)",
+      "fileMatch": ["oscal*assessment-results.json", "oscal*assessment_results.json", "*ar.json"],
+      "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-results_schema.json",
+      "versions": {
+        "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-results_schema.json",
+        "1.1.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_assessment-results_schema.json",
+        "1.1.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_assessment-results_schema.json",
+        "1.0.6": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.6/oscal_assessment-results_schema.json",
+        "1.0.5": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.5/oscal_assessment-results_schema.json",
+        "1.0.4": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.4/oscal_assessment-results_schema.json",
+        "1.0.3": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.3/oscal_assessment-results_schema.json",
+        "1.0.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.2/oscal_assessment-results_schema.json",
+        "1.0.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.1/oscal_assessment-results_schema.json",
+        "1.0.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.0/oscal_assessment-results_schema.json"
+      }
+    },
+    {
+      "name": "OSCAL Catalog",
+      "description": "NIST Open Security Controls Assessment Language (OSCAL) Catalog. (https://pages.nist.gov/OSCAL-Reference)",
+      "fileMatch": ["oscal*catalog.json"],
+      "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_catalog_schema.json",
+      "versions": {
+        "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_catalog_schema.json",
+        "1.1.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_catalog_schema.json",
+        "1.1.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_catalog_schema.json",
+        "1.0.6": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.6/oscal_catalog_schema.json",
+        "1.0.5": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.5/oscal_catalog_schema.json",
+        "1.0.4": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.4/oscal_catalog_schema.json",
+        "1.0.3": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.3/oscal_catalog_schema.json",
+        "1.0.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.2/oscal_catalog_schema.json",
+        "1.0.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.1/oscal_catalog_schema.json",
+        "1.0.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.0/oscal_catalog_schema.json"
+      }
+    },
+    {
+      "name": "OSCAL Component Definition (CDef)",
+      "description": "NIST Open Security Controls Assessment Language (OSCAL) Component Definition. (https://pages.nist.gov/OSCAL-Reference)",
+      "fileMatch": ["oscal*component.json", "oscal*cdef.json"],
+      "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_component_schema.json",
+      "versions": {
+        "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_component_schema.json",
+        "1.1.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_component_schema.json",
+        "1.1.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_component_schema.json",
+        "1.0.6": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.6/oscal_component_schema.json",
+        "1.0.5": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.5/oscal_component_schema.json",
+        "1.0.4": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.4/oscal_component_schema.json",
+        "1.0.3": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.3/oscal_component_schema.json",
+        "1.0.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.2/oscal_component_schema.json",
+        "1.0.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.1/oscal_component_schema.json",
+        "1.0.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.0/oscal_component_schema.json"
+      }
+    },
+    {
+      "name": "OSCAL Plan of Action and Milestones (POA&M)",
+      "description": "NIST Open Security Controls Assessment Language (OSCAL) Plan of Action and Milestones. (https://pages.nist.gov/OSCAL-Reference)",
+      "fileMatch": ["oscal*poam.json"],
+      "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_poam_schema.json",
+      "versions": {
+        "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_poam_schema.json",
+        "1.1.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_poam_schema.json",
+        "1.1.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_poam_schema.json",
+        "1.0.6": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.6/oscal_poam_schema.json",
+        "1.0.5": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.5/oscal_poam_schema.json",
+        "1.0.4": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.4/oscal_poam_schema.json",
+        "1.0.3": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.3/oscal_poam_schema.json",
+        "1.0.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.2/oscal_poam_schema.json",
+        "1.0.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.1/oscal_poam_schema.json",
+        "1.0.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.0/oscal_poam_schema.json"
+      }
+    },
+    {
+      "name": "OSCAL Profile",
+      "description": "NIST Open Security Controls Assessment Language (OSCAL) Profile. (https://pages.nist.gov/OSCAL-Reference)",
+      "fileMatch": ["oscal*profile.json"],
+      "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_profile_schema.json",
+      "versions": {
+        "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_profile_schema.json",
+        "1.1.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_profile_schema.json",
+        "1.1.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_profile_schema.json",
+        "1.0.6": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.6/oscal_profile_schema.json",
+        "1.0.5": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.5/oscal_profile_schema.json",
+        "1.0.4": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.4/oscal_profile_schema.json",
+        "1.0.3": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.3/oscal_profile_schema.json",
+        "1.0.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.2/oscal_profile_schema.json",
+        "1.0.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.1/oscal_profile_schema.json",
+        "1.0.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.0/oscal_profile_schema.json"
+      }
+    },
+    {
+      "name": "OSCAL System Security Plan (SSP)",
+      "description": "NIST Open Security Controls Assessment Language (OSCAL) System Security Plan. (https://pages.nist.gov/OSCAL-Reference)",
+      "fileMatch": ["oscal*ssp.json"],
+      "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.json",
+      "versions": {
+        "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.json",
+        "1.1.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.1/oscal_ssp_schema.json",
+        "1.1.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.0/oscal_ssp_schema.json",
+        "1.0.6": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.6/oscal_ssp_schema.json",
+        "1.0.5": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.5/oscal_ssp_schema.json",
+        "1.0.4": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.4/oscal_ssp_schema.json",
+        "1.0.3": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.3/oscal_ssp_schema.json",
+        "1.0.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.2/oscal_ssp_schema.json",
+        "1.0.1": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.1/oscal_ssp_schema.json",
+        "1.0.0": "https://github.com/usnistgov/OSCAL/releases/download/v1.0.0/oscal_ssp_schema.json"
+      }
+    },
+    {
       "name": "OSS Review Toolkit configuration",
       "description": "ORT's main configuration file",
       "fileMatch": ["**/.ort/config/config.yml", "**/.ort/config/config.yaml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3743,7 +3743,10 @@
     {
       "name": "OSCAL Assessment Results (AR)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Assessment Results. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*assessment-results.json", "oscal*assessment_results.json"],
+      "fileMatch": [
+        "oscal*assessment-results.json",
+        "oscal*assessment_results.json"
+      ],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-results_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-results_schema.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3725,7 +3725,7 @@
     {
       "name": "OSCAL Assessment Plan (AP)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Assessment Plan. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*assessment-plan.json", "oscal*assessment_plan.json", "*ap.json"],
+      "fileMatch": ["oscal*assessment-plan.json", "oscal*assessment_plan.json"],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-plan_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-plan_schema.json",
@@ -3743,7 +3743,7 @@
     {
       "name": "OSCAL Assessment Results (AR)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Assessment Results. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*assessment-results.json", "oscal*assessment_results.json", "*ar.json"],
+      "fileMatch": ["oscal*assessment-results.json", "oscal*assessment_results.json"],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-results_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-results_schema.json",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This adds NIST OSCAL schemas to the catalog. Original commit by [brian-comply0](https://github.com/brian-comply0). If support for testing remote schemas is added to `cli.js`, then the test files should be merged in a later PR.