### PR TITLE
Add `type` field to GitHub issue form schema

### DIFF
--- a/src/schemas/json/github-issue-forms.json
+++ b/src/schemas/json/github-issue-forms.json
@@ -2196,6 +2196,12 @@
         }
       ]
     },
+    "type": {
+      "description": "An issue type, currently in beta\nhttps://github.com/orgs/community/discussions/139933",
+      "type": "string",
+      "minLength": 1,
+      "examples": ["Bug", "Enhancement"]
+    },
     "body": {
       "description": "An issue template body\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
       "type": "array",


### PR DESCRIPTION
Context: https://github.com/orgs/community/discussions/139933

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
