### PR TITLE
feat(circleciconfig): extend the schema of the requires stanza

### DIFF
--- a/src/negative_test/circleciconfig/invalid-workflow-job-requires.yml
+++ b/src/negative_test/circleciconfig/invalid-workflow-job-requires.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../schemas/json/circleciconfig.json
+version: 2.1
+
+workflows:
+  test-workflow:
+    jobs:
+      - foo
+      - bar:
+          requires:
+            - foo: invalid_job_status

--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -1071,7 +1071,38 @@
           "description": "Jobs are run in parallel by default, so you must explicitly require any dependencies by their job name.",
           "type": "array",
           "items": {
-            "type": "string"
+            "oneOf": [
+              {
+                "description": "A dependency defined by their job name.",
+                "type": "string"
+              },
+              {
+                "description": "A dependency defined by their job name, and required statuses.",
+                "type": "object",
+                "minProperties": 1,
+                "maxProperties": 1,
+                "patternProperties": {
+                  "^[A-Za-z][A-Za-z\\s\\d_-]*$": {
+                    "oneOf": [
+                      {
+                        "description": "A status that the job must have to satisfy the dependency.",
+                        "type": "string",
+                        "enum": ["success", "failed", "canceled"]
+                      },
+                      {
+                        "description": "A list of statuses that the job must have one of to satisfy the dependency.",
+                        "type": "array",
+                        "minLength": 1,
+                        "items": {
+                          "type": "string",
+                          "enum": ["success", "failed", "canceled"]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
           }
         },
         "name": {

--- a/src/test/circleciconfig/workflow-job-requires.yaml
+++ b/src/test/circleciconfig/workflow-job-requires.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../schemas/json/circleciconfig.json
+version: 2.1
+
+workflows:
+  test-workflow:
+    jobs:
+      - foo
+      - bar
+      - baz
+      - qux:
+          requires:
+            - foo
+            - bar: failed
+            - baz:
+                - success
+                - canceled


### PR DESCRIPTION
This PR updates the schema of the `requires` key for CircleCI workflow jobs.
