### PR TITLE
Update entry for openapi.json in catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3644,10 +3644,10 @@
       "name": "openapi.json",
       "description": "A Open API documentation files",
       "fileMatch": ["openapi.json", "openapi.yml", "openapi.yaml"],
-      "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json",
+      "url": "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
       "versions": {
-        "3.0": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json",
-        "3.1": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json"
+        "3.0": "https://spec.openapis.org/oas/3.0/schema/2021-09-28",
+        "3.1": "https://spec.openapis.org/oas/3.1/schema/2022-10-07"
       }
     },
     {


### PR DESCRIPTION
The old URLs were never intended for public use and no longer work.

Replaced them with the intended and stable URLs.
