### PR TITLE
fix: update Backstage schema to support k8s service locator methods

### DIFF
--- a/src/schemas/json/app-config.json
+++ b/src/schemas/json/app-config.json
@@ -3551,7 +3551,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["multiTenant","singleTenant","catalogRelation"]
+              "enum": ["multiTenant", "singleTenant", "catalogRelation"]
             }
           }
         },

--- a/src/schemas/json/app-config.json
+++ b/src/schemas/json/app-config.json
@@ -3551,7 +3551,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["multiTenant"]
+              "enum": ["multiTenant","singleTenant","catalogRelation"]
             }
           }
         },


### PR DESCRIPTION
As per [the Backstage documentation](https://backstage.io/docs/features/kubernetes/configuration/#servicelocatormethod), additional service locator methods are accepted.