### PR TITLE
Black also targets Python 3.13

### DIFF
--- a/src/schemas/json/partial-black.json
+++ b/src/schemas/json/partial-black.json
@@ -27,7 +27,8 @@
           "py39",
           "py310",
           "py311",
-          "py312"
+          "py312",
+          "py313"
         ]
       },
       "description": "Python versions that should be supported by Black's output. You should include all versions that your code supports. By default, Black will infer target versions from the project metadata in pyproject.toml. If this does not yield conclusive results, Black will use per-file auto-detection."


### PR DESCRIPTION
From `black --help`.

``` 
-t, --target-version [py33|py34|py35|py36|py37|py38|py39|py310|py311|py312|py313]
```