### PR TITLE
Use lowercase for TypeScript moduleResolution compiler option

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -423,17 +423,17 @@
               "anyOf": [
                 {
                   "enum": [
-                    "Classic",
-                    "Node",
-                    "Node10",
-                    "Node16",
-                    "NodeNext",
-                    "Bundler"
+                    "classic",
+                    "node",
+                    "node10",
+                    "node16",
+                    "nodenext",
+                    "bundler"
                   ],
                   "markdownEnumDescriptions": [
-                    "It’s recommended to use `\"Node16\"` instead",
-                    "Deprecated, use `\"Node10\"` in TypeScript 5.0+ instead",
-                    "It’s recommended to use `\"Node16\"` instead",
+                    "It’s recommended to use `\"node16\"` instead",
+                    "Deprecated, use `\"node10\"` in TypeScript 5.0+ instead",
+                    "It’s recommended to use `\"node16\"` instead",
                     "This is the recommended setting for libraries and Node.js applications",
                     "This is the recommended setting for libraries and Node.js applications",
                     "This is the recommended setting in TypeScript 5.0+ for applications that use a bundler"

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -426,17 +426,17 @@
               "anyOf": [
                 {
                   "enum": [
-                    "Classic",
-                    "Node",
-                    "Node10",
-                    "Node16",
-                    "NodeNext",
-                    "Bundler"
+                    "classic",
+                    "node",
+                    "node10",
+                    "node16",
+                    "nodenext",
+                    "bundler"
                   ],
                   "markdownEnumDescriptions": [
-                    "It’s recommended to use `\"Node16\"` instead",
-                    "Deprecated, use `\"Node10\"` in TypeScript 5.0+ instead",
-                    "It’s recommended to use `\"Node16\"` instead",
+                    "It’s recommended to use `\"node16\"` instead",
+                    "Deprecated, use `\"node10\"` in TypeScript 5.0+ instead",
+                    "It’s recommended to use `\"node16\"` instead",
                     "This is the recommended setting for libraries and Node.js applications",
                     "This is the recommended setting for libraries and Node.js applications",
                     "This is the recommended setting in TypeScript 5.0+ for applications that use a bundler"


### PR DESCRIPTION
The casing is a bit inconsistent, it's lowercase in the cli and the most of the documentation, but PascalCase in the default of the doc and the JSON schema. I think using the lowercase like in the cli make more sense.

I can make this change for more enums if needed.

Pinging @RyanCavanaugh @jakebailey that seems to be owner of the schema 