### PR TITLE
Add `.ctfd.yaml` JSON schema

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,7 @@ src/negative_test/youtrack-app/ @skoch13 @andrey-skl @zmaks
 src/schemas/json/venvironment-* @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj
 src/test/venvironment-* @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj
 src/negative_test/venvironment-* @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj
+
+# Managed by CTFer.io team:
+src/schemas/json/ctfd.json @pandatix @NicoFgrx
+src/test/ctfd/* @pandatix @NicoFgrx

--- a/cli.js
+++ b/cli.js
@@ -1212,7 +1212,7 @@ async function assertSchemaHasValidSchemaField(
       printErrorAndExit(new Error(), [
         `Schema version is too high => in file ${schema.name}`,
         `Schema version '${schema.json.$schema}' is not supported by many editors and IDEs`,
-        `${schema.json} must use a lower schema version.`,
+        `Schema file "${schema.path}" must use a lower schema version.`,
       ])
     }
   }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7241,6 +7241,12 @@
       "description": "Chamaleon environment",
       "fileMatch": ["**/environments/*-cha.json"],
       "url": "https://raw.githubusercontent.com/gerardorodriguezdev/chamaleon/refs/heads/master/schemas/environment-schema.json"
+    },
+    {
+      "name": "ctfd-setup configuration file",
+      "description": "CTFer.io ctfd-setup utility configuration file",
+      "fileMatch": [".ctfd.yaml"],
+      "url": "https://json.schemastore.org/ctfd.json"
     }
   ]
 }

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -291,7 +291,8 @@
     "license-report-config.json",
     "openweather.current.json",
     "openweather.roadrisk.json",
-    "specif-1.1.json"
+    "specif-1.1.json",
+    "ctfd.json"
   ],
   "missingCatalogUrl": [
     // Below this line are subschemas that are included from other schema

--- a/src/schemas/json/ctfd.json
+++ b/src/schemas/json/ctfd.json
@@ -386,7 +386,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "description": "Settings for ressources visibility."
+      "description": "Settings for resources visibility."
     },
     "Social": {
       "properties": {

--- a/src/schemas/json/ctfd.json
+++ b/src/schemas/json/ctfd.json
@@ -63,11 +63,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "name",
-        "email",
-        "password"
-      ],
+      "required": ["name", "email", "password"],
       "description": "Admin accesses."
     },
     "Appearance": {
@@ -87,10 +83,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "name",
-        "description"
-      ],
+      "required": ["name", "description"],
       "description": "Appearance of the CTFd."
     },
     "Config": {
@@ -133,20 +126,14 @@
         },
         "mode": {
           "type": "string",
-          "enum": [
-            "users",
-            "teams"
-          ],
+          "enum": ["users", "teams"],
           "description": "The mode of your CTFd, either users or teams.",
           "default": "users"
         }
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "appearance",
-        "admin"
-      ]
+      "required": ["appearance", "admin"]
     },
     "Email": {
       "properties": {
@@ -305,10 +292,7 @@
         },
         "format": {
           "type": "string",
-          "enum": [
-            "markdown",
-            "html"
-          ],
+          "enum": ["markdown", "html"],
           "description": "Format to consume the content.",
           "default": "markdown"
         },
@@ -334,11 +318,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "title",
-        "route",
-        "content"
-      ],
+      "required": ["title", "route", "content"],
       "description": "Page to configure and display on the CTFd."
     },
     "Pages": {
@@ -377,41 +357,25 @@
       "properties": {
         "challenge_visibility": {
           "type": "string",
-          "enum": [
-            "public",
-            "private",
-            "admins"
-          ],
+          "enum": ["public", "private", "admins"],
           "description": "The visibility for the challenges. Please refer to CTFd documentation (https://docs.ctfd.io/docs/settings/visibility-settings/).",
           "default": "private"
         },
         "account_visibility": {
           "type": "string",
-          "enum": [
-            "public",
-            "private",
-            "admins"
-          ],
+          "enum": ["public", "private", "admins"],
           "description": "The visibility for the accounts. Please refer to CTFd documentation (https://docs.ctfd.io/docs/settings/visibility-settings/).",
           "default": "public"
         },
         "score_visibility": {
           "type": "string",
-          "enum": [
-            "public",
-            "private",
-            "admins"
-          ],
+          "enum": ["public", "private", "admins"],
           "description": "The visibility for the scoreboard. Please refer to CTFd documentation (https://docs.ctfd.io/docs/settings/visibility-settings/).",
           "default": "public"
         },
         "registration_visibility": {
           "type": "string",
-          "enum": [
-            "public",
-            "private",
-            "admins"
-          ],
+          "enum": ["public", "private", "admins"],
           "description": "The visibility for the registration. Please refer to CTFd documentation (https://docs.ctfd.io/docs/settings/visibility-settings/).",
           "default": "public"
         },

--- a/src/schemas/json/ctfd.json
+++ b/src/schemas/json/ctfd.json
@@ -1,0 +1,498 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://json.schemastore.org/ctfd.json",
+  "$ref": "#/$defs/Config",
+  "$defs": {
+    "Accounts": {
+      "properties": {
+        "domain_whitelist": {
+          "type": "string",
+          "description": "The domain whitelist (a list separated by colons) to allow users to have email addresses from."
+        },
+        "verify_emails": {
+          "type": "boolean",
+          "description": "Whether to verify emails once a user register or not."
+        },
+        "team_creation": {
+          "type": "boolean",
+          "description": "Whether to allow team creation by players or not."
+        },
+        "team_size": {
+          "type": "integer",
+          "description": "Maximum size (number of players) in a team."
+        },
+        "num_teams": {
+          "type": "integer",
+          "description": "The total number of teams allowed."
+        },
+        "num_users": {
+          "type": "integer",
+          "description": "The total number of users allowed."
+        },
+        "team_disbanding": {
+          "type": "string",
+          "description": "Whether to allow teams to be disbanded or not. Could be inactive_only or disabled."
+        },
+        "incorrect_submissions_per_minutes": {
+          "type": "integer",
+          "description": "Maximum number of invalid submissions per minute (per user/team). We suggest you use it as part of an anti-brute-force strategy (rate limiting)."
+        },
+        "name_changes": {
+          "type": "boolean",
+          "description": "Whether a user can change its name or not."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Accounts parameters, like rate limiting or default permissions."
+    },
+    "Admin": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The administrator name. Immutable, or need the administrator to change the CTFd data AND the configuration file."
+        },
+        "email": {
+          "type": "string",
+          "description": "The administrator email address. Immutable, or need the administrator to change the CTFd data AND the configuration file."
+        },
+        "password": {
+          "$ref": "#/$defs/FromEnv",
+          "description": "The administrator password, recommended to use the varenvs. Immutable, or need the administrator to change the CTFd data AND the configuration file."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "email",
+        "password"
+      ],
+      "description": "Admin accesses."
+    },
+    "Appearance": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of your CTF, displayed as is."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of your CTF, displayed as is."
+        },
+        "default_locale": {
+          "type": "string",
+          "description": "The default language for the users."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "description"
+      ],
+      "description": "Appearance of the CTFd."
+    },
+    "Config": {
+      "properties": {
+        "appearance": {
+          "$ref": "#/$defs/Appearance"
+        },
+        "theme": {
+          "$ref": "#/$defs/Theme"
+        },
+        "accounts": {
+          "$ref": "#/$defs/Accounts"
+        },
+        "pages": {
+          "$ref": "#/$defs/Pages"
+        },
+        "major_league_cyber": {
+          "$ref": "#/$defs/MajorLeagueCyber"
+        },
+        "settings": {
+          "$ref": "#/$defs/Settings"
+        },
+        "security": {
+          "$ref": "#/$defs/Security"
+        },
+        "email": {
+          "$ref": "#/$defs/Email"
+        },
+        "time": {
+          "$ref": "#/$defs/Time"
+        },
+        "social": {
+          "$ref": "#/$defs/Social"
+        },
+        "legal": {
+          "$ref": "#/$defs/Legal"
+        },
+        "admin": {
+          "$ref": "#/$defs/Admin"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "users",
+            "teams"
+          ],
+          "description": "The mode of your CTFd, either users or teams.",
+          "default": "users"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "appearance",
+        "admin"
+      ]
+    },
+    "Email": {
+      "properties": {
+        "registration": {
+          "$ref": "#/$defs/EmailContent",
+          "description": "The registration email."
+        },
+        "confirmation": {
+          "$ref": "#/$defs/EmailContent",
+          "description": "The confirmation email."
+        },
+        "new_account": {
+          "$ref": "#/$defs/EmailContent",
+          "description": "The new account email."
+        },
+        "password_reset": {
+          "$ref": "#/$defs/EmailContent",
+          "description": "The password reset email."
+        },
+        "password_reset_confirmation": {
+          "$ref": "#/$defs/EmailContent",
+          "description": "The password reset confirmation email."
+        },
+        "from": {
+          "type": "string",
+          "description": "The 'From:' to sent to mail with."
+        },
+        "server": {
+          "type": "string",
+          "description": "The mail server to use."
+        },
+        "port": {
+          "type": "string",
+          "description": "The mail server port to reach."
+        },
+        "username": {
+          "type": "string",
+          "description": "The username to log in to the mail server."
+        },
+        "password": {
+          "type": "string",
+          "description": "The password to log in to the mail server."
+        },
+        "tls_ssl": {
+          "type": "boolean",
+          "description": "Whether to turn on TLS/SSL or not."
+        },
+        "starttls": {
+          "type": "boolean",
+          "description": "Whether to turn on STARTTLS or not."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Email rules and server credentials."
+    },
+    "EmailContent": {
+      "properties": {
+        "subject": {
+          "type": "string",
+          "description": "Subject of the email."
+        },
+        "body": {
+          "type": "string",
+          "description": "Body (or content) or the email."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExternalReference": {
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL to access the content."
+        },
+        "content": {
+          "$ref": "#/$defs/File",
+          "description": "The content of the reference."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "File": {
+      "oneOf": [
+        {
+          "properties": {
+            "from_file": {
+              "type": "string",
+              "description": "The file to import content from."
+            }
+          },
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "FromEnv": {
+      "oneOf": [
+        {
+          "properties": {
+            "from_env": {
+              "type": "string",
+              "description": "The environment variable to look at."
+            }
+          },
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Legal": {
+      "properties": {
+        "tos": {
+          "$ref": "#/$defs/ExternalReference",
+          "description": "The Terms of Services."
+        },
+        "privacy_policy": {
+          "$ref": "#/$defs/ExternalReference",
+          "description": "The Privacy Policy."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Legal contents for players."
+    },
+    "MajorLeagueCyber": {
+      "properties": {
+        "client_id": {
+          "type": "string",
+          "description": "The MajorLeagueCyber OAuth ClientID."
+        },
+        "client_secret": {
+          "type": "string",
+          "description": "The MajorLeagueCyber OAuth Client Secret."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "MajorLeagueCyber credentials to register the CTF."
+    },
+    "Page": {
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Title of the page."
+        },
+        "route": {
+          "type": "string",
+          "description": "Route to serve."
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "markdown",
+            "html"
+          ],
+          "description": "Format to consume the content.",
+          "default": "markdown"
+        },
+        "content": {
+          "$ref": "#/$defs/File",
+          "description": "The page content. If you need to use images, please use an external CDN to make sure the content is replicable."
+        },
+        "draft": {
+          "type": "boolean",
+          "description": "Set the page as a draft.",
+          "default": false
+        },
+        "hidden": {
+          "type": "boolean",
+          "description": "Hide or show the page to users.",
+          "default": false
+        },
+        "auth_required": {
+          "type": "boolean",
+          "description": "Configure whether the page require authentication or not.",
+          "default": false
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "title",
+        "route",
+        "content"
+      ],
+      "description": "Page to configure and display on the CTFd."
+    },
+    "Pages": {
+      "properties": {
+        "robots_txt": {
+          "$ref": "#/$defs/File",
+          "description": "Define the /robots.txt file content, for web crawlers indexing."
+        },
+        "additional": {
+          "items": {
+            "$ref": "#/$defs/Page"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Pages global configuration."
+    },
+    "Security": {
+      "properties": {
+        "html_sanitization": {
+          "type": "boolean",
+          "description": "Whether to turn on HTML sanitization or not."
+        },
+        "registration_code": {
+          "type": "string",
+          "description": "The registration code (secret) to join the CTF."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Security of contents and accesses."
+    },
+    "Settings": {
+      "properties": {
+        "challenge_visibility": {
+          "type": "string",
+          "enum": [
+            "public",
+            "private",
+            "admins"
+          ],
+          "description": "The visibility for the challenges. Please refer to CTFd documentation (https://docs.ctfd.io/docs/settings/visibility-settings/).",
+          "default": "private"
+        },
+        "account_visibility": {
+          "type": "string",
+          "enum": [
+            "public",
+            "private",
+            "admins"
+          ],
+          "description": "The visibility for the accounts. Please refer to CTFd documentation (https://docs.ctfd.io/docs/settings/visibility-settings/).",
+          "default": "public"
+        },
+        "score_visibility": {
+          "type": "string",
+          "enum": [
+            "public",
+            "private",
+            "admins"
+          ],
+          "description": "The visibility for the scoreboard. Please refer to CTFd documentation (https://docs.ctfd.io/docs/settings/visibility-settings/).",
+          "default": "public"
+        },
+        "registration_visibility": {
+          "type": "string",
+          "enum": [
+            "public",
+            "private",
+            "admins"
+          ],
+          "description": "The visibility for the registration. Please refer to CTFd documentation (https://docs.ctfd.io/docs/settings/visibility-settings/).",
+          "default": "public"
+        },
+        "paused": {
+          "type": "boolean",
+          "description": "Whether the CTFd is paused or not."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Settings for ressources visibility."
+    },
+    "Social": {
+      "properties": {
+        "shares": {
+          "type": "boolean",
+          "description": "Whether to enable users share they solved a challenge or not."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Social network configuration."
+    },
+    "Theme": {
+      "properties": {
+        "logo": {
+          "$ref": "#/$defs/File",
+          "description": "The frontend logo."
+        },
+        "small_icon": {
+          "$ref": "#/$defs/File",
+          "description": "The frontend small icon."
+        },
+        "name": {
+          "type": "string",
+          "description": "The frontend theme name.",
+          "default": "core-beta"
+        },
+        "color": {
+          "type": "string",
+          "description": "The frontend theme color."
+        },
+        "header": {
+          "$ref": "#/$defs/File",
+          "description": "The frontend header."
+        },
+        "footer": {
+          "$ref": "#/$defs/File",
+          "description": "The frontend footer."
+        },
+        "settings": {
+          "$ref": "#/$defs/File",
+          "description": "The frontend settings (JSON)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Theme displayed to end-users."
+    },
+    "Time": {
+      "properties": {
+        "start": {
+          "type": "string",
+          "description": "The start timestamp at which the CTFd will open."
+        },
+        "end": {
+          "type": "string",
+          "description": "The end timestamp at which the CTFd will close."
+        },
+        "freeze": {
+          "type": "string",
+          "description": "The freeze timestamp at which the CTFd will remain open but won't accept any further submissions."
+        },
+        "view_after": {
+          "type": "boolean",
+          "description": "Whether allows users to view challenges after end or not."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Time settings of the CTF."
+    }
+  }
+}

--- a/src/test/ctfd/minimal.yaml
+++ b/src/test/ctfd/minimal.yaml
@@ -1,0 +1,8 @@
+appearance:
+  name: 'MyCTF 20XX'
+  description: 'MyCTF description'
+
+admin:
+  name: 'my-name'
+  email: 'my-email@dns.tld'
+  password: 'dont put password in a config file, use the varenv'


### PR DESCRIPTION
With this PR I propose to add the [ctfd-setup](https://github.com/ctfer-io/ctfd-setup) schema generated by the tool itself, through reflection of its own sources.
This feature has been deployed through v1.5.0 and tested on the repository itself (with GA workflows).

We now want to deploy it largely through the SchemaStore.

As you may observe, we do not exactly fit all recommendations provided by the community, like for the schema version being `2020-12` rather than `draft-07`. This is due to code generation aligning with the practices of @invopop. We do not consider it a pain point to adoption of this schema as we do not expect end-users to use validators/linters not compliant with this version.

Nevertheless, it is a first for us at publishing a JSON Schema thus went for a basic copy-pasta of the generated schema for a first shot. We are open to discuss and take recommendations on the delivery model (e.g. for automation on releases, on schema publication).