### PR TITLE
Add enabled propoerty to the target-based triggers schema

### DIFF
--- a/src/schemas/json/bitrise.json
+++ b/src/schemas/json/bitrise.json
@@ -406,6 +406,9 @@
     },
     "TriggersModel": {
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "push": {
           "items": {
             "$ref": "#/definitions/PushTriggerModel"


### PR DESCRIPTION
This PR adds an[ enabled field](https://github.com/bitrise-io/bitrise/pull/1003) to the target-based triggers model.
