### PR TITLE
add json schema for https://www.eidolonAI.com resources

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7055,6 +7055,17 @@
       "url": "https://json.schemastore.org/linutil-tab-data.json"
     },
     {
+      "name": "Eidolon Resource",
+      "description": "Resource definitions for Eidolon",
+      "fileMatch": [
+        "*.eidolon.yaml",
+        "*.eidolon.yml",
+        "**/eidolon_resources/**/*.yaml",
+        "**/eidolon_resources/**/*.yml"
+      ],
+      "url": "https://www.eidolonai.com/json_schema/v1/resources/overview.json"
+    },
+    {
       "name": "Waku Config",
       "description": "Configuration file for the Waku CLI",
       "fileMatch": [


### PR DESCRIPTION
Add json schema for Eidolon Resources. Eidolon resources are k8's-like resources that are used to define ai agents. See [eidolonai.com](https://www.eidolonai.com/) for more details.