### PR TITLE
Issue #4294: Add enableSelfMonitoring to metricshub.json

### DIFF
--- a/src/schemas/json/metricshub.json
+++ b/src/schemas/json/metricshub.json
@@ -3,6 +3,14 @@
   "$id": "https://json.schemastore.org/metricshub.json",
   "type": "object",
   "definitions": {
+    "sequential": {
+      "type": "boolean",
+      "description": "Sequential mode. This forces all network calls to be ordered in a sequential order."
+    },
+    "enableSelfMonitoring": {
+      "description": "Enables or disables self monitoring signals. E.g. job duration metrics.",
+      "type": "boolean"
+    },
     "duration": {
       "oneOf": [
         {
@@ -67,9 +75,11 @@
               }
             }
           },
+          "enableSelfMonitoring": {
+            "$ref": "#/definitions/enableSelfMonitoring"
+          },
           "sequential": {
-            "type": "boolean",
-            "description": "Sequential mode. This forces all network calls to be ordered in a sequential order."
+            "$ref": "#/definitions/sequential"
           },
           "resolveHostnameToFqdn": {
             "$ref": "#/definitions/resolveHostnameToFqdn"
@@ -1466,9 +1476,11 @@
         }
       }
     },
+    "enableSelfMonitoring": {
+      "$ref": "#/definitions/enableSelfMonitoring"
+    },
     "sequential": {
-      "type": "boolean",
-      "description": "Sequential mode. This forces all network calls to be ordered in a sequential order."
+      "$ref": "#/definitions/sequential"
     },
     "resolveHostnameToFqdn": {
       "$ref": "#/definitions/resolveHostnameToFqdn"
@@ -1619,9 +1631,11 @@
               }
             }
           },
+          "enableSelfMonitoring": {
+            "$ref": "#/definitions/enableSelfMonitoring"
+          },
           "sequential": {
-            "type": "boolean",
-            "description": "Sequential mode. This forces all network calls to be ordered in a sequential order."
+            "$ref": "#/definitions/sequential"
           },
           "resolveHostnameToFqdn": {
             "$ref": "#/definitions/resolveHostnameToFqdn"

--- a/src/test/metricshub/metricshub.yaml
+++ b/src/test/metricshub/metricshub.yaml
@@ -48,10 +48,20 @@ patchDirectory: /opt/dev/connectors
 # Resolve resource hostname to FQDN
 resolveHostnameToFqdn: true
 
+# Sequential mode
+sequential: false
+
+# Self monitoring flag
+enableSelfMonitoring: false
+
 # Resource Groups configuration
 resourceGroups:
   # Resource Group identifier
   data-center-1:
+    # Sequential mode
+    sequential: false
+    # Self monitoring flag
+    enableSelfMonitoring: false
     # Adds additional static attributes to all the resources in the group
     attributes: # old extraLabels
       site: datacenter-1 # Customize this value with your own site naming convention. (Dedicating 1 collector to 1 site is a good practice.)
@@ -81,6 +91,10 @@ resourceGroups:
     resources:
       # # ECS2-01 Resource Configuration
       server-01:
+        # Sequential mode
+        sequential: false
+        # Self monitoring flag
+        enableSelfMonitoring: false
         attributes:
           host.name: server-01
           host.type: linux
@@ -92,6 +106,10 @@ resourceGroups:
 
       # # EMC Disk Array through WBEM
       server-02:
+        # Sequential mode
+        sequential: true
+        # Self monitoring flag
+        enableSelfMonitoring: false
         attributes:
           host.name: server-02
           host.type: storage
@@ -105,6 +123,10 @@ resourceGroups:
           - +EMCDiskArray
 
       pc-user:
+        # Sequential mode
+        sequential: false
+        # Self monitoring flag
+        enableSelfMonitoring: false
         attributes:
           host.name: localhost
           host.type: windows
@@ -119,6 +141,10 @@ resourceGroups:
             force: true
 
       grafana-service:
+        # Sequential mode
+        sequential: false
+        # Self monitoring flag
+        enableSelfMonitoring: false
         attributes:
           service.name: Grafana
           host.name: metricshub-demo.mydomain.com


### PR DESCRIPTION
**Summary**

- Add `enableSelfMonitoring `flag
- Refactor `sequential ` flag reference

**Additional details**

- Add definition for `enableSelfMonitoring `flag
- Use the reference of the created definition of the `enableSelfMonitoring` flag
- Add definition for `sequential `flag
- Use the reference of the created definition of the `sequential ` flag instead of the duplicate definitions