### PR TITLE
feat: add support for subgroups in the poetry git URL field

### DIFF
--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -147,7 +147,7 @@
               "format": "uri"
             },
             {
-              "pattern": "^([A-Za-z0-9\\-]+@|https://|http://)[A-Za-z][A-Za-z0-9+.-]*(:|/)[A-Za-z0-9\\-\\.]+/[A-Za-z0-9\\-_\\.]+\\.git$"
+              "pattern": "^([A-Za-z0-9\\-]+@|https://|http://)[A-Za-z][A-Za-z0-9+.-]*(:|/)[A-Za-z0-9\\-\\.]+(/[A-Za-z0-9\\-_\\.]+)+\\.git$"
             }
           ]
         },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
This is a slight improvement of #3575 to allow for projects belonging to groups in GitLab instances. GitHub doesn't support this, which is why there regex doesn't allow more than 2 path components. However, in custom GitLab instances, you can create groups like `git@gitlab.com:user/group/project.git` or even more deeply nested ones like `git@gitlab.com:user/group/boop/project.git`