### PR TITLE
Added new config options for PDM's dynamic version from SCM

### DIFF
--- a/src/schemas/json/partial-pdm.json
+++ b/src/schemas/json/partial-pdm.json
@@ -547,11 +547,48 @@
             }
           }
         },
+        "fallback_version": {
+          "type": "string",
+          "description": "Specify a default version to be used when building from a source tree where SCM is not available (since pdm-backend v2.2.0)",
+          "examples": [
+            "0.0.0"
+          ],
+          "x-taplo": {
+            "links": {
+              "key": "https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg"
+            }
+          }
+        },
+        "tag_filter": {
+          "type": "string",
+          "description": "Filters the set of tags which are considered as candidates to capture your project's version (scm source)",
+          "examples": [
+            "test/*"
+          ],
+          "x-taplo": {
+            "links": {
+              "key": "https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg"
+            }
+          }
+        },
         "tag_regex": {
           "type": "string",
           "description": "Regex for reading version from source control tag (scm source)",
           "examples": [
-            "^(?:D*)?(?P<version>([1-9][0-9]*!)?(0|[1-9][0-9]*)(.(0|[1-9][0-9]*))*((a|b|c|rc)(0|[1-9][0-9]*))?(.post(0|[1-9][0-9]*))?(.dev(0|[1-9][0-9]*))?$)$"
+            "^test/(?:\\D*)?(?P<version>([1-9][0-9]*!)?(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))*((a|b|c|rc)(0|[1-9][0-9]*))?(\\.post(0|[1-9][0-9]*))?(\\.dev(0|[1-9][0-9]*))?$)$"
+          ],
+          "x-taplo": {
+            "links": {
+              "key": "https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg"
+            }
+          }
+        },
+        "version_format": {
+          "type": "string",
+          "description": "Used to customize the format of the version string (since pdm-backend v2.2.0)",
+          "pattern": "([\\w.]+):([\\w.]+)\\s*(\\([^)]+\\))?",
+          "examples": [
+            "mypackage.version:format_version"
           ],
           "x-taplo": {
             "links": {

--- a/src/schemas/json/partial-pdm.json
+++ b/src/schemas/json/partial-pdm.json
@@ -550,9 +550,7 @@
         "fallback_version": {
           "type": "string",
           "description": "Specify a default version to be used when building from a source tree where SCM is not available (since pdm-backend v2.2.0)",
-          "examples": [
-            "0.0.0"
-          ],
+          "examples": ["0.0.0"],
           "x-taplo": {
             "links": {
               "key": "https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg"
@@ -562,9 +560,7 @@
         "tag_filter": {
           "type": "string",
           "description": "Filters the set of tags which are considered as candidates to capture your project's version (scm source)",
-          "examples": [
-            "test/*"
-          ],
+          "examples": ["test/*"],
           "x-taplo": {
             "links": {
               "key": "https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg"
@@ -587,9 +583,7 @@
           "type": "string",
           "description": "Used to customize the format of the version string (since pdm-backend v2.2.0)",
           "pattern": "([\\w.]+):([\\w.]+)\\s*(\\([^)]+\\))?",
-          "examples": [
-            "mypackage.version:format_version"
-          ],
+          "examples": ["mypackage.version:format_version"],
           "x-taplo": {
             "links": {
               "key": "https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg"


### PR DESCRIPTION
Added new config options documented in <https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg>.

- `fallback_version`: Specify a default version to be used when building from a source tree where SCM is not available (since pdm-backend v2.2.0)
- `tag_filter`: Filters the set of tags which are considered as candidates to capture your project's version (scm source)
- `version_format`: Used to customize the format of the version string (since pdm-backend v2.2.0)
	- This one has a pattern constraint, `([\\w.]+):([\\w.]+)\\s*(\\([^)]+\\))?`, which I took from the original source code for pdm-backend [here](https://github.com/pdm-project/pdm-backend/blob/88c3f443d3654f4e0c97e35e7a2f38ba084c559a/src/pdm/backend/utils.py#L184).
