### PR TITLE
pyproject: Clarify `license` field according to PEP 639

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -252,7 +252,9 @@
               "properties": {
                 "file": {
                   "title": "License file path",
-                  "type": "string"
+                  "description": "DEPRECATED. License file path. Use `license-files` instead.",
+                  "type": "string",
+                  "deprecated": true
                 }
               }
             },
@@ -263,13 +265,15 @@
               "properties": {
                 "text": {
                   "title": "License text",
-                  "type": "string"
+                  "description": "DEPRECATED. License text. Use SPDX license expression instead.",
+                  "type": "string",
+                  "deprecated": true
                 }
               }
             },
             {
               "type": "string",
-              "description": "A SPDX license identifier"
+              "description": "An SPDX license expression"
             }
           ],
           "examples": [


### PR DESCRIPTION
This PR marked `license.text` and `license.file` as deprecated per [PEP 639](https://peps.python.org/pep-0639/).