### PR TITLE
Add wiremock-stub-mapping schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7140,7 +7140,7 @@
     },
     {
       "name": "WireMock stub mapping",
-      "description": "WireMock stub mapping JSON schema. See https://wiremock.org/docs/stubbing/",
+      "description": "WireMock stub mapping JSON. See https://wiremock.org/docs/stubbing/",
       "fileMatch": ["wiremock-stub-mapping.yml", "wiremock-stub-mapping.yaml"],
       "url": "https://json.schemastore.org/wiremock-stub-mapping.json"
     }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7137,6 +7137,12 @@
       "description": "Moonrepo project configuration file",
       "fileMatch": ["moon.yml"],
       "url": "https://raw.githubusercontent.com/moonrepo/moon/master/website/static/schemas/project.json"
+    },
+    {
+      "name": "WireMock stub mapping",
+      "description": "WireMock stub mapping JSON schema. See https://wiremock.org/docs/stubbing/",
+      "fileMatch": ["wiremock-stub-mapping.yml", "wiremock-stub-mapping.yaml"],
+      "url": "https://json.schemastore.org/wiremock-stub-mapping.json"
     }
   ]
 }

--- a/src/negative_test/wiremock-stub-mapping/invalid-request-body-pattern.json
+++ b/src/negative_test/wiremock-stub-mapping/invalid-request-body-pattern.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "bodyPatterns": [
+      {
+        "some-unknown-body-matcher": true
+      }
+    ],
+    "method": "POST",
+    "urlPath": "/user/repos"
+  },
+  "response": {
+    "status": 200
+  }
+}

--- a/src/negative_test/wiremock-stub-mapping/invalid-response-status-type.json
+++ b/src/negative_test/wiremock-stub-mapping/invalid-response-status-type.json
@@ -1,0 +1,9 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/user/repos"
+  },
+  "response": {
+    "status": "this-should-be-an-integer"
+  }
+}

--- a/src/schemas/json/wiremock-stub-mapping.json
+++ b/src/schemas/json/wiremock-stub-mapping.json
@@ -1,6 +1,34 @@
 {
-  "$id": "https://json.schemastore.org/wiremock-stub-mapping.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/wiremock-stub-mapping.json",
+  "$defs": {
+    "dateTimeExpression": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "examples": ["now +3 days"]
+    },
+    "dateFormat": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "examples": ["yyyy-MM-dd"]
+    },
+    "dateTruncation": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "enum": [
+        "first second of minute",
+        "first minute of hour",
+        "first hour of day",
+        "first day of month",
+        "first day of next month",
+        "last day of month",
+        "first day of year",
+        "first day of next year",
+        "last day of year"
+      ],
+      "examples": ["first day of month"]
+    }
+  },
   "description": "WireMock stub mapping",
   "type": "object",
   "additionalProperties": true,
@@ -18,6 +46,7 @@
       "description": "The stub mapping's name"
     },
     "request": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "type": "object",
       "examples": [
         {
@@ -31,10 +60,7 @@
       "properties": {
         "scheme": {
           "type": "string",
-          "enum": [
-            "http",
-            "https"
-          ],
+          "enum": ["http", "https"],
           "description": "The scheme (protocol) part of the request URL"
         },
         "host": {
@@ -107,10 +133,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "username",
-            "password"
-          ]
+          "required": ["username", "password"]
         },
         "cookies": {
           "type": "object",
@@ -123,15 +146,15 @@
           "type": "array",
           "description": "Request body patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
           "items": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "title": "Content pattern",
             "oneOf": [
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "String equals",
                 "type": "object",
-                "required": [
-                  "equalTo"
-                ],
+                "required": ["equalTo"],
                 "properties": {
                   "equalTo": {
                     "type": "string"
@@ -139,23 +162,21 @@
                   "caseInsensitive": {
                     "type": "boolean"
                   }
-                },
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                }
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Binary equals",
                 "type": "object",
-                "required": [
-                  "binaryEqualTo"
-                ],
+                "required": ["binaryEqualTo"],
                 "properties": {
                   "binaryEqualTo": {
                     "$ref": "#/properties/response/allOf/0/properties/base64Body"
                   }
-                },
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                }
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "String contains",
                 "type": "object",
                 "properties": {
@@ -163,12 +184,10 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "contains"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["contains"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "String does not contain",
                 "type": "object",
                 "properties": {
@@ -176,12 +195,10 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "doesNotContain"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["doesNotContain"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Regular expression match",
                 "type": "object",
                 "properties": {
@@ -189,12 +206,10 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "matches"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["matches"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Negative regular expression match",
                 "type": "object",
                 "properties": {
@@ -202,12 +217,10 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "doesNotMatch"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["doesNotMatch"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "NOT modifier",
                 "type": "object",
                 "properties": {
@@ -215,12 +228,10 @@
                     "$ref": "#/properties/request/properties/bodyPatterns/items"
                   }
                 },
-                "required": [
-                  "not"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["not"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Before datetime",
                 "type": "object",
                 "properties": {
@@ -237,12 +248,10 @@
                     "$ref": "#/$defs/dateTruncation"
                   }
                 },
-                "required": [
-                  "before"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["before"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "After datetime",
                 "type": "object",
                 "properties": {
@@ -259,12 +268,10 @@
                     "$ref": "#/$defs/dateTruncation"
                   }
                 },
-                "required": [
-                  "after"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["after"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Equal to datetime",
                 "type": "object",
                 "properties": {
@@ -281,12 +288,10 @@
                     "$ref": "#/$defs/dateTruncation"
                   }
                 },
-                "required": [
-                  "equalToDateTime"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["equalToDateTime"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "JSON equals",
                 "type": "object",
                 "properties": {
@@ -312,12 +317,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "equalToJson"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["equalToJson"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "JSONPath match",
                 "type": "object",
                 "properties": {
@@ -342,19 +345,15 @@
                             "$ref": "#/properties/request/properties/bodyPatterns/items"
                           }
                         ],
-                        "required": [
-                          "expression"
-                        ]
+                        "required": ["expression"]
                       }
                     ]
                   }
                 },
-                "required": [
-                  "matchesJsonPath"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["matchesJsonPath"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "XML equality",
                 "type": "object",
                 "properties": {
@@ -374,12 +373,10 @@
                     "examples": ["]"]
                   }
                 },
-                "required": [
-                  "equalToXml"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["equalToXml"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "XPath match",
                 "type": "object",
                 "properties": {
@@ -404,9 +401,7 @@
                             "$ref": "#/properties/request/properties/bodyPatterns/items"
                           }
                         ],
-                        "required": [
-                          "expression"
-                        ]
+                        "required": ["expression"]
                       }
                     ]
                   },
@@ -417,12 +412,10 @@
                     }
                   }
                 },
-                "required": [
-                  "matchesXPath"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["matchesXPath"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "JSON Schema match",
                 "type": "object",
                 "properties": {
@@ -447,9 +440,7 @@
                             "$ref": "#/properties/request/properties/bodyPatterns/items"
                           }
                         ],
-                        "required": [
-                          "expression"
-                        ]
+                        "required": ["expression"]
                       }
                     ]
                   },
@@ -460,12 +451,10 @@
                     }
                   }
                 },
-                "required": [
-                  "matchesJsonSchema"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["matchesJsonSchema"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Absent matcher",
                 "type": "object",
                 "properties": {
@@ -473,12 +462,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "absent"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["absent"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Logical AND matcher",
                 "type": "object",
                 "properties": {
@@ -489,12 +476,10 @@
                     }
                   }
                 },
-                "required": [
-                  "and"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["and"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Logical AND matcher",
                 "type": "object",
                 "properties": {
@@ -505,12 +490,10 @@
                     }
                   }
                 },
-                "required": [
-                  "or"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["or"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Has exactly multi value matcher",
                 "type": "object",
                 "properties": {
@@ -521,12 +504,10 @@
                     }
                   }
                 },
-                "required": [
-                  "hasExactly"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["hasExactly"]
               },
               {
+                "$schema": "http://json-schema.org/draft-07/schema#",
                 "title": "Has exactly multi value matcher",
                 "type": "object",
                 "properties": {
@@ -537,13 +518,9 @@
                     }
                   }
                 },
-                "required": [
-                  "includes"
-                ],
-                "$schema": "http://json-schema.org/draft-07/schema#"
+                "required": ["includes"]
               }
-            ],
-            "$schema": "http://json-schema.org/draft-07/schema#"
+            ]
           }
         },
         "customMatcher": {
@@ -572,10 +549,7 @@
                 "type": "string",
                 "description": "Determines whether all or any of the parts must match the criteria for an overall match.",
                 "default": "ANY",
-                "enum": [
-                  "ALL",
-                  "ANY"
-                ]
+                "enum": ["ALL", "ANY"]
               },
               "headers": {
                 "type": "object",
@@ -594,10 +568,10 @@
             }
           }
         }
-      },
-      "$schema": "http://json-schema.org/draft-07/schema#"
+      }
     },
     "response": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "allOf": [
         {
           "type": "object",
@@ -636,11 +610,11 @@
               "description": "The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified."
             },
             "base64Body": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
               "title": "Base64 string",
               "type": "string",
               "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
-              "description": "A base64 encoded string used to describe binary data.",
-              "$schema": "http://json-schema.org/draft-07/schema#"
+              "description": "A base64 encoded string used to describe binary data."
             },
             "jsonBody": {
               "description": "The response body as a JSON object. Only one of body, base64Body, jsonBody or bodyFileName may be specified.",
@@ -673,6 +647,7 @@
               "description": "Number of milliseconds to delay be before sending the response."
             },
             "delayDistribution": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
               "type": "object",
               "description": "The delay distribution. Valid property configuration is either median/sigma/type or lower/type/upper.",
               "oneOf": [
@@ -689,15 +664,10 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "lognormal"
-                      ]
+                      "enum": ["lognormal"]
                     }
                   },
-                  "required": [
-                    "median",
-                    "sigma"
-                  ]
+                  "required": ["median", "sigma"]
                 },
                 {
                   "title": "Uniform",
@@ -712,15 +682,10 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "uniform"
-                      ]
+                      "enum": ["uniform"]
                     }
                   },
-                  "required": [
-                    "lower",
-                    "upper"
-                  ]
+                  "required": ["lower", "upper"]
                 },
                 {
                   "title": "Fixed",
@@ -732,17 +697,12 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "fixed"
-                      ]
+                      "enum": ["fixed"]
                     }
                   },
-                  "required": [
-                    "milliseconds"
-                  ]
+                  "required": ["milliseconds"]
                 }
-              ],
-              "$schema": "http://json-schema.org/draft-07/schema#"
+              ]
             },
             "chunkedDribbleDelay": {
               "type": "object",
@@ -755,10 +715,7 @@
                   "type": "integer"
                 }
               },
-              "required": [
-                "numberOfChunks",
-                "totalDuration"
-              ]
+              "required": ["numberOfChunks", "totalDuration"]
             },
             "fromConfiguredStub": {
               "type": "boolean",
@@ -786,7 +743,6 @@
           }
         }
       ],
-      "$schema": "http://json-schema.org/draft-07/schema#",
       "type": "object"
     },
     "persistent": {
@@ -844,34 +800,6 @@
     "metadata": {
       "type": "object",
       "description": "Arbitrary metadata to be used for e.g. tagging, documentation. Can also be used to find and remove stubs."
-    }
-  },
-  "$defs": {
-    "dateTimeExpression": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "type": "string",
-      "examples": ["now +3 days"]
-    },
-    "dateFormat": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "type": "string",
-      "examples": ["yyyy-MM-dd"]
-    },
-    "dateTruncation": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "type": "string",
-      "enum": [
-        "first second of minute",
-        "first minute of hour",
-        "first hour of day",
-        "first day of month",
-        "first day of next month",
-        "last day of month",
-        "first day of year",
-        "first day of next year",
-        "last day of year"
-      ],
-      "examples": ["first day of month"]
     }
   }
 }

--- a/src/schemas/json/wiremock-stub-mapping.json
+++ b/src/schemas/json/wiremock-stub-mapping.json
@@ -1,0 +1,877 @@
+{
+  "$id": "https://json.schemastore.org/wiremock-stub-mapping.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "WireMock stub mapping",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "This stub mapping's unique identifier"
+    },
+    "uuid": {
+      "type": "string",
+      "description": "Alias for the id"
+    },
+    "name": {
+      "type": "string",
+      "description": "The stub mapping's name"
+    },
+    "request": {
+      "type": "object",
+      "examples": [
+        {
+          "method": "POST",
+          "urlPath": "/charges",
+          "headers": {
+            "Content-Type": { "equalTo": "application/json" }
+          }
+        }
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string",
+          "enum": [
+            "http",
+            "https"
+          ],
+          "description": "The scheme (protocol) part of the request URL"
+        },
+        "host": {
+          "type": "string",
+          "description": "The hostname part of the request URL"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "The HTTP port number of the request URL"
+        },
+        "method": {
+          "type": "string",
+          "pattern": "^[A-Z]+$",
+          "description": "The HTTP request method e.g. GET"
+        },
+        "url": {
+          "type": "string",
+          "description": "The path and query to match exactly against. Only one of url, urlPattern, urlPath or urlPathPattern may be specified."
+        },
+        "urlPath": {
+          "type": "string",
+          "description": "The path to match exactly against. Only one of url, urlPattern, urlPath or urlPathPattern may be specified."
+        },
+        "urlPathPattern": {
+          "type": "string",
+          "description": "The path regex to match against. Only one of url, urlPattern, urlPath or urlPathPattern may be specified."
+        },
+        "urlPattern": {
+          "type": "string",
+          "description": "The path and query regex to match against. Only one of url, urlPattern, urlPath or urlPathPattern may be specified."
+        },
+        "pathParameters": {
+          "type": "object",
+          "description": "Path parameter patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form. Can only\nbe used when the urlPathPattern URL match type is in use and all keys must be present as variables\nin the path template.\n",
+          "additionalProperties": {
+            "$ref": "#/properties/request/properties/bodyPatterns/items"
+          }
+        },
+        "queryParameters": {
+          "type": "object",
+          "description": "Query parameter patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+          "additionalProperties": {
+            "$ref": "#/properties/request/properties/bodyPatterns/items"
+          }
+        },
+        "formParameters": {
+          "type": "object",
+          "description": "application/x-www-form-urlencoded form parameter patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+          "additionalProperties": {
+            "$ref": "#/properties/request/properties/bodyPatterns/items"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "description": "Header patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+          "additionalProperties": {
+            "$ref": "#/properties/request/properties/bodyPatterns/items"
+          }
+        },
+        "basicAuthCredentials": {
+          "type": "object",
+          "description": "Pre-emptive basic auth credentials to match against",
+          "properties": {
+            "password": {
+              "type": "string"
+            },
+            "username": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "username",
+            "password"
+          ]
+        },
+        "cookies": {
+          "type": "object",
+          "description": "Cookie patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+          "additionalProperties": {
+            "$ref": "#/properties/request/properties/bodyPatterns/items"
+          }
+        },
+        "bodyPatterns": {
+          "type": "array",
+          "description": "Request body patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+          "items": {
+            "type": "object",
+            "title": "Content pattern",
+            "oneOf": [
+              {
+                "title": "String equals",
+                "type": "object",
+                "required": [
+                  "equalTo"
+                ],
+                "properties": {
+                  "equalTo": {
+                    "type": "string"
+                  },
+                  "caseInsensitive": {
+                    "type": "boolean"
+                  }
+                },
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Binary equals",
+                "type": "object",
+                "required": [
+                  "binaryEqualTo"
+                ],
+                "properties": {
+                  "binaryEqualTo": {
+                    "$ref": "#/properties/response/allOf/0/properties/base64Body"
+                  }
+                },
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "String contains",
+                "type": "object",
+                "properties": {
+                  "contains": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "contains"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "String does not contain",
+                "type": "object",
+                "properties": {
+                  "doesNotContain": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "doesNotContain"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Regular expression match",
+                "type": "object",
+                "properties": {
+                  "matches": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "matches"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Negative regular expression match",
+                "type": "object",
+                "properties": {
+                  "doesNotMatch": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "doesNotMatch"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "NOT modifier",
+                "type": "object",
+                "properties": {
+                  "not": {
+                    "$ref": "#/properties/request/properties/bodyPatterns/items"
+                  }
+                },
+                "required": [
+                  "not"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Before datetime",
+                "type": "object",
+                "properties": {
+                  "before": {
+                    "$ref": "#/$defs/dateTimeExpression"
+                  },
+                  "actualFormat": {
+                    "$ref": "#/$defs/dateFormat"
+                  },
+                  "truncateExpected": {
+                    "$ref": "#/$defs/dateTruncation"
+                  },
+                  "truncateActual": {
+                    "$ref": "#/$defs/dateTruncation"
+                  }
+                },
+                "required": [
+                  "before"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "After datetime",
+                "type": "object",
+                "properties": {
+                  "after": {
+                    "$ref": "#/$defs/dateTimeExpression"
+                  },
+                  "actualFormat": {
+                    "$ref": "#/$defs/dateFormat"
+                  },
+                  "truncateExpected": {
+                    "$ref": "#/$defs/dateTruncation"
+                  },
+                  "truncateActual": {
+                    "$ref": "#/$defs/dateTruncation"
+                  }
+                },
+                "required": [
+                  "after"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Equal to datetime",
+                "type": "object",
+                "properties": {
+                  "equalToDateTime": {
+                    "$ref": "#/$defs/dateTimeExpression"
+                  },
+                  "actualFormat": {
+                    "$ref": "#/$defs/dateFormat"
+                  },
+                  "truncateExpected": {
+                    "$ref": "#/$defs/dateTruncation"
+                  },
+                  "truncateActual": {
+                    "$ref": "#/$defs/dateTruncation"
+                  }
+                },
+                "required": [
+                  "equalToDateTime"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "JSON equals",
+                "type": "object",
+                "properties": {
+                  "equalToJson": {
+                    "type": "object",
+                    "examples": [
+                      {
+                        "amount": {
+                          "value": "${json-unit.any-number}",
+                          "currency_code": "EUR"
+                        },
+                        "invoice_id": "INVOICE-123",
+                        "final_capture": true,
+                        "note_to_payer": "${json-unit.any-string}",
+                        "soft_descriptor": "Bob's Custom Sweaters"
+                      }
+                    ]
+                  },
+                  "ignoreExtraElements": {
+                    "type": "boolean"
+                  },
+                  "ignoreArrayOrder": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "equalToJson"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "JSONPath match",
+                "type": "object",
+                "properties": {
+                  "matchesJsonPath": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "examples": ["$.name"]
+                      },
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "properties": {
+                              "expression": {
+                                "type": "string",
+                                "examples": ["$.name"]
+                              }
+                            }
+                          },
+                          {
+                            "$ref": "#/properties/request/properties/bodyPatterns/items"
+                          }
+                        ],
+                        "required": [
+                          "expression"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "matchesJsonPath"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "XML equality",
+                "type": "object",
+                "properties": {
+                  "equalToXml": {
+                    "type": "string",
+                    "examples": ["<amount>123</amount>"]
+                  },
+                  "enablePlaceholders": {
+                    "type": "boolean"
+                  },
+                  "placeholderOpeningDelimiterRegex": {
+                    "type": "string",
+                    "examples": ["["]
+                  },
+                  "placeholderClosingDelimiterRegex": {
+                    "type": "string",
+                    "examples": ["]"]
+                  }
+                },
+                "required": [
+                  "equalToXml"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "XPath match",
+                "type": "object",
+                "properties": {
+                  "matchesXPath": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "examples": ["//Order/Amount"]
+                      },
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "properties": {
+                              "expression": {
+                                "type": "string",
+                                "examples": ["//Order/Amount"]
+                              }
+                            }
+                          },
+                          {
+                            "$ref": "#/properties/request/properties/bodyPatterns/items"
+                          }
+                        ],
+                        "required": [
+                          "expression"
+                        ]
+                      }
+                    ]
+                  },
+                  "xPathNamespaces": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "matchesXPath"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "JSON Schema match",
+                "type": "object",
+                "properties": {
+                  "matchesJsonSchema": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "examples": ["//Order/Amount"]
+                      },
+                      {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "properties": {
+                              "expression": {
+                                "type": "string",
+                                "examples": ["//Order/Amount"]
+                              }
+                            }
+                          },
+                          {
+                            "$ref": "#/properties/request/properties/bodyPatterns/items"
+                          }
+                        ],
+                        "required": [
+                          "expression"
+                        ]
+                      }
+                    ]
+                  },
+                  "xPathNamespaces": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "matchesJsonSchema"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Absent matcher",
+                "type": "object",
+                "properties": {
+                  "absent": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "absent"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Logical AND matcher",
+                "type": "object",
+                "properties": {
+                  "and": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/properties/request/properties/bodyPatterns/items"
+                    }
+                  }
+                },
+                "required": [
+                  "and"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Logical AND matcher",
+                "type": "object",
+                "properties": {
+                  "or": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/properties/request/properties/bodyPatterns/items"
+                    }
+                  }
+                },
+                "required": [
+                  "or"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Has exactly multi value matcher",
+                "type": "object",
+                "properties": {
+                  "hasExactly": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/properties/request/properties/bodyPatterns/items"
+                    }
+                  }
+                },
+                "required": [
+                  "hasExactly"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "title": "Has exactly multi value matcher",
+                "type": "object",
+                "properties": {
+                  "includes": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/properties/request/properties/bodyPatterns/items"
+                    }
+                  }
+                },
+                "required": [
+                  "includes"
+                ],
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              }
+            ],
+            "$schema": "http://json-schema.org/draft-07/schema#"
+          }
+        },
+        "customMatcher": {
+          "type": "object",
+          "description": "Custom request matcher to match against",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The matcher's name specified in the implementation of the matcher."
+            },
+            "parameters": {
+              "type": "object"
+            }
+          }
+        },
+        "multipartPatterns": {
+          "type": "array",
+          "description": "Multipart patterns to match against headers and body.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "matchingType": {
+                "type": "string",
+                "description": "Determines whether all or any of the parts must match the criteria for an overall match.",
+                "default": "ANY",
+                "enum": [
+                  "ALL",
+                  "ANY"
+                ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Header patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+                "additionalProperties": {
+                  "$ref": "#/properties/request/properties/bodyPatterns/items"
+                }
+              },
+              "bodyPatterns": {
+                "type": "array",
+                "description": "Body patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+                "items": {
+                  "$ref": "#/properties/request/properties/bodyPatterns/items"
+                }
+              }
+            }
+          }
+        }
+      },
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "response": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "integer",
+              "description": "The HTTP status code to be returned"
+            },
+            "statusMessage": {
+              "type": "string",
+              "description": "The HTTP status message to be returned"
+            },
+            "headers": {
+              "type": "object",
+              "description": "Map of response headers to send",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "additionalProxyRequestHeaders": {
+              "type": "object",
+              "description": "Extra request headers to send when proxying to another host.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "removeProxyRequestHeaders": {
+              "type": "array",
+              "description": "Request headers to remove when proxying to another host.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "body": {
+              "type": "string",
+              "description": "The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified."
+            },
+            "base64Body": {
+              "title": "Base64 string",
+              "type": "string",
+              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+              "description": "A base64 encoded string used to describe binary data.",
+              "$schema": "http://json-schema.org/draft-07/schema#"
+            },
+            "jsonBody": {
+              "description": "The response body as a JSON object. Only one of body, base64Body, jsonBody or bodyFileName may be specified.",
+              "oneOf": [
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "array"
+                }
+              ]
+            },
+            "bodyFileName": {
+              "type": "string",
+              "description": "The path to the file containing the response body, relative to the configured file root. Only one of body, base64Body, jsonBody or bodyFileName may be specified.",
+              "examples": ["user-profile-responses/user1.json"]
+            },
+            "fault": {
+              "type": "string",
+              "description": "The fault to apply (instead of a full, valid response).",
+              "enum": [
+                "CONNECTION_RESET_BY_PEER",
+                "EMPTY_RESPONSE",
+                "MALFORMED_RESPONSE_CHUNK",
+                "RANDOM_DATA_THEN_CLOSE"
+              ]
+            },
+            "fixedDelayMilliseconds": {
+              "type": "integer",
+              "description": "Number of milliseconds to delay be before sending the response."
+            },
+            "delayDistribution": {
+              "type": "object",
+              "description": "The delay distribution. Valid property configuration is either median/sigma/type or lower/type/upper.",
+              "oneOf": [
+                {
+                  "title": "Log normal",
+                  "description": "Log normal randomly distributed response delay.",
+                  "type": "object",
+                  "properties": {
+                    "median": {
+                      "type": "integer"
+                    },
+                    "sigma": {
+                      "type": "number"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "lognormal"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "median",
+                    "sigma"
+                  ]
+                },
+                {
+                  "title": "Uniform",
+                  "description": "Uniformly distributed random response delay.",
+                  "type": "object",
+                  "properties": {
+                    "lower": {
+                      "type": "integer"
+                    },
+                    "upper": {
+                      "type": "integer"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "uniform"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "lower",
+                    "upper"
+                  ]
+                },
+                {
+                  "title": "Fixed",
+                  "description": "Fixed response delay.",
+                  "type": "object",
+                  "properties": {
+                    "milliseconds": {
+                      "type": "integer"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "fixed"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "milliseconds"
+                  ]
+                }
+              ],
+              "$schema": "http://json-schema.org/draft-07/schema#"
+            },
+            "chunkedDribbleDelay": {
+              "type": "object",
+              "description": "The parameters for chunked dribble delay - chopping the response into pieces and sending them at delayed intervals",
+              "properties": {
+                "numberOfChunks": {
+                  "type": "integer"
+                },
+                "totalDuration": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "numberOfChunks",
+                "totalDuration"
+              ]
+            },
+            "fromConfiguredStub": {
+              "type": "boolean",
+              "description": "Read-only flag indicating false if this was the default, unmatched response. Not present otherwise."
+            },
+            "proxyBaseUrl": {
+              "type": "string",
+              "description": "The base URL of the target to proxy matching requests to."
+            },
+            "proxyUrlPrefixToRemove": {
+              "type": "string",
+              "description": "A path segment to remove from the beginning in incoming request URL paths before proxying to the target."
+            },
+            "transformerParameters": {
+              "type": "object",
+              "description": "Parameters to apply to response transformers."
+            },
+            "transformers": {
+              "type": "array",
+              "description": "List of names of transformers to apply to this response.",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object"
+    },
+    "persistent": {
+      "type": "boolean",
+      "description": "Indicates that the stub mapping should be persisted immediately on create/update/delete and survive resets to default."
+    },
+    "priority": {
+      "type": "integer",
+      "description": "This stub mapping's priority relative to others. 1 is highest.",
+      "minimum": 1
+    },
+    "scenarioName": {
+      "type": "string",
+      "description": "The name of the scenario that this stub mapping is part of"
+    },
+    "requiredScenarioState": {
+      "type": "string",
+      "description": "The required state of the scenario in order for this stub to be matched."
+    },
+    "newScenarioState": {
+      "type": "string",
+      "description": "The new state for the scenario to be updated to after this stub is served."
+    },
+    "postServeActions": {
+      "type": "object",
+      "description": "A map of the names of post serve action extensions to trigger and their parameters."
+    },
+    "serveEventListeners": {
+      "type": "array",
+      "description": "The list of serve event listeners",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "requestPhases": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "BEFORE_MATCH",
+                "AFTER_MATCH",
+                "BEFORE_RESPONSE_SENT",
+                "AFTER_COMPLETE"
+              ]
+            }
+          },
+          "parameters": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Arbitrary metadata to be used for e.g. tagging, documentation. Can also be used to find and remove stubs."
+    }
+  },
+  "$defs": {
+    "dateTimeExpression": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "examples": ["now +3 days"]
+    },
+    "dateFormat": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "examples": ["yyyy-MM-dd"]
+    },
+    "dateTruncation": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "enum": [
+        "first second of minute",
+        "first minute of hour",
+        "first hour of day",
+        "first day of month",
+        "first day of next month",
+        "last day of month",
+        "first day of year",
+        "first day of next year",
+        "last day of year"
+      ],
+      "examples": ["first day of month"]
+    }
+  }
+}

--- a/src/test/wiremock-stub-mapping/github-200-get-user.json
+++ b/src/test/wiremock-stub-mapping/github-200-get-user.json
@@ -1,0 +1,49 @@
+{
+  "id": "c633c2fd-2872-4695-b124-fe67ecd0a42a",
+  "name": "User lookup by ID",
+  "persistent": true,
+  "request": {
+    "method": "GET",
+    "urlPath": "/2/users/8"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "data": {
+        "created_at": "2013-12-14T04:35:55Z",
+        "id": "2244994945",
+        "name": "Twitter Dev",
+        "protected": false,
+        "username": "TwitterDev"
+      },
+      "includes": {
+        "media": [
+          {
+            "height": 6428722737585564622,
+            "media_key": "5326705140_51078123027441657570424",
+            "type": "l3vcdecv5x7zi74olt3t0l5tf7cvgqy916up9px5y9kdebfzbq7zd2117f7x1t89ca0edly4tyh06zil224vkcrx5",
+            "width": 9087682340593629625
+          }
+        ],
+        "topics": [
+          {
+            "description": "All about technology",
+            "id": "tqri",
+            "name": "Technology"
+          }
+        ],
+        "tweets": [
+          {
+            "author_id": "2244994945",
+            "created_at": "Wed Jan 06 18:40:40 +0000 2021",
+            "id": "1346889436626259968",
+            "text": "Learn how to use the user Tweet timeline and user mention timeline endpoints in the Twitter API v2 to explore Tweet\\u2026 https:\\/\\/t.co\\/56a0vZUx7i"
+          }
+        ]
+      }
+    },
+    "status": 200
+  }
+}

--- a/src/test/wiremock-stub-mapping/github-200-get-user.json
+++ b/src/test/wiremock-stub-mapping/github-200-get-user.json
@@ -17,31 +17,6 @@
         "name": "Twitter Dev",
         "protected": false,
         "username": "TwitterDev"
-      },
-      "includes": {
-        "media": [
-          {
-            "height": 6428722737585564622,
-            "media_key": "5326705140_51078123027441657570424",
-            "type": "l3vcdecv5x7zi74olt3t0l5tf7cvgqy916up9px5y9kdebfzbq7zd2117f7x1t89ca0edly4tyh06zil224vkcrx5",
-            "width": 9087682340593629625
-          }
-        ],
-        "topics": [
-          {
-            "description": "All about technology",
-            "id": "tqri",
-            "name": "Technology"
-          }
-        ],
-        "tweets": [
-          {
-            "author_id": "2244994945",
-            "created_at": "Wed Jan 06 18:40:40 +0000 2021",
-            "id": "1346889436626259968",
-            "text": "Learn how to use the user Tweet timeline and user mention timeline endpoints in the Twitter API v2 to explore Tweet\\u2026 https:\\/\\/t.co\\/56a0vZUx7i"
-          }
-        ]
       }
     },
     "status": 200

--- a/src/test/wiremock-stub-mapping/github-201-create-repo.json
+++ b/src/test/wiremock-stub-mapping/github-201-create-repo.json
@@ -1,0 +1,36 @@
+{
+  "id": "b39c90a0-2336-48e9-8490-08544239b29c",
+  "name": "Create a repository for the authenticated user (application/json) - default",
+  "request": {
+    "headers": {
+      "Accept": {
+        "contains": "application/json"
+      }
+    },
+    "method": "POST",
+    "urlPath": "/user/repos"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "archived": false,
+      "clone_url": "https://github.com/octocat/Hello-World.git",
+      "created_at": "2011-01-26T19:01:12Z",
+      "default_branch": "master",
+      "full_name": "octocat/Hello-World",
+      "homepage": "https://github.com",
+      "id": 1296269,
+      "license": {
+        "key": "mit",
+        "name": "MIT License",
+        "url": "https://api.github.com/licenses/mit"
+      },
+      "name": "Hello-World",
+      "private": false,
+      "watchers": 80
+    },
+    "status": 201
+  }
+}


### PR DESCRIPTION
Add the `wiremock-stub-mapping.json` schema. 
I have extracted it from the [OpenAPI spec](https://github.com/wiremock/wiremock/blob/master/src/main/resources/swagger/wiremock-admin-api.json) in the WireMock repository and added some tests.

More infos about WireMock: https://wiremock.org