### PR TITLE
New version 1.3.0 of IBM ZAPP schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2693,7 +2693,14 @@
       "name": "IBM Zapp document",
       "description": "IBM Z APPlication configuration file for IBM zDevOps development tools such as Z Open Editor",
       "fileMatch": ["zapp.yaml", "zapp.json"],
-      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.2.1.json"
+      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.3.0.json",
+      "versions": {
+        "1.0.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.0.0.json",
+        "1.1.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.1.0.json",
+        "1.2.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.2.0.json",
+        "1.2.1": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.2.1.json",
+        "1.3.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.3.0.json"
+      }
     },
     {
       "name": "IBM zCodeFormatSettings",


### PR DESCRIPTION
A new version of the JSON schema first introduced with this PR: https://github.com/SchemaStore/schemastore/pull/2860 and recently updated with https://github.com/SchemaStore/schemastore/pull/4049

I also added previous versions in the entry as suggested by @hyperupcall in my last PR.

This schema is used by free development tools provided by IBM: https://ibm.github.io/zopeneditor-about/Docs/zapp.html
