### PR TITLE
fix(PDM): omit non-project-local keys and add use_uv key

### DIFF
--- a/src/negative_test/pdm/global_but_not_project_keys.json
+++ b/src/negative_test/pdm/global_but_not_project_keys.json
@@ -1,0 +1,8 @@
+{
+  "pypi": {
+    "ca_certs": "/path/to/bundle",
+    "client_cert": "/path/to/cert",
+    "client_key": "/path/to/key"
+  },
+  "venv": { "location": "/path/to/venv" }
+}

--- a/src/schemas/json/pdm.json
+++ b/src/schemas/json/pdm.json
@@ -72,7 +72,11 @@
       "description": "Isolate the build environment from the project environment\nEnv var: PDM_BUILD_ISOLATION",
       "default": true
     },
-
+    "use_uv": {
+      "type": "boolean",
+      "description": "Use uv for faster resolution and installation\nEnv var: PDM_USE_UV",
+      "default": false
+    },
     "install": {
       "type": "object",
       "additionalProperties": false,

--- a/src/schemas/json/pdm.json
+++ b/src/schemas/json/pdm.json
@@ -72,6 +72,7 @@
       "description": "Isolate the build environment from the project environment\nEnv var: PDM_BUILD_ISOLATION",
       "default": true
     },
+
     "install": {
       "type": "object",
       "additionalProperties": false,
@@ -113,6 +114,7 @@
           "description": "Use virtual environments when available\nEnv var: PDM_USE_VENV",
           "default": true
         },
+
         "providers": {
           "type": "array",
           "description": "List of python provider names for findpython"
@@ -139,18 +141,6 @@
           "type": "boolean",
           "description": "Ignore the configured indexes\nEnv var: PDM_IGNORE_STORED_INDEX",
           "default": false
-        },
-        "ca_certs": {
-          "type": "string",
-          "description": "Path to a PEM-encoded CA cert bundle (used for server cert verification)"
-        },
-        "client_cert": {
-          "type": "string",
-          "description": "Path to a PEM-encoded client cert and optional key"
-        },
-        "client_key": {
-          "type": "string",
-          "description": "Path to a PEM-encoded client cert private key, if not in pypi.client_cert"
         },
         "verify_ssl": {
           "type": "boolean",
@@ -204,10 +194,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "location": {
-          "type": "string",
-          "description": "Parent directory for virtualenvs"
-        },
         "backend": {
           "type": "string",
           "description": "Default backend to create virtualenv\nEnv var: PDM_VENV_BACKEND",

--- a/src/test/pdm/pdm.json
+++ b/src/test/pdm/pdm.json
@@ -1,14 +1,12 @@
 {
   "build_isolation": true,
+
   "install": {
     "cache": true,
     "cache_method": "symlink",
     "parallel": true
   },
   "pypi": {
-    "ca_certs": "/some/path",
-    "client_cert": "/some/path",
-    "client_key": "/some/path",
     "ignore_stored_index": false,
     "json_api": false,
     "password": "password",
@@ -46,7 +44,6 @@
   "venv": {
     "backend": "virtualenv",
     "in_project": true,
-    "location": "/some/path",
     "prompt": "my-project-env",
     "with_pip": false
   }


### PR DESCRIPTION
This PR does 2 things:

1. Remove some configuration keys that don't work within project-local configs (which pdm.json is meant for)
2. Add the new `use_uv` key

References:
https://pdm-project.org/en/latest/reference/configuration/#available-configurations
https://pdm-project.org/en/latest/usage/uv/