### PR TITLE
Add PEP 735 dependency groups to `pyproject.toml`'s schema

### DIFF
--- a/src/negative_test/pyproject/dependency-groups-1.toml
+++ b/src/negative_test/pyproject/dependency-groups-1.toml
@@ -1,0 +1,7 @@
+[project]
+name = "schemastore"
+version = "0.1.0"
+
+[dependency-groups]
+foo = ["pyparsing"]
+bar = [{set-phasers-to = "stun"}]

--- a/src/negative_test/pyproject/dependency-groups-2.toml
+++ b/src/negative_test/pyproject/dependency-groups-2.toml
@@ -1,0 +1,6 @@
+[project]
+name = "schemastore"
+version = "0.1.0"
+
+[dependency-groups]
+a = ["b", {foo = "c"}]

--- a/src/negative_test/pyproject/dependency-groups-3.toml
+++ b/src/negative_test/pyproject/dependency-groups-3.toml
@@ -1,0 +1,7 @@
+[project]
+name = "schemastore"
+version = "0.1.0"
+
+[dependency-groups]
+a = ["b", {include-group = "d", foo = "c"}]
+d = "e"

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -648,6 +648,35 @@
           }
         }
       }
+    },
+    "dependency-groups": {
+      "title": "PEP 735 dependency groups",
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$"
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "title": "PEP 508 dependency specifier",
+              "type": "string"
+            },
+            {
+              "title": "Include group",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "include-group": {
+                  "type": "string",
+                  "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$"
+                }
+              }
+            }
+          ]
+        }
+      }
     }
   },
   "title": "JSON schema for Python project metadata and configuration",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -652,29 +652,30 @@
     "dependency-groups": {
       "title": "PEP 735 dependency groups",
       "type": "object",
-      "propertyNames": {
-        "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$"
-      },
-      "additionalProperties": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {
-              "title": "PEP 508 dependency specifier",
-              "type": "string"
-            },
-            {
-              "title": "Include group",
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "include-group": {
-                  "type": "string",
-                  "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$"
+      "additionalProperties": false,
+      "patternProperties": {
+        "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "title": "PEP 508 dependency specifier",
+                "type": "string"
+              },
+              {
+                "title": "Include group",
+                "description": "Another dependency group to include in this one",
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "include-group": {
+                    "type": "string",
+                    "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$"
+                  }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       }
     }

--- a/src/test/pyproject/dependency-groups-1.toml
+++ b/src/test/pyproject/dependency-groups-1.toml
@@ -1,0 +1,6 @@
+[project]
+name = "schemastore"
+version = "0.1.0"
+
+[dependency-groups]
+test = ["pytest>7", "coverage"]

--- a/src/test/pyproject/dependency-groups-2.toml
+++ b/src/test/pyproject/dependency-groups-2.toml
@@ -1,0 +1,9 @@
+[project]
+name = "schemastore"
+version = "0.1.0"
+
+[dependency-groups]
+group-a = ["foo"]
+group-b = ["foo>1.0"]
+group-c = ["foo<1.0"]
+all = ["foo", {include-group = "group-a"}, {include-group = "group-b"}, {include-group = "group-c"}]

--- a/src/test/pyproject/dependency-groups-3.toml
+++ b/src/test/pyproject/dependency-groups-3.toml
@@ -1,0 +1,9 @@
+[project]
+name = "schemastore"
+version = "0.1.0"
+
+[dependency-groups]
+test = ["pytest", "coverage"]
+docs = ["sphinx", "sphinx-rtd-theme"]
+typing = ["mypy", "types-requests"]
+typing-test = [{include-group = "typing"}, {include-group = "test"}, "useful-types"]


### PR DESCRIPTION
[PEP 735](https://peps.python.org/pep-0735/) has just been accepted. As I understand it, the PEP introduces a new top-level `dependency-groups` table whose:

* Each property key must be a [valid non-normalized name](https://packaging.python.org/en/latest/specifications/name-normalization/#valid-non-normalized-names).
* Each property value must be an array, of which each element is either:
	* A PEP 508 dependency specifiers.
	* An inline table consisting of exactly one property, `include-group`, and this property's value must be another group's name.

In Python's typing system:

```python
# (?i)^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$
type GroupName = str

# PEP 508
type DependencySpecifier = str

DependencyGroupInclude = TypedDict('DependencyGroupInclude', {
    "include-group": GroupName
})

type DependencyGroup = list[DependencySpecifier | DependencyGroupInclude]
type DependencyGroupsTable = dict[GroupName, DependencyGroup]
```

Most tests were copied from the PEP itself.