### PR TITLE
Update location for ioBroker JSON UI schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2794,7 +2794,7 @@
       "name": "ioBroker JSON UI",
       "description": "ioBroker JSON-based admin user interfaces - config, custom and tabs",
       "fileMatch": ["jsonConfig.json", "jsonCustom.json", "jsonTab.json"],
-      "url": "https://raw.githubusercontent.com/ioBroker/adapter-react-v5/main/schemas/jsonConfig.json"
+      "url": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/packages/jsonConfig/schemas/jsonConfig.json"
     },
     {
       "name": "ioBroker Package manifest",


### PR DESCRIPTION
This PR updates the location of ioBroker JSON UI schema to https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/packages/jsonConfig/schemas/jsonConfig.json
