### PR TITLE
Add npm package name schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7184,6 +7184,11 @@
       "description": "WireMock stub mapping JSON. See https://wiremock.org/docs/stubbing/",
       "fileMatch": ["wiremock-stub-mapping.yml", "wiremock-stub-mapping.yaml"],
       "url": "https://json.schemastore.org/wiremock-stub-mapping.json"
+    },
+    {
+      "name": "npm package name",
+      "description": "A valid npm package name, with optional scope",
+      "url": "https://json.schemastore.org/npm-package-name.json"
     }
   ]
 }

--- a/src/negative_test/npm-package-name/npm-package-name.json
+++ b/src/negative_test/npm-package-name/npm-package-name.json
@@ -1,0 +1,3 @@
+{
+  "name": "package name"
+}

--- a/src/schemas/json/npm-package-name.json
+++ b/src/schemas/json/npm-package-name.json
@@ -1,0 +1,10 @@
+{
+  "$id": "https://json.schemastore.org/npm-package-name.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "A valid npm package name, with optional scope",
+  "$comment": "https://github.com/npm/validate-npm-package-name#naming-rules",
+  "type": "string",
+  "minLength": 1,
+  "maxLength": 214,
+  "pattern": "^(@[a-z0-9-~][a-z0-9-._~]*\\/)?[a-z0-9-~][a-z0-9-._~]*$"
+}

--- a/src/schemas/json/npm-package-name.json
+++ b/src/schemas/json/npm-package-name.json
@@ -1,8 +1,8 @@
 {
-  "$id": "https://json.schemastore.org/npm-package-name.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "A valid npm package name, with optional scope",
+  "$id": "https://json.schemastore.org/npm-package-name.json",
   "$comment": "https://github.com/npm/validate-npm-package-name#naming-rules",
+  "description": "A valid npm package name, with optional scope",
   "type": "string",
   "minLength": 1,
   "maxLength": 214,

--- a/src/test/npm-package-name/npm-package-name.json
+++ b/src/test/npm-package-name/npm-package-name.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-name",
+  "scoped": "@scope/package-name"
+}


### PR DESCRIPTION
For use as `$ref`erence, for example:
~~~ jsonc
"$schema": "http://json-schema.org/draft-07/schema#",
"$id": "/schemas/npm-package-name",
"properties": {
  "dependencies": {
    "type": "object",
    "propertyNames": {
      "$ref": "https://json.schemastore.org/npm-package-name.json"
    }
  }
}
~~~
~~~ jsonc
"$schema": "/schemas/npm-package-name",
"dependencies": {
  "@scope/package-name": "^1.0.0",
  "package-name": "^1.0.0"
},
~~~