### PR TITLE
Add `version-bumper` config schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5240,6 +5240,16 @@
       "url": "https://json.schemastore.org/venvironment-basic-schema.json"
     },
     {
+      "name": "Version Bumper config",
+      "description": "Configuration for Version Bumper, a Composer plugin to bump project versions during release preparations",
+      "fileMatch": [
+        "version-bumper.json",
+        "version-bumper.yaml",
+        "version-bumper.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/eliashaeussler/version-bumper/refs/heads/main/res/version-bumper.schema.json"
+    },
+    {
       "name": "version.json",
       "description": "A project version descriptor file used by Nerdbank.GitVersioning",
       "fileMatch": ["version.json"],


### PR DESCRIPTION
This PR adds the config file schema of [`version-bumper`](https://github.com/eliashaeussler/version-bumper) to the schema catalog.