### PR TITLE
Add moon.yml manifest to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7089,6 +7089,12 @@
       "description": "Mod manifset file for the CCLoader mod loader for the game CrossCode",
       "fileMatch": ["ccmod.json"],
       "url": "https://raw.githubusercontent.com/CCDirectLink/CCModDB/refs/heads/master/ccmod-json-schema.json"
+    },
+    {
+      "name": "moon.yml",
+      "description": "Moonrepo project configuration file",
+      "fileMatch": ["moon.yml"],
+      "url": "https://raw.githubusercontent.com/moonrepo/moon/master/website/static/schemas/project.json"
     }
   ]
 }


### PR DESCRIPTION
Adds `moon.yml` manifest to the catalogue.

https://moonrepo.dev/docs/config/project - more on the `moon.yml` config file.
https://github.com/moonrepo/moon - moon GitHub repo 😄.

Thanks!