### PR TITLE
feat(schema): ✨ add `saveTextLockfile` option to `bunfig.json`

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -191,6 +191,12 @@
           "type": "boolean",
           "default": false
         },
+        "saveTextLockfile": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#install-savetextlockfile",
+          "description": "Generate `bun.lock`, a human-readable text-based lockfile. Once generated, Bun will use this file instead of `bun.lockb`, choosing it over the binary lockfile if both are present.\n\nDefault false. In Bun v1.2.0 the default lockfile format will change to bun.lock.\nhttps://bun.sh/docs/runtime/bunfig#install-savetextlockfile",
+          "type": "boolean",
+          "default": false
+        },
         "auto": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-auto",
           "description": "To configure Bun's package auto-install behavior. Default `\"auto\"` — when no `node_modules` folder is found, Bun will automatically install dependencies on the fly during execution\nhttps://bun.sh/docs/runtime/bunfig#install-auto",

--- a/src/test/bunfig/bunfig.toml
+++ b/src/test/bunfig/bunfig.toml
@@ -24,6 +24,7 @@ telemetry = false
 auto = "auto"
 dev = true
 dryRun = false
+saveTextLockfile=true
 exact = false
 frozenLockfile = false
 globalBinDir = "~/.bun/bin"


### PR DESCRIPTION
* Introduced a new boolean option `saveTextLockfile` to enable the generation of a human-readable text-based lockfile (`bun.lock`).
* This option allows Bun to prefer the text lockfile over the binary lockfile when both are present.
* Default value is set to `false`.
* Updated documentation links for clarity on usage.

https://bun.sh/docs/runtime/bunfig#install-savetextlockfile

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
