### PR TITLE
use fewer negative lookahead assertions in regular expressions

### DIFF
--- a/src/negative_test/stylelintrc/objectRule.json
+++ b/src/negative_test/stylelintrc/objectRule.json
@@ -1,0 +1,15 @@
+{
+  "rules": {
+    "declaration-property-unit-whitelist": [
+      {
+        "message": []
+      },
+      {
+        "/^animation/": "s",
+        "font-size": "em",
+        "line-height": [],
+        "message": []
+      }
+    ]
+  }
+}

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -139,7 +139,7 @@
         }
       },
       "patternProperties": {
-        "^(?![\\.0-9]).": {
+        "^[^.0-9]+$": {
           "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this environment matches the property name."
         }

--- a/src/schemas/json/stylelintrc.json
+++ b/src/schemas/json/stylelintrc.json
@@ -193,8 +193,7 @@
           "type": "null"
         },
         {
-          "type": "boolean",
-          "enum": [true, []]
+          "type": "boolean"
         },
         {
           "type": "array",
@@ -205,8 +204,7 @@
             "type": ["boolean", "object"],
             "anyOf": [
               {
-                "type": "boolean",
-                "enum": [true, {}]
+                "type": "boolean"
               },
               {
                 "$ref": "#/definitions/coreRule"
@@ -217,6 +215,7 @@
       ]
     },
     "coreRule": {
+      "type": "object",
       "properties": {
         "disableFix": {
           "type": "boolean"
@@ -427,48 +426,36 @@
       ]
     },
     "objectRule": {
-      "type": ["null", "object", "array"],
       "oneOf": [
         {
           "type": "null"
         },
         {
           "type": "object",
-          "patternProperties": {
-            ".*": {
-              "$ref": "#/definitions/simpleArrayStringRule"
-            }
+          "additionalProperties": {
+            "$ref": "#/definitions/simpleStringOrArrayStringRule"
           }
         },
         {
           "type": "array",
           "minItems": 2,
           "maxItems": 2,
-          "uniqueItems": true,
-          "items": {
-            "type": ["object"],
-            "anyOf": [
-              {
-                "type": "object",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/coreRule"
-                  }
-                ],
-                "patternProperties": {
-                  "^((?!message|severity).)*$": {
-                    "$ref": "#/definitions/simpleArrayStringRule"
-                  }
-                }
+          "items": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/simpleStringOrArrayStringRule"
               }
-            ]
-          }
+            },
+            {
+              "$ref": "#/definitions/coreRule"
+            }
+          ]
         }
       ]
     },
     "simpleArrayStringRule": {
       "type": "array",
-      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "type": "string"
@@ -572,8 +559,7 @@
             "type": ["string", "object"],
             "anyOf": [
               {
-                "type": "string",
-                "enum": [{}]
+                "type": "string"
               },
               {
                 "$ref": "#/definitions/coreRule"

--- a/src/test/stylelintrc/objectRule.json
+++ b/src/test/stylelintrc/objectRule.json
@@ -1,0 +1,15 @@
+{
+  "rules": {
+    "declaration-property-unit-whitelist": [
+      {
+        "/^animation/": "s",
+        "/message/": "blah",
+        "font-size": "em",
+        "line-height": []
+      },
+      {
+        "message": "it failed!"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The latest version of the JSON Schema specification mentions the fact that there are many different regular expression variants and says:

> given the high disparity in regular expression constructs support,
> schema authors SHOULD limit themselves to the following regular expression tokens:

(See https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#name-regular-expressions)

One example of such a variant is Go's regular expression evaluator which, despite, and in fact because of, some limitations, such as no backreferences or lookahead, has some technical advantages such as a guaranteed non-exponential runtime (see
https://swtch.com/~rsc/regexp/regexp1.html for some background).

Our JSON Schema checker uses that implementation for matching regular expressions, which means that it cannot check the regular expressions in `ci.json` that contain negative lookahead assertions.

Given the above, this PR changes two schemas to avoid using negative lookahead assertions in their regular expressions.

The first, in `package.json` is straightforward: the replacement pattern is exactly equivalent to the original..

The second, in `stylelintrc.json`, is somewhat less so.

As pointed out in #4047, this schema has many problems. One of those is that in many places, `stylelint` accepts an array of two values, the first of which is the actual value and the second of which corresponds to the coreRule schema. However the `stylelint` schema squashes both of those into a single `anyOf` schema where it could instead use an array value for `items`, defining a tuple that expresses exactly the constraint needed.

I've done that for `objectRule` here, which avoids the need to use the negative-lookahead regexp in `patternProperties`, which wasn't actually expressing the right constraint in any case (any field containing the substring `message` or `severity` would just be ignored.

Hopefully this should point the way towards future fixes in the rest of the schema.

In fixing this, it became clear that there were a couple of other issues that needed to be fixed to make the tests pass:

- boolean values [are not always required to be true](e.g. https://stylelint.io/user-guide/configure/#reportdescriptionlessdisables)
- array values [_can_ be empty](https://stylelint.io/user-guide/rules/declaration-property-unit-allowed-list/)
- the values inside `objectRule` [_can_ contain strings and empty arrays](https://stylelint.io/user-guide/rules/declaration-property-unit-allowed-list/)

I verified the above by actually checking a `.stylelintrc.json` file with `stylelint` itself.

As an aside, this schema does not actually represent the current version of `stylelint`: various fields have been renamed or removed (for example all the `*-whitelist` and `*-blacklist` fields have been renamed to `*-allowed-list` and `*-disallowed-list`.
