### PR TITLE
Add `imports` field to `package.json` schema

### DIFF
--- a/src/negative_test/package/imports-no-char-test.json
+++ b/src/negative_test/package/imports-no-char-test.json
@@ -1,0 +1,7 @@
+{
+  "description": "# is invalid",
+  "imports": {
+    "#": "./foo.js"
+  },
+  "name": "my-mod"
+}

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -330,6 +330,17 @@
         }
       ]
     },
+    "imports": {
+      "description": "The \"imports\" field is used to create private mappings that only apply to import specifiers from within the package itself.",
+      "type": "object",
+      "patternProperties": {
+        "^#.+$": {
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
+          "description": "The module path that is resolved when this environment matches the property name."
+        }
+      },
+      "additionalProperties": false
+    },
     "bin": {
       "type": [
         "string",

--- a/src/test/package/imports-test.json
+++ b/src/test/package/imports-test.json
@@ -1,0 +1,10 @@
+{
+  "description": "subpath/pattern to path/pattern",
+  "imports": {
+    "#*": "./*.js",
+    "#foo/*": "./bar/*.js",
+    "#foo/bar": "./foo/bar.js",
+    "#foo/bar/baz.js": "./foo/bar/baz.js"
+  },
+  "name": "my-mod"
+}

--- a/src/test/package/imports-test2.json
+++ b/src/test/package/imports-test2.json
@@ -1,0 +1,11 @@
+{
+  "description": "subpaths with conditions to paths",
+  "imports": {
+    "#bar": {
+      "default": "./feature.js",
+      "node": "./feature-node.js"
+    },
+    "#foo": "./main.js"
+  },
+  "name": "my-mod"
+}

--- a/src/test/package/imports-test3.json
+++ b/src/test/package/imports-test3.json
@@ -1,0 +1,13 @@
+{
+  "description": "nested conditions",
+  "imports": {
+    "#foo": {
+      "default": "./feature.mjs",
+      "node": {
+        "import": "./feature-node.mjs",
+        "require": "./feature-node.cjs"
+      }
+    }
+  },
+  "name": "my-mod"
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This PR adds `imports` field to `package.json` schema.
https://nodejs.org/docs/latest/api/packages.html#imports
