### PR TITLE
fix: expr can be an integer or string

### DIFF
--- a/src/schemas/json/prometheus.rules.json
+++ b/src/schemas/json/prometheus.rules.json
@@ -46,7 +46,7 @@
         },
         "expr": {
           "description": "The PromQL expression to evaluate. Every evaluation cycle this is evaluated at the current time, and the result recorded as a new set of time series with the metric name as given by 'record'.",
-          "type": "string"
+          "anyOf": [{ "type": "string" }, { "type": "integer" }]
         },
         "labels": {
           "$ref": "#/definitions/labels",
@@ -65,7 +65,7 @@
         },
         "expr": {
           "description": "The PromQL expression to evaluate. Every evaluation cycle this is evaluated at the current time, and all resultant time series become pending/firing alerts.",
-          "type": "string"
+          "anyOf": [{ "type": "string" }, { "type": "integer" }]
         },
         "for": {
           "$ref": "#/definitions/duration",

--- a/src/schemas/json/prometheus.rules.test.json
+++ b/src/schemas/json/prometheus.rules.test.json
@@ -72,7 +72,7 @@
         },
         "expr": {
           "description": "PromQL expression to evaluate",
-          "type": "string"
+          "anyOf": [{ "type": "string" }, { "type": "integer" }]
         }
       },
       "required": ["expr", "eval_time"],


### PR DESCRIPTION
Hey 👋,

I was getting some validation errors while validating some [Pyrra generated Prometheus Rules](https://github.com/pyrra-dev/pyrra/blob/ee4821dc683cdfb95cf1d7dcc81b71886af0e322/slo/rules.go#L1161-L1164) and noticed that it was because the current schema only accepts strings for the expr field.

Looking at the [prometheus-operator Rule struct](https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/apis/monitoring/v1/prometheusrule_types.go#L101), integers should be acceptable too.
