### PR TITLE
feat: Add `nitro.json` to catalog (self-hosted)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5689,7 +5689,7 @@
     {
       "name": "nitro.json",
       "description": "Nitro Modules configuration file. Documentation: https://margelo.nitro.com",
-      "fileMatch": ["nitro.json"],
+      "fileMatch": [],
       "url": "https://nitro.margelo.com/nitro.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5688,7 +5688,7 @@
     },
     {
       "name": "nitro.json",
-      "description": "A configuration file for Nitro Modules",
+      "description": "Nitro Modules configuration file. Documentation: https://margelo.nitro.com",
       "fileMatch": ["nitro.json"],
       "url": "https://nitro.margelo.com/nitro.schema.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5688,7 +5688,7 @@
     },
     {
       "name": "nitro.json",
-      "description": "A configuration file for Nitro Modules.",
+      "description": "A configuration file for Nitro Modules",
       "fileMatch": ["nitro.json"],
       "url": "https://nitro.margelo.com/nitro.schema.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5687,6 +5687,12 @@
       "url": "https://json.schemastore.org/httpmockrc.json"
     },
     {
+      "name": "nitro.json",
+      "description": "A configuration file for Nitro Modules.",
+      "fileMatch": ["nitro.json"],
+      "url": "https://nitro.margelo.com/nitro.schema.json"
+    },
+    {
       "name": "neoload",
       "description": "Neotys as-code load test specification. Documentation: https://github.com/Neotys-Labs/neoload-cli",
       "fileMatch": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

A follow up PR to #4257 - but I self-host the `nitro.schema.json` file on Nitro's official website instead of the schema store.

nitro.json is for https://github.com/mrousavy/nitro - a library for bridging JS code to C++/Swift/Kotlin. Used to create react native modules.
