### PR TITLE
(partial-pyright) Drop all unnecessary invocation of regex matching

### DIFF
--- a/src/schemas/json/partial-pyright.json
+++ b/src/schemas/json/partial-pyright.json
@@ -6,13 +6,7 @@
   "type": "object",
   "definitions": {
     "diagnostic": {
-      "anyOf": [
-        { "type": "boolean" },
-        {
-          "type": "string",
-          "enum": ["none", "information", "warning", "error"]
-        }
-      ]
+      "enum": ["none", "information", "warning", "error", true, false]
     },
     "extraPaths": {
       "type": "array",
@@ -21,8 +15,7 @@
       "items": {
         "type": "string",
         "title": "Additional import search resolution path",
-        "default": "",
-        "pattern": "^(.*)$"
+        "default": ""
       }
     },
     "pythonVersion": {
@@ -36,14 +29,13 @@
       "pattern": "^3\\.[0-9]+$"
     },
     "pythonPlatform": {
-      "type": "string",
+      "enum": ["Windows", "Darwin", "Linux", "All"],
       "title": "Python platform to assume during type analysis",
       "description": "Specifies the target platform that will be used to execute the source code. Should be one of `Windows`, `Darwin`, `Linux`, or `All`. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
       "markdownDescription": "Specifies the target platform that will be used to execute the source code. Should be one of `Windows`, `Darwin`, `Linux`, or `All`. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
       "x-intellij-html-description": "Specifies the target platform that will be used to execute the source code. Should be one of <code>Windows</code>, <code>Darwin</code>, <code>Linux</code>, or <code>All</code>. If specified, pyright will tailor its use of type stub files, which conditionalize type definitions based on the platform. If no platform is specified, pyright will use the current platform.",
       "default": "",
-      "examples": ["Linux"],
-      "pattern": "^(Linux|Windows|Darwin|All)$"
+      "examples": ["Linux"]
     },
     "disableBytesTypePromotions": {
       "type": "boolean",
@@ -674,8 +666,7 @@
       "title": "Path to configuration file that this configuration extends",
       "description": "Path to another `.json` or `.toml` file that is used as a \"base configuration\", allowing this configuration to inherit configuration settings. Top-level keys within this configuration overwrite top-level keys in the base configuration. Multiple levels of inheritance are supported. Relative paths specified in a configuration file are resolved relative to the location of that configuration file.",
       "markdownDescription": "Path to another `.json` or `.toml` file that is used as a \"base configuration\", allowing this configuration to inherit configuration settings. Top-level keys within this configuration overwrite top-level keys in the base configuration. Multiple levels of inheritance are supported. Relative paths specified in a configuration file are resolved relative to the location of that configuration file.",
-      "x-intellij-html-description": "Path to another <code>.json</code> or <code>.toml</code> file that is used as a &quot;base configuration&quot;, allowing this configuration to inherit configuration settings. Top-level keys within this configuration overwrite top-level keys in the base configuration. Multiple levels of inheritance are supported. Relative paths specified in a configuration file are resolved relative to the location of that configuration file.",
-      "pattern": "^(.*)$"
+      "x-intellij-html-description": "Path to another <code>.json</code> or <code>.toml</code> file that is used as a &quot;base configuration&quot;, allowing this configuration to inherit configuration settings. Top-level keys within this configuration overwrite top-level keys in the base configuration. Multiple levels of inheritance are supported. Relative paths specified in a configuration file are resolved relative to the location of that configuration file."
     },
     "include": {
       "type": "array",
@@ -685,8 +676,7 @@
       "x-intellij-html-description": "Paths of directories or files that should be considered part of the project. If no paths are specified, pyright defaults to the directory that contains the config file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no include paths are specified, the root path for the workspace is assumed.",
       "items": {
         "type": "string",
-        "description": "File or directory to include in type analysis",
-        "pattern": "^(.*)$"
+        "description": "File or directory to include in type analysis"
       }
     },
     "exclude": {
@@ -697,8 +687,7 @@
       "x-intellij-html-description": "Paths of directories or files that should not be considered part of the project. These override the includes directories and files, allowing specific subdirectories to be excluded. Note that files in the exclude paths may still be included in the analysis if they are referenced (imported) by source files that are not excluded. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character). If no exclude paths are specified, Pyright automatically excludes the following: <code>**/node_modules</code>, <code>**/__pycache__</code>, <code>**/.*</code> and any virtual environment directories.",
       "items": {
         "type": "string",
-        "title": "File or directory to exclude from type analysis",
-        "pattern": "^(.*)$"
+        "title": "File or directory to exclude from type analysis"
       }
     },
     "ignore": {
@@ -709,8 +698,7 @@
       "x-intellij-html-description": "Paths of directories or files whose diagnostic output (errors and warnings) should be suppressed even if they are an included file or within the transitive closure of an included file. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character).",
       "items": {
         "type": "string",
-        "title": "File or directory where diagnostics should be suppressed",
-        "pattern": "^(.*)$"
+        "title": "File or directory where diagnostics should be suppressed"
       }
     },
     "strict": {
@@ -721,8 +709,7 @@
       "x-intellij-html-description": "Paths of directories or files that should use &quot;strict&quot; analysis if they are included. This is the same as manually adding a <code># pyright: strict</code> comment. In strict mode, most type-checking rules are enabled. Paths may contain wildcard characters: <code>**</code> (a directory or multiple levels of directories), <code>*</code> (a sequence of zero or more characters), or <code>?</code> (a single character).",
       "items": {
         "type": "string",
-        "title": "File or directory that should use \"strict\" type checking rules",
-        "pattern": "^(.*)$"
+        "title": "File or directory that should use \"strict\" type checking rules"
       }
     },
     "defineConstant": {
@@ -738,7 +725,6 @@
       }
     },
     "typeCheckingMode": {
-      "type": "string",
       "enum": ["off", "basic", "standard", "strict"],
       "title": "Specifies the default rule set to use for type checking",
       "description": "Specifies the default rule set to use. Some rules can be overridden using additional configuration flags documented below. If set to `off`, all type-checking rules are disabled, but Python syntax and semantic errors are still reported.",
@@ -758,8 +744,7 @@
       "description": "Path to a directory that contains `typeshed` type stub files. Pyright ships with a bundled copy of `typeshed` type stubs. If you want to use a different version of `typeshed` stubs, you can clone the `typeshed` GitHub repo (https://github.com/python/typeshed) to a local directory and reference the location with this path. This option is useful if you're actively contributing updates to `typeshed`.",
       "markdownDescription": "Path to a directory that contains `typeshed` type stub files. Pyright ships with a bundled copy of `typeshed` type stubs. If you want to use a different version of `typeshed` stubs, you can clone [the `typeshed` GitHub repo](https://github.com/python/typeshed) to a local directory and reference the location with this path. This option is useful if you're actively contributing updates to `typeshed`.",
       "x-intellij-html-description": "Path to a directory that contains <code>typeshed</code> type stub files. Pyright ships with a bundled copy of <code>typeshed</code> type stubs. If you want to use a different version of <code>typeshed</code> stubs, you can clone <a href=\"https://github.com/python/typeshed\">the <code>typeshed</code> GitHub repo</a> to a local directory and reference the location with this path. This option is useful if you&#39;re actively contributing updates to <code>typeshed</code>.",
-      "default": "",
-      "pattern": "^(.*)$"
+      "default": ""
     },
     "stubPath": {
       "type": "string",
@@ -767,8 +752,7 @@
       "description": "Path to a directory that contains custom type stubs. Each package's type stub file(s) are expected to be in its own subdirectory.",
       "x-intellij-html-description": "Path to a directory that contains custom type stubs. Each package&#39;s type stub file(s) are expected to be in its own subdirectory.",
       "default": "./typings",
-      "examples": ["src/typestubs"],
-      "pattern": "^(.*)$"
+      "examples": ["src/typestubs"]
     },
     "disableBytesTypePromotions": {
       "$ref": "#/definitions/disableBytesTypePromotions"
@@ -1058,8 +1042,7 @@
       "description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a `venv` setting, pyright will search for imports in the virtual environment's site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
       "markdownDescription": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a `venv` setting, pyright will search for imports in the virtual environment's site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
       "x-intellij-html-description": "Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a <code>venv</code> setting, pyright will search for imports in the virtual environment&#39;s site-packages directory rather than the paths specified by the default Python interpreter. If you are working on a project with other developers, it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a per-user setting.",
-      "default": "",
-      "pattern": "^(.*)$"
+      "default": ""
     },
     "venv": {
       "type": "string",
@@ -1068,8 +1051,7 @@
       "markdownDescription": "Used in conjunction with the `venvPath`, specifies the virtual environment to use.",
       "x-intellij-html-description": "Used in conjunction with the <code>venvPath</code>, specifies the virtual environment to use.",
       "default": "",
-      "examples": ["python37"],
-      "pattern": "^(.*)$"
+      "examples": ["python37"]
     },
     "verboseOutput": {
       "type": "boolean",
@@ -1090,8 +1072,7 @@
             "type": "string",
             "title": "Path to code subdirectory to which these settings apply",
             "description": "Root path for the code that will execute within this execution environment.",
-            "default": "",
-            "pattern": "^(.*)$"
+            "default": ""
           },
           "disableBytesTypePromotions": {
             "$ref": "#/definitions/disableBytesTypePromotions"


### PR DESCRIPTION
Will try to sync change back to `pyright` later on
