### PR TITLE
Add wrapStandAloneImageWithinParagraph property to [markup.goldmark.parser] in hugo.json

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -1257,7 +1257,7 @@
                   "description": "\nhttps://gohugo.io/getting-started/configuration-markup#goldmark",
                   "type": "boolean",
                   "default": true
-                }                
+                }
               },
               "additionalProperties": false
             },

--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -913,7 +913,8 @@
               "title": true
             },
             "autoHeadingID": true,
-            "autoHeadingIDType": "github"
+            "autoHeadingIDType": "github",
+            "wrapStandAloneImageWithinParagraph": true
           },
           "renderer": {
             "hardWraps": false,
@@ -1139,7 +1140,8 @@
                 "title": true
               },
               "autoHeadingID": true,
-              "autoHeadingIDType": "github"
+              "autoHeadingIDType": "github",
+              "wrapStandAloneImageWithinParagraph": true
             },
             "renderer": {
               "hardWraps": false,
@@ -1216,7 +1218,8 @@
                   "title": true
                 },
                 "autoHeadingID": true,
-                "autoHeadingIDType": "github"
+                "autoHeadingIDType": "github",
+                "wrapStandAloneImageWithinParagraph": true
               },
               "properties": {
                 "attribute": {
@@ -1249,7 +1252,12 @@
                   "description": "\nhttps://gohugo.io/getting-started/configuration-markup#goldmark",
                   "type": "string",
                   "default": "github"
-                }
+                },
+                "wrapStandAloneImageWithinParagraph": {
+                  "description": "\nhttps://gohugo.io/getting-started/configuration-markup#goldmark",
+                  "type": "boolean",
+                  "default": true
+                }                
               },
               "additionalProperties": false
             },


### PR DESCRIPTION
This adds `wrapStandAloneImageWithinParagraph` boolean property to `[markup.goldmark.parser]` in hugo.json schema for validating [Hugo](https://gohugo.io/) configuration files (e.g. hugo.toml, hugo.yaml or hugo.json).

See: https://gohugo.io/getting-started/configuration-markup/#goldmark

hugo.toml
```
[markup]
  [markup.goldmark]
    [markup.goldmark.parser]
      ....
      wrapStandAloneImageWithinParagraph = true
```


