### PR TITLE
Kustomize HelmCharts add missing SkipHooks to schema

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -152,6 +152,9 @@
         "includeCRDs": {
           "type": "boolean"
         },
+        "skipHooks": {
+          "type": "boolean"
+        },
         "additionalValuesFiles": {
           "type": "array",
           "items": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
https://github.com/kubernetes-sigs/kustomize/blob/bb7a28070905adae77c6f82b912a862de2b3a052/api/types/helmchartargs.go#L86