### PR TITLE
asmdef.json: rootNamespace can be empty

### DIFF
--- a/src/schemas/json/asmdef.json
+++ b/src/schemas/json/asmdef.json
@@ -71,8 +71,7 @@
     },
     "rootNamespace": {
       "description": "The root namespace of the assembly. Requires Unity 2020.2",
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     },
     "references": {
       "description": "A list of assembly names or assembly asset GUIDs to reference",


### PR DESCRIPTION
It's valid for a Unity asmdef to have an empty rootNamespace, see https://github.com/search?q=path%3A*asmdef+rootNamespace&type=code