### PR TITLE
Add npm SemVer schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7184,6 +7184,11 @@
       "description": "WireMock stub mapping JSON. See https://wiremock.org/docs/stubbing/",
       "fileMatch": ["wiremock-stub-mapping.yml", "wiremock-stub-mapping.yaml"],
       "url": "https://json.schemastore.org/wiremock-stub-mapping.json"
+    },
+    {
+      "name": "npm SemVer range",
+      "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency",
+      "url": "https://json.schemastore.org/npm-semver.json"
     }
   ]
 }

--- a/src/schemas/json/npm-semver.json
+++ b/src/schemas/json/npm-semver.json
@@ -1,0 +1,9 @@
+{
+  "$id": "https://json.schemastore.org/npm-semver.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency",
+  "$comment": "https://github.com/npm/node-semver#range-grammar",
+  "type": "string",
+  "minLength": 3,
+  "pattern": "^(?:\\*|latest|next|(?:^v?|\\sv?|[~^]|[<>]=?)?(0|[1-9xX*]\\d*)\\.(0|[1-9xX*]\\d*)(?:\\.(0|[1-9xX*]\\d*)(?:-((?:0|[1-9xX*]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9xX*]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)$"
+}

--- a/src/schemas/json/npm-semver.json
+++ b/src/schemas/json/npm-semver.json
@@ -1,8 +1,8 @@
 {
-  "$id": "https://json.schemastore.org/npm-semver.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency",
+  "$id": "https://json.schemastore.org/npm-semver.json",
   "$comment": "https://github.com/npm/node-semver#range-grammar",
+  "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency",
   "type": "string",
   "minLength": 3,
   "pattern": "^(?:\\*|latest|next|(?:^v?|\\sv?|[~^]|[<>]=?)?(0|[1-9xX*]\\d*)\\.(0|[1-9xX*]\\d*)(?:\\.(0|[1-9xX*]\\d*)(?:-((?:0|[1-9xX*]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9xX*]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)$"

--- a/src/test/npm-semver/npm-semver.json
+++ b/src/test/npm-semver/npm-semver.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "caret": "^1.0.0",
-    "tilde": "~1.0.0",
-    "range": "1.x",
-    "more": ">=1.0.0",
     "less": "<=2.0.0",
-    "wildcard": "*",
-    "tag": "latest"
+    "more": ">=1.0.0",
+    "range": "1.x",
+    "tag": "latest",
+    "tilde": "~1.0.0",
+    "wildcard": "*"
   }
 }

--- a/src/test/npm-semver/npm-semver.json
+++ b/src/test/npm-semver/npm-semver.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "caret": "^1.0.0",
+    "tilde": "~1.0.0",
+    "range": "1.x",
+    "more": ">=1.0.0",
+    "less": "<=2.0.0",
+    "wildcard": "*",
+    "tag": "latest"
+  }
+}


### PR DESCRIPTION
For use as `$ref`erence, for example:
~~~ jsonc
"$schema": "http://json-schema.org/draft-07/schema#",
"$id": "/schemas/npm-semver",
"properties": {
  "dependencies": {
    "type": "object",
    "additionalProperties": {
      "$ref": "https://json.schemastore.org/npm-semver.json"
    }
  }
}
~~~
~~~ jsonc
"$schema": "/schemas/npm-semver",
"dependencies": {
  "caret": "^1.0.0",
  "tilde": "~1.0.0",
  "range": "1.x",
  "more": ">=1.0.0",
  "less": "<=2.0.0",
  "wildcard": "*",
  "tag": "latest"
}
~~~