### PR TITLE
Use usernames as codeowners for venvironment schemas 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,6 @@ src/test/youtrack-app/ @skoch13 @andrey-skl @zmaks
 src/negative_test/youtrack-app/ @skoch13 @andrey-skl @zmaks
 
 # Managed by Vector Informatik canoe-ci-tools team
-src/schemas/json/venvironment-* @vectorgrp/canoe-ci-tools
-src/test/venvironment-* @vectorgrp/canoe-ci-tools
-src/negative_test/venvironment-* @vectorgrp/canoe-ci-tools
+src/schemas/json/venvironment-* @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj
+src/test/venvironment-* @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj
+src/negative_test/venvironment-* @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj


### PR DESCRIPTION
(as suggested in #4190)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
