### PR TITLE
Fixed invalid name in uplugin.json

### DIFF
--- a/src/schemas/json/uplugin.json
+++ b/src/schemas/json/uplugin.json
@@ -270,7 +270,7 @@
       "type": "boolean",
       "default": false
     },
-    "IsPluginExtension": {
+    "bIsPluginExtension": {
       "description": "If true, this plugin from a platform extension extending another plugin",
       "type": "boolean",
       "default": false


### PR DESCRIPTION
Updated 'IsPluginExtension' to 'bIsPluginExtension' as the name must include the 'b' at the start. This has been like this since the first commit of this variable (Aug 13, 2019, release in 4.24) until at least Unreal Engine 5.4.

NOTE: This is different to most other values, but can be confirmed by looking at the parser [Engine/Source/Programs/UnrealBuildTool/System/PluginDescriptor.cs:288](https://github.com/EpicGames/UnrealEngine/blob/40eea367040d50aadd9f030ed5909fc890c159c2/Engine/Source/Programs/UnrealBuildTool/System/PluginDescriptor.cs#L288C4-L288C13) (you can gain access to the Unreal Engine github repository, for free, by following [this guide](https://www.unrealengine.com/en-US/ue-on-github))

