### PR TITLE
feat: Add `nitro.json` schema

### DIFF
--- a/src/schemas/json/nitro.json
+++ b/src/schemas/json/nitro.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Nitro Modules Configuration",
+  "type": "object",
+  "required": [
+    "cxxNamespace",
+    "ios",
+    "android",
+    "autolinking"
+  ],
+  "properties": {
+    "cxxNamespace": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "description": "Represents the C++ namespace of the module that will be generated. This can have multiple sub-namespaces, and is always relative to `margelo::nitro`."
+    },
+    "ios": {
+      "type": "object",
+      "required": [
+        "iosModuleName"
+      ],
+      "properties": {
+        "iosModuleName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Represents the iOS module name of the module that will be generated This will be used to generate Swift bridges, as those are always namespaced within the clang module. If you are using CocoaPods, this should be the Pod name defined in the `.podspec`."
+        }
+      },
+      "description": "Required: iOS configuration"
+    },
+    "android": {
+      "type": "object",
+      "required": [
+        "androidNamespace",
+        "androidCxxLibName"
+      ],
+      "properties": {
+        "androidNamespace": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Represents the Android namespace ('package') of the module that will be generated. This can have multiple sub-namespaces, and is always relative to `com.margelo.nitro`."
+        },
+        "androidCxxLibName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Represents the name of the Android C++ library (aka name in CMakeLists.txt `add_library(..)`). This will be loaded via `System.loadLibrary(...)`."
+        }
+      },
+      "description": "Required: Android configuration"
+    },
+    "autolinking": {
+      "type": "object",
+      "description": "Configures the code that gets generated for autolinking (registering) Hybrid Object constructors.",
+      "patternProperties": {
+        "^.*$": {
+          "type": "object",
+          "oneOf": [
+            {
+              "properties": {
+                "cpp": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "cpp"
+              ]
+            },
+            {
+              "properties": {
+                "swift": {
+                  "type": "string"
+                },
+                "kotlin": {
+                  "type": "string"
+                }
+              },
+              "minProperties": 1,
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "ignorePaths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "A list of paths relative to the project directory that should be ignored by nitrogen. Nitrogen will not look for `.nitro.ts` files in these directories."
+    }
+  }
+}

--- a/src/schemas/json/nitro.json
+++ b/src/schemas/json/nitro.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/nitro.json",
   "definitions": {},
-  "id": "https://json.schemastore.org/nitro.json",
   "title": "Nitro Modules Configuration",
   "type": "object",
   "required": [

--- a/src/schemas/json/nitro.json
+++ b/src/schemas/json/nitro.json
@@ -1,5 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {},
+  "id": "https://json.schemastore.org/nitro.json",
   "title": "Nitro Modules Configuration",
   "type": "object",
   "required": [


### PR DESCRIPTION
For https://github.com/mrousavy/nitro - a library for bridging JS code to C++/Swift/Kotlin. Used to create react native modules.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
