### PR TITLE
cibuildwheel: update for 2.22

### DIFF
--- a/src/schemas/json/partial-cibuildwheel.json
+++ b/src/schemas/json/partial-cibuildwheel.json
@@ -6,10 +6,14 @@
       "enum": ["none", "prepend", "append"],
       "default": "none",
       "description": "How to inherit the parent's value."
-    }
+    },
+    "enable": {
+      "enum": ["cpython-freethreading", "cpython-prerelease", "pypy"]
+    },
+    "description": "A Python version or flavor to enable."
   },
   "additionalProperties": false,
-  "description": "cibuildwheel's toml file, generated with ./bin/generate_schema.py --schemastore from cibuildwheel.",
+  "description": "cibuildwheel's settings.",
   "type": "object",
   "properties": {
     "archs": {
@@ -203,6 +207,21 @@
       "type": "string",
       "title": "CIBW_DEPENDENCY_VERSIONS"
     },
+    "enable": {
+      "description": "Enable or disable certain builds.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/enable"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/enable"
+          }
+        }
+      ],
+      "title": "CIBW_ENABLE"
+    },
     "environment": {
       "description": "Set environment variables needed during the build.",
       "oneOf": [
@@ -240,12 +259,18 @@
       "type": "boolean",
       "default": false,
       "description": "The project supports free-threaded builds of Python (PEP703)",
+      "deprecated": "Use the `enable` option instead.",
       "title": "CIBW_FREE_THREADED_SUPPORT"
     },
     "manylinux-aarch64-image": {
       "type": "string",
       "description": "Specify alternative manylinux / musllinux container images",
       "title": "CIBW_MANYLINUX_AARCH64_IMAGE"
+    },
+    "manylinux-armv7l-image": {
+      "type": "string",
+      "description": "Specify alternative manylinux / musllinux container images",
+      "title": "CIBW_MANYLINUX_ARMV7L_IMAGE"
     },
     "manylinux-i686-image": {
       "type": "string",
@@ -372,6 +397,21 @@
       ],
       "title": "CIBW_TEST_EXTRAS"
     },
+    "test-groups": {
+      "description": "Install extra groups when testing",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ],
+      "title": "CIBW_TEST_GROUPS"
+    },
     "test-requires": {
       "description": "Install Python dependencies before running the tests",
       "oneOf": [
@@ -496,6 +536,9 @@
           "manylinux-aarch64-image": {
             "$ref": "#/properties/manylinux-aarch64-image"
           },
+          "manylinux-armv7l-image": {
+            "$ref": "#/properties/manylinux-armv7l-image"
+          },
           "manylinux-i686-image": {
             "$ref": "#/properties/manylinux-i686-image"
           },
@@ -544,6 +587,9 @@
           "test-extras": {
             "$ref": "#/properties/test-extras"
           },
+          "test-groups": {
+            "$ref": "#/properties/test-groups"
+          },
           "test-requires": {
             "$ref": "#/properties/test-requires"
           }
@@ -586,6 +632,9 @@
         },
         "manylinux-aarch64-image": {
           "$ref": "#/properties/manylinux-aarch64-image"
+        },
+        "manylinux-armv7l-image": {
+          "$ref": "#/properties/manylinux-armv7l-image"
         },
         "manylinux-i686-image": {
           "$ref": "#/properties/manylinux-i686-image"
@@ -648,6 +697,9 @@
         "test-extras": {
           "$ref": "#/properties/test-extras"
         },
+        "test-groups": {
+          "$ref": "#/properties/test-groups"
+        },
         "test-requires": {
           "$ref": "#/properties/test-requires"
         }
@@ -692,6 +744,9 @@
         },
         "test-extras": {
           "$ref": "#/properties/test-extras"
+        },
+        "test-groups": {
+          "$ref": "#/properties/test-groups"
         },
         "test-requires": {
           "$ref": "#/properties/test-requires"
@@ -751,6 +806,9 @@
         "test-extras": {
           "$ref": "#/properties/test-extras"
         },
+        "test-groups": {
+          "$ref": "#/properties/test-groups"
+        },
         "test-requires": {
           "$ref": "#/properties/test-requires"
         }
@@ -795,6 +853,9 @@
         },
         "test-extras": {
           "$ref": "#/properties/test-extras"
+        },
+        "test-groups": {
+          "$ref": "#/properties/test-groups"
         },
         "test-requires": {
           "$ref": "#/properties/test-requires"


### PR DESCRIPTION
Includes fix in https://github.com/pypa/cibuildwheel/pull/2093.
