### PR TITLE
Add minimal dtool dataset metadata schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7190,6 +7190,13 @@
       "description": "An encoding workflow from a single configuration template",
       "fileMatch": ["*.bitmovin.json", "*.bitmovin.yml", "*.bitmovin.yaml"],
       "url": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json"
+    },
+    {
+      "name": "dtool dataset metadata",
+      "description": "Metadata attached to a dtool dataset",
+      "fileMatch": ["dtool-dataset-metadata.yml", "dtool-dataset-metadata.yaml"],
+      "url": "https://json.schemastore.org/dtool-dataset-metadata.json"
     }
+
   ]
 }

--- a/src/schemas/json/dtool-dataset-metadata.json
+++ b/src/schemas/json/dtool-dataset-metadata.json
@@ -1,0 +1,84 @@
+{
+  "$id": "https://json.schemastore.org/dtool-dataset-metadata.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "title": "DToolDataset",
+  "description": "Schema for metadata attached to a dtool dataset",
+  "type": "object",
+  "properties": {
+    "uuid": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "base_uri": {
+      "type": "string"
+    },
+    "uri": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "readme": {
+      "type": "string"
+    },
+    "manifest": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "hash": {
+                "type": "string"
+              },
+              "relpath": {
+                "type": "string"
+              },
+              "size_in_bytes": {
+                "type": "integer"
+              },
+              "utc_timestamp": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "hash_function": {
+          "type": "string"
+        },
+        "dtoolcore_version": {
+          "type": "string"
+        }
+      }
+    },
+    "creator_username": {
+      "type": "string"
+    },
+    "frozen_at": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "annotations": {
+      "type": "object"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "number_of_items": {
+      "type": "integer"
+    },
+    "size_in_bytes": {
+      "type": "integer"
+    }
+  }
+}

--- a/src/test/dtool-dataset-metadata/dtool-dataset-metadata.json
+++ b/src/test/dtool-dataset-metadata/dtool-dataset-metadata.json
@@ -1,0 +1,30 @@
+{
+    "base_uri": "s3://snow-white",
+    "uuid": "af6727bf-29c7-43dd-b42f-a5d7ede28337",
+    "uri": "s3://snow-white/af6727bf-29c7-43dd-b42f-a5d7ede28337",
+    "name": "my-dataset",
+    "type": "dataset",
+    "readme": "---\ndescription: test dataset",
+    "manifest": {
+        "dtoolcore_version": "3.7.0",
+        "hash_function": "md5sum_hexdigest",
+        "items": {
+            "e4cc3a7dc281c3d89ed4553293c4b4b110dc9bf3": {
+                "hash": "d89117c9da2cc34586e183017cb14851",
+                "relpath": "U00096.3.rev.1.bt2",
+                "size_in_bytes": 5741810,
+                "utc_timestamp": 1536832115.0
+            }
+        }
+    },
+    "creator_username": "olssont",
+    "frozen_at": "1536238185.881941",
+    "annotations": {
+        "software": "bowtie2"
+    },
+    "tags": [
+        "rnaseq"
+    ],
+    "number_of_items": 1,
+    "size_in_bytes": 5741810
+}


### PR DESCRIPTION
I would like to create a universal JSON schema for validating metadata attached to dtool datasets (see articles https://peerj.com/articles/6562/, https://doi.org/10.1371/journal.pone.0306100, and dserver demonstrator at  https://demo.dtool.dev).

I have no experience with creating schema, but I believe these changes should be a minimal starting point.
