### PR TITLE
Fix 404ing link on homepage (#4142)

### DIFF
--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -20,7 +20,7 @@
 	</p>
 
 	<p>
-		See <a href="http://json-schema.org/implementations.html">a list</a>
+		See <a href="https://json-schema.org/tools">a list</a>
 		of editors, validators and other software supporting JSON schemas.
 	</p>
 </article>


### PR DESCRIPTION
Fixes #4142 where a link on the homepage was 404ing. If you removed `.html` from the old link, it'd redirect to this new page path.