### PR TITLE
web-manifest: describe enum values for `orientation`

### DIFF
--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -151,15 +151,39 @@
     },
     "orientation": {
       "description": "The orientation member is a string that serves as the default orientation for all  top-level browsing contexts of the web application.",
-      "enum": [
-        "any",
-        "natural",
-        "landscape",
-        "portrait",
-        "portrait-primary",
-        "portrait-secondary",
-        "landscape-primary",
-        "landscape-secondary"
+      "oneOf": [
+        {
+          "const": "any",
+          "description": "Displays the web app in any orientation allowed by the device's operating system or user settings. It allows the app to rotate freely to match the orientation of the device when it is rotated. "
+        },
+        {
+          "const": "natural",
+          "description": "Displays the web app in the orientation considered most natural for the device, as determined by the browser, operating system, user settings, or the screen itself. It corresponds to how the device is most commonly held or used: On devices typically held vertically, such as mobile phones, natural is usually portrait-primary.  On devices typically used horizontally, such as computer monitors and tablets, natural is usually landscape-primary.  When the device is rotated, the app may or may not rotate so as to match the device's natural orientation; this behavior may vary depending on the specific device, browser implementation, and user settings."
+        },
+        {
+          "const": "landscape",
+          "description": "Displays the web app with width greater than height. It allows the app to switch between landscape-primary and landscape-secondary orientations when the device is rotated."
+        },
+        {
+          "const": "portrait",
+          "description": "Displays the web app with height greater than width. It allows the app to switch between portrait-primary and portrait-secondary orientations when the device is rotated."
+        },
+        {
+          "const": "portrait-primary",
+          "description": "Displays the web app in portrait mode, typically with the device held upright. This is usually the default app orientation on devices that are naturally portrait. Depending on the device and browser implementation, the app will typically maintain this orientation even when the device is rotated."
+        },
+        {
+          "const": "portrait-secondary",
+          "description": "Displays the web app in inverted portrait mode, which is portrait-primary rotated 180 degrees. Depending on the device and browser implementation, the app will typically maintain this orientation even when the device is rotated."
+        },
+        {
+          "const": "landscape-primary",
+          "description": "Displays the web app in landscape mode, typically with the device held in its standard horizontal position. This is usually the default app orientation on devices that are naturally landscape. Depending on the device and browser implementation, the app will typically maintain this orientation even when the device is rotated."
+        },
+        {
+          "const": "landscape-secondary",
+          "description": "Displays the web app in inverted landscape mode, which is landscape-primary rotated 180 degrees. Depending on the device and browser implementation, the app will typically maintain this orientation even when the device is rotated."
+        }
       ]
     },
     "prefer_related_applications": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This adds enum descriptions (with the officially accepted "hack" of turning `enum` into a `oneOf` of `const` subschemas, see https://github.com/json-schema-org/json-schema-spec/issues/57) to the  `orientation` field for PWA manifest files. Might do more enums.

Main motivation is to show descriptions on auto-complete in IDEs (vscode unfortunately does not show them nicely, i've opened a separate issue https://github.com/microsoft/vscode/issues/236074)

The descriptions are sourced from https://developer.mozilla.org/en-US/docs/Web/Manifest/orientation