### PR TITLE
support automapSubstitutions option in cloudbuild.json

### DIFF
--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -26,6 +26,14 @@
           },
           "examples": [1, 2]
         },
+        "automapSubstitutions" : {
+          "description": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to only this build step.",
+          "markdownDescription": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to only this build step.",
+          "items": {
+            "type":"boolean"
+          },
+          "examples" : [true, false]
+        },
         "waitFor": {
           "description": "The ID(s) of the step(s) that this build step depends on. This build step will not start until all the build steps in waitFor have completed successfully. If waitFor is empty, this build step will start when all previous build steps in the list have completed successfully. If waitFor is set to '-', the step runs immediately when the build starts.",
           "markdownDescription": "The `id`(s) of the step(s) that this build step depends on. This build step will not start until all the build steps in `waitFor` have completed successfully. If `waitFor` is empty, this build step will start when all previous build steps in the list have completed successfully. If `waitFor` is set to `'-'`, the step runs immediately when the build starts.",
@@ -96,6 +104,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "automapSubstitutions" : {
+          "description": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to every step of this build.",
+          "markdownDescription": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to every step of this build.",
+          "items": {
+            "type":"boolean"
+          },
+          "examples" : [true, false]
+        },
         "machineType": {
           "description": "Compute Engine machine type on which to run the build.",
           "type": "string",

--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -3,6 +3,12 @@
   "$id": "https://json.schemastore.org/cloudbuild",
   "$comment": "See the Cloud Build config schema at https://cloud.google.com/build/docs/build-config-file-schema for the definitions.",
   "definitions": {
+    "automapSubstitutions": {
+      "description": "If set to true, automatically map all subsistutions and make them available as environment variables in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build.",
+      "markdownDescription": "If set to true, automatically map all subsistutions  and make them available as environment variables in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build.",
+      "type": "boolean",
+      "examples": [true, false]
+    },
     "BuildStep": {
       "description": "A step in the build pipeline.",
       "type": "object",
@@ -27,12 +33,7 @@
           "examples": [1, 2]
         },
         "automapSubstitutions": {
-          "description": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to only this build step.",
-          "markdownDescription": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to only this build step.",
-          "items": {
-            "type": "boolean"
-          },
-          "examples": [true, false]
+          "$ref": "#/definitions/automapSubstitutions"
         },
         "waitFor": {
           "description": "The ID(s) of the step(s) that this build step depends on. This build step will not start until all the build steps in waitFor have completed successfully. If waitFor is empty, this build step will start when all previous build steps in the list have completed successfully. If waitFor is set to '-', the step runs immediately when the build starts.",
@@ -105,12 +106,7 @@
       "additionalProperties": false,
       "properties": {
         "automapSubstitutions": {
-          "description": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to every step of this build.",
-          "markdownDescription": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to every step of this build.",
-          "items": {
-            "type": "boolean"
-          },
-          "examples": [true, false]
+          "$ref": "#/definitions/automapSubstitutions"
         },
         "machineType": {
           "description": "Compute Engine machine type on which to run the build.",

--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -26,13 +26,13 @@
           },
           "examples": [1, 2]
         },
-        "automapSubstitutions" : {
+        "automapSubstitutions": {
           "description": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to only this build step.",
           "markdownDescription": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to only this build step.",
           "items": {
-            "type":"boolean"
+            "type": "boolean"
           },
-          "examples" : [true, false]
+          "examples": [true, false]
         },
         "waitFor": {
           "description": "The ID(s) of the step(s) that this build step depends on. This build step will not start until all the build steps in waitFor have completed successfully. If waitFor is empty, this build step will start when all previous build steps in the list have completed successfully. If waitFor is set to '-', the step runs immediately when the build starts.",
@@ -104,13 +104,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "automapSubstitutions" : {
+        "automapSubstitutions": {
           "description": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to every step of this build.",
           "markdownDescription": "If set to true, automatically map all subsistutions  and make them available as environment variable in a single step. If set to false, ignore substitutions for that step. Can be used for a build step or for an entire build. When used here, it will apply to every step of this build.",
           "items": {
-            "type":"boolean"
+            "type": "boolean"
           },
-          "examples" : [true, false]
+          "examples": [true, false]
         },
         "machineType": {
           "description": "Compute Engine machine type on which to run the build.",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Fixes #4171 

noticed when writing some cloud build stuff using [automapSubstitutions](https://cloud.google.com/build/docs/build-config-file-schema#automapsubstitutions) that schemastore (through my YAML linter) doesn't allow for using an option that is valid.

This PR is to add that option.