### PR TITLE
Add Bitmovin Encoding Template schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7183,7 +7183,7 @@
         "*.encoding.yml",
         "*.encoding.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/refs/heads/main/bitmovin-encoding-template.json"
+      "url": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7175,11 +7175,7 @@
     {
       "name": "Bitmovin Encoding Template",
       "description": "An encoding workflow from a single configuration template",
-      "fileMatch": [
-        "*.bitmovin.json",
-        "*.bitmovin.yml",
-        "*.bitmovin.yaml"
-      ],
+      "fileMatch": ["*.bitmovin.json", "*.bitmovin.yml", "*.bitmovin.yaml"],
       "url": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json"
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7178,10 +7178,7 @@
       "fileMatch": [
         "*.bitmovin.json",
         "*.bitmovin.yml",
-        "*.bitmovin.yaml",
-        "*.encoding.json",
-        "*.encoding.yml",
-        "*.encoding.yaml"
+        "*.bitmovin.yaml"
       ],
       "url": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json"
     }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7171,6 +7171,19 @@
       "description": "WireMock stub mapping JSON. See https://wiremock.org/docs/stubbing/",
       "fileMatch": ["wiremock-stub-mapping.yml", "wiremock-stub-mapping.yaml"],
       "url": "https://json.schemastore.org/wiremock-stub-mapping.json"
+    },
+    {
+      "name": "Bitmovin Encoding Template",
+      "description": "An encoding workflow from a single configuration template",
+      "fileMatch": [
+        "*.bitmovin.json",
+        "*.bitmovin.yml",
+        "*.bitmovin.yaml",
+        "*.encoding.json",
+        "*.encoding.yml",
+        "*.encoding.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/refs/heads/main/bitmovin-encoding-template.json"
     }
   ]
 }


### PR DESCRIPTION
Add externally-hosted schema for [Bitmovin Encoding Templates](https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json) configuration files
