### PR TITLE
(pyproject) Fix Poe schema

### DIFF
--- a/src/schemas/json/partial-poe.json
+++ b/src/schemas/json/partial-poe.json
@@ -381,7 +381,6 @@
                     "description": "The value(s) that match the control task's output to determine this case should be executed."
                   }
                 },
-                "required": ["case"],
                 "type": "object"
               },
               "type": "array"

--- a/src/schemas/json/partial-poe.json
+++ b/src/schemas/json/partial-poe.json
@@ -592,7 +592,7 @@
     "tasks": {
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z_][a-zA-Z0-9_]*(:[a-zA-Z0-9_]+)?$": {
+        "^[a-zA-Z_][a-zA-Z0-9_:-]*$": {
           "oneOf": [
             {
               "$ref": "#/definitions/cmd_task"

--- a/src/schemas/json/partial-poe.json
+++ b/src/schemas/json/partial-poe.json
@@ -292,8 +292,8 @@
               ]
             },
             "sequence": {
-              "description": "A sequence task is defined by an array of tasks or command names to be run one after the other. Each item in the sequence can be a command name, a command, script, reference to another task, or another sequence.",
-              "$ref": "#/definitions/tasks_array"
+              "$ref": "#/definitions/tasks_array",
+              "description": "A sequence task is defined by an array of tasks or command names to be run one after the other. Each item in the sequence can be a command name, a command, script, reference to another task, or another sequence."
             }
           },
           "required": ["sequence"]

--- a/src/schemas/json/partial-poe.json
+++ b/src/schemas/json/partial-poe.json
@@ -137,13 +137,22 @@
         "env": {
           "additionalProperties": false,
           "patternProperties": {
-            "^[A-Z_][A-Z0-9_]*$": {
+            "^.+$": {
               "description": "The value to be set for the environment variable.",
-              "type": ["string"]
-            },
-            "^[A-Z_][A-Z0-9_]*\\.default$": {
-              "description": "A default value for the environment variable that will be used only if the variable is not already set.",
-              "type": ["string"]
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "default": {
+                      "description": "A default value for an environment variable that will be used only if the variable is not already set.",
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
             }
           },
           "type": "object"
@@ -483,11 +492,20 @@
       "patternProperties": {
         "^.+$": {
           "description": "A POSIX string that may include environment variable interpolations.",
-          "type": "string"
-        },
-        "^.+\\.default$": {
-          "description": "A default value for an environment variable that will be used only if the variable is not already set.",
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "description": "A default value for an environment variable that will be used only if the variable is not already set.",
+                  "type": "string"
+                }
+              }
+            }
+          ]
         }
       },
       "type": "object"

--- a/src/schemas/json/partial-poe.json
+++ b/src/schemas/json/partial-poe.json
@@ -293,35 +293,7 @@
             },
             "sequence": {
               "description": "A sequence task is defined by an array of tasks or command names to be run one after the other. Each item in the sequence can be a command name, a command, script, reference to another task, or another sequence.",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/definitions/cmd_task"
-                  },
-                  {
-                    "$ref": "#/definitions/script_task"
-                  },
-                  {
-                    "$ref": "#/definitions/sequence_task"
-                  },
-                  {
-                    "$ref": "#/definitions/shell_task"
-                  },
-                  {
-                    "$ref": "#/definitions/expr_task"
-                  },
-                  {
-                    "$ref": "#/definitions/switch_task"
-                  },
-                  {
-                    "$ref": "#/definitions/ref_task"
-                  }
-                ]
-              },
-              "type": "array"
+              "$ref": "#/definitions/tasks_array"
             }
           },
           "required": ["sequence"]
@@ -380,32 +352,7 @@
           "type": "object",
           "properties": {
             "control": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/definitions/cmd_task"
-                },
-                {
-                  "$ref": "#/definitions/script_task"
-                },
-                {
-                  "$ref": "#/definitions/sequence_task"
-                },
-                {
-                  "$ref": "#/definitions/shell_task"
-                },
-                {
-                  "$ref": "#/definitions/expr_task"
-                },
-                {
-                  "$ref": "#/definitions/switch_task"
-                },
-                {
-                  "$ref": "#/definitions/ref_task"
-                }
-              ],
+              "$ref": "#/definitions/one_of_tasks",
               "description": "A required definition for a task to be executed to determine which case task to run."
             },
             "default": {
@@ -417,30 +364,7 @@
             "switch": {
               "description": "A list of cases with tasks to execute based on the control task's output.",
               "items": {
-                "allOf": [
-                  {
-                    "oneOf": [
-                      {
-                        "$ref": "#/definitions/cmd_task"
-                      },
-                      {
-                        "$ref": "#/definitions/script_task"
-                      },
-                      {
-                        "$ref": "#/definitions/shell_task"
-                      },
-                      {
-                        "$ref": "#/definitions/sequence_task"
-                      },
-                      {
-                        "$ref": "#/definitions/expr_task"
-                      },
-                      {
-                        "$ref": "#/definitions/switch_task"
-                      }
-                    ]
-                  }
-                ],
+                "$ref": "#/definitions/one_of_tasks",
                 "properties": {
                   "case": {
                     "anyOf": [
@@ -466,6 +390,40 @@
           "required": ["control", "switch"]
         }
       ]
+    },
+    "one_of_tasks": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/cmd_task"
+        },
+        {
+          "$ref": "#/definitions/script_task"
+        },
+        {
+          "$ref": "#/definitions/shell_task"
+        },
+        {
+          "$ref": "#/definitions/sequence_task"
+        },
+        {
+          "$ref": "#/definitions/expr_task"
+        },
+        {
+          "$ref": "#/definitions/switch_task"
+        },
+        {
+          "$ref": "#/definitions/ref_task"
+        }
+      ]
+    },
+    "tasks_array": {
+      "items": {
+        "$ref": "#/definitions/one_of_tasks"
+      },
+      "type": "array"
     }
   },
   "properties": {
@@ -595,25 +553,10 @@
         "^[a-zA-Z_][a-zA-Z0-9_:-]*$": {
           "oneOf": [
             {
-              "$ref": "#/definitions/cmd_task"
+              "$ref": "#/definitions/one_of_tasks"
             },
             {
-              "$ref": "#/definitions/script_task"
-            },
-            {
-              "$ref": "#/definitions/shell_task"
-            },
-            {
-              "$ref": "#/definitions/sequence_task"
-            },
-            {
-              "$ref": "#/definitions/expr_task"
-            },
-            {
-              "$ref": "#/definitions/switch_task"
-            },
-            {
-              "$ref": "#/definitions/ref_task"
+              "$ref": "#/definitions/tasks_array"
             }
           ]
         }


### PR DESCRIPTION
Related to #3564 #4275



### env.*.default

`VAR1.default=x` in toml is not `{"VAR1.default":"x"}` but `{"VAR1":{"default":"x"}}`.

https://poethepoet.natn.io/global_options.html

```toml
[tool.poe.env]
VAR1.default = "FOO"
```

### name of task

The name of task is allowed to contain `-`.

https://poethepoet.natn.io/tasks/index.html
https://github.com/nat-n/poethepoet/blob/3884fcd2409d9ed15404971e12883e863f21eedd/poethepoet/task/base.py#L272-L281

```toml
[tool.poe.tasks.test-quick]
help = "Run tests excluding those makes as slow."
cmd  = "pytest -m \"not slow\"" # here the cmd key identifies the task type and content
```

### Define `one_of_tasks` and `tasks_array`

Use with `$ref`.

### string task or array task

https://poethepoet.natn.io/tasks/index.html

```toml
[tool.poe.tasks]
test   = "pytest"
_build = "poetry build"
build  = ["test", "_build"] # this task runs the two referenced tasks in sequence
```

### default case of switch tasks

> the default case (i.e. the switch item with no case option defined)

https://poethepoet.natn.io/tasks/task_types/switch.html

```toml
[tool.poe.tasks.build]
control.expr = "sys.platform"

  [[tool.poe.tasks.build.switch]]
  case = "win32"
  cmd  = "windows_build"

  [[tool.poe.tasks.build.switch]]
  cmd  = "posix_build"
```
