### PR TITLE
Update Open Data Contract Standard with latest v3.0.0 version

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3705,11 +3705,12 @@
       "url": "https://raw.githubusercontent.com/openrewrite/rewrite/main/rewrite-core/openrewrite.json"
     },
     {
-      "name": "Open Data Contract Standard (ODCS))",
+      "name": "Open Data Contract Standard (ODCS)",
       "description": "Open Data Contract Standard contract file",
       "fileMatch": ["*.odcs.yaml", "*.odcs.yml"],
       "url": "https://raw.githubusercontent.com/bitol-io/open-data-contract-standard/main/schema/odcs-json-schema-latest.json",
       "versions": {
+        "v3.0.0": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.0.0.json",
         "v2.2.2": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v2.2.2.json"
       }
     },


### PR DESCRIPTION
- Update to show [v3.0.0 JSON schema for Open Data Contract Standard](https://github.com/bitol-io/open-data-contract-standard/tree/main/schema).
- Fix name to remove extra `)`