### PR TITLE
Adds control_plane_name under Konnect

### DIFF
--- a/src/schemas/json/kong_json_schema.json
+++ b/src/schemas/json/kong_json_schema.json
@@ -1128,6 +1128,9 @@
     },
     "Konnect": {
       "properties": {
+        "control_plane_name": {
+          "type": "string"
+        },
         "runtime_group_name": {
           "type": "string"
         }


### PR DESCRIPTION
Kong renamed 'runtime groups' to 'control planes' in 2023, this PR finally updates that in this schema.

Some context:
https://konghq.com/blog/engineering/kong-gateway-transformer-plugins
