### PR TITLE
Fix typo

### DIFF
--- a/src/schemas/json/github-funding.json
+++ b/src/schemas/json/github-funding.json
@@ -72,7 +72,7 @@
     "patreon": {
       "$ref": "#/definitions/nullable_string",
       "title": "Patreon",
-      "description": "Username on Pateron.",
+      "description": "Username on Patreon.",
       "minLength": 1,
       "maxLength": 100
     },


### PR DESCRIPTION
Fixes a small typo. _Patreon_ has been spelled as _Pateron_.