### PR TITLE
Add the Okteto Manifest schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3676,6 +3676,12 @@
       "url": "https://raw.githubusercontent.com/inetis-ch/october-schemas/master/fields.json"
     },
     {
+      "name": "Okteto",
+      "description": "Okteto Manifest Schema",
+      "fileMatch": ["okteto.json"],
+      "url": "https://raw.githubusercontent.com/okteto/okteto/refs/heads/master/schema.json"
+    }
+    {
       "name": "omnisharp.json",
       "description": "Omnisharp Configuration file",
       "fileMatch": ["omnisharp.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3680,7 +3680,7 @@
       "description": "Okteto Manifest Schema",
       "fileMatch": ["okteto.json"],
       "url": "https://raw.githubusercontent.com/okteto/okteto/refs/heads/master/schema.json"
-    }
+    },
     {
       "name": "omnisharp.json",
       "description": "Omnisharp Configuration file",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3677,7 +3677,7 @@
     },
     {
       "name": "Okteto",
-      "description": "Okteto Manifest Schema",
+      "description": "The Okteto Manifest",
       "fileMatch": ["okteto.json"],
       "url": "https://raw.githubusercontent.com/okteto/okteto/refs/heads/master/schema.json"
     },


### PR DESCRIPTION
Add the Okteto Manifest schema so that users of Okteto can have suggestions and validation in their IDE when creating Okteto Manifests.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
