### PR TITLE
Add `supported-os.json` property to `dotnet-releases-index`

### DIFF
--- a/src/schemas/json/dotnet-releases-index.json
+++ b/src/schemas/json/dotnet-releases-index.json
@@ -70,7 +70,7 @@
         "latest-sdk": {
           "$ref": "#/definitions/releaseVersion",
           "title": "LatestSdkVersion",
-          "description": "The version of the SDK included in the latest release.  This is usually the SDK with the highest feature band. A ProductRelease may include multiple SDKs across different feature bands, all of which carry the same runtime version."
+          "description": "The version of the SDK included in the latest release. This is usually the SDK with the highest feature band. A ProductRelease may include multiple SDKs across different feature bands, all of which carry the same runtime version."
         },
         "product": {
           "type": "string",
@@ -79,7 +79,7 @@
         },
         "releases.json": {
           "$comment": "Since this is always an absolute uri, the 'uri' format is unambiguous",
-          "description": "The URL pointing to the releases.json file that contains information about all the releases  associated with this Product.",
+          "description": "The URL pointing to the releases.json file that contains information about all the releases associated with this Product.",
           "type": "string",
           "format": "uri"
         },
@@ -90,6 +90,12 @@
         "support-phase": {
           "$ref": "#/definitions/supportPhase",
           "description": "The support phase of the Product."
+        },
+        "supported-os.json": {
+          "$comment": "Since this is always an absolute uri, the 'uri' format is unambiguous",
+          "description": "The URL pointing to the supported-os.json file that contains information about the operating systems supported by this Product.",
+          "type": "string",
+          "format": "uri"
         }
       },
       "required": [


### PR DESCRIPTION
Since .NET 6, the `releases-index.json` for .NET[^1] has a new property called `supported-os.json`. For example:

```json
{
    "channel-version": "6.0",
    "latest-release": "6.0.35",
    "latest-release-date": "2024-10-08",
    "security": true,
    "latest-runtime": "6.0.35",
    "latest-sdk": "6.0.427",
    "product": ".NET",
    "support-phase": "maintenance",
    "eol-date": "2024-11-12",
    "release-type": "lts",
    "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json",
    "supported-os.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/supported-os.json"
}
```

[^1]: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json)