### PR TITLE
Fix `.pre-commit-config.yml` `repo` field validation

### DIFF
--- a/src/schemas/json/pre-commit-config.json
+++ b/src/schemas/json/pre-commit-config.json
@@ -53,7 +53,7 @@
         "repo": {
           "description": "A repository url\nhttps://pre-commit.com/#2-add-a-pre-commit-configuration",
           "type": "string",
-          "pattern": "^(?!.*(local|meta)).*$"
+          "pattern": "^(?!(?:meta|local)$).*$"
         },
         "rev": {
           "description": "A revision or tag to clone at\nhttps://pre-commit.com/#2-add-a-pre-commit-configuration",

--- a/src/test/pre-commit-config/pre-commit-config-test.json
+++ b/src/test/pre-commit-config/pre-commit-config-test.json
@@ -77,6 +77,42 @@
         }
       ],
       "repo": "meta"
+    },
+    {
+      "hooks": [
+        {
+          "id": "some-hook"
+        }
+      ],
+      "repo": "https://github.com/some-org/project-with-meta",
+      "rev": "v1.0.0"
+    },
+    {
+      "hooks": [
+        {
+          "id": "some-hook"
+        }
+      ],
+      "repo": "https://github.com/some-org/project-with-metadata",
+      "rev": "v1.0.0"
+    },
+    {
+      "hooks": [
+        {
+          "id": "some-hook"
+        }
+      ],
+      "repo": "https://github.com/some-org/project-with-local",
+      "rev": "v1.0.0"
+    },
+    {
+      "hooks": [
+        {
+          "id": "some-hook"
+        }
+      ],
+      "repo": "https://github.com/some-org/project-with-local-things",
+      "rev": "v1.0.0"
     }
   ]
 }


### PR DESCRIPTION
This fixes the validation of the `repo` field, allowing for repositories with "local" or "meta" in their URLs.

See: #4136 