### PR TITLE
fix: update filematch for deployer

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1765,7 +1765,7 @@
     {
       "name": "Deployer Recipe",
       "description": "A Deployer yaml recipes",
-      "fileMatch": ["deploy.yaml", "deploy.yml"],
+      "fileMatch": [],
       "url": "https://raw.githubusercontent.com/deployphp/deployer/master/src/schema.json"
     },
     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

When trying to create a GitHub workflow for deployment (at `.github/workflows/deploy.yml`) this file match got in the way.