### PR TITLE
feat(pyproject): Add PDM Dockerize  `tool.pdm.dockerize` schema

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -303,6 +303,7 @@
     "partial-cibuildwheel.json", // pyproject.json[tool.cibuildwheel]
     "partial-mypy.json", // pyproject.json[tool.mypy]
     "partial-pdm.json", // pyproject.json[tool.pdm]
+    "partial-pdm-dockerize.json", // pyproject.json[tool.pdm.dockerize]
     "partial-poetry.json", // pyproject.json[tool.poetry]
     "partial-eslint-plugins.json", // eslintrc.json[rules.*]
     "partial-fusion-pack-metadata.json", // minecraft-pack-mcmeta.json[fusion]
@@ -905,7 +906,11 @@
       "unknownKeywords": ["markdownDescription", "x-intellij-html-description"]
     },
     "partial-pdm.json": {
-      "unknownKeywords": ["x-taplo", "x-taplo-info"]
+      "unknownKeywords": ["x-taplo", "x-taplo-info"],
+      "externalSchema": ["partial-pdm-dockerize.json"]
+    },
+    "partial-pdm-dockerize.json": {
+      "unknownKeywords": ["x-taplo"]
     },
     "partial-poetry.json": {
       "externalSchema": ["base.json"]
@@ -959,6 +964,7 @@
         "partial-cibuildwheel.json",
         "partial-mypy.json",
         "partial-pdm.json",
+        "partial-pdm-dockerize.json",
         "partial-poetry.json",
         "partial-pyright.json",
         "partial-scikit-build.json",

--- a/src/schemas/json/partial-pdm-dockerize.json
+++ b/src/schemas/json/partial-pdm-dockerize.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/partial-pdm-dockerize.json",
+  "$comment": "PDM Dockerize plugin table in pyproject.toml",
+  "definitions": {
+    "fnmatch-filter": {
+      "type": "string",
+      "description": "A Unix filename pattern filter",
+      "examples": ["filename", "filename.*", "*.ext", "script?/*-[!-_].sh"],
+      "x-taplo": {
+        "links": {
+          "key": "https://docs.python.org/3/library/fnmatch.html"
+        }
+      }
+    },
+    "selector": {
+      "oneOf": [
+        { "$ref": "#/definitions/fnmatch-filter" },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/fnmatch-filter"
+          }
+        }
+      ]
+    }
+  },
+  "properties": {
+    "include": {
+      "$ref": "#/definitions/selector",
+      "description": "fnmatch filter patterns for included PDM scripts",
+      "x-taplo": {
+        "links": {
+          "key": "https://github.com/noirbizarre/pdm-dockerize?#selecting-scripts"
+        }
+      }
+    },
+    "exclude": {
+      "$ref": "#/definitions/selector",
+      "description": "fnmatch filter patterns for excluded PDM scripts",
+      "x-taplo": {
+        "links": {
+          "key": "https://github.com/noirbizarre/pdm-dockerize?#selecting-scripts"
+        }
+      }
+    },
+    "include_bins": {
+      "$ref": "#/definitions/selector",
+      "description": "fnmatch filter patterns for included binaries",
+      "x-taplo": {
+        "links": {
+          "key": "https://github.com/noirbizarre/pdm-dockerize?#selecting-binaries"
+        }
+      }
+    },
+    "exclude_bins": {
+      "$ref": "#/definitions/selector",
+      "description": "fnmatch filter patterns for excluded binaries",
+      "x-taplo": {
+        "links": {
+          "key": "https://github.com/noirbizarre/pdm-dockerize?#selecting-binaries"
+        }
+      }
+    },
+    "env_file": {
+      "type": "string",
+      "description": "Path to a file with environment variables",
+      "x-taplo": {
+        "links": {
+          "key": "https://github.com/noirbizarre/pdm-dockerize?#loading-docker-only-environment-files"
+        }
+      }
+    },
+    "env": {
+      "type": "object",
+      "description": "Environment variables applied when running the script",
+      "additionalProperties": { "type": "string" },
+      "x-taplo": {
+        "links": {
+          "key": "https://github.com/noirbizarre/pdm-dockerize?#defining-docker-only-environment-variables"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "x-taplo": {
+    "links": {
+      "key": "https://github.com/noirbizarre/pdm-dockerize?#usage"
+    }
+  }
+}

--- a/src/schemas/json/partial-pdm.json
+++ b/src/schemas/json/partial-pdm.json
@@ -739,6 +739,9 @@
           "key": "https://backend.pdm-project.org/build_config/#specify-the-package-files"
         }
       }
+    },
+    "dockerize": {
+      "$ref": "https://json.schemastore.org/partial-pdm-dockerize.json"
     }
   },
   "type": "object",

--- a/src/test/pyproject/pdm_tool_dockerize.toml
+++ b/src/test/pyproject/pdm_tool_dockerize.toml
@@ -1,0 +1,9 @@
+[tool.pdm.dockerize]
+include = "*"
+exclude = "some-script"
+include_bins = "*"
+exclude_bins = "some-bin"
+env_file = "my.env"
+
+[tool.pdm.dockerize.env]
+VAR = "value"

--- a/src/test/pyproject/pdm_tool_dockerize_list.toml
+++ b/src/test/pyproject/pdm_tool_dockerize_list.toml
@@ -1,0 +1,9 @@
+[tool.pdm.dockerize]
+include = ["*"]
+exclude = ["some-script"]
+include_bins = ["*"]
+exclude_bins = ["some-bin"]
+env_file = "my.env"
+
+[tool.pdm.dockerize.env]
+VAR = "value"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Hello,

This PR add supports for the [PDM Dockerize extension](https://github.com/noirbizarre/pdm-dockerize) which is using the `tool.pdm.dockerize` table in `pyproject.toml`.
As it is an extension, I chose to submit the schema as an extra `partial-pdm-dockerize.json` schema instead of having it inlined in `partial-pdm.json`
