### PR TITLE
github-workflow: factor "step" into its own definition

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -395,6 +395,100 @@
         }
       ]
     },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "dependencies": {
+        "working-directory": ["run"],
+        "shell": ["run"]
+      },
+      "oneOf": [
+        {
+          "required": ["uses"]
+        },
+        {
+          "required": ["run"]
+        }
+      ],
+      "properties": {
+        "id": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsid",
+          "description": "A unique identifier for the step. You can use the id to reference the step in contexts. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
+          "type": "string"
+        },
+        "if": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsif",
+          "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
+          "type": ["boolean", "number", "string"]
+        },
+        "name": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname",
+          "description": "A name for your step to display on GitHub.",
+          "type": "string"
+        },
+        "uses": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses",
+          "description": "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, or in a published Docker container image (https://hub.docker.com/).\nWe strongly recommend that you include the version of the action you are using by specifying a Git ref, SHA, or Docker tag number. If you don't specify a version, it could break your workflows or cause unexpected behavior when the action owner publishes an update.\n- Using the commit SHA of a released action version is the safest for stability and security.\n- Using the specific major action version allows you to receive critical fixes and security patches while still maintaining compatibility. It also assures that your workflow should still work.\n- Using the master branch of an action may be convenient, but if someone releases a new major version with a breaking change, your workflow could break.\nSome actions require inputs that you must set using the with keyword. Review the action's README file to determine the inputs required.\nActions are either JavaScript files or Docker containers. If the action you're using is a Docker container you must run the job in a Linux virtual environment. For more details, see https://help.github.com/en/articles/virtual-environments-for-github-actions.",
+          "type": "string"
+        },
+        "run": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun",
+          "description": "Runs command-line programs using the operating system's shell. If you do not provide a name, the step name will default to the text specified in the run command.\nCommands run using non-login shells by default. You can choose a different shell and customize the shell used to run commands. For more information, see https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell.\nEach run keyword represents a new process and shell in the virtual environment. When you provide multi-line commands, each line runs in the same shell.",
+          "type": "string"
+        },
+        "working-directory": {
+          "$ref": "#/definitions/working-directory"
+        },
+        "shell": {
+          "$ref": "#/definitions/shell"
+        },
+        "with": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith",
+          "$ref": "#/definitions/env",
+          "description": "A map of the input parameters defined by the action. Each input parameter is a key/value pair. Input parameters are set as environment variables. The variable is prefixed with INPUT_ and converted to upper case.",
+          "properties": {
+            "args": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswithargs",
+              "type": "string"
+            },
+            "entrypoint": {
+              "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswithentrypoint",
+              "type": "string"
+            }
+          }
+        },
+        "env": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsenv",
+          "$ref": "#/definitions/env",
+          "description": "Sets environment variables for steps to use in the virtual environment. You can also set environment variables for the entire workflow or a job."
+        },
+        "continue-on-error": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error",
+          "description": "Prevents a job from failing when a step fails. Set to true to allow a job to pass when this step fails.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
+            }
+          ],
+          "default": false
+        },
+        "timeout-minutes": {
+          "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes",
+          "description": "The maximum number of minutes to run the step before killing the process.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
+            }
+          ]
+        }
+      }
+    },
     "types": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onevent_nametypes",
       "description": "Selects the types of activity that will trigger a workflow run. Most GitHub events are triggered by more than one type of activity. For example, the event for the release resource is triggered when a release is published, unpublished, created, edited, deleted, or prereleased. The types keyword enables you to narrow down activity that causes the workflow to run. When only one activity type triggers a webhook event, the types keyword is unnecessary.\nYou can use an array of event types. For more information about each event and their activity types, see https://help.github.com/en/articles/events-that-trigger-workflows#webhook-events.",
@@ -662,116 +756,7 @@
           "description": "A job contains a sequence of tasks called steps. Steps can run commands, run setup tasks, or run an action in your repository, a public repository, or an action published in a Docker registry. Not all steps run actions, but all actions run as a step. Each step runs in its own process in the virtual environment and has access to the workspace and filesystem. Because steps run in their own process, changes to environment variables are not preserved between steps. GitHub provides built-in steps to set up and complete a job.\nMust contain either `uses` or `run`\n",
           "type": "array",
           "items": {
-            "allOf": [
-              {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "uses": {
-                        "type": "string"
-                      }
-                    },
-                    "required": ["uses"]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "run": {
-                        "type": "string"
-                      }
-                    },
-                    "required": ["run"]
-                  }
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsid",
-                    "description": "A unique identifier for the step. You can use the id to reference the step in contexts. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-                    "type": "string"
-                  },
-                  "if": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsif",
-                    "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
-                    "type": ["boolean", "number", "string"]
-                  },
-                  "name": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsname",
-                    "description": "A name for your step to display on GitHub.",
-                    "type": "string"
-                  },
-                  "uses": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsuses",
-                    "description": "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, or in a published Docker container image (https://hub.docker.com/).\nWe strongly recommend that you include the version of the action you are using by specifying a Git ref, SHA, or Docker tag number. If you don't specify a version, it could break your workflows or cause unexpected behavior when the action owner publishes an update.\n- Using the commit SHA of a released action version is the safest for stability and security.\n- Using the specific major action version allows you to receive critical fixes and security patches while still maintaining compatibility. It also assures that your workflow should still work.\n- Using the master branch of an action may be convenient, but if someone releases a new major version with a breaking change, your workflow could break.\nSome actions require inputs that you must set using the with keyword. Review the action's README file to determine the inputs required.\nActions are either JavaScript files or Docker containers. If the action you're using is a Docker container you must run the job in a Linux virtual environment. For more details, see https://help.github.com/en/articles/virtual-environments-for-github-actions.",
-                    "type": "string"
-                  },
-                  "run": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun",
-                    "description": "Runs command-line programs using the operating system's shell. If you do not provide a name, the step name will default to the text specified in the run command.\nCommands run using non-login shells by default. You can choose a different shell and customize the shell used to run commands. For more information, see https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell.\nEach run keyword represents a new process and shell in the virtual environment. When you provide multi-line commands, each line runs in the same shell.",
-                    "type": "string"
-                  },
-                  "working-directory": {
-                    "$ref": "#/definitions/working-directory"
-                  },
-                  "shell": {
-                    "$ref": "#/definitions/shell"
-                  },
-                  "with": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith",
-                    "$ref": "#/definitions/env",
-                    "description": "A map of the input parameters defined by the action. Each input parameter is a key/value pair. Input parameters are set as environment variables. The variable is prefixed with INPUT_ and converted to upper case.",
-                    "properties": {
-                      "args": {
-                        "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswithargs",
-                        "type": "string"
-                      },
-                      "entrypoint": {
-                        "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswithentrypoint",
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "env": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsenv",
-                    "$ref": "#/definitions/env",
-                    "description": "Sets environment variables for steps to use in the virtual environment. You can also set environment variables for the entire workflow or a job."
-                  },
-                  "continue-on-error": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error",
-                    "description": "Prevents a job from failing when a step fails. Set to true to allow a job to pass when this step fails.",
-                    "oneOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "$ref": "#/definitions/expressionSyntax"
-                      }
-                    ],
-                    "default": false
-                  },
-                  "timeout-minutes": {
-                    "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes",
-                    "description": "The maximum number of minutes to run the step before killing the process.",
-                    "oneOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/definitions/expressionSyntax"
-                      }
-                    ]
-                  }
-                },
-                "dependencies": {
-                  "working-directory": ["run"],
-                  "shell": ["run"]
-                },
-                "additionalProperties": false
-              }
-            ]
+            "$ref": "#/definitions/step"
           },
           "minItems": 1
         },


### PR DESCRIPTION
Currently if a schema wishes to make independent use of the "step" schema, it must use a JSON Pointer reference into the schema structure, which is generally [not considered a good idea](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-00#embedded):

> Since URIs involving JSON Pointer fragments relative to the parent schema resource's URI cease to be valid when the embedded schema is moved to a separate document and referenced, applications and schemas SHOULD NOT use such URIs to identify embedded schema resources or locations within them.

This PR factors the step schema into its own definition, located at `#/definitions/step`.

It also refactors the schema slightly to remove redundancy and improve readability:
- the properties can be defined at the top level rather than inside an `allOf`, something encouraged by Kubernetes' [structural schemas](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema)
- the "type" and "properties" keywords inside the `oneOf` are redundant with respect to the top level "type" and "properties" keywords.

Unfortunately, although the overall schema remains identical (it should accept exactly the same set of JSON documents as before), as with any schema restructing, this change is backwardly incompatible because external schemas might be pointing directly into the structure. The way forward depends somewhat on the policy of this repository. Some possible approaches:

- go ahead anyway, as dependencies should not really be relying on internal schema structure, as mentioned above
- duplicate the original step schema, leaving the original structure intact, but at the cost of maintaining a separate copy of the schema
- create a new version of the `github-workflow` schema, leaving the original unchanged.
- reject this PR as it's generally not considered worthwhile to factor subschemas into their own definitions.

From a pragmatic point of view, I'd opt for the first of the above choices, leaving any schemas that use direct JSON Pointers into the substructure to fix things up (something that one should generally be prepared to do in that situation), but I totally understand if one of the other options is preferred.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
