### PR TITLE
pyproject: support for PEP 639

### DIFF
--- a/src/negative_test/pyproject/pep639-mismatch.toml
+++ b/src/negative_test/pyproject/pep639-mismatch.toml
@@ -1,0 +1,5 @@
+[project]
+name = "example"
+version = "1.2.3"
+license.text = "Something"
+license-files = ["LICENSE.txt"]

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -283,6 +283,13 @@
             "LicenseRef-Proprietary"
           ]
         },
+        "license-files": {
+          "description": "Paths or globs to paths of license files.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "authors": {
           "title": "Project authors",
           "type": "array",
@@ -417,6 +424,7 @@
               "readme",
               "requires-python",
               "license",
+              "license-files",
               "authors",
               "maintainers",
               "keywords",
@@ -516,6 +524,30 @@
               }
             }
           }
+        },
+        "license-files": {
+          "allOf": [
+            {
+              "not": {
+                "required": ["dynamic"],
+                "properties": {
+                  "dynamic": {
+                    "type": "array",
+                    "contains": {
+                      "const": "license-files"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "properties": {
+                "license": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
         },
         "authors": {
           "not": {

--- a/src/test/pyproject/pep639.toml
+++ b/src/test/pyproject/pep639.toml
@@ -1,0 +1,5 @@
+[project]
+name = "example"
+version = "1.2.3"
+license = "MIT"
+license-files = ["LICENSE.txt"]


### PR DESCRIPTION
This updates the pyproject.toml with the recently accepted [PEP 639](https://peps.python.org/pep-0639). Part of the PEP was already there (string-valued license entries), this adds the other part. Marking the table-valued license as deprecated should wait until there is broad support among build backends, I believe.


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
