### PR TITLE
Add schema for the CloudCannon configuration file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -497,6 +497,19 @@
       "url": "https://raw.githubusercontent.com/codifyCLI/codify-schemas/main/src/schemastore/codify-schema.json"
     },
     {
+      "name": "CloudCannon Configuration",
+      "description": "Configuration file for CloudCannon, the Git-based CMS that brings visual editing to your modern tech stack, freeing developers from content tasks while empowering editors to make changes.",
+      "fileMatch": [
+        "cloudcannon.config.yml",
+        "cloudcannon.config.yaml",
+        "cloudcannon.config.json",
+        "*.cloudcannon.config.yml",
+        "*.cloudcannon.config.yaml",
+        "*.cloudcannon.config.json"
+      ],
+      "url": "https://github.com/cloudcannon/configuration-types/releases/latest/download/cloudcannon-config.schema.json"
+    },
+    {
       "name": "latexindent configuration",
       "description": "Configuration file for latexindent",
       "fileMatch": ["latexindent.yaml", ".latexindent.yaml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -498,7 +498,7 @@
     },
     {
       "name": "CloudCannon Configuration",
-      "description": "Configuration file for CloudCannon, the Git-based CMS that brings visual editing to your modern tech stack, freeing developers from content tasks while empowering editors to make changes.",
+      "description": "Configuration file for CloudCannon, the Git-based CMS that brings visual editing to your modern tech stack, freeing developers from content tasks while empowering editors to make changes",
       "fileMatch": [
         "cloudcannon.config.yml",
         "cloudcannon.config.yaml",


### PR DESCRIPTION
Add externally hosted schema for the CloudCannon configuration file.

- Issue: https://github.com/SchemaStore/schemastore/issues/4225
- Externally hosted schema: https://github.com/cloudcannon/configuration-types/releases/latest/download/cloudcannon-config.schema.json
