### PR TITLE
Update Library Manager Schema

### DIFF
--- a/src/schemas/json/libman.json
+++ b/src/schemas/json/libman.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
     {
       "anyOf": [
@@ -20,11 +20,19 @@
           "$ref": "#/definitions/defaultDestination"
         }
       ]
+    },
+    {
+      "if": {
+        "$ref": "#/definitions/fileMapping"
+      },
+      "then": {
+        "$ref": "#/definitions/manifestVersion3"
+      }
     }
   ],
   "definitions": {
     "libraryEntry": {
-      "required": ["library"],
+      "required": [ "library" ],
       "properties": {
         "files": {
           "description": "The file names of the individual files to copy to the project.",
@@ -49,6 +57,34 @@
           "description": "The unique identifier of the provider",
           "type": "string",
           "minLength": 1
+        },
+        "fileMappings": {
+          "description": "A list of file mappings.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "root": {
+                "description": "The mapping root within the library contents. If omitted, defaults to the library root.",
+                "type": "string",
+                "minLength": 1
+              },
+              "destination": {
+                "description": "The destination for files included in this mapping. If omitted, defaults to a destination set for the library.",
+                "type": "string",
+                "minLength": 1
+              },
+              "files": {
+                "description": "The file names of the individual files to copy to the project, relative to the specified root. If omitted, defaults to all files.",
+                "type": "array",
+                "default": null,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -56,12 +92,12 @@
       "properties": {
         "libraries": {
           "items": {
-            "required": ["provider"]
+            "required": [ "provider" ]
           }
         }
       },
       "not": {
-        "required": ["defaultProvider"]
+        "required": [ "defaultProvider" ]
       }
     },
     "defaultProvider": {
@@ -77,12 +113,12 @@
       "properties": {
         "libraries": {
           "items": {
-            "required": ["destination"]
+            "required": [ "destination" ]
           }
         }
       },
       "not": {
-        "required": ["defaultDestination"]
+        "required": [ "defaultDestination" ]
       }
     },
     "defaultDestination": {
@@ -93,9 +129,26 @@
           "minLength": 1
         }
       }
+    },
+    "fileMapping": {
+      "properties": {
+        "libraries": {
+          "contains": {
+            "required": [ "fileMappings" ]
+          }
+        }
+      }
+    },
+    "manifestVersion3": {
+      "properties": {
+        "version": {
+          "const": "3.0"
+        }
+      },
+      "required": [ "version" ]
     }
   },
-  "id": "https://json.schemastore.org/libman.json",
+  "$id": "https://json.schemastore.org/libman.json",
   "properties": {
     "libraries": {
       "description": "A list of library references.",
@@ -105,12 +158,12 @@
       }
     },
     "version": {
-      "description": "The syntax version of this config file. Can only be 1.0",
-      "enum": ["1.0"],
-      "default": "1.0"
+      "description": "The syntax version of this config file.",
+      "enum": [ "1.0", "3.0" ],
+      "default": "3.0"
     }
   },
-  "required": ["libraries"],
+  "required": [ "libraries", "version" ],
   "title": "JSON schema for client-side library config files",
   "type": "object"
 }

--- a/src/schemas/json/libman.json
+++ b/src/schemas/json/libman.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/libman.json",
   "allOf": [
     {
       "anyOf": [
@@ -32,7 +33,7 @@
   ],
   "definitions": {
     "libraryEntry": {
-      "required": [ "library" ],
+      "required": ["library"],
       "properties": {
         "files": {
           "description": "The file names of the individual files to copy to the project.",
@@ -92,12 +93,12 @@
       "properties": {
         "libraries": {
           "items": {
-            "required": [ "provider" ]
+            "required": ["provider"]
           }
         }
       },
       "not": {
-        "required": [ "defaultProvider" ]
+        "required": ["defaultProvider"]
       }
     },
     "defaultProvider": {
@@ -113,12 +114,12 @@
       "properties": {
         "libraries": {
           "items": {
-            "required": [ "destination" ]
+            "required": ["destination"]
           }
         }
       },
       "not": {
-        "required": [ "defaultDestination" ]
+        "required": ["defaultDestination"]
       }
     },
     "defaultDestination": {
@@ -134,7 +135,7 @@
       "properties": {
         "libraries": {
           "contains": {
-            "required": [ "fileMappings" ]
+            "required": ["fileMappings"]
           }
         }
       }
@@ -145,10 +146,9 @@
           "const": "3.0"
         }
       },
-      "required": [ "version" ]
+      "required": ["version"]
     }
   },
-  "$id": "https://json.schemastore.org/libman.json",
   "properties": {
     "libraries": {
       "description": "A list of library references.",
@@ -159,11 +159,11 @@
     },
     "version": {
       "description": "The syntax version of this config file.",
-      "enum": [ "1.0", "3.0" ],
+      "enum": ["1.0", "3.0"],
       "default": "3.0"
     }
   },
-  "required": [ "libraries", "version" ],
+  "required": ["libraries", "version"],
   "title": "JSON schema for client-side library config files",
   "type": "object"
 }

--- a/src/test/libman/v3Basic.json
+++ b/src/test/libman/v3Basic.json
@@ -1,10 +1,10 @@
 {
-  "version": "3.0",
   "defaultProvider": "cdnjs",
   "libraries": [
     {
-      "library": "jquery@3.7.1",
-      "destination": "lib/jquery/"
+      "destination": "lib/jquery/",
+      "library": "jquery@3.7.1"
     }
-  ]
+  ],
+  "version": "3.0"
 }

--- a/src/test/libman/v3Basic.json
+++ b/src/test/libman/v3Basic.json
@@ -1,0 +1,10 @@
+{
+  "version": "3.0",
+  "defaultProvider": "cdnjs",
+  "libraries": [
+    {
+      "library": "jquery@3.7.1",
+      "destination": "lib/jquery/"
+    }
+  ]
+}

--- a/src/test/libman/v3DefaultDestinationWithOverride.json
+++ b/src/test/libman/v3DefaultDestinationWithOverride.json
@@ -1,0 +1,20 @@
+{
+  "version": "3.0",
+  "defaultProvider": "cdnjs",
+  "defaultDestination": "lib/jquery/",
+  "libraries": [
+    {
+      "library": "knockout@3.5.1",
+      "destination": "lib/knockout/debug",
+      "files": [
+        "knockout-latest.debug.min.js",
+        "knockout-latest.debug.js",
+        "knockout-latest.debug.min.js.map"
+      ]
+    },
+    {
+      "provider": "cdnjs",
+      "library": "jquery@3.7.1"
+    }
+  ]
+}

--- a/src/test/libman/v3DefaultDestinationWithOverride.json
+++ b/src/test/libman/v3DefaultDestinationWithOverride.json
@@ -1,20 +1,20 @@
 {
-  "version": "3.0",
-  "defaultProvider": "cdnjs",
   "defaultDestination": "lib/jquery/",
+  "defaultProvider": "cdnjs",
   "libraries": [
     {
-      "library": "knockout@3.5.1",
       "destination": "lib/knockout/debug",
       "files": [
         "knockout-latest.debug.min.js",
         "knockout-latest.debug.js",
         "knockout-latest.debug.min.js.map"
-      ]
+      ],
+      "library": "knockout@3.5.1"
     },
     {
-      "provider": "cdnjs",
-      "library": "jquery@3.7.1"
+      "library": "jquery@3.7.1",
+      "provider": "cdnjs"
     }
-  ]
+  ],
+  "version": "3.0"
 }

--- a/src/test/libman/v3WithFileMappings.json
+++ b/src/test/libman/v3WithFileMappings.json
@@ -1,0 +1,36 @@
+{
+  "version": "3.0",
+  "defaultProvider": "cdnjs",
+  "libraries": [
+    {
+      "library": "knockout@3.5.1",
+      "destination": "lib/knockout",
+      "files": [
+        "knockout-latest.debug.min.js",
+        "knockout-latest.debug.js",
+        "knockout-latest.debug.min.js.map",
+        "knockout-latest.min.js",
+        "knockout-latest.js",
+        "knockout-latest.min.js.map"
+      ],
+      "fileMappings": [
+        {
+          "destination": "debug",
+          "files": [
+            "knockout-latest.debug.min.js",
+            "knockout-latest.debug.js",
+            "knockout-latest.debug.min.js.map"
+          ]
+        },
+        {
+          "destination": "release",
+          "files": [
+            "knockout-latest.min.js",
+            "knockout-latest.js",
+            "knockout-latest.min.js.map"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/libman/v3WithFileMappings.json
+++ b/src/test/libman/v3WithFileMappings.json
@@ -1,18 +1,8 @@
 {
-  "version": "3.0",
   "defaultProvider": "cdnjs",
   "libraries": [
     {
-      "library": "knockout@3.5.1",
       "destination": "lib/knockout",
-      "files": [
-        "knockout-latest.debug.min.js",
-        "knockout-latest.debug.js",
-        "knockout-latest.debug.min.js.map",
-        "knockout-latest.min.js",
-        "knockout-latest.js",
-        "knockout-latest.min.js.map"
-      ],
       "fileMappings": [
         {
           "destination": "debug",
@@ -30,7 +20,17 @@
             "knockout-latest.min.js.map"
           ]
         }
-      ]
+      ],
+      "files": [
+        "knockout-latest.debug.min.js",
+        "knockout-latest.debug.js",
+        "knockout-latest.debug.min.js.map",
+        "knockout-latest.min.js",
+        "knockout-latest.js",
+        "knockout-latest.min.js.map"
+      ],
+      "library": "knockout@3.5.1"
     }
-  ]
+  ],
+  "version": "3.0"
 }


### PR DESCRIPTION
To match https://github.com/aspnet/LibraryManager/commit/1b30db96a246d99bb7c92a61e4d06234195508e3, as part of https://github.com/aspnet/LibraryManager/pull/756

Adds version 3.0, fileMappings, and the ability to override the default destination at the individual "library" level.

Adds tests that exercise the new parts of the schema.