### PR TITLE
update vCluster schema url

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6917,7 +6917,7 @@
         "vcluster.yaml",
         "vcluster.yml"
       ],
-      "url": "https://raw.githubusercontent.com/loft-sh/vcluster/main/chart/values.schema.json"
+      "url": "https://raw.githubusercontent.com/loft-sh/vcluster-config/main/vcluster.schema.json"
     },
     {
       "name": "well-known-fursona",


### PR DESCRIPTION
We now have a separate repo where we keep up-to-date vCluster configuration in the jsonschema format.
