### PR TITLE
Add rule group labels to Prometheus schema

### DIFF
--- a/src/schemas/json/prometheus.rules.json
+++ b/src/schemas/json/prometheus.rules.json
@@ -103,6 +103,10 @@
             "$ref": "#/definitions/duration",
             "description": "How often rules in the group are evaluated."
           },
+          "labels": {
+            "$ref": "#/definitions/labels",
+            "description": "Labels to add or overwrite before storing the result for its rules. Labels defined in <rule> will override the key if it has a collision."
+          },
           "limit": {
             "description": "Limit the number of alerts an alerting rule and series a recording rule can produce. 0 is no limit.",
             "type": ["integer", "null"],

--- a/src/test/prometheus.rules/rules.json
+++ b/src/test/prometheus.rules/rules.json
@@ -1,6 +1,9 @@
 {
   "groups": [
     {
+      "labels": {
+        "severity": "critical"
+      },
       "name": "my-group-name",
       "rules": [
         {


### PR DESCRIPTION
The Prometheus config now supports adding labels on rule groups, starting with Prometheus 3.0.0.
Ref: https://github.com/prometheus/prometheus/commit/f253d36361ef67228ecf3bfc3d8b359e05d35606 or https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group