### PR TITLE
Add Plex Prerolls config schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4027,7 +4027,7 @@
     {
       "name": "Plex Prerolls",
       "description": "Plex Prerolls configuration",
-      "fileMatch": ["config.yml", "config.yaml"],
+      "fileMatch": [],
       "url": "https://raw.githubusercontent.com/nwithan8/plex-prerolls/main/.schema/config.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4025,6 +4025,12 @@
       }
     },
     {
+      "name": "Plex Prerolls",
+      "description": "Plex Prerolls configuration",
+      "fileMatch": ["config.yaml"],
+      "url": "https://raw.githubusercontent.com/nwithan8/plex-prerolls/main/.schema/config.schema.json"
+    },
+    {
       "name": "podbard.yaml",
       "description": "Configuration file for Podbard - a podcast site generator",
       "fileMatch": ["podbard.yaml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4027,7 +4027,7 @@
     {
       "name": "Plex Prerolls",
       "description": "Plex Prerolls configuration",
-      "fileMatch": ["config.yaml"],
+      "fileMatch": ["config.yml", "config.yaml"],
       "url": "https://raw.githubusercontent.com/nwithan8/plex-prerolls/main/.schema/config.schema.json"
     },
     {


### PR DESCRIPTION
Add externally-hosted schema for [Plex Prerolls](https://raw.githubusercontent.com/nwithan8/plex-prerolls/main/.schema/config.schema.json) configuration files
