### PR TITLE
Add SemVer schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7184,6 +7184,11 @@
       "description": "WireMock stub mapping JSON. See https://wiremock.org/docs/stubbing/",
       "fileMatch": ["wiremock-stub-mapping.yml", "wiremock-stub-mapping.yaml"],
       "url": "https://json.schemastore.org/wiremock-stub-mapping.json"
+    },
+    {
+      "name": "SemVer",
+      "description": "A semver.org compliant semantic version number",
+      "url": "https://json.schemastore.org/semver.json"
     }
   ]
 }

--- a/src/negative_test/semver/semver.json
+++ b/src/negative_test/semver/semver.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "caret": "^1.0.0",
-    "tilde": "~1.0.0",
     "range": "1.x",
-    "wildcard": "*",
-    "tag": "latest"
+    "tag": "latest",
+    "tilde": "~1.0.0",
+    "wildcard": "*"
   }
 }

--- a/src/negative_test/semver/semver.json
+++ b/src/negative_test/semver/semver.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "caret": "^1.0.0",
+    "tilde": "~1.0.0",
+    "range": "1.x",
+    "wildcard": "*",
+    "tag": "latest"
+  }
+}

--- a/src/schemas/json/semver.json
+++ b/src/schemas/json/semver.json
@@ -1,0 +1,9 @@
+{
+  "$id": "https://json.schemastore.org/semver.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "A semver.org compliant semantic version number",
+  "$comment": "https://semver.org#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string",
+  "type": "string",
+  "minLength": 3,
+  "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+}

--- a/src/schemas/json/semver.json
+++ b/src/schemas/json/semver.json
@@ -1,8 +1,8 @@
 {
-  "$id": "https://json.schemastore.org/semver.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "A semver.org compliant semantic version number",
+  "$id": "https://json.schemastore.org/semver.json",
   "$comment": "https://semver.org#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string",
+  "description": "A semver.org compliant semantic version number",
   "type": "string",
   "minLength": 3,
   "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"

--- a/src/test/semver/semver.json
+++ b/src/test/semver/semver.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "major": "1.0.0",
+    "minor": "0.10.0",
+    "patch": "0.0.1"
+  }
+}


### PR DESCRIPTION
For use as `$ref`erence, for example:
~~~ jsonc
"$schema": "http://json-schema.org/draft-07/schema#",
"$id": "/schemas/semver",
"properties": {
  "dependencies": {
    "type": "object",
    "additionalProperties": {
      "$ref": "https://json.schemastore.org/semver.json"
    }
  }
}
~~~
~~~ jsonc
"$schema": "/schemas/semver",
"dependencies": {
  "semver": "1.0.0",
  "minor": "0.10.0"
},
~~~