### PR TITLE
Add CCLoader manifest to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7106,6 +7106,12 @@
         "**/.waku.json"
       ],
       "url": "https://waku.ngjx.org/static/schema.json"
+    },
+    {
+      "name": "ccmod.json",
+      "description": "Mod manifset file for the CCLoader mod loader for the game CrossCode",
+      "fileMatch": ["ccmod.json"],
+      "url": "https://raw.githubusercontent.com/CCDirectLink/CCModDB/refs/heads/master/ccmod-json-schema.json"
     }
   ]
 }


### PR DESCRIPTION
Mod manifest file for the [CCLoader](https://github.com/CCDirectLink/CCLoader) mod loader for the game [CrossCode](https://cross-code.com/en/home).

More info about the file:
https://github.com/CCDirectLink/CCModDB/blob/master/docs/CCMOD-STANDARD.md

Also, is it not possible to provide test files for external schemas?  
I don't see any way to do that, but I might be missing something.