### PR TITLE
Update `bunfig.toml` schema to current updates

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -259,6 +259,18 @@
           "type": "object",
           "additionalProperties": true
         },
+        "ca": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
+          "description": "The CA certificate as a string\nhttps://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
+          "type": "string",
+          "examples": ["-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"]
+        },
+        "cafile": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
+          "description": "A path to a CA certificate file. The file can contain multiple certificates.\nhttps://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
+          "type": "string",
+          "examples": ["~/.bun/ca.pem"]
+        },
         "cache": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-cache",
           "description": "To configure the cache behavior\nhttps://bun.sh/docs/runtime/bunfig#install-cache",

--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -271,7 +271,7 @@
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
           "description": "A path to a CA certificate file. The file can contain multiple certificates.\nhttps://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
           "type": "string",
-          "examples": ["~/.bun/ca.pem"]
+          "examples": ["path/to/cafile"]
         },
         "cache": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-cache",

--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -263,7 +263,9 @@
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
           "description": "The CA certificate as a string\nhttps://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
           "type": "string",
-          "examples": ["-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"]
+          "examples": [
+            "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+          ]
         },
         "cafile": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",

--- a/src/test/bunfig/bunfig.toml
+++ b/src/test/bunfig/bunfig.toml
@@ -33,6 +33,10 @@ optional = true
 peer = true
 production = false
 registry = "https://registry.npmjs.org"
+# The CA certificate as a string
+ca = "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+# A path to a CA certificate file. The file can contain multiple certificates.
+cafile = "path/to/cafile"
 
 [install.cache]
 # the directory to use for the cache


### PR DESCRIPTION
Added support for [`ca` and `cafile` properties](https://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile) in `[install]` section which were [added in Bun version 1.1.31](https://bun.sh/blog/bun-v1.1.31#ca-support-in-bun-install)
