### PR TITLE
Update Chromia Model external schema location in catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -977,7 +977,7 @@
       "name": "Chromia Model",
       "description": "Chromia Model Config File",
       "fileMatch": ["chromia.yml", "chromia.yaml"],
-      "url": "https://gitlab.com/chromaway/core-tools/chromia-cli/-/raw/dev/chromia-build-tools/src/main/resources/chromia-model-schema.json"
+      "url": "https://gitlab.com/chromaway/core-tools/chromia-cli-tools/-/raw/dev/chromia-build-tools/src/main/resources/chromia-model-schema.json"
     },
     {
       "name": "cibuildwheel",


### PR DESCRIPTION
Chromia Model schema was moved to another repository. Updating link to it

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
